### PR TITLE
fix(ci): repair downloads-page sync + bundle AX framework for v1.5.19

### DIFF
--- a/.github/workflows/sync-downloads.yml
+++ b/.github/workflows/sync-downloads.yml
@@ -19,44 +19,68 @@ jobs:
         id: release
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          EVENT_RELEASE_JSON: ${{ toJson(github.event.release) }}
+          EVENT_TAG: ${{ github.event.release.tag_name }}
           INPUT_RELEASE_TAG: ${{ inputs.release_tag }}
           REPO: ${{ github.repository }}
         run: |
           set -euo pipefail
 
-          if [ -n "${EVENT_RELEASE_JSON:-}" ] && [ "${EVENT_RELEASE_JSON}" != "null" ]; then
-            printf '%s' "${EVENT_RELEASE_JSON}" > release.json
-          elif [ -n "${INPUT_RELEASE_TAG:-}" ]; then
-            gh api "repos/${REPO}/releases/tags/${INPUT_RELEASE_TAG}" > release.json
-          else
-            echo "No published release payload or manual release_tag provided" >&2
+          TAG="${EVENT_TAG:-}"
+          if [ -z "${TAG}" ]; then
+            TAG="${INPUT_RELEASE_TAG:-}"
+          fi
+          if [ -z "${TAG}" ]; then
+            echo "No release tag from event payload or manual release_tag input" >&2
             exit 1
           fi
 
-          jq -e '
-            {
-              version: (.tag_name | sub("^v"; "")),
-              tag_name: .tag_name,
-              release_name: (.name // .tag_name),
-              published_at,
-              release_url: .html_url,
-              changelog_markdown: (.body // ""),
-              macos_arm64_url: ([.assets[] | select(.name == "BetterFlow-macOS-arm64.dmg") | .browser_download_url] | first // ""),
-              macos_x64_url: ([.assets[] | select(.name == "BetterFlow-macOS-x86_64.dmg") | .browser_download_url] | first // ""),
-              windows_url: ([.assets[] | select(.name == "BetterFlow-Windows.zip") | .browser_download_url] | first // "")
-            }
-          ' release.json > payload.json
+          # Always fetch the release fresh from the API and poll until every
+          # platform installer is attached. The `release: published` event can
+          # fire before the build matrix finishes uploading the per-platform
+          # DMGs/ZIP, so a one-shot read of the event payload races the upload
+          # (this is why every prior sync run failed). Retry until complete.
+          attempts=0
+          max_attempts=30          # 30 * 20s = up to 10 minutes
+          while : ; do
+            gh api "repos/${REPO}/releases/tags/${TAG}" > release.json
 
-          jq -e '
-            (.version | length) > 0 and
-            (.published_at | length) > 0 and
-            (.release_url | length) > 0 and
-            (.release_name | length) > 0 and
-            (.macos_arm64_url | length) > 0 and
-            (.macos_x64_url | length) > 0 and
-            (.windows_url | length) > 0
-          ' payload.json > /dev/null
+            jq -e '
+              {
+                version: (.tag_name | sub("^v"; "")),
+                tag_name: .tag_name,
+                release_name: (.name // .tag_name),
+                published_at: (.published_at // .created_at),
+                release_url: .html_url,
+                changelog_markdown: (.body // ""),
+                macos_arm64_url: ([.assets[] | select(.name == "BetterFlow-macOS-arm64.dmg") | .browser_download_url] | first // ""),
+                macos_x64_url: ([.assets[] | select(.name == "BetterFlow-macOS-x86_64.dmg") | .browser_download_url] | first // ""),
+                windows_url: ([.assets[] | select(.name == "BetterFlow-Windows.zip") | .browser_download_url] | first // "")
+              }
+            ' release.json > payload.json
+
+            if jq -e '
+              (.version | length) > 0 and
+              (.published_at | length) > 0 and
+              (.release_url | length) > 0 and
+              (.release_name | length) > 0 and
+              (.macos_arm64_url | length) > 0 and
+              (.macos_x64_url | length) > 0 and
+              (.windows_url | length) > 0
+            ' payload.json > /dev/null; then
+              echo "All platform assets present for ${TAG}."
+              break
+            fi
+
+            attempts=$((attempts + 1))
+            if [ "${attempts}" -ge "${max_attempts}" ]; then
+              echo "Timed out waiting for all platform assets on ${TAG}" >&2
+              echo "--- last payload.json ---" >&2
+              cat payload.json >&2
+              exit 1
+            fi
+            echo "Not all platform assets present yet for ${TAG} (attempt ${attempts}/${max_attempts}); retrying in 20s..."
+            sleep 20
+          done
 
           {
             echo "version=$(jq -r '.version' payload.json)"
@@ -70,14 +94,14 @@ jobs:
         run: |
           set -euo pipefail
 
-          if [ -z "${BACKEND_URL:-}" ]; then
-            echo "Missing DOWNLOADS_SYNC_BACKEND_URL secret" >&2
-            exit 1
-          fi
-
-          if [ -z "${RELEASE_SYNC_TOKEN:-}" ]; then
-            echo "Missing DOWNLOADS_SYNC_TOKEN secret" >&2
-            exit 1
+          # Sync is optional automation: the download page also derives its
+          # version/links from the backend's agent.version config fallback.
+          # If the sync secrets are not configured, skip cleanly with a loud
+          # warning rather than failing the release (avoids perpetual red runs
+          # on a feature that needs org-level secrets to be provisioned).
+          if [ -z "${BACKEND_URL:-}" ] || [ -z "${RELEASE_SYNC_TOKEN:-}" ]; then
+            echo "::warning::Downloads sync skipped — set the DOWNLOADS_SYNC_BACKEND_URL and DOWNLOADS_SYNC_TOKEN repository secrets (and the backend AGENT_RELEASE_SYNC_TOKEN env) to enable automatic download-page updates."
+            exit 0
           fi
 
           curl --fail --show-error --silent \

--- a/build.spec
+++ b/build.spec
@@ -99,6 +99,7 @@ hiddenimports = [
     "AppKit",
     "Foundation",
     "SystemConfiguration",
+    "ApplicationServices",  # AX API for MacOSWindowWatcher window titles + AXIsProcessTrusted
     "_build_info",  # Generated at build time by the spec preamble
 ]
 


### PR DESCRIPTION
## Why

The public download page (https://app.betterflow.eu/download) has been **frozen at v1.4.2** for all three platforms. Two root causes:

1. **The release→page sync has failed on every release.** `sync-downloads.yml` posts release metadata to the backend (`/api/internal/releases/desktop` → `storage/app/desktop-release.json`). It read `github.event.release` **once**, racing the build matrix that uploads the per-platform DMGs/ZIP — so the strict "all three assets present" validation failed every time (incl. v1.5.13, where the sync fired at 12:25:49 but assets landed at 12:27:09). The JSON was never written, so the page fell back to the `config('agent.version')` default of `1.4.2`.

2. **Mid-series releases (v1.5.3–v1.5.12) shipped arm64-only assets**, so Intel/Windows users had no newer complete build than Silicon — matching the "Intel/Windows is an older build" report. v1.5.13 was the last release with all three.

## What this changes

- **`sync-downloads.yml`**: always refetch the release from the API and **poll until all three platform installers are attached** (up to 10 min), eliminating the published-event race. When the optional `DOWNLOADS_SYNC_*` secrets are unset, the backend POST now **skips with a loud `::warning::`** instead of hard-failing the run.
- **`build.spec`**: bundle `ApplicationServices` (AX API) as a hidden import so window titles / `AXIsProcessTrusted` resolve in the packaged macOS app.

## Note for maintainers

Automatic sync still requires the `DOWNLOADS_SYNC_BACKEND_URL` + `DOWNLOADS_SYNC_TOKEN` repo secrets (and the backend `AGENT_RELEASE_SYNC_TOKEN` env) — these are **not currently set**, so the page is updated via the backend `agent.version` config bump (separate PR in internal-tool2) for now.

🤖 Generated with [Claude Code](https://claude.com/claude-code)