### PR TITLE
feat(linux): Linux (X11) support + AppImage + cross-platform auto-update

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -29,6 +29,11 @@ jobs:
             artifact_name: BetterFlow.exe
             asset_name: BetterFlow-Windows
             package_type: zip
+          - os: ubuntu-latest
+            target_arch: ''
+            artifact_name: BetterFlow
+            asset_name: BetterFlow-linux-x86_64
+            package_type: AppImage
 
     runs-on: ${{ matrix.os }}
 
@@ -39,6 +44,17 @@ jobs:
         uses: actions/setup-python@v5
         with:
           python-version: '3.11'
+
+      # PyGObject (AppIndicator tray backend) is built from source by pip and
+      # needs GObject-introspection + cairo dev headers; libnotify-bin provides
+      # notify-send at runtime; the AppIndicator typelib is bundled by PyInstaller.
+      - name: Install Linux system dependencies
+        if: runner.os == 'Linux'
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y --no-install-recommends \
+            libgirepository1.0-dev gir1.2-gtk-3.0 gir1.2-ayatanaappindicator3-0.1 \
+            libcairo2-dev pkg-config python3-dev libnotify-bin
 
       - name: Install dependencies
         run: |
@@ -67,6 +83,10 @@ jobs:
         if: matrix.os == 'windows-latest'
         run: dir dist
 
+      - name: List dist contents (Linux)
+        if: runner.os == 'Linux'
+        run: ls -la dist/
+
       - name: Create macOS DMG
         if: runner.os == 'macOS'
         run: |
@@ -88,6 +108,12 @@ jobs:
           cd dist
           Compress-Archive -Path "BetterFlow.exe" -DestinationPath "${{ matrix.asset_name }}.zip"
 
+      - name: Create Linux AppImage
+        if: runner.os == 'Linux'
+        run: |
+          chmod +x scripts/build-appimage.sh
+          ./scripts/build-appimage.sh "dist/${{ matrix.asset_name }}.AppImage"
+
       - name: Upload artifact
         uses: actions/upload-artifact@v4
         with:
@@ -95,6 +121,7 @@ jobs:
           path: |
             dist/${{ matrix.asset_name }}.dmg
             dist/${{ matrix.asset_name }}.zip
+            dist/${{ matrix.asset_name }}.AppImage
           retention-days: 30
 
   release:
@@ -121,6 +148,12 @@ jobs:
           name: BetterFlow-Windows
           path: ./artifacts
 
+      - name: Download Linux artifact
+        uses: actions/download-artifact@v4
+        with:
+          name: BetterFlow-linux-x86_64
+          path: ./artifacts
+
       - name: Create Release
         uses: softprops/action-gh-release@v1
         with:
@@ -128,6 +161,7 @@ jobs:
             artifacts/BetterFlow-macOS-arm64.dmg
             artifacts/BetterFlow-macOS-x86_64.dmg
             artifacts/BetterFlow-Windows.zip
+            artifacts/BetterFlow-linux-x86_64.AppImage
           draft: true
           generate_release_notes: true
         env:

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,7 +4,7 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 ## Project Overview
 
-BetterFlow is a Python desktop app that syncs ActivityWatch data to BetterFlow for automatic time tracking. It runs as a system tray application on macOS and Windows, polling ActivityWatch locally and sending events to the BetterFlow API.
+BetterFlow is a Python desktop app that syncs ActivityWatch data to BetterFlow for automatic time tracking. It runs as a system tray application on macOS, Windows, and Linux (X11), polling ActivityWatch locally and sending events to the BetterFlow API.
 
 ## Commands
 
@@ -23,9 +23,18 @@ make build            # Build for current platform (requires pyinstaller)
 make build-mac        # Build macOS .app bundle
 make dmg              # Build macOS DMG installer (requires create-dmg)
 
+# Linux build (run on Linux; needs gobject-introspection + libnotify-bin)
+make build-linux      # Build dist/BetterFlow/ one-dir bundle
+make appimage         # Package as dist/BetterFlow-linux-x86_64.AppImage
+
 # Windows build (run on Windows)
 powershell -ExecutionPolicy Bypass -File build-windows.ps1
 ```
+
+The Linux build mirrors the Windows path: it runs the external bundled
+ActivityWatch trackers (server + window + idle) as subprocesses with no
+in-process watchers and no permissions model. The in-app updater replaces the
+running `.AppImage` in place via the `$APPIMAGE` env var.
 
 ## Architecture
 

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 # BetterFlow - Build Makefile
 
-.PHONY: install install-dev install-mac test lint format clean build build-mac build-windows run download-aw clean-aw
+.PHONY: install install-dev install-mac test lint format clean build build-mac build-windows build-linux appimage run download-aw clean-aw
 
 # Install production dependencies
 install:
@@ -79,6 +79,16 @@ sign-mac:
 build-windows: download-aw
 	pyinstaller build.spec --clean
 	@echo "Built: dist/BetterFlow.exe"
+
+# Build for Linux (run on Linux) — produces dist/BetterFlow/ one-dir bundle
+build-linux: download-aw
+	pyinstaller build.spec --clean
+	@echo "Built: dist/BetterFlow/"
+
+# Package the Linux build as a single portable AppImage
+appimage: build-linux
+	./scripts/build-appimage.sh
+	@echo "Built: dist/BetterFlow-linux-x86_64.AppImage"
 
 # Run the application (development)
 run:

--- a/build.spec
+++ b/build.spec
@@ -29,6 +29,7 @@ _build_info.write_text(
 # Determine platform
 is_mac = platform.system() == "Darwin"
 is_windows = platform.system() == "Windows"
+is_linux = platform.system() == "Linux"
 
 # Paths
 root_dir = Path(SPECPATH)
@@ -41,7 +42,12 @@ datas = [
 ]
 
 # Tracker binaries (included as binaries to preserve execute permissions)
-aw_platform = "darwin" if is_mac else "windows"
+if is_mac:
+    aw_platform = "darwin"
+elif is_windows:
+    aw_platform = "windows"
+else:
+    aw_platform = "linux"
 aw_dir = resources_dir / "trackers" / aw_platform
 aw_binaries = []
 if aw_dir.exists():
@@ -56,10 +62,43 @@ from PyInstaller.utils.hooks import collect_data_files, collect_dynamic_libs
 tcl_tk_datas = collect_data_files("tkinter")
 tcl_tk_binaries = collect_dynamic_libs("_tkinter")
 
+# Platform-specific hidden imports (tray backend, keyring backend, native libs).
+if is_mac:
+    platform_hiddenimports = [
+        "pystray._darwin",
+        "keyring.backends.macOS",
+        # macOS frameworks for in-process watchers (CGEventTap, AX API, etc.)
+        "Quartz",
+        "CoreFoundation",
+        "AppKit",
+        "Foundation",
+        "SystemConfiguration",
+        "ApplicationServices",
+    ]
+elif is_windows:
+    platform_hiddenimports = [
+        "pystray._win32",
+        "keyring.backends.Windows",
+    ]
+else:  # Linux
+    platform_hiddenimports = [
+        "pystray._appindicator",
+        "pystray._xorg",
+        "gi",
+        "gi.repository.Gtk",
+        "gi.repository.AyatanaAppIndicator3",
+        "Xlib",
+        "Xlib.support.unix_connect",
+        "keyring.backends.SecretService",
+        "secretstorage",
+        "jeepney",
+        "jeepney.io.blocking",
+        "jeepney.bus_messages",
+    ]
+
 # Hidden imports for pystray, keyring backends, and our modules
 hiddenimports = [
-    "pystray._darwin" if is_mac else "pystray._win32",
-    "keyring.backends.macOS" if is_mac else "keyring.backends.Windows",
+    *platform_hiddenimports,
     "tkinter",
     "_tkinter",
     "PIL._tkinter_finder",
@@ -93,13 +132,6 @@ hiddenimports = [
     "auth.browser_auth",
     "sync.macos_window_watcher",
     "sync.macos_input_watcher",
-    # macOS frameworks for in-process watchers (CGEventTap, etc.)
-    "Quartz",
-    "CoreFoundation",
-    "AppKit",
-    "Foundation",
-    "SystemConfiguration",
-    "ApplicationServices",  # AX API for MacOSWindowWatcher window titles + AXIsProcessTrusted
     "_build_info",  # Generated at build time by the spec preamble
 ]
 
@@ -192,4 +224,32 @@ elif is_windows:
         argv_emulation=False,
         target_arch=TARGET_ARCH,
         icon=str(resources_dir / "icon.ico") if (resources_dir / "icon.ico").exists() else None,
+    )
+
+elif is_linux:
+    # One-dir build; scripts/build-appimage.sh wraps dist/BetterFlow into an
+    # AppDir and packages it as a single .AppImage.
+    exe = EXE(
+        pyz,
+        a.scripts,
+        exclude_binaries=True,
+        name="BetterFlow",
+        debug=False,
+        bootloader_ignore_signals=False,
+        strip=False,
+        upx=True,
+        console=False,
+        disable_windowed_traceback=False,
+        argv_emulation=False,
+        target_arch=TARGET_ARCH,
+    )
+
+    coll = COLLECT(
+        exe,
+        a.binaries,
+        a.zipfiles,
+        a.datas,
+        strip=False,
+        upx=True,
+        name="BetterFlow",
     )

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,6 +8,15 @@ Pillow>=10.0
 pyobjc-framework-SystemConfiguration>=10.0; sys_platform == "darwin"
 pyobjc-framework-ApplicationServices>=10.0; sys_platform == "darwin"
 
+# Linux-only dependencies
+# PyGObject -> AppIndicator tray backend; python-xlib -> XOrg fallback backend;
+# jeepney -> systemd-logind sleep/wake D-Bus signals; SecretStorage -> keyring
+# Secret Service backend (also pulled in transitively by keyring on Linux).
+PyGObject>=3.42; sys_platform == "linux"
+python-xlib>=0.33; sys_platform == "linux"
+jeepney>=0.8; sys_platform == "linux"
+SecretStorage>=3.3; sys_platform == "linux"
+
 # Development dependencies (install with: pip install -r requirements-dev.txt)
 # pytest>=7.0
 # pytest-mock>=3.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -12,7 +12,10 @@ pyobjc-framework-ApplicationServices>=10.0; sys_platform == "darwin"
 # PyGObject -> AppIndicator tray backend; python-xlib -> XOrg fallback backend;
 # jeepney -> systemd-logind sleep/wake D-Bus signals; SecretStorage -> keyring
 # Secret Service backend (also pulled in transitively by keyring on Linux).
-PyGObject>=3.42; sys_platform == "linux"
+# Pin <3.50: PyGObject 3.50+ requires girepository-2.0 (libgirepository-2.0-dev);
+# 3.48 builds against girepository-1.0, which is present on far more distros and
+# keeps the bundled AppImage portable.
+PyGObject>=3.42,<3.50; sys_platform == "linux"
 python-xlib>=0.33; sys_platform == "linux"
 jeepney>=0.8; sys_platform == "linux"
 SecretStorage>=3.3; sys_platform == "linux"

--- a/scripts/build-appimage.sh
+++ b/scripts/build-appimage.sh
@@ -1,0 +1,85 @@
+#!/usr/bin/env bash
+#
+# Package the PyInstaller one-dir Linux build (dist/BetterFlow) into a single
+# portable .AppImage.
+#
+# Prereq: `pyinstaller build.spec --clean` has been run on Linux first, leaving
+# dist/BetterFlow/BetterFlow (the launcher) + dist/BetterFlow/_internal/...
+#
+# Usage: scripts/build-appimage.sh [output.AppImage]
+#   Default output: dist/BetterFlow-linux-x86_64.AppImage
+#   (the "BetterFlow-linux" stem is what the in-app updater matches against —
+#    see src/update_checker.py::_ASSET_PATTERNS)
+
+set -euo pipefail
+
+ARCH="${ARCH:-x86_64}"
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+DIST="${ROOT}/dist"
+DIST_APP="${DIST}/BetterFlow"
+APPDIR="${DIST}/BetterFlow.AppDir"
+OUTPUT="${1:-${DIST}/BetterFlow-linux-${ARCH}.AppImage}"
+ICON_SRC="${ROOT}/resources/icon.png"
+
+if [ ! -x "${DIST_APP}/BetterFlow" ]; then
+    echo "ERROR: ${DIST_APP}/BetterFlow not found. Run 'pyinstaller build.spec --clean' first." >&2
+    exit 1
+fi
+
+echo "[appimage] Assembling AppDir at ${APPDIR}"
+rm -rf "${APPDIR}"
+mkdir -p "${APPDIR}/usr/bin" \
+         "${APPDIR}/usr/share/applications" \
+         "${APPDIR}/usr/share/icons/hicolor/256x256/apps"
+
+# The PyInstaller one-dir payload (launcher + _internal/) lives under usr/bin.
+cp -a "${DIST_APP}/." "${APPDIR}/usr/bin/"
+
+# Icon — required at the AppDir root with a basename matching Icon= below.
+if [ -f "${ICON_SRC}" ]; then
+    cp "${ICON_SRC}" "${APPDIR}/betterflow.png"
+    cp "${ICON_SRC}" "${APPDIR}/usr/share/icons/hicolor/256x256/apps/betterflow.png"
+else
+    echo "[appimage] WARNING: ${ICON_SRC} missing — building without an icon"
+fi
+
+# Desktop entry — required at the AppDir root (and mirrored under usr/share).
+cat > "${APPDIR}/betterflow.desktop" <<'DESKTOP'
+[Desktop Entry]
+Type=Application
+Name=BetterFlow
+Comment=Sync ActivityWatch data to BetterFlow for automatic time tracking
+Exec=BetterFlow
+Icon=betterflow
+Categories=Utility;Office;
+Terminal=false
+DESKTOP
+cp "${APPDIR}/betterflow.desktop" "${APPDIR}/usr/share/applications/betterflow.desktop"
+
+# AppRun — entrypoint appimagetool wires up; execs our launcher.
+cat > "${APPDIR}/AppRun" <<'APPRUN'
+#!/bin/sh
+HERE="$(dirname "$(readlink -f "${0}")")"
+exec "${HERE}/usr/bin/BetterFlow" "$@"
+APPRUN
+chmod +x "${APPDIR}/AppRun"
+
+# Fetch appimagetool if it isn't already on PATH.
+if command -v appimagetool >/dev/null 2>&1; then
+    APPIMAGETOOL="$(command -v appimagetool)"
+else
+    APPIMAGETOOL="${DIST}/appimagetool-${ARCH}.AppImage"
+    if [ ! -f "${APPIMAGETOOL}" ]; then
+        echo "[appimage] Downloading appimagetool"
+        curl -fsSL -o "${APPIMAGETOOL}" \
+            "https://github.com/AppImage/appimagetool/releases/download/continuous/appimagetool-${ARCH}.AppImage"
+        chmod +x "${APPIMAGETOOL}"
+    fi
+fi
+
+echo "[appimage] Building ${OUTPUT}"
+# Extract-and-run avoids needing FUSE (unavailable on most CI runners).
+export APPIMAGE_EXTRACT_AND_RUN=1
+ARCH="${ARCH}" "${APPIMAGETOOL}" "${APPDIR}" "${OUTPUT}"
+
+echo "[appimage] Done: ${OUTPUT}"

--- a/scripts/download_aw.py
+++ b/scripts/download_aw.py
@@ -29,6 +29,7 @@ RELEASE_BASE = (
 RELEASE_ASSETS = {
     "darwin": f"activitywatch-{AW_VERSION}-macos-x86_64.zip",
     "windows": f"activitywatch-{AW_VERSION}-windows-x86_64.zip",
+    "linux": f"activitywatch-{AW_VERSION}-linux-x86_64.zip",
 }
 
 # Output directory relative to project root
@@ -43,6 +44,8 @@ def get_platform() -> str:
         return "darwin"
     elif system == "Windows":
         return "windows"
+    elif system == "Linux":
+        return "linux"
     else:
         print(f"Unsupported platform: {system}")
         sys.exit(1)
@@ -143,8 +146,8 @@ def extract_binaries(zip_path: str, output_dir: str, plat: str) -> None:
 
 
 def fix_permissions(output_dir: str, plat: str) -> None:
-    """Make binaries executable on macOS and strip quarantine xattr."""
-    if plat != "darwin":
+    """Make launchers executable on POSIX; strip quarantine xattr on macOS."""
+    if plat not in ("darwin", "linux"):
         return
 
     for root, _, files in os.walk(output_dir):
@@ -154,10 +157,11 @@ def fix_permissions(output_dir: str, plat: str) -> None:
                 st = os.stat(path)
                 os.chmod(path, st.st_mode | stat.S_IEXEC | stat.S_IXGRP | stat.S_IXOTH)
                 print(f"  Fixed permissions: {path}")
-            subprocess.run(
-                ["xattr", "-d", "com.apple.quarantine", path],
-                capture_output=True,
-            )
+            if plat == "darwin":
+                subprocess.run(
+                    ["xattr", "-d", "com.apple.quarantine", path],
+                    capture_output=True,
+                )
 
 
 def main() -> None:

--- a/src/__init__.py
+++ b/src/__init__.py
@@ -1,4 +1,4 @@
 """BetterFlow - ActivityWatch to BetterFlow sync companion app."""
 
-__version__ = "1.5.21"
+__version__ = "1.5.22"
 __author__ = "BetterQA"

--- a/src/autostart.py
+++ b/src/autostart.py
@@ -6,6 +6,7 @@ import platform
 import subprocess
 import sys
 from pathlib import Path
+from typing import Optional
 
 logger = logging.getLogger(__name__)
 
@@ -23,6 +24,8 @@ def set_auto_start(enabled: bool) -> bool:
             return _set_macos(enabled)
         elif system == "Windows":
             return _set_windows(enabled)
+        elif system == "Linux":
+            return _set_linux(enabled)
         else:
             logger.warning(f"Auto-start not supported on {system}")
             return False
@@ -39,6 +42,8 @@ def get_auto_start() -> bool:
             return _get_macos()
         elif system == "Windows":
             return _get_windows()
+        elif system == "Linux":
+            return _get_linux()
         else:
             return False
     except Exception:
@@ -203,3 +208,68 @@ def _get_windows() -> bool:
             winreg.CloseKey(key)
     except OSError:
         return False
+
+
+# -- Linux: XDG autostart .desktop entry --------------------------------------
+
+
+def _desktop_entry_path() -> Path:
+    """Path to the freedesktop autostart entry (honors XDG_CONFIG_HOME)."""
+    config_home = os.environ.get("XDG_CONFIG_HOME") or str(Path.home() / ".config")
+    return Path(config_home) / "autostart" / f"{LAUNCHAGENT_LABEL}.desktop"
+
+
+def _linux_exec_command() -> Optional[str]:
+    """Determine the command to relaunch the app at login.
+
+    Running as an AppImage, $APPIMAGE is the real .AppImage path. Returns None
+    in dev mode (where there's nothing stable to point launch at)."""
+    appimage = os.environ.get("APPIMAGE")
+    if appimage:
+        return appimage
+    if getattr(sys, "frozen", False):
+        return sys.executable
+    return None
+
+
+def _set_linux(enabled: bool) -> bool:
+    entry = _desktop_entry_path()
+
+    if not enabled:
+        if entry.exists():
+            entry.unlink()
+            logger.info(f"Removed autostart desktop entry: {entry}")
+        return True
+
+    if not getattr(sys, "frozen", False):
+        # In dev mode there is no stable executable to point Exec= at.
+        logger.warning("Auto-start not supported in dev mode on Linux")
+        return False
+
+    exec_cmd = _linux_exec_command()
+    if not exec_cmd:
+        logger.warning("Cannot determine Linux executable path for auto-start")
+        return False
+
+    # The desktop-entry spec requires reserved characters (incl. spaces) to be
+    # double-quoted in the Exec field.
+    exec_field = f'"{exec_cmd}"' if " " in exec_cmd else exec_cmd
+
+    entry.parent.mkdir(parents=True, exist_ok=True)
+    content = (
+        "[Desktop Entry]\n"
+        "Type=Application\n"
+        "Name=BetterFlow\n"
+        f"Exec={exec_field}\n"
+        "Icon=betterflow\n"
+        "Comment=Sync ActivityWatch data to BetterFlow\n"
+        "Terminal=false\n"
+        "X-GNOME-Autostart-enabled=true\n"
+    )
+    entry.write_text(content, encoding="utf-8")
+    logger.info(f"Wrote autostart desktop entry: {entry}")
+    return True
+
+
+def _get_linux() -> bool:
+    return _desktop_entry_path().exists()

--- a/src/aw_manager.py
+++ b/src/aw_manager.py
@@ -19,7 +19,13 @@ from datetime import datetime, timezone
 from pathlib import Path
 from typing import Optional
 
+from platformdirs import user_data_dir
+
 logger = logging.getLogger(__name__)
+
+# Identity used for platformdirs paths on Linux (matches src/config.py).
+APP_NAME = "BetterFlow"
+APP_AUTHOR = "BetterQA"
 
 # Binaries to manage (start order matters: server first, then watchers)
 # These are renamed from aw-* originals for white-labeling
@@ -34,6 +40,7 @@ RELEASE_BASE = (
 RELEASE_ASSETS = {
     "darwin": f"activitywatch-{AW_VERSION}-macos-x86_64.zip",
     "windows": f"activitywatch-{AW_VERSION}-windows-x86_64.zip",
+    "linux": f"activitywatch-{AW_VERSION}-linux-x86_64.zip",
 }
 
 # Mapping from original AW names to our branded names (used during download/extract)
@@ -49,27 +56,38 @@ STALE_THRESHOLD = 120  # seconds with no new events before force-restarting watc
 
 
 def _get_platform_key() -> str:
-    return "darwin" if platform.system() == "Darwin" else "windows"
+    system = platform.system()
+    if system == "Darwin":
+        return "darwin"
+    if system == "Windows":
+        return "windows"
+    return "linux"
+
+
+def _app_support_base() -> str:
+    """Base application-support directory shared by trackers and the DB.
+
+    Kept identical to the historical macOS/Windows locations so existing
+    installs are not orphaned; Linux uses the XDG data dir (matching
+    src/config.py's platformdirs usage).
+    """
+    system = platform.system()
+    if system == "Darwin":
+        return os.path.expanduser("~/Library/Application Support/BetterFlow")
+    if system == "Windows":
+        base = os.environ.get("APPDATA", os.path.expanduser("~"))
+        return os.path.join(base, "BetterQA", "BetterFlow")
+    return user_data_dir(APP_NAME, APP_AUTHOR)
 
 
 def _get_install_dir() -> str:
     """Get persistent directory for tracker binaries (survives app updates)."""
-    if platform.system() == "Darwin":
-        base = os.path.expanduser("~/Library/Application Support/BetterFlow")
-    else:
-        base = os.environ.get("APPDATA", os.path.expanduser("~"))
-        base = os.path.join(base, "BetterQA", "BetterFlow")
-    return os.path.join(base, "trackers", _get_platform_key())
+    return os.path.join(_app_support_base(), "trackers", _get_platform_key())
 
 
 def _get_db_dir() -> str:
     """Get sqlite file path for tracker database storage."""
-    if platform.system() == "Darwin":
-        base = os.path.expanduser("~/Library/Application Support/BetterFlow")
-    else:
-        base = os.environ.get("APPDATA", os.path.expanduser("~"))
-        base = os.path.join(base, "BetterQA", "BetterFlow")
-    return os.path.join(base, "data", "aw-db.sqlite")
+    return os.path.join(_app_support_base(), "data", "aw-db.sqlite")
 
 
 def _binaries_present(directory: str) -> bool:
@@ -186,8 +204,9 @@ def _download_aw_binaries(install_dir: str) -> bool:
             logger.error("Tracker extraction incomplete after install")
             return False
 
-        # macOS: fix permissions + strip quarantine
-        if plat == "darwin":
+        # POSIX: make launchers executable. macOS additionally strips the
+        # quarantine xattr (no such concept on Linux).
+        if plat in ("darwin", "linux"):
             for root, _, files in os.walk(install_dir):
                 for file_name in files:
                     path = os.path.join(root, file_name)
@@ -196,10 +215,11 @@ def _download_aw_binaries(install_dir: str) -> bool:
                         os.chmod(
                             path, st.st_mode | stat.S_IEXEC | stat.S_IXGRP | stat.S_IXOTH
                         )
-                    subprocess.run(
-                        ["xattr", "-d", "com.apple.quarantine", path],
-                        capture_output=True,
-                    )
+                    if plat == "darwin":
+                        subprocess.run(
+                            ["xattr", "-d", "com.apple.quarantine", path],
+                            capture_output=True,
+                        )
 
         logger.info("Tracker binaries installed successfully")
         return True
@@ -455,9 +475,10 @@ class AWManager:
             # Platform-specific: prevent dock icon on macOS
             if platform.system() == "Darwin":
                 env["LSBackgroundOnly"] = "1"
-                # Watchers with bundled runtime expect execution from their own dir.
-                if name in BF_WATCHERS:
-                    kwargs["cwd"] = os.path.dirname(binary_path)
+            # Watchers ship as bundled runtimes (macOS/Linux) and expect to be
+            # launched from their own directory so they can find their payload.
+            if platform.system() in ("Darwin", "Linux") and name in BF_WATCHERS:
+                kwargs["cwd"] = os.path.dirname(binary_path)
 
             # Platform-specific: prevent console window on Windows
             if platform.system() == "Windows":
@@ -620,11 +641,13 @@ class AWManager:
                             if os.path.basename(p).startswith("bf-"):
                                 st = os.stat(p)
                                 os.chmod(p, st.st_mode | stat.S_IEXEC | stat.S_IXGRP | stat.S_IXOTH)
-                            # Strip quarantine
-                            subprocess.run(
-                                ["xattr", "-d", "com.apple.quarantine", p],
-                                capture_output=True,
-                            )
+                            # Strip quarantine (macOS only; `xattr` does not exist
+                            # on Linux and would raise FileNotFoundError here).
+                            if platform.system() == "Darwin":
+                                subprocess.run(
+                                    ["xattr", "-d", "com.apple.quarantine", p],
+                                    capture_output=True,
+                                )
             logger.info(f"Installed tracker binaries to {install_dir}")
             return _binaries_present(install_dir)
         except Exception as e:

--- a/src/notifications.py
+++ b/src/notifications.py
@@ -90,6 +90,8 @@ def send_notification(title: str, message: str, sound: bool = True) -> None:
             _send_macos_osascript(title, message, sound)
         elif system == "Windows":
             _send_windows(title, message)
+        elif system == "Linux":
+            _send_linux(title, message)
         else:
             logger.debug("Notifications not supported on %s", system)
     except Exception as e:
@@ -274,4 +276,38 @@ def _clear_windows() -> None:
             "_clear_windows failed (rc=%s): %s",
             result.returncode,
             result.stderr.decode(errors="replace").strip(),
+        )
+
+
+# --------------------------------------------------------------------------
+# Linux — notify-send (libnotify)
+# --------------------------------------------------------------------------
+
+
+def _send_linux(title: str, message: str) -> None:
+    """Send a desktop notification via notify-send (libnotify).
+
+    Arguments are passed as an argv list (no shell), so notify-send handles
+    quoting; we still strip control chars and cap length defensively. If
+    notify-send is not installed we log at debug and return rather than raise.
+    """
+    safe_title = re.sub(r'[\x00-\x1f\x7f]', '', title)[:200]
+    safe_message = re.sub(r'[\x00-\x1f\x7f]', '', message)[:500]
+
+    args = ["notify-send", "--app-name=BetterFlow"]
+    icon_path = _resolve_icon_path()
+    if icon_path is not None:
+        args.append(f"--icon={icon_path}")
+    args.extend([safe_title, safe_message])
+
+    try:
+        result = subprocess.run(args, capture_output=True, timeout=5)
+    except FileNotFoundError:
+        logger.debug("notify-send not found — desktop notification skipped")
+        return
+    if result.returncode != 0:
+        logger.warning(
+            "notify-send failed (exit %s): %s",
+            result.returncode,
+            result.stderr.decode(errors="replace")[:200],
         )

--- a/src/self_updater.py
+++ b/src/self_updater.py
@@ -1,6 +1,7 @@
-"""Self-update: download a new release, replace the running .app, and relaunch.
+"""Self-update: download a new release, replace the running app, and relaunch.
 
-Supports both ZIP and DMG formats (macOS uses DMG, Windows uses ZIP).
+Supports three formats: macOS uses DMG, Windows uses ZIP, Linux uses a single
+.AppImage file replaced in place.
 """
 
 import logging
@@ -23,7 +24,8 @@ logger = logging.getLogger(__name__)
 
 
 def _get_app_bundle_path() -> Optional[Path]:
-    """Return the path to the running .app bundle (macOS) or .exe dir (Windows).
+    """Return the path to the running app: .app bundle (macOS), .exe dir
+    (Windows), or the .AppImage file (Linux).
 
     Works for both PyInstaller bundles and dev mode.
     """
@@ -41,6 +43,14 @@ def _get_app_bundle_path() -> Optional[Path]:
         # PyInstaller: dist/BetterFlow/BetterFlow.exe - the folder is the app
         if getattr(sys, "frozen", False):
             return Path(sys._MEIPASS).parent if hasattr(sys, "_MEIPASS") else exe.parent
+        return None
+
+    elif sys.platform.startswith("linux"):
+        # AppImage sets $APPIMAGE to the real path of the .AppImage file
+        # (sys.executable points into the read-only squashfs mount instead).
+        appimage = os.environ.get("APPIMAGE")
+        if appimage:
+            return Path(appimage).resolve()
         return None
 
     return None
@@ -89,7 +99,13 @@ def apply_update(
         # Parse URL path to detect format (handles query params like ?token=abc)
         url_path = urlparse(download_url).path.lower()
         is_dmg = url_path.endswith(".dmg")
-        dl_filename = "update.dmg" if is_dmg else "update.zip"
+        is_appimage = url_path.endswith(".appimage")
+        if is_appimage:
+            dl_filename = "update.AppImage"
+        elif is_dmg:
+            dl_filename = "update.dmg"
+        else:
+            dl_filename = "update.zip"
         dl_path = tmp_dir / dl_filename
 
         total = int(resp.headers.get("content-length", 0))
@@ -101,6 +117,11 @@ def apply_update(
                 if total > 0:
                     pct = int(downloaded / total * 100)
                     _status(f"Downloading... {pct}%")
+
+        # Linux: the downloaded AppImage *is* the new app — replace in place,
+        # no extraction or .app/.exe discovery needed.
+        if sys.platform.startswith("linux"):
+            return _install_appimage(dl_path, app_path, _status, on_pre_exit)
 
         # 2. Extract
         _status("Extracting...")
@@ -221,6 +242,62 @@ def apply_update(
         # Clean up temp dir (except on Windows where bat script needs it)
         if tmp_dir and sys.platform != "win32":
             shutil.rmtree(tmp_dir, ignore_errors=True)
+
+
+def _install_appimage(
+    new_appimage: Path,
+    app_path: Path,
+    status: Callable[[str], None],
+    on_pre_exit: Optional[Callable[[], None]],
+) -> bool:
+    """Replace the running .AppImage in place and relaunch (Linux).
+
+    A running AppImage can be safely renamed/replaced: the kernel keeps the
+    executing inode alive (and the FUSE mount with it) until this process
+    exits, so we move the old file aside, drop the new one in, and exec it.
+    """
+    # Sanity check: AppImages are ELF binaries (magic \x7fELF).
+    try:
+        with open(new_appimage, "rb") as f:
+            if f.read(4) != b"\x7fELF":
+                status("Downloaded file is not a valid AppImage - update aborted")
+                return False
+    except OSError as e:
+        status(f"Could not read downloaded update: {e}")
+        return False
+
+    status("Installing...")
+    new_appimage.chmod(0o755)
+
+    # Use an explicit ".old" suffix on the full name (with_suffix would strip
+    # the ".AppImage" extension).
+    backup_path = Path(str(app_path) + ".old")
+    if backup_path.exists():
+        backup_path.unlink()
+
+    app_path.rename(backup_path)
+    try:
+        shutil.move(str(new_appimage), str(app_path))
+        app_path.chmod(0o755)
+    except Exception:
+        # Rollback so the user is never left without a runnable app.
+        if backup_path.exists() and not app_path.exists():
+            backup_path.rename(app_path)
+        raise
+
+    backup_path.unlink(missing_ok=True)
+
+    if on_pre_exit:
+        status("Flushing data...")
+        try:
+            on_pre_exit()
+        except Exception as e:
+            logger.warning("Pre-exit flush failed: %s", e)
+
+    status("Restarting...")
+    subprocess.Popen([str(app_path)])
+    # os._exit works from any thread, unlike sys.exit.
+    os._exit(0)
 
 
 def _find_app_in(directory: Path) -> Optional[Path]:

--- a/src/system_events.py
+++ b/src/system_events.py
@@ -3,6 +3,7 @@
 Platform-specific implementations:
 - macOS: pyobjc NSWorkspace notifications + SCNetworkReachability
 - Windows: ctypes hidden window message pump
+- Linux: systemd-logind PrepareForSleep D-Bus signal (via jeepney)
 - Fallback: socket-based network poller
 """
 
@@ -54,6 +55,8 @@ def start_system_event_listener(
                 _start_macos_screen_lock_listener(on_screen_lock, on_screen_unlock)
         elif _system == "Windows":
             _start_windows_listener(on_sleep, on_wake, on_shutdown, on_screen_lock, on_screen_unlock)
+        elif _system == "Linux":
+            _start_linux_power_listener(on_sleep, on_wake)
         return
 
     if _system == "Darwin":
@@ -63,6 +66,9 @@ def start_system_event_listener(
             _start_macos_screen_lock_listener(on_screen_lock, on_screen_unlock)
     elif _system == "Windows":
         _start_windows_listener(on_sleep, on_wake, on_shutdown, on_screen_lock, on_screen_unlock)
+        _start_network_poller(on_network_change, host=host, port=reachability_port)
+    elif _system == "Linux":
+        _start_linux_power_listener(on_sleep, on_wake)
         _start_network_poller(on_network_change, host=host, port=reachability_port)
     else:
         logger.warning(f"System events not supported on {_system}")
@@ -419,6 +425,77 @@ def _start_windows_listener(
             user32.DispatchMessageW(ctypes.byref(msg))
 
     thread = threading.Thread(target=run_message_pump, name="system-power-listener", daemon=True)
+    thread.start()
+
+
+# ---------------------------------------------------------------------------
+# Linux: systemd-logind PrepareForSleep signal (via jeepney)
+# ---------------------------------------------------------------------------
+
+def _start_linux_power_listener(
+    on_sleep: Callable,
+    on_wake: Callable,
+) -> None:
+    """Listen for suspend/resume via systemd-logind's PrepareForSleep signal.
+
+    logind emits ``PrepareForSleep(True)`` just before the system suspends and
+    ``PrepareForSleep(False)`` after it resumes. Shutdown is intentionally not
+    handled here — the process receives SIGTERM on logout/shutdown, which is
+    wired up separately. Uses jeepney (pure-Python D-Bus, no native deps).
+    """
+    try:
+        from jeepney import MatchRule
+        from jeepney.bus_messages import message_bus
+        from jeepney.io.blocking import open_dbus_connection
+    except ImportError:
+        logger.warning("jeepney not available — sleep/wake detection disabled on Linux")
+        return
+
+    def run_loop():
+        try:
+            conn = open_dbus_connection(bus="SYSTEM")
+        except Exception as e:
+            logger.warning("Could not connect to system D-Bus (%s) — sleep/wake disabled", e)
+            return
+
+        rule = MatchRule(
+            type="signal",
+            sender="org.freedesktop.login1",
+            interface="org.freedesktop.login1.Manager",
+            member="PrepareForSleep",
+            path="/org/freedesktop/login1",
+        )
+        try:
+            conn.send_and_get_reply(message_bus.AddMatch(rule))
+        except Exception as e:
+            logger.warning("Failed to register logind match rule: %s", e)
+            conn.close()
+            return
+
+        logger.debug("Linux logind sleep/wake listener started")
+        try:
+            with conn.filter(rule) as queue:
+                while not _stop_event.is_set():
+                    try:
+                        msg = conn.recv_until_filtered(queue, timeout=1.0)
+                    except TimeoutError:
+                        continue
+                    try:
+                        going_to_sleep = bool(msg.body[0])
+                    except (IndexError, TypeError):
+                        continue
+                    if going_to_sleep:
+                        logger.info("System sleep detected (logind) — pausing")
+                        _safe_call(on_sleep)
+                    else:
+                        logger.info("System wake detected (logind) — resuming")
+                        _safe_call(on_wake)
+        except Exception:
+            logger.exception("Linux sleep/wake listener stopped unexpectedly")
+        finally:
+            conn.close()
+
+    thread = threading.Thread(target=run_loop, name="system-power-listener", daemon=True)
     thread.start()
 
 

--- a/src/ui/tray.py
+++ b/src/ui/tray.py
@@ -1,5 +1,10 @@
 """System tray icon and menu."""
 
+# Annotations are lazy (PEP 563) so the module imports cleanly on headless hosts
+# where pystray is unavailable (pystray=None) — type hints like `-> pystray.Menu`
+# must not be evaluated at definition time.
+from __future__ import annotations
+
 import logging
 import math
 import os

--- a/src/ui/tray.py
+++ b/src/ui/tray.py
@@ -156,12 +156,42 @@ class TrayModel:
         self.needs_permissions: bool = False
 
 
+# On Linux, pystray binds its backend at import time. Choose it explicitly:
+# AppIndicator (gives a proper status-menu) when the GTK/AppIndicator GObject
+# bindings are present, otherwise the pure-Xlib XOrg backend. Respect an
+# operator-provided PYSTRAY_BACKEND if already set.
+if sys.platform.startswith("linux") and not os.environ.get("PYSTRAY_BACKEND"):
+    try:
+        import gi  # noqa: F401
+
+        gi.require_version("Gtk", "3.0")
+        try:
+            gi.require_version("AyatanaAppIndicator3", "0.1")
+        except ValueError:
+            gi.require_version("AppIndicator3", "0.1")
+        os.environ["PYSTRAY_BACKEND"] = "appindicator"
+    except (ImportError, ValueError):
+        os.environ["PYSTRAY_BACKEND"] = "xorg"
+
 try:
     import pystray
     from pystray import MenuItem as Item
 except ImportError:
-    pystray = None
-    Item = None
+    # On Linux the chosen backend may fail to import even when its bindings
+    # looked present; retry once with the pure-Xlib XOrg backend before giving
+    # up. A failed `import pystray` is dropped from sys.modules, so re-importing
+    # re-runs pystray's backend selection against the new env var.
+    if sys.platform.startswith("linux") and os.environ.get("PYSTRAY_BACKEND") != "xorg":
+        os.environ["PYSTRAY_BACKEND"] = "xorg"
+        try:
+            import pystray
+            from pystray import MenuItem as Item
+        except ImportError:
+            pystray = None
+            Item = None
+    else:
+        pystray = None
+        Item = None
 
 logger = logging.getLogger(__name__)
 

--- a/src/ui/tray.py
+++ b/src/ui/tray.py
@@ -176,22 +176,24 @@ if sys.platform.startswith("linux") and not os.environ.get("PYSTRAY_BACKEND"):
 try:
     import pystray
     from pystray import MenuItem as Item
-except ImportError:
-    # On Linux the chosen backend may fail to import even when its bindings
-    # looked present; retry once with the pure-Xlib XOrg backend before giving
-    # up. A failed `import pystray` is dropped from sys.modules, so re-importing
-    # re-runs pystray's backend selection against the new env var.
+except Exception:
+    # A backend can fail to bind for reasons beyond ImportError — on a headless
+    # box GTK fails to initialise (AppIndicator) or Xlib finds no display
+    # (XOrg). Any failure here just means "no usable tray backend"; the app
+    # already treats pystray=None as run-without-tray (e.g. headless servers,
+    # CI). Try the pure-Xlib XOrg backend once — a failed import is dropped from
+    # sys.modules, so re-importing re-runs pystray's backend selection — then
+    # degrade gracefully.
+    pystray = None
+    Item = None
     if sys.platform.startswith("linux") and os.environ.get("PYSTRAY_BACKEND") != "xorg":
         os.environ["PYSTRAY_BACKEND"] = "xorg"
         try:
             import pystray
             from pystray import MenuItem as Item
-        except ImportError:
+        except Exception:
             pystray = None
             Item = None
-    else:
-        pystray = None
-        Item = None
 
 logger = logging.getLogger(__name__)
 

--- a/src/update_checker.py
+++ b/src/update_checker.py
@@ -47,6 +47,7 @@ def _matches_channel(release: dict, channel: str) -> bool:
 _ASSET_PATTERNS = {
     "Darwin": "BetterFlow-macOS",
     "Windows": "BetterFlow-Windows",
+    "Linux": "BetterFlow-linux",
 }
 
 
@@ -59,6 +60,7 @@ def _find_platform_asset(
 
     On macOS: prefers architecture-specific DMG (arm64/x86_64), falls back to ZIP.
     On Windows: matches ZIP assets.
+    On Linux: matches the .AppImage asset.
 
     Args:
         release: GitHub release dict with "assets" list.
@@ -72,6 +74,14 @@ def _find_platform_asset(
         return None
 
     assets = release.get("assets", [])
+    if system == "Linux":
+        for asset in assets:
+            name = asset.get("name", "")
+            url = asset.get("browser_download_url")
+            if pattern in name and name.endswith(".AppImage") and url:
+                return url
+        return None
+
     if system == "Darwin":
         # Prefer arch-specific DMG
         for asset in assets:

--- a/tests/test_linux_support.py
+++ b/tests/test_linux_support.py
@@ -1,0 +1,172 @@
+"""Tests for the Linux platform branches added for the AppImage build.
+
+These run on any host (they patch platform/sys), so they execute as part of
+the normal macOS/CI suite without needing a Linux machine.
+"""
+
+import importlib.util
+import os
+import pathlib
+from unittest.mock import MagicMock, patch
+
+import src.autostart as autostart
+import src.aw_manager as awm
+import src.notifications as notifications_module
+import src.self_updater as self_updater
+from src.notifications import send_notification
+from src.update_checker import _ASSET_PATTERNS, _find_platform_asset
+
+# ---------------------------------------------------------------------------
+# update_checker: Linux .AppImage asset selection
+# ---------------------------------------------------------------------------
+
+class TestUpdateCheckerLinux:
+    def test_linux_pattern_registered(self):
+        assert _ASSET_PATTERNS["Linux"] == "BetterFlow-linux"
+
+    def test_finds_appimage_asset(self):
+        release = {
+            "assets": [
+                {"name": "BetterFlow-macOS-arm64.dmg", "browser_download_url": "https://x/m.dmg"},
+                {"name": "BetterFlow-Windows.zip", "browser_download_url": "https://x/w.zip"},
+                {"name": "BetterFlow-linux-x86_64.AppImage", "browser_download_url": "https://x/l.AppImage"},
+            ]
+        }
+        assert _find_platform_asset(release, system="Linux") == "https://x/l.AppImage"
+
+    def test_returns_none_when_no_appimage(self):
+        release = {"assets": [{"name": "BetterFlow-Windows.zip", "browser_download_url": "https://x/w.zip"}]}
+        assert _find_platform_asset(release, system="Linux") is None
+
+
+# ---------------------------------------------------------------------------
+# aw_manager / download_aw: Linux platform key, asset, paths
+# ---------------------------------------------------------------------------
+
+class TestAwManagerLinux:
+    def test_release_asset_present(self):
+        assert "linux" in awm.RELEASE_ASSETS
+        assert awm.RELEASE_ASSETS["linux"].endswith("-linux-x86_64.zip")
+
+    def test_platform_key(self, monkeypatch):
+        monkeypatch.setattr(awm.platform, "system", lambda: "Linux")
+        assert awm._get_platform_key() == "linux"
+
+    def test_install_and_db_dirs_use_xdg(self, monkeypatch, tmp_path):
+        monkeypatch.setattr(awm.platform, "system", lambda: "Linux")
+        monkeypatch.setattr(awm, "user_data_dir", lambda *a, **k: str(tmp_path / "BetterFlow"))
+
+        install_dir = awm._get_install_dir()
+        db_dir = awm._get_db_dir()
+
+        assert install_dir.endswith(os.path.join("trackers", "linux"))
+        assert str(tmp_path) in install_dir
+        assert db_dir.endswith(os.path.join("data", "aw-db.sqlite"))
+        assert str(tmp_path) in db_dir
+
+
+def _load_download_aw():
+    path = pathlib.Path(__file__).resolve().parent.parent / "scripts" / "download_aw.py"
+    spec = importlib.util.spec_from_file_location("download_aw", path)
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+class TestDownloadAwScriptLinux:
+    def test_release_asset_present(self):
+        download_aw = _load_download_aw()
+        assert "linux" in download_aw.RELEASE_ASSETS
+
+    def test_get_platform_linux(self, monkeypatch):
+        download_aw = _load_download_aw()
+        monkeypatch.setattr(download_aw.platform, "system", lambda: "Linux")
+        assert download_aw.get_platform() == "linux"
+
+
+# ---------------------------------------------------------------------------
+# autostart: XDG .desktop entry
+# ---------------------------------------------------------------------------
+
+class TestAutostartLinux:
+    def test_write_and_remove(self, monkeypatch, tmp_path):
+        monkeypatch.setattr(autostart.platform, "system", lambda: "Linux")
+        monkeypatch.setenv("XDG_CONFIG_HOME", str(tmp_path))
+        monkeypatch.setenv("APPIMAGE", "/home/u/Apps/BetterFlow.AppImage")
+        monkeypatch.setattr(autostart.sys, "frozen", True, raising=False)
+
+        assert autostart.set_auto_start(True) is True
+        entry = tmp_path / "autostart" / "co.betterqa.betterflow.desktop"
+        assert entry.exists()
+        content = entry.read_text()
+        assert "Exec=/home/u/Apps/BetterFlow.AppImage" in content
+        assert "X-GNOME-Autostart-enabled=true" in content
+        assert autostart.get_auto_start() is True
+
+        assert autostart.set_auto_start(False) is True
+        assert not entry.exists()
+        assert autostart.get_auto_start() is False
+
+    def test_quotes_exec_path_with_spaces(self, monkeypatch, tmp_path):
+        monkeypatch.setattr(autostart.platform, "system", lambda: "Linux")
+        monkeypatch.setenv("XDG_CONFIG_HOME", str(tmp_path))
+        monkeypatch.setenv("APPIMAGE", "/home/u/My Apps/BetterFlow.AppImage")
+        monkeypatch.setattr(autostart.sys, "frozen", True, raising=False)
+
+        assert autostart.set_auto_start(True) is True
+        content = (tmp_path / "autostart" / "co.betterqa.betterflow.desktop").read_text()
+        assert 'Exec="/home/u/My Apps/BetterFlow.AppImage"' in content
+
+    def test_dev_mode_refused(self, monkeypatch, tmp_path):
+        monkeypatch.setattr(autostart.platform, "system", lambda: "Linux")
+        monkeypatch.setenv("XDG_CONFIG_HOME", str(tmp_path))
+        monkeypatch.setattr(autostart.sys, "frozen", False, raising=False)
+        assert autostart.set_auto_start(True) is False
+
+
+# ---------------------------------------------------------------------------
+# notifications: notify-send dispatch
+# ---------------------------------------------------------------------------
+
+class TestNotificationsLinux:
+    def test_dispatch_calls_notify_send(self, monkeypatch):
+        monkeypatch.setattr(notifications_module.platform, "system", lambda: "Linux")
+        with patch("src.notifications.subprocess.run") as mock_run, patch(
+            "src.notifications._resolve_icon_path", return_value=None
+        ):
+            mock_run.return_value = MagicMock(returncode=0)
+            send_notification("Title", "Body")
+
+        mock_run.assert_called_once()
+        args = mock_run.call_args[0][0]
+        assert args[0] == "notify-send"
+        assert "Title" in args
+        assert "Body" in args
+
+    def test_missing_notify_send_is_silent(self, monkeypatch):
+        monkeypatch.setattr(notifications_module.platform, "system", lambda: "Linux")
+        with patch("src.notifications.subprocess.run", side_effect=FileNotFoundError), patch(
+            "src.notifications._resolve_icon_path", return_value=None
+        ):
+            # Should not raise.
+            send_notification("Title", "Body")
+
+
+# ---------------------------------------------------------------------------
+# self_updater: AppImage path resolution
+# ---------------------------------------------------------------------------
+
+class TestSelfUpdaterLinux:
+    def test_app_bundle_path_from_appimage_env(self, monkeypatch, tmp_path):
+        # Use a real file so .resolve() is stable across hosts (macOS firmlinks
+        # rewrite non-existent /home paths, which is irrelevant on Linux).
+        appimage = tmp_path / "BetterFlow.AppImage"
+        appimage.write_text("")
+        monkeypatch.setattr(self_updater.sys, "platform", "linux")
+        monkeypatch.setenv("APPIMAGE", str(appimage))
+        assert self_updater._get_app_bundle_path() == appimage.resolve()
+
+    def test_app_bundle_path_none_without_appimage(self, monkeypatch):
+        monkeypatch.setattr(self_updater.sys, "platform", "linux")
+        monkeypatch.delenv("APPIMAGE", raising=False)
+        assert self_updater._get_app_bundle_path() is None

--- a/tests/test_notifications.py
+++ b/tests/test_notifications.py
@@ -73,9 +73,10 @@ class TestSendNotification:
         args = mock_run.call_args
         assert args[0][0][0] == "powershell"
 
-    @patch("src.notifications.platform.system", return_value="Linux")
+    @patch("src.notifications.platform.system", return_value="FreeBSD")
     @patch("src.notifications.subprocess.run")
     def test_unsupported_platform_no_error(self, mock_run, _mock_sys):
+        # macOS/Windows/Linux are all supported; anything else is a silent no-op.
         send_notification("Title", "Body")
         mock_run.assert_not_called()
 


### PR DESCRIPTION
Adds a Linux build distributed as a single **AppImage** (X11; Wayland via XWayland). Architecturally mirrors the Windows path — external bundled ActivityWatch trackers, no in-process watchers, no permissions model.

## What's included
- **AW trackers** (`aw_manager.py`/`download_aw.py`): `linux` platform key, AW linux asset, XDG paths, chmod-only perms.
- **Notifications**: `notify-send` (libnotify).
- **Autostart**: `~/.config/autostart/co.betterqa.betterflow.desktop`.
- **Sleep/wake**: systemd-logind `PrepareForSleep` via pure-Python `jeepney`.
- **Tray**: pystray AppIndicator backend with automatic XOrg fallback.
- **Auto-update (all platforms)**: in-place `.AppImage` replace via `$APPIMAGE`; Linux asset matching in `update_checker`.
- **Build/CI**: `build.spec` Linux one-dir branch + `scripts/build-appimage.sh`; new `ubuntu-latest` CI job builds and publishes the AppImage.
- **Tests**: `tests/test_linux_support.py` (15 platform-overridden tests). Full suite green (316).

Version bumped to **1.5.22**.

## Notes / risk
- The **PyGObject/AppIndicator bundling under PyInstaller** is the area most likely to need CI iteration; the XOrg backend is the runtime fallback.
- macOS auto-update remains gated on signing (`_verify_codesign`) — unchanged here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)