### PR TITLE
fix: restore resilience patterns removed in dev refactor

### DIFF
--- a/src/auth/browser_auth.py
+++ b/src/auth/browser_auth.py
@@ -112,7 +112,15 @@ def _normalize_state(value: Optional[str]) -> str:
 
 
 def _allow_state_mismatch() -> bool:
-    """Opt-in local-dev bypass for strict state matching."""
+    """Opt-in local-dev bypass for strict state matching.
+
+    Requires BOTH env vars to be set:
+    - BETTERFLOW_ALLOW_STATE_MISMATCH=1
+    - BETTERFLOW_SYNC_ENV=development
+    This prevents accidental CSRF bypass in production builds.
+    """
+    if os.getenv("BETTERFLOW_SYNC_ENV", "").strip().lower() != "development":
+        return False
     return os.getenv("BETTERFLOW_ALLOW_STATE_MISMATCH", "").strip().lower() in {
         "1",
         "true",
@@ -151,9 +159,9 @@ class _CallbackHandler(BaseHTTPRequestHandler):
             )
             if not state_ok:
                 if code and _allow_state_mismatch():
-                    logger.warning(
+                    logger.error(
                         "State mismatch bypassed because "
-                        "BETTERFLOW_ALLOW_STATE_MISMATCH is enabled"
+                        "BETTERFLOW_ALLOW_STATE_MISMATCH is enabled (dev only)"
                     )
                     self.send_response(200)
                     self.send_header("Content-Type", "text/html")

--- a/src/display_info.py
+++ b/src/display_info.py
@@ -53,8 +53,7 @@ class DisplayTracker:
 def _start_macos_tracker() -> DisplayTracker:
     """Start a macOS display tracker using NSScreen and CGSGetActiveSpace."""
     from AppKit import NSScreen, NSWorkspace, NSObject
-    from Foundation import NSRunLoop, NSDate, NSTimer
-    from PyObjCTools import AppHelper
+    from Foundation import NSRunLoop, NSDate
 
     # Try importing private Quartz APIs for space tracking
     _cgs_available = False
@@ -148,6 +147,8 @@ def _start_macos_tracker() -> DisplayTracker:
     _stop_event = threading.Event()
 
     def _run() -> None:
+        observer = None
+        nc = None
         try:
             observer = _Observer.alloc().init()
             nc = NSWorkspace.sharedWorkspace().notificationCenter()
@@ -171,38 +172,20 @@ def _start_macos_tracker() -> DisplayTracker:
             _update_monitor_state()
             _update_desktop_state()
 
-            # Poll mainScreen every 5s via timer on the run loop
+            # Poll mainScreen every 5s
             # (no notification fires when the focused window moves to another monitor)
-            def _poll_timer_fired(timer) -> None:
-                if _stop_event.is_set():
-                    AppHelper.stopEventLoop()
-                    return
-                _update_monitor_state()
-
-            NSTimer.scheduledTimerWithTimeInterval_target_selector_userInfo_repeats_(
-                5.0,
-                observer,
-                "pollTimer:",
-                None,
-                True,
-            )
-
-            # Add pollTimer: method dynamically
-            import objc
-            def pollTimer_(self, timer):
-                _poll_timer_fired(timer)
-
-            # Use a simpler approach: run the event loop with periodic checks
             while not _stop_event.is_set():
-                NSRunLoop.currentRunLoop().runMode_beforeDate_(
-                    "NSDefaultRunLoopMode",
-                    NSDate.dateWithTimeIntervalSinceNow_(5.0),
-                )
-                _update_monitor_state()
-
-            nc.removeObserver_(observer)
+                _stop_event.wait(5.0)
+                if not _stop_event.is_set():
+                    _update_monitor_state()
         except Exception as e:
             logger.debug(f"macOS display tracker run loop failed: {e}")
+        finally:
+            if nc is not None and observer is not None:
+                try:
+                    nc.removeObserver_(observer)
+                except Exception:
+                    pass
 
     def _stop() -> None:
         _stop_event.set()
@@ -358,11 +341,12 @@ def _start_windows_tracker() -> DisplayTracker:
 
     def _poll() -> None:
         """Poll loop for Windows -- runs every 2s."""
+        com_initialized = False
         try:
-            # Initialize COM for this thread
             if _vd_available:
                 try:
                     ctypes.windll.ole32.CoInitialize(None)  # type: ignore[attr-defined]
+                    com_initialized = True
                 except Exception:
                     pass
 
@@ -377,6 +361,12 @@ def _start_windows_tracker() -> DisplayTracker:
                 )
         except Exception as e:
             logger.debug(f"Windows display tracker poll failed: {e}")
+        finally:
+            if com_initialized:
+                try:
+                    ctypes.windll.ole32.CoUninitialize()  # type: ignore[attr-defined]
+                except Exception:
+                    pass
 
     def _stop() -> None:
         _stop_event.set()

--- a/src/main.py
+++ b/src/main.py
@@ -8,14 +8,14 @@ import threading
 import zipfile
 from datetime import datetime
 from pathlib import Path
-from typing import Optional
+from typing import Callable, Optional
 
 from apscheduler.schedulers.background import BackgroundScheduler
 from apscheduler.triggers.interval import IntervalTrigger
 
 # Support both relative imports (module) and absolute imports (PyInstaller)
 try:
-    from . import __version__
+    from .__init__ import __version__
     from .auth import KeychainManager, LoginManager
     from .aw_manager import AWManager
     from .config import Config, setup_logging
@@ -84,10 +84,14 @@ class SyncCoordinator:
         self.paused_by_network = False
 
         # Optional callback wired by the app for auth-error re-login
-        self._on_auth_error: Optional[callable] = None
+        self._on_auth_error: Optional[Callable] = None
+        self._sync_in_progress = False
 
     def start(self) -> None:
         """Run the initial sync and start the periodic scheduler."""
+        # BackgroundScheduler.shutdown() is terminal -- create a fresh one
+        if not self.scheduler.running:
+            self.scheduler = BackgroundScheduler()
         self._do_sync()
         self._fetch_trends()
 
@@ -182,6 +186,7 @@ class SyncCoordinator:
 
     def _do_sync(self) -> None:
         """Perform a sync cycle."""
+        self._sync_in_progress = True
         try:
             if self.sync_engine.is_private:
                 return
@@ -249,6 +254,8 @@ class SyncCoordinator:
         except Exception as e:
             logger.exception(f"Sync error: {e}")
             self.tray.set_state(TrayState.ERROR, "Sync error")
+        finally:
+            self._sync_in_progress = False
 
     def _fetch_hours_today(self) -> str:
         """Fetch today's tracked hours from API."""
@@ -359,7 +366,10 @@ class BetterFlowSyncApp:
         )
         self.queue = OfflineQueue()
         self.keychain = KeychainManager()
-        self.display_tracker = start_display_tracker()
+        if self.config.privacy.track_display_info:
+            self.display_tracker = start_display_tracker()
+        else:
+            self.display_tracker = None
 
         # In-process window watcher on macOS (inherits Accessibility permission)
         self.window_watcher = None
@@ -416,6 +426,7 @@ class BetterFlowSyncApp:
         # State
         self._shutdown_done = False
         self._shutdown_event = threading.Event()
+        self._user_paused = False
 
     def run(self) -> None:
         """Run the application."""
@@ -466,22 +477,28 @@ class BetterFlowSyncApp:
             self.tray.set_state(TrayState.WAITING_AUTH, "Waiting for browser login...")
 
         # Start system event listeners
-        start_system_event_listener(
-            on_sleep=self._on_system_sleep,
-            on_wake=self._on_system_wake,
-            on_shutdown=self._on_system_shutdown,
-            on_network_change=self._on_network_change,
-            on_screen_lock=self._on_screen_lock,
-            on_screen_unlock=self._on_screen_unlock,
-        )
+        try:
+            start_system_event_listener(
+                on_sleep=self._on_system_sleep,
+                on_wake=self._on_system_wake,
+                on_shutdown=self._on_system_shutdown,
+                on_network_change=self._on_network_change,
+                on_screen_lock=self._on_screen_lock,
+                on_screen_unlock=self._on_screen_unlock,
+            )
+        except Exception:
+            logger.exception("Failed to start system event listeners")
 
         # Check for updates in background
-        if self.config.check_updates:
-            check_for_update(
-                (__version__ if isinstance(__version__, str) else __version__.__version__),
-                channel=self.config.update_channel,
-                callback=self._on_update_available,
-            )
+        try:
+            if self.config.check_updates:
+                check_for_update(
+                    (__version__ if isinstance(__version__, str) else __version__.__version__),
+                    channel=self.config.update_channel,
+                    callback=self._on_update_available,
+                )
+        except Exception:
+            logger.exception("Failed to start update checker")
 
         logger.info("BetterFlow Sync running")
         try:
@@ -509,10 +526,10 @@ class BetterFlowSyncApp:
                     "Accessibility permission in System Settings > Privacy & Security"
                 )
                 try:
-                    from .notifications import show_notification
+                    from .notifications import send_notification
                 except ImportError:
-                    from notifications import show_notification
-                show_notification(
+                    from notifications import send_notification
+                send_notification(
                     "BetterFlow Sync",
                     "Grant Accessibility permission to ActivityWatch in "
                     "System Settings > Privacy & Security for window tracking.",
@@ -524,10 +541,10 @@ class BetterFlowSyncApp:
         """Handle update available notification."""
         logger.info(f"Update available: v{version} — {url}")
         try:
-            from .notifications import show_notification
+            from .notifications import send_notification
         except ImportError:
-            from notifications import show_notification
-        show_notification(
+            from notifications import send_notification
+        send_notification(
             "BetterFlow Sync Update",
             f"Version {version} is available. Click to download.",
         )
@@ -572,6 +589,7 @@ class BetterFlowSyncApp:
 
     def _on_pause(self) -> None:
         """Handle pause action."""
+        self._user_paused = True
         self.coordinator.paused_by_network = False
         self.sync_engine.pause()
         self.tray.set_paused(True)
@@ -580,6 +598,7 @@ class BetterFlowSyncApp:
 
     def _on_resume(self) -> None:
         """Handle resume action."""
+        self._user_paused = False
         self.coordinator.paused_by_network = False
         self.sync_engine.resume()
         self.tray.set_paused(False)
@@ -622,6 +641,10 @@ class BetterFlowSyncApp:
 
     def _on_system_wake(self) -> None:
         """Handle system wake from sleep."""
+        self.bf.reset_session()
+        if self._user_paused:
+            logger.info("System wake — staying paused (user-initiated pause active)")
+            return
         self.sync_engine.resume()
         self.tray.set_state(TrayState.SYNCING)
         self.reminder_manager.on_tracking_started()
@@ -638,12 +661,17 @@ class BetterFlowSyncApp:
         logger.info("Screen locked — pausing tracking")
         self.sync_engine.pause()
         self.tray.set_state(TrayState.PAUSED, "Screen locked")
+        self.reminder_manager.on_tracking_stopped()
 
     def _on_screen_unlock(self) -> None:
         """Handle screen unlock — resume tracking."""
         logger.info("Screen unlocked — resuming tracking")
+        if self._user_paused:
+            logger.info("Screen unlock — staying paused (user-initiated pause active)")
+            return
         self.sync_engine.resume()
         self.tray.set_state(TrayState.SYNCING)
+        self.reminder_manager.on_tracking_started()
         self.coordinator.trigger_sync("unlock_sync")
 
     def _on_network_change(self, is_online: bool) -> None:
@@ -655,10 +683,15 @@ class BetterFlowSyncApp:
                 self.coordinator.paused_by_network = False
             self.coordinator.trigger_sync("network_sync")
         else:
-            logger.info("Network offline — pausing sync immediately")
-            self.sync_engine.pause()
-            self.coordinator.paused_by_network = True
-            self.tray.set_state(TrayState.QUEUED, "Offline")
+            if self.coordinator._sync_in_progress:
+                logger.info("Network offline — sync in progress, will pause after completion")
+                self.coordinator.paused_by_network = True
+                self.tray.set_state(TrayState.QUEUED, "Offline")
+            else:
+                logger.info("Network offline — pausing sync immediately")
+                self.sync_engine.pause()
+                self.coordinator.paused_by_network = True
+                self.tray.set_state(TrayState.QUEUED, "Offline")
 
     def _on_export_logs(self) -> None:
         """Export logs and redacted config to a zip file on the Desktop."""
@@ -795,7 +828,8 @@ class BetterFlowSyncApp:
         self.sync_engine.shutdown()
         if self.window_watcher:
             self.window_watcher.stop()
-        self.display_tracker.stop()
+        if self.display_tracker is not None:
+            self.display_tracker.stop()
         self.aw.close()
         self.bf.close()
         self.queue.close()

--- a/src/sync/bf_client.py
+++ b/src/sync/bf_client.py
@@ -3,6 +3,7 @@
 import hashlib
 import logging
 import platform
+import uuid
 from dataclasses import dataclass, field
 from typing import Optional
 
@@ -226,11 +227,12 @@ class BetterFlowClient(BaseApiClient):
             return SyncResult(success=True, events_synced=0)
 
         try:
+            idempotency_key = str(uuid.uuid4())
             response = self._request(
-                "POST",
-                "events/batch",
+                "POST", "events/batch",
                 data={"events": events},
                 compress=True,
+                extra_headers={"X-Idempotency-Key": idempotency_key},
             )
             return SyncResult(
                 success=True,
@@ -255,16 +257,21 @@ class BetterFlowClient(BaseApiClient):
         """
         return self._request("POST", "sessions/end", data={"reason": reason})
 
+    _HEARTBEAT_RETRY = RetryConfig(max_retries=1, base_delay=1.0, max_delay=5.0)
+
     def heartbeat(self, agent_version: str = AGENT_VERSION) -> dict:
         """Send heartbeat to server.
 
-        Returns server commands (pause/deregister) and config update flag.
+        Uses a shorter timeout (5s) and fewer retries (1) to avoid
+        blocking the sync loop when the server is slow (N14).
         """
         return self._request(
             "POST", "heartbeat", data={
                 "agent_version": agent_version,
                 "timezone": self._detect_timezone(),
-            }
+            },
+            timeout_override=5,
+            retry_config_override=self._HEARTBEAT_RETRY,
         )
 
     @staticmethod

--- a/src/sync/http_client.py
+++ b/src/sync/http_client.py
@@ -4,6 +4,7 @@ import gzip
 import json
 import logging
 import os
+import socket
 from typing import Optional
 from urllib.parse import urlparse
 
@@ -145,6 +146,9 @@ class BaseApiClient:
         files: Optional[dict] = None,
         compress: bool = False,
         retry: bool = True,
+        extra_headers: Optional[dict] = None,
+        timeout_override: Optional[int] = None,
+        retry_config_override: Optional[RetryConfig] = None,
     ) -> dict:
         """Make request to BetterFlow API.
 
@@ -155,6 +159,9 @@ class BaseApiClient:
             files: Files for multipart upload, e.g. {"file": ("name", bytes, "mime")}
             compress: Whether to gzip compress the payload
             retry: Whether to retry on transient failures
+            extra_headers: Additional headers to merge into the request
+            timeout_override: Override the default timeout for this request
+            retry_config_override: Override the default retry config for this request
 
         Returns:
             Response data as dict
@@ -165,7 +172,10 @@ class BaseApiClient:
         """
         url = f"{self.api_url}/{endpoint.lstrip('/')}"
         headers = self._get_headers()
-        kwargs: dict = {"timeout": self.timeout, "headers": headers}
+        if extra_headers:
+            headers.update(extra_headers)
+        effective_timeout = timeout_override if timeout_override is not None else self.timeout
+        kwargs: dict = {"timeout": effective_timeout, "headers": headers}
 
         if files:
             # Multipart upload — data goes as form fields, not JSON
@@ -193,6 +203,18 @@ class BaseApiClient:
                 if response.status_code == 403:
                     raise BetterFlowAuthError("Device not authorized")
 
+                if response.status_code in (408, 429, 503, 504):
+                    retry_after = response.headers.get("Retry-After")
+                    msg = f"Server returned {response.status_code}"
+                    if retry_after:
+                        msg += f" (Retry-After: {retry_after}s)"
+                        try:
+                            import time as _time
+                            _time.sleep(min(float(retry_after), 60))
+                        except (ValueError, TypeError):
+                            pass
+                    raise _TransientError(msg)
+
                 # Server errors (5xx) are retryable
                 if response.status_code >= 500:
                     raise _TransientError(f"Server error: {response.status_code}")
@@ -200,8 +222,20 @@ class BaseApiClient:
                 response.raise_for_status()
                 return response.json() if response.content else {}
 
-            except requests.exceptions.ConnectionError:
+            except requests.exceptions.ConnectionError as e:
+                # DNS resolution failures are not retryable (N8)
+                cause = e.__cause__
+                while cause is not None:
+                    if isinstance(cause, socket.gaierror):
+                        raise BetterFlowClientError(
+                            f"DNS resolution failed: {cause}"
+                        ) from e
+                    cause = getattr(cause, "__cause__", None) or getattr(cause, "__context__", None)
                 raise _TransientError("Cannot connect to BetterFlow API")
+            except requests.exceptions.ChunkedEncodingError:
+                raise _TransientError("Connection dropped mid-response")
+            except requests.exceptions.ContentDecodingError:
+                raise _TransientError("Response body decoding failed")
             except requests.exceptions.Timeout:
                 raise _TransientError("Request timed out")
             except requests.exceptions.HTTPError as e:
@@ -214,11 +248,13 @@ class BaseApiClient:
                     f"API error ({e.response.status_code}): {error_detail or str(e)}"
                 ) from e
 
+        effective_retry_config = retry_config_override or self.retry_config
+
         if retry:
             try:
                 return retry_with_backoff(
                     do_request,
-                    config=self.retry_config,
+                    config=effective_retry_config,
                     retryable_exceptions=(_TransientError,),
                 )
             except RetryExhausted as e:
@@ -230,6 +266,20 @@ class BaseApiClient:
                 return do_request()
             except _TransientError as e:
                 raise BetterFlowClientError(str(e)) from e
+
+    def reset_session(self) -> None:
+        """Drop pooled connections and create a fresh session.
+
+        Call after laptop wake to avoid stale TCP connections that would
+        block the first request with a 30s timeout.
+        """
+        if self._owns_session and self._session is not None:
+            try:
+                self._session.close()
+            except Exception:
+                pass
+        self._session = requests.Session()
+        self._owns_session = True
 
     def set_credentials(self, token: str, device_id: str) -> None:
         """Set authentication credentials."""

--- a/src/sync/queue.py
+++ b/src/sync/queue.py
@@ -4,6 +4,7 @@ import json
 import logging
 import sqlite3
 import threading
+import time
 from contextlib import contextmanager
 from dataclasses import dataclass
 from datetime import datetime, timedelta, timezone
@@ -58,6 +59,8 @@ class OfflineQueue:
         self._local = threading.local()
         self._connections: list[sqlite3.Connection] = []
         self._connections_lock = threading.Lock()
+        self._last_integrity_check: float = time.monotonic()
+        self._integrity_check_interval: float = 3600.0  # 1 hour
         self._init_db()
 
     def _get_connection(self) -> sqlite3.Connection:
@@ -148,6 +151,27 @@ class OfflineQueue:
                 """
             )
 
+    def check_integrity(self) -> bool:
+        """Run periodic SQLite integrity check (N2).
+
+        Returns True if database is healthy, False if corruption detected.
+        """
+        now = time.monotonic()
+        if now - self._last_integrity_check < self._integrity_check_interval:
+            return True
+        self._last_integrity_check = now
+        try:
+            with self._cursor() as cursor:
+                cursor.execute("PRAGMA quick_check")
+                result = cursor.fetchone()
+                if result[0] != "ok":
+                    logger.error(f"SQLite quick_check failed: {result[0]}")
+                    return False
+            return True
+        except sqlite3.DatabaseError as e:
+            logger.error(f"SQLite integrity check error: {e}")
+            return False
+
     def enqueue(self, events: list[dict]) -> int:
         """Add events to the queue.
 
@@ -184,24 +208,22 @@ class OfflineQueue:
             )
             return cursor.rowcount
 
-    def dequeue(self, batch_size: int = 100) -> list[QueuedEvent]:
+    def dequeue(self, batch_size: int = 100, max_retries: int = 5) -> list[QueuedEvent]:
         """Get a batch of events from the queue (oldest first).
 
-        Args:
-            batch_size: Maximum number of events to return
-
-        Returns:
-            List of QueuedEvent objects
+        Skips events that have exceeded max_retries (N7).
         """
+        self.check_integrity()
         with self._cursor() as cursor:
             cursor.execute(
                 """
                 SELECT id, event_data, created_at, retry_count
                 FROM queued_events
+                WHERE retry_count < ?
                 ORDER BY created_at ASC
                 LIMIT ?
                 """,
-                (batch_size,),
+                (max_retries, batch_size),
             )
             return [QueuedEvent.from_row(tuple(row)) for row in cursor.fetchall()]
 

--- a/src/sync/retry.py
+++ b/src/sync/retry.py
@@ -54,9 +54,9 @@ def calculate_delay(
     delay = min(delay, max_delay)
 
     if jitter:
-        # Add +/- 25% jitter
+        # Add 0-25% jitter (always increases, never below base delay) (N15)
         jitter_range = delay * 0.25
-        delay = delay + random.uniform(-jitter_range, jitter_range)
+        delay = delay + random.uniform(0, jitter_range)
 
     return max(0, delay)
 

--- a/src/sync/sync_engine.py
+++ b/src/sync/sync_engine.py
@@ -1,9 +1,11 @@
 """Sync engine - orchestrates data flow from ActivityWatch to BetterFlow."""
 
 import logging
+import threading
+from collections import OrderedDict
 from dataclasses import dataclass, field
 from datetime import datetime, timedelta, timezone
-from typing import Optional
+from typing import Callable, Optional
 from urllib.parse import urlparse
 
 try:
@@ -63,7 +65,7 @@ class SyncEngine:
         bf: BFClientProtocol,
         queue: OfflineQueueProtocol,
         config: Config,
-        on_config_updated: Optional[callable] = None,
+        on_config_updated: Optional[Callable] = None,
         display_tracker=None,
         activity_analyzer: Optional[ActivityAnalyzer] = None,
         time_tracker: Optional[DailyTimeTracker] = None,
@@ -94,12 +96,13 @@ class SyncEngine:
         # Dedup: track (bucket_id, event_id) pairs already sent this session.
         # The lookback window re-fetches recent events for duration updates —
         # we only re-send if the duration actually changed.
-        self._sent_cache: dict[tuple[str, int], float] = {}
-        self._SENT_CACHE_MAX = 10_000
+        self._sent_cache: OrderedDict[tuple[str, int], float] = OrderedDict()
+        self._SENT_CACHE_MAX = 5_000
 
         # App category cache — avoids SQLite lookups on every event.
         # Populated lazily; invalidated when categories are refreshed.
         self._category_cache: Optional[dict[str, str]] = None
+        self._category_cache_lock = threading.Lock()
 
         # Activity analysis for fraud detection (DIP)
         self._activity_analyzer = activity_analyzer or ActivityAnalyzer(
@@ -167,13 +170,15 @@ class SyncEngine:
 
     def invalidate_category_cache(self) -> None:
         """Clear the in-memory category cache so next lookup re-reads from DB."""
-        self._category_cache = None
+        with self._category_cache_lock:
+            self._category_cache = None
 
     def _get_category(self, app_name: str) -> Optional[str]:
-        """Look up category for an app, using in-memory cache."""
-        if self._category_cache is None:
-            self._category_cache = self.queue.get_all_categories()
-        return self._category_cache.get(app_name)
+        """Look up category for an app, using thread-safe in-memory cache (M3)."""
+        with self._category_cache_lock:
+            if self._category_cache is None:
+                self._category_cache = self.queue.get_all_categories()
+            return self._category_cache.get(app_name)
 
     def fetch_server_config(self) -> None:
         """Fetch and apply server-side configuration."""
@@ -220,11 +225,16 @@ class SyncEngine:
 
         # Start session if needed (attempt directly; no pre-check to avoid TOCTOU)
         if not self._session_active:
-            try:
-                self.bf.start_session()
-                self._session_active = True
-            except BetterFlowClientError as e:
-                logger.warning(f"Failed to start session: {e}")
+            for attempt in range(2):
+                try:
+                    self.bf.start_session()
+                    self._session_active = True
+                    break
+                except BetterFlowClientError as e:
+                    if attempt == 0:
+                        logger.debug(f"Session start attempt 1 failed: {e}, retrying")
+                    else:
+                        logger.warning(f"Failed to start session after retry: {e}")
 
         # Get buckets to sync
         try:
@@ -255,6 +265,7 @@ class SyncEngine:
 
         # Sync window buckets with gap-filling
         all_events = []
+        pending_checkpoints: list[tuple[str, datetime, Optional[int]]] = []
         for bucket in window_buckets:
             try:
                 raw_events, _ = self._fetch_bucket_events(bucket.id, stats)
@@ -268,10 +279,12 @@ class SyncEngine:
                     filled = self._fill_window_gaps(raw_events, afk_events)
                     stats.gaps_filled += filled
 
-                    transformed = self._transform_and_checkpoint(
+                    transformed, checkpoint = self._transform_and_checkpoint(
                         raw_events, bucket.id, bucket.type, stats
                     )
                     all_events.extend(transformed)
+                    if checkpoint:
+                        pending_checkpoints.append(checkpoint)
                 stats.buckets_synced += 1
             except AWClientError as e:
                 stats.errors.append(f"Failed to sync bucket {bucket.id}: {e}")
@@ -279,15 +292,20 @@ class SyncEngine:
         # Sync non-window buckets normally
         for bucket in web_buckets + afk_buckets + input_buckets:
             try:
-                events = self._sync_bucket(bucket.id, bucket.type, stats)
+                events, checkpoint = self._sync_bucket(bucket.id, bucket.type, stats)
                 all_events.extend(events)
+                if checkpoint:
+                    pending_checkpoints.append(checkpoint)
                 stats.buckets_synced += 1
             except AWClientError as e:
                 stats.errors.append(f"Failed to sync bucket {bucket.id}: {e}")
 
-        # Send events
+        # Send events, then commit checkpoints only on success (N5)
         if all_events:
             self._send_events(all_events, stats)
+        if stats.events_sent > 0 or not all_events:
+            for bucket_id, ts, event_id in pending_checkpoints:
+                self.queue.set_checkpoint(bucket_id, ts, event_id)
 
         # Process offline queue if we're online
         if self.bf.is_reachable() and not self.queue.is_empty():
@@ -330,11 +348,13 @@ class SyncEngine:
         bucket_id: str,
         bucket_type: str,
         stats: SyncStats,
-    ) -> list[dict]:
-        """Transform events to BetterFlow format and update checkpoint.
+    ) -> tuple[list[dict], Optional[tuple[str, datetime, Optional[int]]]]:
+        """Transform events to BetterFlow format and compute pending checkpoint.
 
         Skips events already sent with unchanged duration (dedup).
         Re-sends if duration has grown (heartbeat extension).
+        Returns (transformed_events, pending_checkpoint) — caller commits the
+        checkpoint only after a successful send (N5).
         """
         # Feed window events to activity analyzer for window change detection
         if bucket_type in (BUCKET_TYPE_WINDOW, BUCKET_TYPE_WINDOW_ALT):
@@ -353,24 +373,22 @@ class SyncEngine:
             if transformed_event:
                 transformed.append(transformed_event)
                 self._sent_cache[cache_key] = event.duration
+                self._sent_cache.move_to_end(cache_key)
+                if len(self._sent_cache) > self._SENT_CACHE_MAX:
+                    self._sent_cache.popitem(last=False)
             else:
                 stats.events_filtered += 1
 
-        # Evict oldest entries if cache grows too large
-        if len(self._sent_cache) > self._SENT_CACHE_MAX:
-            excess = len(self._sent_cache) - self._SENT_CACHE_MAX
-            for key in list(self._sent_cache)[:excess]:
-                del self._sent_cache[key]
-
+        pending_checkpoint = None
         if events:
             newest = max(events, key=lambda e: e.timestamp)
-            self.queue.set_checkpoint(bucket_id, newest.timestamp, newest.id)
+            pending_checkpoint = (bucket_id, newest.timestamp, newest.id)
 
-        return transformed
+        return transformed, pending_checkpoint
 
     def _sync_bucket(
         self, bucket_id: str, bucket_type: str, stats: SyncStats
-    ) -> list[dict]:
+    ) -> tuple[list[dict], Optional[tuple[str, datetime, Optional[int]]]]:
         """Sync events from a single bucket.
 
         ActivityWatch extends the duration of the current (most recent) event
@@ -382,7 +400,7 @@ class SyncEngine:
         """
         events, _ = self._fetch_bucket_events(bucket_id, stats)
         if not events:
-            return []
+            return [], None
         return self._transform_and_checkpoint(events, bucket_id, bucket_type, stats)
 
     def _get_afk_events_for_range(
@@ -542,6 +560,9 @@ class SyncEngine:
                     data["desktop_index"] = ds.desktop_index
         elif bucket_type in (BUCKET_TYPE_AFK, BUCKET_TYPE_AFK_ALT):
             data["status"] = event.status
+            # Send AFK periods as "break" bucket_type for chart display
+            if event.status == "afk":
+                bucket_type = "break"
         elif bucket_type == BUCKET_TYPE_INPUT:
             # Input events track keystrokes, clicks, scrolls for fraud detection
             data["presses"] = event.presses
@@ -665,6 +686,11 @@ class SyncEngine:
                             self.queue.enqueue(failed)
                             stats.events_queued += len(failed)
                     else:
+                        # N11: server returned non-success without accepted_ids
+                        logger.warning(
+                            "Server returned partial failure without accepted_ids - "
+                            "re-queuing entire batch"
+                        )
                         self.queue.enqueue(batch)
                         stats.events_queued += len(batch)
                     if result.error:
@@ -856,10 +882,13 @@ class SyncEngine:
     def shutdown(self) -> None:
         """Shutdown the sync engine gracefully."""
         if self._session_active:
-            try:
-                self.bf.end_session("app_quit")
-            except BetterFlowClientError:
-                pass
+            for attempt in range(2):
+                try:
+                    self.bf.end_session("app_quit")
+                    break
+                except BetterFlowClientError:
+                    if attempt == 0:
+                        logger.debug("Session end attempt 1 failed, retrying")
             self._session_active = False
 
         # Close time tracker

--- a/src/system_events.py
+++ b/src/system_events.py
@@ -16,6 +16,10 @@ logger = logging.getLogger(__name__)
 
 _system = platform.system()
 
+# Store observer refs for cleanup (M5)
+_registered_observers: list[tuple] = []  # [(center, observer), ...]
+_observers_lock = threading.Lock()
+
 
 def start_system_event_listener(
     on_sleep: Callable,
@@ -109,8 +113,15 @@ def _start_macos_power_listener(
             "NSWorkspaceWillPowerOffNotification", None,
         )
 
+        # Store refs for cleanup (M5)
+        with _observers_lock:
+            _registered_observers.append((center, observer))
+
         logger.debug("macOS power event listener started")
-        AppHelper.runConsoleEventLoop()
+        try:
+            AppHelper.runConsoleEventLoop()
+        finally:
+            center.removeObserver_(observer)
 
     thread = threading.Thread(target=run_loop, name="system-power-listener", daemon=True)
     thread.start()
@@ -156,11 +167,29 @@ def _start_macos_screen_lock_listener(
             "com.apple.screenIsUnlocked", None,
         )
 
+        # Store refs for cleanup (M5)
+        with _observers_lock:
+            _registered_observers.append((center, observer))
+
         logger.debug("macOS screen lock listener started")
-        AppHelper.runConsoleEventLoop()
+        try:
+            AppHelper.runConsoleEventLoop()
+        finally:
+            center.removeObserver_(observer)
 
     thread = threading.Thread(target=run_loop, name="screen-lock-listener", daemon=True)
     thread.start()
+
+
+def cleanup_observers() -> None:
+    """Remove all registered macOS notification observers (M5)."""
+    with _observers_lock:
+        for center, observer in _registered_observers:
+            try:
+                center.removeObserver_(observer)
+            except Exception:
+                pass
+        _registered_observers.clear()
 
 
 # ---------------------------------------------------------------------------
@@ -355,6 +384,8 @@ def _start_network_poller(
     state = {"online": None}  # None = unknown
 
     def poll():
+        # Immediate first check before entering the wait loop (N10)
+        first = True
         while True:
             try:
                 socket.create_connection((host, 443), timeout=5).close()
@@ -362,11 +393,15 @@ def _start_network_poller(
             except OSError:
                 online = False
 
-            if state["online"] is not None and state["online"] != online:
+            if state["online"] != online:
                 status = "online" if online else "offline"
                 logger.info(f"Network change detected — {status}")
                 _safe_call(on_change, online)
+            elif first:
+                # Fire initial state so the app knows network status at startup
+                _safe_call(on_change, online)
             state["online"] = online
+            first = False
 
             threading.Event().wait(interval)
 

--- a/src/ui/tray.py
+++ b/src/ui/tray.py
@@ -4,6 +4,7 @@ import logging
 import os
 import platform
 import threading
+import time
 import webbrowser
 from enum import Enum
 from typing import TYPE_CHECKING, Callable, Optional, TypedDict
@@ -14,17 +15,28 @@ if TYPE_CHECKING:
     from ..config import Config
 
 
-def _hide_from_dock() -> None:
-    """Hide the app from the macOS Dock."""
+def _prevent_termination() -> None:
+    """Prevent macOS from silently killing the tray app.
+
+    Without these calls, macOS may terminate a background-only app after
+    a few minutes via Sudden Termination or Automatic Termination.
+
+    Note: Dock hiding is handled by LSUIElement=True in the Info.plist
+    (set in build.spec).  We intentionally do NOT call
+    setActivationPolicy_(1) here because it conflicts with pystray's
+    NSApplication setup and can prevent the status bar item from appearing.
+    """
     if platform.system() != "Darwin":
         return
     try:
-        import AppKit
-        ns_app = AppKit.NSApplication.sharedApplication()
-        # NSApplicationActivationPolicyAccessory = 1 (no Dock icon)
-        ns_app.setActivationPolicy_(1)
+        import Foundation
+
+        proc_info = Foundation.NSProcessInfo.processInfo()
+        proc_info.setAutomaticTerminationSupportEnabled_(False)
+        proc_info.disableSuddenTermination()
     except Exception:
         pass
+
 
 __all__ = ["TrayIcon", "TrayState", "TrayModel", "STATE_COLORS", "create_icon_image", "ProjectDict"]
 
@@ -194,6 +206,12 @@ class TrayIcon:
 
         self._icon: Optional[pystray.Icon] = None
         self._thread: Optional[threading.Thread] = None
+
+        # Menu debounce: rebuild at most once per second
+        self._menu_debounce_interval = 1.0
+        self._menu_last_rebuild: float = 0.0
+        self._menu_pending: bool = False
+        self._menu_lock = threading.Lock()
 
     def _create_menu(self) -> pystray.Menu:
         """Create the tray menu."""
@@ -669,8 +687,7 @@ class TrayIcon:
         total_seconds = int(active_time.total_seconds())
         hours = total_seconds // 3600
         minutes = (total_seconds % 3600) // 60
-        self._hours_today = f"{hours}h {minutes}m"
-        self.model.hours_today = self._hours_today
+        self.model.hours_today = f"{hours}h {minutes}m"
         self._update_tooltip(f"BetterFlow Sync - Today: {hours}h {minutes}m active")
         self._update_menu()
 
@@ -680,14 +697,88 @@ class TrayIcon:
             self._icon.title = tooltip
 
     def _update_icon(self) -> None:
-        """Update the tray icon image and menu."""
-        if self._icon:
-            color = STATE_COLORS.get(self.model.state, STATE_COLORS[TrayState.STARTING])
-            self._icon.icon = create_icon_image(color)
-            self._icon.menu = self._create_menu()
+        """Update the tray icon image and menu.
+
+        On macOS, image updates are dispatched to the main thread via
+        performSelectorOnMainThread because AppKit calls from background
+        threads silently fail in PyInstaller .app bundles.
+        """
+        if not self._icon:
+            return
+        color = STATE_COLORS.get(self.model.state, STATE_COLORS[TrayState.STARTING])
+        new_image = create_icon_image(color)
+
+        if platform.system() == "Darwin":
+            try:
+                self._set_icon_main_thread(new_image)
+            except Exception:
+                logger.debug("Main-thread icon update failed, using fallback")
+                self._icon.icon = new_image
+        else:
+            self._icon.icon = new_image
+
+        self._icon.menu = self._create_menu()
+
+    def _set_icon_main_thread(self, pil_img: Image.Image) -> None:
+        """Update the NSStatusItem button image on the main thread (macOS).
+
+        Converts a PIL image to NSImage and dispatches setImage: to the
+        main thread run loop where AppKit can properly render it.
+        """
+        import AppKit
+        import Foundation
+        import io
+
+        thickness = 22
+        try:
+            thickness = max(int(self._icon._status_bar.thickness()), 22)
+        except Exception:
+            pass
+
+        sz = thickness
+        if pil_img.size != (sz, sz):
+            pil_img = pil_img.resize((sz, sz), Image.LANCZOS)
+
+        buf = io.BytesIO()
+        pil_img.save(buf, "png")
+        ns_data = Foundation.NSData(buf.getvalue())
+        ns_img = AppKit.NSImage.alloc().initWithData_(ns_data)
+        ns_img.setSize_(Foundation.NSSize(sz, sz))
+
+        # Update pystray internal state to prevent stale-image redraws
+        self._icon._icon = pil_img
+        self._icon._icon_valid = True
+
+        # Dispatch setImage: to the main thread where AppKit works correctly
+        button = self._icon._status_item.button()
+        if button:
+            button.performSelectorOnMainThread_withObject_waitUntilDone_(
+                b"setImage:", ns_img, False,
+            )
 
     def _update_menu(self) -> None:
-        """Update the tray menu."""
+        """Update the tray menu (debounced: max once per second)."""
+        if not self._icon:
+            return
+        now = time.monotonic()
+        with self._menu_lock:
+            elapsed = now - self._menu_last_rebuild
+            if elapsed >= self._menu_debounce_interval:
+                self._menu_last_rebuild = now
+                self._menu_pending = False
+                self._icon.menu = self._create_menu()
+            elif not self._menu_pending:
+                self._menu_pending = True
+                delay = self._menu_debounce_interval - elapsed
+                timer = threading.Timer(delay, self._flush_menu)
+                timer.daemon = True
+                timer.start()
+
+    def _flush_menu(self) -> None:
+        """Deferred menu rebuild after debounce delay."""
+        with self._menu_lock:
+            self._menu_pending = False
+            self._menu_last_rebuild = time.monotonic()
         if self._icon:
             self._icon.menu = self._create_menu()
 
@@ -719,17 +810,48 @@ class TrayIcon:
     def run_blocking(self) -> None:
         """Run the tray icon in the main thread (blocking).
 
-        Must be called from the main thread — pystray/NSApplication requires it.
-        Dock hiding is handled by LSUIElement in Info.plist for bundled apps,
-        and by _hide_from_dock() as a fallback for source runs.
+        Retries up to 3 times if the event loop exits within 2 seconds,
+        which can happen on macOS when NSApplication fails to initialise.
         """
-        _hide_from_dock()
-        if self._icon is None:
-            color = STATE_COLORS[self.model.state]
-            self._icon = pystray.Icon(
-                "BetterFlow Sync",
-                create_icon_image(color),
-                "BetterFlow Sync",
-                self._create_menu(),
+        _prevent_termination()
+
+        max_retries = 3
+        for attempt in range(1, max_retries + 1):
+            if self._icon is None:
+                color = STATE_COLORS[self.model.state]
+                self._icon = pystray.Icon(
+                    "BetterFlow Sync",
+                    create_icon_image(color),
+                    "BetterFlow Sync",
+                    self._create_menu(),
+                )
+
+            # Ensure activation policy is Accessory (1) for tray apps.
+            try:
+                policy = self._icon._app.activationPolicy()
+                logger.debug("NSApp activation policy: %d", policy)
+                if policy != 1:
+                    self._icon._app.setActivationPolicy_(1)
+                    logger.debug("Set activation policy to Accessory (1)")
+            except Exception:
+                logger.debug("Failed to check/set activation policy", exc_info=True)
+
+            self._icon.visible = True
+
+            start = time.monotonic()
+            logger.info("Tray event loop starting (attempt %d/%d)", attempt, max_retries)
+            self._icon.run(setup=lambda icon: None)
+            elapsed = time.monotonic() - start
+
+            if elapsed > 2.0:
+                logger.info("Tray event loop exited after %.1fs", elapsed)
+                return
+
+            logger.warning(
+                "Tray event loop exited after %.1fs (attempt %d/%d)",
+                elapsed, attempt, max_retries,
             )
-        self._icon.run()
+            self._icon = None
+            time.sleep(0.5)
+
+        logger.error("Tray icon failed to start after %d attempts", max_retries)

--- a/tests/test_bf_client.py
+++ b/tests/test_bf_client.py
@@ -223,7 +223,7 @@ class TestBetterFlowClient:
             status=429,
         )
 
-        with pytest.raises(BetterFlowClientError, match="429.*Rate limit exceeded"):
+        with pytest.raises(BetterFlowClientError, match="Server returned 429"):
             self.client._request("GET", "test")
 
     @responses.activate
@@ -588,7 +588,7 @@ class TestRetryBehavior:
                 status=503,
             )
 
-        with pytest.raises(BetterFlowClientError, match="Server error"):
+        with pytest.raises(BetterFlowClientError, match="Server returned 503"):
             self.client._request("GET", "test")
 
     @responses.activate
@@ -617,7 +617,7 @@ class TestRetryBehavior:
             status=503,
         )
 
-        with pytest.raises(BetterFlowClientError, match="Server error"):
+        with pytest.raises(BetterFlowClientError, match="Server returned 503"):
             self.client._request("GET", "test", retry=False)
 
         # Should only call once


### PR DESCRIPTION
## Summary

- Restores 16 critical reliability and safety patterns stripped during the in-process window watcher refactor (7e4aaec..4601f88)
- Fixes 4 runtime crashes (`show_notification` -> `send_notification`, type hint `callable` -> `Callable`, `__version__` import)
- Preserves all of Martin's new features (MacOSWindowWatcher, FraudSignalDetector, FraudDetectionConfig)
- All 191 tests pass

## What was restored

| File | Patterns Restored |
|------|-------------------|
| `tray.py` | `_prevent_termination`, main-thread icon dispatch, menu debounce, `run_blocking` retry |
| `main.py` | `_user_paused` flag, `_sync_in_progress` guard, scheduler recreation, display tracker guard, `reset_session` on wake |
| `http_client.py` | Retry-After support (408/429/503/504), DNS error handling, `ChunkedEncodingError`, `reset_session()` |
| `bf_client.py` | Idempotency keys (`X-Idempotency-Key`), heartbeat retry config |
| `queue.py` | SQLite integrity check, `max_retries` in `dequeue()` |
| `retry.py` | Jitter fix: one-sided +0-25% (was bidirectional, could fire faster than base delay) |
| `sync_engine.py` | OrderedDict LRU (5k cap), category cache lock, session start/shutdown retry, checkpoint-after-send |
| `browser_auth.py` | Dual-check CSRF bypass (requires both `BETTERFLOW_SYNC_ENV=development` AND `BETTERFLOW_ALLOW_STATE_MISMATCH=1`) |
| `system_events.py` | Observer cleanup, initial network state fire |
| `display_info.py` | Observer cleanup, Windows COM cleanup |

## Test plan

- [x] All 191 tests pass
- [ ] Manual: verify tray icon appears on macOS
- [ ] Manual: verify pause/resume cycle works
- [ ] Manual: verify offline queue drains after reconnect


🤖 Generated with [Claude Code](https://claude.com/claude-code)