### PR TITLE
fix: correct broken import preventing auto-updates

### DIFF
--- a/src/__init__.py
+++ b/src/__init__.py
@@ -1,4 +1,4 @@
 """BetterFlow - ActivityWatch to BetterFlow sync companion app."""
 
-__version__ = "1.5.8"
+__version__ = "1.5.9"
 __author__ = "BetterQA"

--- a/src/update_handler.py
+++ b/src/update_handler.py
@@ -39,9 +39,9 @@ class UpdateHandler:
             self._update_jobs_started = True
 
         try:
-            from .version_check import check_for_update
+            from .update_checker import check_for_update
         except ImportError:
-            from version_check import check_for_update
+            from update_checker import check_for_update
 
         from apscheduler.triggers.interval import IntervalTrigger
 
@@ -110,9 +110,9 @@ class UpdateHandler:
                 return
 
         try:
-            from .version_check import check_for_update
+            from .update_checker import check_for_update
         except ImportError:
-            from version_check import check_for_update
+            from update_checker import check_for_update
 
         try:
             check_for_update(


### PR DESCRIPTION
## Summary
- Fixed `update_handler.py` importing from non-existent `version_check` module instead of `update_checker`, which silently broke the auto-update system
- Bumps version to 1.5.9

## Test plan
- [x] Verified `from src.update_handler import UpdateHandler` succeeds
- [x] All 298 tests pass
- [x] Built arm64 DMG, installed, app launches and shows v1.5.9
- [x] App status shows "Active" (no longer stuck on "Error" from partial bucket failures)
- [x] "Check for Update" menu item visible in Preferences submenu

🤖 Generated with [Claude Code](https://claude.com/claude-code)