### PR TITLE
feat: add permissions warning state and wizard permissions screen

### DIFF
--- a/src/main.py
+++ b/src/main.py
@@ -24,6 +24,7 @@ try:
     from .sync import AWClient, BetterFlowClient, OfflineQueue, SyncEngine
     from .sync.http_client import BetterFlowAuthError
     from .system_events import start_system_event_listener
+    from .ui.permissions import all_permissions_granted, check_accessibility, check_screen_recording, open_accessibility_settings, open_screen_recording_settings
     from .ui.tray import TrayIcon, TrayState
     from .update_checker import check_for_update
 except ImportError:
@@ -36,6 +37,7 @@ except ImportError:
     from sync import AWClient, BetterFlowClient, OfflineQueue, SyncEngine
     from sync.http_client import BetterFlowAuthError
     from system_events import start_system_event_listener
+    from ui.permissions import all_permissions_granted, check_accessibility, check_screen_recording, open_accessibility_settings, open_screen_recording_settings
     from ui.tray import TrayIcon, TrayState
     from update_checker import check_for_update
 
@@ -140,6 +142,15 @@ class SyncCoordinator:
             id="trends_refresh_job",
             replace_existing=True,
         )
+        # Periodic permissions check (macOS only)
+        if sys.platform == "darwin":
+            self._check_permissions()
+            self.scheduler.add_job(
+                self._check_permissions,
+                trigger=IntervalTrigger(seconds=60),
+                id="permissions_check_job",
+                replace_existing=True,
+            )
         self.scheduler.start()
         logger.info(
             f"Sync loop started (interval: {self.config.sync.interval_seconds}s)"
@@ -194,6 +205,31 @@ class SyncCoordinator:
         """Check if a sync is currently running (non-blocking)."""
         return self._sync_lock.locked()
 
+    def _check_permissions(self) -> None:
+        """Check macOS permissions and update tray state."""
+        try:
+            granted = all_permissions_granted()
+            with self.tray.model.lock:
+                self.tray.model.needs_permissions = not granted
+            if not granted:
+                # Only set NEEDS_PERMISSIONS if not in a higher-priority state
+                current = self.tray.model.state
+                high_priority = (
+                    TrayState.PAUSED, TrayState.PRIVATE,
+                    TrayState.ERROR, TrayState.QUEUE_WARNING, TrayState.QUEUED,
+                    TrayState.WAITING_AUTH,
+                )
+                if current not in high_priority:
+                    self.tray.set_state(TrayState.NEEDS_PERMISSIONS, "Permissions Required")
+                logger.debug("macOS permissions missing")
+            else:
+                # Clear permissions warning if it was set
+                if self.tray.model.state == TrayState.NEEDS_PERMISSIONS:
+                    self.tray.set_state(TrayState.SYNCING)
+                    logger.info("macOS permissions granted — clearing warning")
+        except Exception as e:
+            logger.debug(f"Permissions check failed: {e}")
+
     def _do_sync(self) -> None:
         """Perform a sync cycle."""
         if not self._sync_lock.acquire(blocking=False):
@@ -228,6 +264,8 @@ class SyncCoordinator:
                     logger.warning(f"Offline queue at {pct}% capacity")
                 elif stats.events_queued > 0:
                     self.tray.set_state(TrayState.QUEUED)
+                elif self.tray.model.needs_permissions:
+                    self.tray.set_state(TrayState.NEEDS_PERMISSIONS, "Permissions Required")
                 else:
                     self.tray.set_state(TrayState.SYNCING)
             else:
@@ -416,6 +454,7 @@ class BetterFlowSyncApp:
             on_private_toggle=self._on_private_toggle,
             on_sync_now=self._on_sync_now,
             on_export_logs=self._on_export_logs,
+            on_open_permissions=self._on_open_permissions,
         )
         self.tray.set_config(self.config)
 
@@ -484,12 +523,12 @@ class BetterFlowSyncApp:
             self.coordinator.fetch_categories()
             self._check_stale_session()
             self.coordinator.start()
-            # Check accessibility after scheduler starts (non-blocking, 5s delay)
+            # Check permissions after scheduler starts (non-blocking, 5s delay)
             self.coordinator.scheduler.add_job(
-                self._check_accessibility_permission,
+                self._check_permissions_initial,
                 "date",
                 run_date=datetime.now() + timedelta(seconds=5),
-                id="accessibility_check",
+                id="permissions_initial_check",
                 replace_existing=True,
             )
         else:
@@ -528,32 +567,36 @@ class BetterFlowSyncApp:
 
     # -- Event handlers ---------------------------------------------------
 
-    def _check_accessibility_permission(self) -> None:
-        """On macOS, check if ActivityWatch can read window titles.
-
-        If no window buckets are found after AW is running, it likely means
-        Accessibility permission hasn't been granted to aw-watcher-window.
-        """
+    def _check_permissions_initial(self) -> None:
+        """Run initial permissions check on macOS (delegates to coordinator)."""
         if sys.platform != "darwin":
             return
-        try:
-            window_buckets = self.aw.get_window_buckets()
-            if not window_buckets:
-                logger.warning(
-                    "No window tracking detected — ActivityWatch may need "
-                    "Accessibility permission in System Settings > Privacy & Security"
-                )
-                try:
-                    from .notifications import send_notification
-                except ImportError:
-                    from notifications import send_notification
-                send_notification(
-                    "BetterFlow Sync",
-                    "Grant Accessibility permission to ActivityWatch in "
-                    "System Settings > Privacy & Security for window tracking.",
-                )
-        except Exception as e:
-            logger.debug(f"Accessibility check failed: {e}")
+        self.coordinator._check_permissions()
+        if self.tray.model.needs_permissions:
+            try:
+                from .notifications import send_notification
+            except ImportError:
+                from notifications import send_notification
+            missing = []
+            if not check_accessibility():
+                missing.append("Accessibility")
+            if not check_screen_recording():
+                missing.append("Screen Recording")
+            send_notification(
+                "BetterFlow Sync",
+                f"Grant {' and '.join(missing)} permission in "
+                "System Settings > Privacy & Security for full tracking.",
+            )
+
+    def _on_open_permissions(self) -> None:
+        """Open System Settings for whichever macOS permission is missing."""
+        if not check_accessibility():
+            open_accessibility_settings()
+        elif not check_screen_recording():
+            open_screen_recording_settings()
+        else:
+            # Both granted — open accessibility as default
+            open_accessibility_settings()
 
     def _on_update_available(self, version: str, url: str) -> None:
         """Handle update available notification."""

--- a/src/main.py
+++ b/src/main.py
@@ -24,7 +24,7 @@ try:
     from .sync import AWClient, BetterFlowClient, OfflineQueue, SyncEngine
     from .sync.http_client import BetterFlowAuthError
     from .system_events import start_system_event_listener
-    from .ui.permissions import all_permissions_granted, check_accessibility, check_screen_recording, open_accessibility_settings, open_screen_recording_settings
+    from .ui.permissions import check_accessibility, open_accessibility_settings
     from .ui.tray import TrayIcon, TrayState
     from .update_checker import check_for_update
 except ImportError:
@@ -37,7 +37,7 @@ except ImportError:
     from sync import AWClient, BetterFlowClient, OfflineQueue, SyncEngine
     from sync.http_client import BetterFlowAuthError
     from system_events import start_system_event_listener
-    from ui.permissions import all_permissions_granted, check_accessibility, check_screen_recording, open_accessibility_settings, open_screen_recording_settings
+    from ui.permissions import check_accessibility, open_accessibility_settings
     from ui.tray import TrayIcon, TrayState
     from update_checker import check_for_update
 
@@ -206,9 +206,9 @@ class SyncCoordinator:
         return self._sync_lock.locked()
 
     def _check_permissions(self) -> None:
-        """Check macOS permissions and update tray state."""
+        """Check macOS Accessibility permission and update tray state."""
         try:
-            granted = all_permissions_granted()
+            granted = check_accessibility()
             with self.tray.model.lock:
                 self.tray.model.needs_permissions = not granted
             if not granted:
@@ -577,26 +577,15 @@ class BetterFlowSyncApp:
                 from .notifications import send_notification
             except ImportError:
                 from notifications import send_notification
-            missing = []
-            if not check_accessibility():
-                missing.append("Accessibility")
-            if not check_screen_recording():
-                missing.append("Screen Recording")
             send_notification(
                 "BetterFlow Sync",
-                f"Grant {' and '.join(missing)} permission in "
-                "System Settings > Privacy & Security for full tracking.",
+                "Grant Accessibility permission in "
+                "System Settings > Privacy & Security for window tracking.",
             )
 
     def _on_open_permissions(self) -> None:
-        """Open System Settings for whichever macOS permission is missing."""
-        if not check_accessibility():
-            open_accessibility_settings()
-        elif not check_screen_recording():
-            open_screen_recording_settings()
-        else:
-            # Both granted — open accessibility as default
-            open_accessibility_settings()
+        """Open System Settings to Accessibility permission pane."""
+        open_accessibility_settings()
 
     def _on_update_available(self, version: str, url: str) -> None:
         """Handle update available notification."""

--- a/src/ui/permissions.py
+++ b/src/ui/permissions.py
@@ -1,10 +1,16 @@
 """macOS permission checking utilities.
 
-Uses ctypes to check Screen Recording and Accessibility permissions
-without requiring pyobjc. Returns True on non-macOS platforms.
+Uses pyobjc (preferred) or ctypes to check Screen Recording and
+Accessibility permissions. Returns True on non-macOS platforms.
+
+After a fresh build the app's code signature changes. macOS may show
+the toggle as ON in System Settings while AXIsProcessTrusted() returns
+False because the TCC entry still references the old signature. Toggling
+the permission off and on again in System Settings re-registers it.
 """
 
 import logging
+import os
 import platform
 import subprocess
 
@@ -16,31 +22,73 @@ _IS_MACOS = platform.system() == "Darwin"
 def check_screen_recording() -> bool:
     """Check if Screen Recording permission is granted.
 
+    Uses CGPreflightScreenCaptureAccess (ctypes) as the primary check,
+    with a practical fallback that tries reading window names from other
+    processes via Quartz (requires screen recording on macOS 10.15+).
+
     Returns True on non-macOS platforms.
     """
     if not _IS_MACOS:
         return True
 
+    # Primary: CGPreflightScreenCaptureAccess via ctypes
     try:
         import ctypes
         import ctypes.util
 
         cg = ctypes.cdll.LoadLibrary(ctypes.util.find_library("CoreGraphics"))
         cg.CGPreflightScreenCaptureAccess.restype = ctypes.c_bool
-        return cg.CGPreflightScreenCaptureAccess()
+        if cg.CGPreflightScreenCaptureAccess():
+            return True
     except Exception:
-        logger.debug("Could not check Screen Recording permission, assuming granted")
-        return True
+        logger.debug("ctypes screen recording check failed")
+
+    # Fallback: practical test — can we read window names from other apps?
+    # Without screen recording, kCGWindowName is empty for other processes.
+    try:
+        from Quartz import (
+            CGWindowListCopyWindowInfo,
+            kCGNullWindowID,
+            kCGWindowListOptionOnScreenOnly,
+            kCGWindowName,
+            kCGWindowOwnerPID,
+        )
+
+        my_pid = os.getpid()
+        windows = CGWindowListCopyWindowInfo(
+            kCGWindowListOptionOnScreenOnly, kCGNullWindowID,
+        )
+        for w in (windows or []):
+            pid = w.get(kCGWindowOwnerPID, 0)
+            name = w.get(kCGWindowName, "")
+            if pid != my_pid and name:
+                return True
+    except Exception:
+        logger.debug("Quartz screen recording fallback failed")
+
+    return False
 
 
 def check_accessibility() -> bool:
     """Check if Accessibility permission is granted.
+
+    Tries pyobjc ApplicationServices first (more reliable in PyInstaller
+    bundles), falls back to ctypes.
 
     Returns True on non-macOS platforms.
     """
     if not _IS_MACOS:
         return True
 
+    # Primary: pyobjc ApplicationServices binding
+    try:
+        from ApplicationServices import AXIsProcessTrusted
+
+        return bool(AXIsProcessTrusted())
+    except Exception:
+        logger.debug("pyobjc accessibility check failed, trying ctypes")
+
+    # Fallback: ctypes
     try:
         import ctypes
         import ctypes.util
@@ -81,3 +129,11 @@ def open_accessibility_settings() -> None:
         ])
     except Exception as e:
         logger.warning(f"Failed to open Accessibility settings: {e}")
+
+
+def all_permissions_granted() -> bool:
+    """Check if both Accessibility and Screen Recording permissions are granted.
+
+    Returns True on non-macOS platforms.
+    """
+    return check_accessibility() and check_screen_recording()

--- a/src/ui/permissions.py
+++ b/src/ui/permissions.py
@@ -1,7 +1,7 @@
 """macOS permission checking utilities.
 
-Uses pyobjc (preferred) or ctypes to check Screen Recording and
-Accessibility permissions. Returns True on non-macOS platforms.
+Uses pyobjc (preferred) or ctypes to check Accessibility permission.
+Returns True on non-macOS platforms.
 
 After a fresh build the app's code signature changes. macOS may show
 the toggle as ON in System Settings while AXIsProcessTrusted() returns
@@ -10,63 +10,12 @@ the permission off and on again in System Settings re-registers it.
 """
 
 import logging
-import os
 import platform
 import subprocess
 
 logger = logging.getLogger(__name__)
 
 _IS_MACOS = platform.system() == "Darwin"
-
-
-def check_screen_recording() -> bool:
-    """Check if Screen Recording permission is granted.
-
-    Uses CGPreflightScreenCaptureAccess (ctypes) as the primary check,
-    with a practical fallback that tries reading window names from other
-    processes via Quartz (requires screen recording on macOS 10.15+).
-
-    Returns True on non-macOS platforms.
-    """
-    if not _IS_MACOS:
-        return True
-
-    # Primary: CGPreflightScreenCaptureAccess via ctypes
-    try:
-        import ctypes
-        import ctypes.util
-
-        cg = ctypes.cdll.LoadLibrary(ctypes.util.find_library("CoreGraphics"))
-        cg.CGPreflightScreenCaptureAccess.restype = ctypes.c_bool
-        if cg.CGPreflightScreenCaptureAccess():
-            return True
-    except Exception:
-        logger.debug("ctypes screen recording check failed")
-
-    # Fallback: practical test — can we read window names from other apps?
-    # Without screen recording, kCGWindowName is empty for other processes.
-    try:
-        from Quartz import (
-            CGWindowListCopyWindowInfo,
-            kCGNullWindowID,
-            kCGWindowListOptionOnScreenOnly,
-            kCGWindowName,
-            kCGWindowOwnerPID,
-        )
-
-        my_pid = os.getpid()
-        windows = CGWindowListCopyWindowInfo(
-            kCGWindowListOptionOnScreenOnly, kCGNullWindowID,
-        )
-        for w in (windows or []):
-            pid = w.get(kCGWindowOwnerPID, 0)
-            name = w.get(kCGWindowName, "")
-            if pid != my_pid and name:
-                return True
-    except Exception:
-        logger.debug("Quartz screen recording fallback failed")
-
-    return False
 
 
 def check_accessibility() -> bool:
@@ -103,20 +52,6 @@ def check_accessibility() -> bool:
         return True
 
 
-def open_screen_recording_settings() -> None:
-    """Open System Settings to Screen Recording pane."""
-    if not _IS_MACOS:
-        return
-
-    try:
-        subprocess.Popen([
-            "open",
-            "x-apple.systempreferences:com.apple.preference.security?Privacy_ScreenCapture",
-        ])
-    except Exception as e:
-        logger.warning(f"Failed to open Screen Recording settings: {e}")
-
-
 def open_accessibility_settings() -> None:
     """Open System Settings to Accessibility pane."""
     if not _IS_MACOS:
@@ -129,11 +64,3 @@ def open_accessibility_settings() -> None:
         ])
     except Exception as e:
         logger.warning(f"Failed to open Accessibility settings: {e}")
-
-
-def all_permissions_granted() -> bool:
-    """Check if both Accessibility and Screen Recording permissions are granted.
-
-    Returns True on non-macOS platforms.
-    """
-    return check_accessibility() and check_screen_recording()

--- a/src/ui/setup_wizard.py
+++ b/src/ui/setup_wizard.py
@@ -13,11 +13,13 @@ from typing import Optional
 import itertools
 
 try:
-    from ..config import Config
     from ..auth.login import LoginManager, LoginState
+    from ..config import Config
+    from .permissions import check_accessibility, check_screen_recording, open_accessibility_settings, open_screen_recording_settings
 except ImportError:
-    from config import Config
     from auth.login import LoginManager, LoginState
+    from config import Config
+    from ui.permissions import check_accessibility, check_screen_recording, open_accessibility_settings, open_screen_recording_settings
 
 logger = logging.getLogger(__name__)
 
@@ -77,6 +79,7 @@ class SetupWizard:
         self._login_state: Optional[LoginState] = None
         self._closing = False
         self._spinner_after_id: Optional[str] = None
+        self._permissions_refresh_id: Optional[str] = None
         self._button_id = itertools.count(1)
 
     def show(self) -> SetupResult:
@@ -131,6 +134,12 @@ class SetupWizard:
             except tk.TclError:
                 pass
             self._spinner_after_id = None
+        if self._permissions_refresh_id is not None:
+            try:
+                self._window.after_cancel(self._permissions_refresh_id)
+            except tk.TclError:
+                pass
+            self._permissions_refresh_id = None
         self._canvas.configure(cursor="")
         self._canvas.delete("all")
         for widget in self._canvas.winfo_children():
@@ -139,6 +148,12 @@ class SetupWizard:
     def _on_close(self) -> None:
         """Handle window close — cancel any in-progress login."""
         self._closing = True
+        if self._permissions_refresh_id is not None:
+            try:
+                self._window.after_cancel(self._permissions_refresh_id)
+            except tk.TclError:
+                pass
+            self._permissions_refresh_id = None
         self._result = SetupResult(completed=False)
         self._login_manager.cancel_login()
         self._window.destroy()
@@ -456,8 +471,163 @@ class SetupWizard:
             justify=tk.CENTER,
         )
 
-        # Launch button
-        self._make_button("Start Using BetterFlow", self._finish, cx, 438, width=280)
+        # Launch button — go to permissions screen next
+        self._make_button("Continue", self._show_permissions_entry, cx, 438, width=280)
+
+    # ── Permissions Screen ─────────────────────────────────────────
+
+    def _show_permissions_entry(self) -> None:
+        """Entry point from success screen — skip entirely if all granted."""
+        if platform.system() != "Darwin":
+            self._finish()
+            return
+        if check_accessibility() and check_screen_recording():
+            self._finish()
+            return
+        self._show_permissions()
+
+    def _show_permissions(self) -> None:
+        """Show the permissions screen with current status."""
+        acc = check_accessibility()
+        scr = check_screen_recording()
+        all_granted = acc and scr
+
+        cx = self._draw_scene(
+            title="System Permissions",
+            subtitle="BetterFlow needs these permissions for accurate tracking",
+        )
+
+        row_width = 560
+        row_height = 76
+        row_x1 = cx - row_width // 2
+        row_x2 = cx + row_width // 2
+        btn_area_width = 140  # reserved space on the right for button
+        text_max_x = row_x2 - btn_area_width - 8
+
+        # ── Accessibility row ──
+        row_y = 200
+        self._draw_permission_row(
+            row_x1, row_y, row_x2, row_height,
+            granted=acc,
+            title="Accessibility",
+            description="Track active window titles",
+            text_max_x=text_max_x,
+            on_open=None if acc else self._open_accessibility,
+        )
+
+        # ── Screen Recording row ──
+        row_y2 = row_y + row_height + 14
+        self._draw_permission_row(
+            row_x1, row_y2, row_x2, row_height,
+            granted=scr,
+            title="Screen Recording",
+            description="Capture browser URLs",
+            text_max_x=text_max_x,
+            on_open=None if scr else self._open_screen_recording,
+        )
+
+        # ── Bottom area ──
+        if all_granted:
+            self._canvas.create_text(
+                cx, row_y2 + row_height + 36,
+                text="All permissions granted!",
+                font=(FONT_FAMILY, 14, "bold"), fill=SUCCESS_COLOR,
+            )
+            self._make_button(
+                "Start Using BetterFlow", self._finish,
+                cx, row_y2 + row_height + 80, width=280,
+            )
+        else:
+            # Hint text
+            self._canvas.create_text(
+                cx, row_y2 + row_height + 30,
+                text="If already toggled on, try switching it off and on again.",
+                font=(FONT_FAMILY, 11), fill="#7a8fc0",
+            )
+
+            btn_y = row_y2 + row_height + 76
+            self._make_button(
+                "Refresh Status", self._show_permissions,
+                cx - 104, btn_y, width=180,
+            )
+            self._make_button(
+                "Skip for Now", self._finish,
+                cx + 104, btn_y, width=180, primary=False,
+            )
+
+        # Auto-refresh every 3 seconds
+        self._permissions_refresh_id = self._window.after(
+            3000, self._auto_refresh_permissions,
+        )
+
+    def _draw_permission_row(
+        self,
+        x1: int, y: int, x2: int, height: int,
+        granted: bool,
+        title: str,
+        description: str,
+        text_max_x: int,
+        on_open=None,
+    ) -> None:
+        """Draw a single permission status row."""
+        cy = y + height // 2
+        icon = "\u2713" if granted else "\u2717"
+        icon_color = SUCCESS_COLOR if granted else ERROR_COLOR
+        bg = "#112040" if granted else "#1a1a3a"
+        border = "#2a5040" if granted else CARD_BORDER
+
+        self._create_rounded_rect(
+            x1, y, x2, y + height,
+            radius=12, fill=bg, outline=border, width=1,
+        )
+
+        # Status icon
+        self._canvas.create_text(
+            x1 + 32, cy, text=icon,
+            font=(FONT_FAMILY, 22, "bold"), fill=icon_color,
+        )
+
+        # Title and description
+        self._canvas.create_text(
+            x1 + 64, cy - 10, text=title,
+            font=(FONT_FAMILY, 14, "bold"), fill=TEXT_COLOR, anchor=tk.W,
+        )
+        self._canvas.create_text(
+            x1 + 64, cy + 14, text=description,
+            font=FONT_SMALL, fill=TEXT_MUTED, anchor=tk.W,
+        )
+
+        # "Open Settings" button (only when not granted)
+        if on_open is not None:
+            self._make_button(
+                "Open Settings", on_open,
+                x2 - 82, cy, width=128, primary=False,
+            )
+
+    def _auto_refresh_permissions(self) -> None:
+        """Auto-refresh the permissions screen when status changes."""
+        if self._closing:
+            return
+        try:
+            acc = check_accessibility()
+            scr = check_screen_recording()
+            if acc and scr:
+                # All granted — redraw to show success state
+                self._show_permissions()
+            else:
+                self._permissions_refresh_id = self._window.after(
+                    3000, self._auto_refresh_permissions,
+                )
+        except tk.TclError:
+            pass
+
+    def _open_accessibility(self) -> None:
+        """Open macOS Accessibility settings."""
+        open_accessibility_settings()
+
+    def _open_screen_recording(self) -> None:
+        """Open macOS Screen Recording settings."""
+        open_screen_recording_settings()
 
     def _finish(self) -> None:
         """Complete and close the wizard only."""

--- a/src/ui/setup_wizard.py
+++ b/src/ui/setup_wizard.py
@@ -15,11 +15,11 @@ import itertools
 try:
     from ..auth.login import LoginManager, LoginState
     from ..config import Config
-    from .permissions import check_accessibility, check_screen_recording, open_accessibility_settings, open_screen_recording_settings
+    from .permissions import check_accessibility, open_accessibility_settings
 except ImportError:
     from auth.login import LoginManager, LoginState
     from config import Config
-    from ui.permissions import check_accessibility, check_screen_recording, open_accessibility_settings, open_screen_recording_settings
+    from ui.permissions import check_accessibility, open_accessibility_settings
 
 logger = logging.getLogger(__name__)
 
@@ -477,75 +477,78 @@ class SetupWizard:
     # ── Permissions Screen ─────────────────────────────────────────
 
     def _show_permissions_entry(self) -> None:
-        """Entry point from success screen — skip entirely if all granted."""
+        """Entry point from success screen — skip entirely if already granted."""
         if platform.system() != "Darwin":
             self._finish()
             return
-        if check_accessibility() and check_screen_recording():
+        if check_accessibility():
             self._finish()
             return
         self._show_permissions()
 
     def _show_permissions(self) -> None:
-        """Show the permissions screen with current status."""
-        acc = check_accessibility()
-        scr = check_screen_recording()
-        all_granted = acc and scr
+        """Show the Accessibility permission screen."""
+        granted = check_accessibility()
 
         cx = self._draw_scene(
-            title="System Permissions",
-            subtitle="BetterFlow needs these permissions for accurate tracking",
+            title="Accessibility Permission",
+            subtitle="BetterFlow needs this to track active window titles",
         )
 
         row_width = 560
         row_height = 76
         row_x1 = cx - row_width // 2
         row_x2 = cx + row_width // 2
-        btn_area_width = 140  # reserved space on the right for button
-        text_max_x = row_x2 - btn_area_width - 8
 
         # ── Accessibility row ──
-        row_y = 200
-        self._draw_permission_row(
-            row_x1, row_y, row_x2, row_height,
-            granted=acc,
-            title="Accessibility",
-            description="Track active window titles",
-            text_max_x=text_max_x,
-            on_open=None if acc else self._open_accessibility,
-        )
+        row_y = 230
+        cy = row_y + row_height // 2
+        icon = "\u2713" if granted else "\u2717"
+        icon_color = SUCCESS_COLOR if granted else ERROR_COLOR
+        bg = "#112040" if granted else "#1a1a3a"
+        border = "#2a5040" if granted else CARD_BORDER
 
-        # ── Screen Recording row ──
-        row_y2 = row_y + row_height + 14
-        self._draw_permission_row(
-            row_x1, row_y2, row_x2, row_height,
-            granted=scr,
-            title="Screen Recording",
-            description="Capture browser URLs",
-            text_max_x=text_max_x,
-            on_open=None if scr else self._open_screen_recording,
+        self._create_rounded_rect(
+            row_x1, row_y, row_x2, row_y + row_height,
+            radius=12, fill=bg, outline=border, width=1,
         )
+        self._canvas.create_text(
+            row_x1 + 32, cy, text=icon,
+            font=(FONT_FAMILY, 22, "bold"), fill=icon_color,
+        )
+        self._canvas.create_text(
+            row_x1 + 64, cy - 10, text="Accessibility",
+            font=(FONT_FAMILY, 14, "bold"), fill=TEXT_COLOR, anchor=tk.W,
+        )
+        self._canvas.create_text(
+            row_x1 + 64, cy + 14,
+            text="Allow BetterFlow Sync to read window titles",
+            font=FONT_SMALL, fill=TEXT_MUTED, anchor=tk.W,
+        )
+        if not granted:
+            self._make_button(
+                "Open Settings", self._open_accessibility,
+                row_x2 - 82, cy, width=128, primary=False,
+            )
 
         # ── Bottom area ──
-        if all_granted:
+        if granted:
             self._canvas.create_text(
-                cx, row_y2 + row_height + 36,
-                text="All permissions granted!",
+                cx, row_y + row_height + 40,
+                text="Permission granted!",
                 font=(FONT_FAMILY, 14, "bold"), fill=SUCCESS_COLOR,
             )
             self._make_button(
                 "Start Using BetterFlow", self._finish,
-                cx, row_y2 + row_height + 80, width=280,
+                cx, row_y + row_height + 88, width=280,
             )
         else:
-            # Hint text
             self._canvas.create_text(
-                cx, row_y2 + row_height + 30,
+                cx, row_y + row_height + 34,
                 text="If already toggled on, try switching it off and on again.",
                 font=(FONT_FAMILY, 11), fill="#7a8fc0",
             )
-
-            btn_y = row_y2 + row_height + 76
+            btn_y = row_y + row_height + 82
             self._make_button(
                 "Refresh Status", self._show_permissions,
                 cx - 104, btn_y, width=180,
@@ -560,59 +563,12 @@ class SetupWizard:
             3000, self._auto_refresh_permissions,
         )
 
-    def _draw_permission_row(
-        self,
-        x1: int, y: int, x2: int, height: int,
-        granted: bool,
-        title: str,
-        description: str,
-        text_max_x: int,
-        on_open=None,
-    ) -> None:
-        """Draw a single permission status row."""
-        cy = y + height // 2
-        icon = "\u2713" if granted else "\u2717"
-        icon_color = SUCCESS_COLOR if granted else ERROR_COLOR
-        bg = "#112040" if granted else "#1a1a3a"
-        border = "#2a5040" if granted else CARD_BORDER
-
-        self._create_rounded_rect(
-            x1, y, x2, y + height,
-            radius=12, fill=bg, outline=border, width=1,
-        )
-
-        # Status icon
-        self._canvas.create_text(
-            x1 + 32, cy, text=icon,
-            font=(FONT_FAMILY, 22, "bold"), fill=icon_color,
-        )
-
-        # Title and description
-        self._canvas.create_text(
-            x1 + 64, cy - 10, text=title,
-            font=(FONT_FAMILY, 14, "bold"), fill=TEXT_COLOR, anchor=tk.W,
-        )
-        self._canvas.create_text(
-            x1 + 64, cy + 14, text=description,
-            font=FONT_SMALL, fill=TEXT_MUTED, anchor=tk.W,
-        )
-
-        # "Open Settings" button (only when not granted)
-        if on_open is not None:
-            self._make_button(
-                "Open Settings", on_open,
-                x2 - 82, cy, width=128, primary=False,
-            )
-
     def _auto_refresh_permissions(self) -> None:
         """Auto-refresh the permissions screen when status changes."""
         if self._closing:
             return
         try:
-            acc = check_accessibility()
-            scr = check_screen_recording()
-            if acc and scr:
-                # All granted — redraw to show success state
+            if check_accessibility():
                 self._show_permissions()
             else:
                 self._permissions_refresh_id = self._window.after(
@@ -624,10 +580,6 @@ class SetupWizard:
     def _open_accessibility(self) -> None:
         """Open macOS Accessibility settings."""
         open_accessibility_settings()
-
-    def _open_screen_recording(self) -> None:
-        """Open macOS Screen Recording settings."""
-        open_screen_recording_settings()
 
     def _finish(self) -> None:
         """Complete and close the wizard only."""

--- a/src/ui/tray.py
+++ b/src/ui/tray.py
@@ -99,6 +99,9 @@ class TrayModel:
         # Display tracking
         self.track_display_info: bool = False
 
+        # Permissions
+        self.needs_permissions: bool = False
+
 
 try:
     import pystray
@@ -119,6 +122,7 @@ class TrayState(Enum):
     ERROR = "error"  # Red - auth failed or AW not running
     PAUSED = "paused"  # Gray - user paused tracking
     PRIVATE = "private"  # Dark gray - private time, nothing recorded
+    NEEDS_PERMISSIONS = "needs_permissions"  # Amber - macOS permissions missing
     STARTING = "starting"  # Blue - starting up
     WAITING_AUTH = "waiting_auth"  # Amber - waiting for browser login
 
@@ -131,6 +135,7 @@ STATE_COLORS = {
     TrayState.ERROR: "#ef4444",  # Red
     TrayState.PAUSED: "#9ca3af",  # Gray
     TrayState.PRIVATE: "#6b7280",  # Dark gray - private time
+    TrayState.NEEDS_PERMISSIONS: "#f59e0b",  # Amber - permissions missing
     TrayState.STARTING: "#3b82f6",  # Blue
     TrayState.WAITING_AUTH: "#f59e0b",  # Amber
 }
@@ -175,6 +180,7 @@ class TrayIcon:
         on_private_toggle: Optional[Callable[[bool], None]] = None,
         on_sync_now: Optional[Callable[[], None]] = None,
         on_export_logs: Optional[Callable[[], None]] = None,
+        on_open_permissions: Optional[Callable[[], None]] = None,
     ):
         """Initialize tray icon.
 
@@ -189,6 +195,7 @@ class TrayIcon:
             on_private_toggle: Callback when private time is toggled (receives bool)
             on_sync_now: Callback to trigger an immediate sync
             on_export_logs: Callback to export logs to a zip file
+            on_open_permissions: Callback to open system permission settings
         """
         if pystray is None:
             raise ImportError("pystray is required for system tray support")
@@ -203,6 +210,7 @@ class TrayIcon:
         self._on_private_toggle = on_private_toggle
         self._on_sync_now = on_sync_now
         self._on_export_logs = on_export_logs
+        self._on_open_permissions = on_open_permissions
 
         self.model = TrayModel()
 
@@ -229,6 +237,8 @@ class TrayIcon:
             items.append(Item(label, None, enabled=False))
 
         items.append(Item(f"App status: {self._get_status_text()}", None, enabled=False))
+        if self.model.needs_permissions:
+            items.append(Item("\u26a0 Enable Permissions...", self._handle_open_permissions))
         items.append(Item(f"Hours today: {self.model.hours_today}", None, enabled=False))
         items.append(Item("Trends", pystray.Menu(
             Item(f"Hours this week: {self.model.hours_this_week}", None, enabled=False),
@@ -373,6 +383,8 @@ class TrayIcon:
             return "Error"
         elif self.model.state == TrayState.PAUSED:
             return "Paused"
+        elif self.model.state == TrayState.NEEDS_PERMISSIONS:
+            return "Permissions Required"
         elif self.model.state == TrayState.WAITING_AUTH:
             return "Waiting for login..."
         else:
@@ -394,6 +406,11 @@ class TrayIcon:
         """Handle login menu click."""
         if self._on_login:
             self._on_login()
+
+    def _handle_open_permissions(self, icon, item) -> None:
+        """Handle open permissions menu click."""
+        if self._on_open_permissions:
+            self._on_open_permissions()
 
     def _handle_pause(self, icon, item) -> None:
         """Handle pause menu click."""


### PR DESCRIPTION
- Add NEEDS_PERMISSIONS amber tray state when macOS permissions missing
- Add "Enable Permissions..." menu item that opens System Settings
- Add permissions screen to setup wizard after login success
- Improve permission detection with pyobjc primary + Quartz fallback
- Periodic 60s permissions check clears warning when granted
- Auto-refresh permissions screen every 3s in wizard