### PR TITLE
fix(macos): surface error when Input Monitoring is off + gate setup on permissions

### DIFF
--- a/src/__init__.py
+++ b/src/__init__.py
@@ -1,4 +1,4 @@
 """BetterFlow - ActivityWatch to BetterFlow sync companion app."""
 
-__version__ = "1.5.24"
+__version__ = "1.5.25"
 __author__ = "BetterQA"

--- a/src/__init__.py
+++ b/src/__init__.py
@@ -1,4 +1,4 @@
 """BetterFlow - ActivityWatch to BetterFlow sync companion app."""
 
-__version__ = "1.5.23"
+__version__ = "1.5.24"
 __author__ = "BetterQA"

--- a/src/main.py
+++ b/src/main.py
@@ -144,6 +144,16 @@ class SyncCoordinator:
         # Optional callback wired by the app for auth-error re-login
         self._on_auth_error: Optional[Callable] = None
 
+        # macOS permission-warning throttle. Input Monitoring can be revoked
+        # silently (e.g. a new build changes the code signature and macOS drops
+        # the TCC grant), which leaves us collecting window time but no
+        # keystrokes/clicks — server-side that looks like a jiggler and flags
+        # the day as suspicious. We surface a notification, throttled to one per
+        # state-change plus a periodic re-warn so it can't spam the user.
+        self._perm_lock = threading.Lock()
+        self._input_tracking_ok: Optional[bool] = None  # None = not yet checked
+        self._last_perm_warn_at: Optional[datetime] = None
+
     @property
     def logged_in(self) -> bool:
         with self._state_lock:
@@ -225,9 +235,16 @@ class SyncCoordinator:
             id="startup_trends",
             replace_existing=True,
         )
-        # Permissions check removed — macOS AXIsProcessTrusted() is unreliable
-        # after rebuilds (returns False even when toggle is ON in System Settings).
-        # Watchers handle missing permissions gracefully on their own.
+        # Surface a missing-permission warning soon after launch. Delayed a few
+        # seconds so the in-process watchers have attempted their own start and
+        # any TCC grant has settled. The 60s tick re-checks thereafter, so the
+        # warning clears automatically once the user toggles the permission on.
+        self.scheduler.add_job(
+            self._check_permissions,
+            trigger=DateTrigger(run_date=now + timedelta(seconds=8)),
+            id="startup_permissions",
+            replace_existing=True,
+        )
 
     def stop(self) -> None:
         """Shut down the scheduler if running."""
@@ -283,11 +300,33 @@ class SyncCoordinator:
         """Check if a sync is currently running (non-blocking)."""
         return self._sync_lock.locked()
 
+    # Re-warn about disabled input tracking at most this often while it stays off.
+    _PERM_REWARN_INTERVAL = timedelta(hours=4)
+
     def _check_permissions(self) -> None:
-        """Check macOS tracking permissions and update tray state."""
+        """Check macOS tracking permissions and surface a visible warning.
+
+        Two grants matter on macOS:
+        - Accessibility: window titles (app names still work without it).
+        - Input Monitoring: keystroke/click capture. Without it we collect
+          active time but zero input, which the server reads as a jiggler and
+          flags the day as suspicious — so this is a hard, user-visible error
+          rather than a silent degradation.
+
+        No-op on non-macOS, where both checks return True.
+        """
         try:
             has_accessibility = check_accessibility()
-            granted = has_accessibility
+            has_input = check_input_monitoring()
+            granted = has_accessibility and has_input
+
+            if not has_input:
+                status = "Input tracking OFF — Fix Permissions"
+            elif not has_accessibility:
+                status = "Limited tracking — Fix Permissions"
+            else:
+                status = None
+
             high_priority = (
                 TrayState.PAUSED, TrayState.PRIVATE, TrayState.ON_BREAK,
                 TrayState.ERROR, TrayState.QUEUE_WARNING, TrayState.QUEUED,
@@ -295,14 +334,14 @@ class SyncCoordinator:
             )
             with self.tray.model.lock:
                 previous_needs_permissions = self.tray.model.needs_permissions
-                previous_hours_today = self.tray.model.hours_today
+                previous_input_ok = self.tray.model.input_monitoring_ok
                 self.tray.model.needs_permissions = not granted
+                self.tray.model.input_monitoring_ok = has_input
                 current_state = self.tray.model.state
                 if not granted:
-                    self.tray.model.hours_today = "---"
                     if current_state not in high_priority:
                         self.tray.model.state = TrayState.NEEDS_PERMISSIONS
-                        self.tray.model.status_text = "Limited Tracking"
+                        self.tray.model.status_text = status
                         should_update_icon = True
                     else:
                         should_update_icon = False
@@ -314,18 +353,50 @@ class SyncCoordinator:
                         should_update_icon = False
                 should_update_menu = (
                     previous_needs_permissions != self.tray.model.needs_permissions
-                    or previous_hours_today != self.tray.model.hours_today
+                    or previous_input_ok != self.tray.model.input_monitoring_ok
                 )
             if should_update_icon:
                 self.tray._update_icon()
             if should_update_icon or should_update_menu:
                 self.tray._update_menu()
-            if not granted:
-                logger.debug("macOS Accessibility permission missing")
-            elif should_update_icon:
+
+            self._maybe_warn_input_tracking(has_input)
+
+            if granted and should_update_icon:
                 logger.info("macOS permissions granted — clearing warning")
         except Exception as e:
-            logger.debug(f"Permissions check failed: {e}")
+            logger.warning("Permissions check failed: %s", e)
+
+    def _maybe_warn_input_tracking(self, has_input: bool) -> None:
+        """Notify the user when keystroke/click capture is disabled.
+
+        Throttled to one notification per OFF transition, then re-warned every
+        _PERM_REWARN_INTERVAL while it remains off so a long session can't hide
+        the problem.
+        """
+        now = datetime.now(timezone.utc)
+        with self._perm_lock:
+            self._input_tracking_ok = has_input
+            if has_input:
+                self._last_perm_warn_at = None
+                return
+            recently_warned = (
+                self._last_perm_warn_at is not None
+                and (now - self._last_perm_warn_at) < self._PERM_REWARN_INTERVAL
+            )
+            if recently_warned:
+                return
+            self._last_perm_warn_at = now
+
+        logger.warning(
+            "Input Monitoring permission missing — keystroke/click capture disabled"
+        )
+        send_notification(
+            "Input tracking is off",
+            "BetterFlow can't record keystrokes or clicks, so your hours may be "
+            "flagged as suspicious. Click the BetterFlow menu bar icon → "
+            "Fix Permissions to turn on Input Monitoring.",
+        )
 
     def _tick_60s(self) -> None:
         """Unified 60-second tick - one wakeup instead of five.
@@ -337,6 +408,7 @@ class SyncCoordinator:
         self.tray.tick_clock()
         self._check_idle_status()
         self._refresh_hours_today()
+        self._check_permissions()
         if self.reminder_manager:
             self.reminder_manager.check()
 

--- a/src/main.py
+++ b/src/main.py
@@ -3,6 +3,7 @@
 import logging
 import os
 import signal
+import subprocess
 import sys
 import threading
 import time
@@ -865,6 +866,18 @@ class BetterFlowApp:
             if result.logged_in and result.login_state:
                 wizard_login_state = result.login_state
 
+        # macOS tracking permissions are a hard precondition. Unlike the
+        # first-run wizard, this gate runs on EVERY launch and keeps showing
+        # until both Accessibility and Input Monitoring are granted — if the
+        # user revoked them, or a new build's signature dropped them, they get
+        # the gate again rather than silently-degraded tracking.
+        #
+        # macOS only exposes a freshly-granted Input Monitoring permission to a
+        # newly-launched process, so the gate relaunches the app to re-check
+        # rather than polling in place (which can never see the new grant).
+        if not self._ensure_macos_permissions():
+            return
+
         self._set_startup_status("Starting...")
         self._startup_thread = threading.Thread(
             target=self._background_startup,
@@ -879,6 +892,61 @@ class BetterFlowApp:
             self.tray.run_blocking()
         finally:
             self._shutdown()
+
+    def _ensure_macos_permissions(self) -> bool:
+        """Block on the permission gate until tracking permissions are granted.
+
+        Returns True to continue startup, False if the app should exit. On
+        non-macOS platforms this is always True (no such permissions).
+
+        Shows the gate window when Accessibility or Input Monitoring is missing.
+        The gate returns 'granted' (proceed), 'restart' (relaunch so a new
+        grant takes effect, then re-check) or 'quit' (user closed it — the app
+        must not run without approval).
+        """
+        if sys.platform != "darwin":
+            return True
+        try:
+            from .ui.permissions import check_accessibility, check_input_monitoring
+            from .ui.setup_wizard import run_permission_gate
+        except ImportError:
+            from ui.permissions import check_accessibility, check_input_monitoring  # type: ignore[no-redef]
+            from ui.setup_wizard import run_permission_gate  # type: ignore[no-redef]
+
+        if check_accessibility() and check_input_monitoring():
+            return True
+
+        result = run_permission_gate(self.config)
+        if result == "granted":
+            return True
+        if result == "restart":
+            logger.info("Relaunching to apply newly granted permissions")
+            self._relaunch()
+            return False
+        logger.info("Tracking permissions not granted — exiting")
+        return False
+
+    def _relaunch(self) -> None:
+        """Relaunch the app so a freshly granted macOS permission is picked up.
+
+        Never returns — the process exits after spawning its replacement.
+        """
+        try:
+            if getattr(sys, "frozen", False):
+                # .../BetterFlow.app/Contents/MacOS/BetterFlow -> the .app bundle
+                exe = Path(sys.executable)
+                bundle = exe.parents[2] if len(exe.parents) >= 3 else None
+                if bundle is not None and bundle.suffix == ".app":
+                    subprocess.Popen(["open", str(bundle)])
+                else:
+                    subprocess.Popen([str(exe)])
+            else:
+                # Dev mode: re-exec the same interpreter + args.
+                os.execv(sys.executable, [sys.executable, *sys.argv])
+                return
+        except Exception:
+            logger.exception("Relaunch failed")
+        os._exit(0)
 
     # -- Event handlers ---------------------------------------------------
 

--- a/src/main.py
+++ b/src/main.py
@@ -31,6 +31,7 @@ try:
         check_accessibility,
         check_input_monitoring,
         grant_tcc_permissions,
+        input_monitoring_active,
     )
     from .ui.tray import TrayIcon, TrayState
     from .update_checker import check_for_update
@@ -53,6 +54,7 @@ except ImportError:
         check_accessibility,
         check_input_monitoring,
         grant_tcc_permissions,
+        input_monitoring_active,
     )
     from ui.tray import TrayIcon, TrayState
     from update_checker import check_for_update
@@ -305,28 +307,19 @@ class SyncCoordinator:
     _PERM_REWARN_INTERVAL = timedelta(hours=4)
 
     def _check_permissions(self) -> None:
-        """Check macOS tracking permissions and surface a visible warning.
+        """Surface a visible warning when Input Monitoring is off.
 
-        Two grants matter on macOS:
-        - Accessibility: window titles (app names still work without it).
-        - Input Monitoring: keystroke/click capture. Without it we collect
-          active time but zero input, which the server reads as a jiggler and
-          flags the day as suspicious — so this is a hard, user-visible error
-          rather than a silent degradation.
+        Input Monitoring is the only tracking permission BetterFlow requires —
+        without it we collect active time but zero keystrokes/clicks, which the
+        server reads as a jiggler and flags the day as suspicious. App names and
+        durations come from NSWorkspace and don't need Accessibility.
 
-        No-op on non-macOS, where both checks return True.
+        No-op on non-macOS, where the check returns True.
         """
         try:
-            has_accessibility = check_accessibility()
-            has_input = check_input_monitoring()
-            granted = has_accessibility and has_input
-
-            if not has_input:
-                status = "Input tracking OFF — Fix Permissions"
-            elif not has_accessibility:
-                status = "Limited tracking — Fix Permissions"
-            else:
-                status = None
+            has_input = input_monitoring_active()
+            granted = has_input
+            status = None if has_input else "Input tracking OFF — Fix Permissions"
 
             high_priority = (
                 TrayState.PAUSED, TrayState.PRIVATE, TrayState.ON_BREAK,
@@ -866,11 +859,11 @@ class BetterFlowApp:
             if result.logged_in and result.login_state:
                 wizard_login_state = result.login_state
 
-        # macOS tracking permissions are a hard precondition. Unlike the
-        # first-run wizard, this gate runs on EVERY launch and keeps showing
-        # until both Accessibility and Input Monitoring are granted — if the
-        # user revoked them, or a new build's signature dropped them, they get
-        # the gate again rather than silently-degraded tracking.
+        # macOS Input Monitoring is a hard precondition. Unlike the first-run
+        # wizard, this gate runs on EVERY launch and keeps showing until the
+        # grant is present — if the user revoked it, or a new build's signature
+        # dropped it, they get the gate again rather than silently-degraded
+        # tracking (active time with no input, which the server flags).
         #
         # macOS only exposes a freshly-granted Input Monitoring permission to a
         # newly-launched process, so the gate relaunches the app to re-check
@@ -894,26 +887,26 @@ class BetterFlowApp:
             self._shutdown()
 
     def _ensure_macos_permissions(self) -> bool:
-        """Block on the permission gate until tracking permissions are granted.
+        """Block on the permission gate until Input Monitoring is granted.
 
         Returns True to continue startup, False if the app should exit. On
-        non-macOS platforms this is always True (no such permissions).
+        non-macOS platforms this is always True (no such permission).
 
-        Shows the gate window when Accessibility or Input Monitoring is missing.
-        The gate returns 'granted' (proceed), 'restart' (relaunch so a new
-        grant takes effect, then re-check) or 'quit' (user closed it — the app
-        must not run without approval).
+        Input Monitoring is the single required grant. The gate returns
+        'granted' (proceed), 'restart' (relaunch so a freshly-toggled grant
+        takes effect, then re-check) or 'quit' (user closed it — the app must
+        not run without approval).
         """
         if sys.platform != "darwin":
             return True
         try:
-            from .ui.permissions import check_accessibility, check_input_monitoring
+            from .ui.permissions import input_monitoring_active
             from .ui.setup_wizard import run_permission_gate
         except ImportError:
-            from ui.permissions import check_accessibility, check_input_monitoring  # type: ignore[no-redef]
+            from ui.permissions import input_monitoring_active  # type: ignore[no-redef]
             from ui.setup_wizard import run_permission_gate  # type: ignore[no-redef]
 
-        if check_accessibility() and check_input_monitoring():
+        if input_monitoring_active():
             return True
 
         result = run_permission_gate(self.config)

--- a/src/ui/permissions.py
+++ b/src/ui/permissions.py
@@ -114,6 +114,93 @@ def check_input_monitoring(prompt: bool = False) -> bool:
     return False
 
 
+def _probe_listen_event_tap() -> bool:
+    """Create a throwaway listen-only CGEventTap.
+
+    Doing so is the canonical way to (1) make the app appear in System Settings
+    > Privacy & Security > Input Monitoring — without this the app is never
+    listed and the user has no toggle to flip — and (2) authoritatively detect
+    the grant: CGEventTapCreate only returns a tap when access is granted.
+
+    Returns True if the tap was created (access granted), else False.
+    """
+    try:
+        from Quartz import (
+            CGEventTapCreate,
+            kCGEventTapOptionListenOnly,
+            kCGHeadInsertEventTap,
+            kCGSessionEventTap,
+        )
+    except Exception as e:
+        logger.debug("Quartz event-tap import failed: %s", e)
+        return False
+
+    def _noop(proxy, event_type, event, refcon):
+        return event
+
+    tap = None
+    try:
+        # kCGEventKeyDown == 10. A minimal mask is enough to trigger the grant
+        # check and register the app in the Input Monitoring list.
+        tap = CGEventTapCreate(
+            kCGSessionEventTap,
+            kCGHeadInsertEventTap,
+            kCGEventTapOptionListenOnly,
+            (1 << 10),
+            _noop,
+            None,
+        )
+        return tap is not None
+    except Exception as e:
+        logger.debug("CGEventTapCreate probe failed: %s", e)
+        return False
+    finally:
+        # We never run this tap — tear it down so it doesn't leak.
+        if tap is not None:
+            try:
+                from CoreFoundation import CFMachPortInvalidate, CFRelease
+
+                CFMachPortInvalidate(tap)
+                CFRelease(tap)
+            except Exception as e:
+                logger.debug("event-tap probe cleanup failed: %s", e)
+
+
+def input_monitoring_active(prompt: bool = False) -> bool:
+    """Authoritative Input Monitoring check that also registers the app.
+
+    Fast path: CGPreflightListenEventAccess. If that reports False (it returns
+    false negatives for some signatures and never lists the app), fall back to
+    actually creating a listen-only event tap, which both registers the app in
+    System Settings and tells us the true grant state.
+
+    Args:
+        prompt: When True, surface the native dialog the first time.
+
+    Returns True on non-macOS platforms.
+    """
+    if not _IS_MACOS:
+        return True
+
+    try:
+        from Quartz import CGPreflightListenEventAccess
+
+        if CGPreflightListenEventAccess():
+            return True
+    except Exception as e:
+        logger.debug("CGPreflightListenEventAccess failed: %s", e)
+
+    if prompt:
+        try:
+            from Quartz import CGRequestListenEventAccess
+
+            CGRequestListenEventAccess()
+        except Exception as e:
+            logger.debug("CGRequestListenEventAccess failed: %s", e)
+
+    return _probe_listen_event_tap()
+
+
 def prompt_accessibility() -> bool:
     """Show the native Accessibility prompt and register the app in the list.
 

--- a/src/ui/permissions.py
+++ b/src/ui/permissions.py
@@ -114,6 +114,33 @@ def check_input_monitoring(prompt: bool = False) -> bool:
     return False
 
 
+def prompt_accessibility() -> bool:
+    """Show the native Accessibility prompt and register the app in the list.
+
+    AXIsProcessTrustedWithOptions({prompt: True}) both reports the current
+    trust state and, when untrusted, surfaces Apple's dialog and adds the app
+    to System Settings > Privacy & Security > Accessibility so the user can
+    toggle it. Falls back to the plain check on any binding error.
+
+    Returns True on non-macOS platforms.
+    """
+    if not _IS_MACOS:
+        return True
+
+    try:
+        from ApplicationServices import (
+            AXIsProcessTrustedWithOptions,
+            kAXTrustedCheckOptionPrompt,
+        )
+
+        return bool(
+            AXIsProcessTrustedWithOptions({kAXTrustedCheckOptionPrompt: True})
+        )
+    except Exception as e:
+        logger.debug("Accessibility prompt failed, falling back to check: %s", e)
+        return check_accessibility()
+
+
 def open_accessibility_settings() -> None:
     """Open System Settings to Accessibility pane."""
     if not _IS_MACOS:

--- a/src/ui/setup_wizard.py
+++ b/src/ui/setup_wizard.py
@@ -511,70 +511,62 @@ class SetupWizard:
     # ── Permissions Gate (macOS) ─────────────────────────────────────
 
     def _request_permissions_once(self) -> None:
-        """Fire the native prompts a single time on first entry.
+        """Register the app and show the native prompt once on first entry.
 
-        Only prompts for permissions that are actually missing — prompting for
-        an already-granted one pops a needless dialog and, for Accessibility,
-        opens the wrong System Settings pane (which made users think they'd
-        granted Input Monitoring when they hadn't).
+        input_monitoring_active(prompt=True) creates a listen-only event tap,
+        which is what makes BetterFlow appear in System Settings > Input
+        Monitoring — without it the app is never listed and there's no toggle
+        to flip.
         """
         if getattr(self, "_perm_prompted", False):
             return
         self._perm_prompted = True
         try:
-            from ..ui.permissions import (
-                check_accessibility,
-                check_input_monitoring,
-                prompt_accessibility,
-            )
+            from ..ui.permissions import input_monitoring_active
         except ImportError:
-            from ui.permissions import (
-                check_accessibility,
-                check_input_monitoring,
-                prompt_accessibility,
-            )
+            from ui.permissions import input_monitoring_active
         try:
-            if not check_accessibility():
-                prompt_accessibility()
-            if not check_input_monitoring():
-                check_input_monitoring(prompt=True)
+            input_monitoring_active(prompt=True)
         except Exception:
-            logger.exception("Permission prompt failed during setup")
+            logger.exception("Input Monitoring prompt failed during setup")
 
     def _render_permissions(self) -> None:
-        """Draw the permissions scene and re-poll until both are granted."""
+        """Draw the single-permission gate and re-poll until granted.
+
+        Only Input Monitoring is required — app names and durations come from
+        NSWorkspace without Accessibility, so we don't make the user grant two
+        permissions. The check also registers the app in the Input Monitoring
+        list so there's a toggle to flip.
+        """
         if self._closing or not self._canvas.winfo_exists():
             return
         try:
-            from ..ui.permissions import check_accessibility, check_input_monitoring
+            from ..ui.permissions import input_monitoring_active
         except ImportError:
-            from ui.permissions import check_accessibility, check_input_monitoring
+            from ui.permissions import input_monitoring_active
 
-        has_accessibility = check_accessibility()
-        has_input = check_input_monitoring()
+        has_input = input_monitoring_active()
 
         cx = self._draw_scene(
-            title="Grant Permissions",
-            subtitle="Required so BetterFlow can track and protect your hours",
+            title="Grant Permission",
+            subtitle="One permission lets BetterFlow protect your hours",
         )
 
-        self._perm_row(cx, 236, "Accessibility", has_accessibility, "App & window names")
-        # Friendly label — the literal macOS pane is called "Input Monitoring",
-        # which reads as surveillance and scares users off. We name it for what
-        # it does and point to the system pane in the instruction line below.
+        # Friendly label — the literal macOS pane is "Input Monitoring", which
+        # reads as surveillance; the instruction line names the pane for findability.
         self._perm_row(
-            cx, 296, "Keyboard & Click Activity", has_input,
+            cx, 258, "Keyboard & Click Activity", has_input,
             "Counts keystrokes & clicks (no content) — prevents false fraud flags",
         )
 
-        if has_accessibility and has_input:
+        if has_input:
             self._canvas.create_text(
-                cx, 364,
+                cx, 332,
                 text="All set — you're ready to go.",
                 font=FONT_SMALL, fill=SUCCESS_COLOR, justify=tk.CENTER,
             )
             self._make_button(
-                "Continue", lambda: self._finish_gate("granted"), cx, 438, width=280
+                "Continue", lambda: self._finish_gate("granted"), cx, 430, width=280
             )
             return
 
@@ -582,23 +574,22 @@ class SetupWizard:
         # freshly-launched process, so the user must restart after enabling it —
         # we can't detect it live. Make Restart the primary action.
         self._canvas.create_text(
-            cx, 356,
-            text=("In System Settings, turn BetterFlow ON under both\n"
-                  "“Accessibility” and “Input Monitoring”, then Restart."),
+            cx, 330,
+            text=("In System Settings, turn BetterFlow ON under\n"
+                  "“Input Monitoring”, then click Restart."),
             font=FONT_SMALL, fill=TEXT_MUTED, justify=tk.CENTER,
         )
         self._make_button(
             "Open System Settings", self._open_permission_settings,
-            cx - 132, 440, width=236, primary=False,
+            cx - 132, 430, width=236, primary=False,
         )
         self._make_button(
             "Restart", lambda: self._finish_gate("restart"),
-            cx + 132, 440, width=196, primary=True,
+            cx + 132, 430, width=196, primary=True,
         )
 
-        # Keep polling so the Accessibility badge updates live (Input Monitoring
-        # won't flip until restart). _draw_scene -> _clear cancels this id before
-        # the next redraw, so there's no overlapping callback leak.
+        # Poll so the badge refreshes. _draw_scene -> _clear cancels this id
+        # before the next redraw, so there's no overlapping callback leak.
         self._spinner_after_id = self._window.after(1500, self._render_permissions)
 
     def _finish_gate(self, result: str) -> None:
@@ -640,29 +631,22 @@ class SetupWizard:
         self._canvas.create_text(x, y, text=text, font=FONT_BUTTON, fill="#6f6390")
 
     def _open_permission_settings(self) -> None:
-        """Open the System Settings pane for whichever grant is still missing."""
+        """Register the app (so it's listed) and open the Input Monitoring pane."""
         try:
             from ..ui.permissions import (
-                check_accessibility,
-                check_input_monitoring,
-                open_accessibility_settings,
+                input_monitoring_active,
                 open_input_monitoring_settings,
             )
         except ImportError:
             from ui.permissions import (
-                check_accessibility,
-                check_input_monitoring,
-                open_accessibility_settings,
+                input_monitoring_active,
                 open_input_monitoring_settings,
             )
         try:
-            if not check_input_monitoring():
-                check_input_monitoring(prompt=True)
-                open_input_monitoring_settings()
-            elif not check_accessibility():
-                open_accessibility_settings()
+            input_monitoring_active(prompt=True)
+            open_input_monitoring_settings()
         except Exception:
-            logger.exception("Failed to open permission settings during setup")
+            logger.exception("Failed to open Input Monitoring settings during setup")
 
     def _finish(self) -> None:
         """Complete and close the wizard only."""

--- a/src/ui/setup_wizard.py
+++ b/src/ui/setup_wizard.py
@@ -501,17 +501,33 @@ class SetupWizard:
         self._render_permissions()
 
     def _request_permissions_once(self) -> None:
-        """Fire the native prompts a single time on first entry."""
+        """Fire the native prompts a single time on first entry.
+
+        Only prompts for permissions that are actually missing — prompting for
+        an already-granted one pops a needless dialog and, for Accessibility,
+        opens the wrong System Settings pane (which made users think they'd
+        granted Input Monitoring when they hadn't).
+        """
         if getattr(self, "_perm_prompted", False):
             return
         self._perm_prompted = True
         try:
-            from ..ui.permissions import check_input_monitoring, prompt_accessibility
+            from ..ui.permissions import (
+                check_accessibility,
+                check_input_monitoring,
+                prompt_accessibility,
+            )
         except ImportError:
-            from ui.permissions import check_input_monitoring, prompt_accessibility
+            from ui.permissions import (
+                check_accessibility,
+                check_input_monitoring,
+                prompt_accessibility,
+            )
         try:
-            prompt_accessibility()
-            check_input_monitoring(prompt=True)
+            if not check_accessibility():
+                prompt_accessibility()
+            if not check_input_monitoring():
+                check_input_monitoring(prompt=True)
         except Exception:
             logger.exception("Permission prompt failed during setup")
 
@@ -533,9 +549,12 @@ class SetupWizard:
         )
 
         self._perm_row(cx, 236, "Accessibility", has_accessibility, "App & window names")
+        # Friendly label — the literal macOS pane is called "Input Monitoring",
+        # which reads as surveillance and scares users off. We name it for what
+        # it does and point to the system pane in the instruction line below.
         self._perm_row(
-            cx, 296, "Input Monitoring", has_input,
-            "Keystrokes & clicks — prevents false fraud flags",
+            cx, 296, "Keyboard & Click Activity", has_input,
+            "Counts keystrokes & clicks (no content) — prevents false fraud flags",
         )
 
         if has_accessibility and has_input:
@@ -549,8 +568,8 @@ class SetupWizard:
 
         self._canvas.create_text(
             cx, 360,
-            text=("Turn BetterFlow ON in System Settings.\n"
-                  "Both permissions are required to continue."),
+            text=("In System Settings, turn BetterFlow ON under both\n"
+                  "“Accessibility” and “Input Monitoring”. Both are required."),
             font=FONT_SMALL, fill=TEXT_MUTED, justify=tk.CENTER,
         )
         self._make_button(

--- a/src/ui/setup_wizard.py
+++ b/src/ui/setup_wizard.py
@@ -90,6 +90,7 @@ class SetupWizard:
         self._spinner_after_id: Optional[str] = None
         self._spinner_angle: int = 0
         self._button_id = itertools.count(1)
+        self._perm_prompted: bool = False
 
     def show(self) -> SetupResult:
         """Show the wizard and return result when closed."""
@@ -403,7 +404,7 @@ class SetupWizard:
             self._show_success(state.user_email or "")
         else:
             safe_error = (state.error or "Login failed")[:200]
-        self._show_error(safe_error)
+            self._show_error(safe_error)
 
     def _show_error(self, error: str) -> None:
         """Show error state with retry."""
@@ -477,8 +478,142 @@ class SetupWizard:
             justify=tk.CENTER,
         )
 
-        # Launch button — go to permissions screen next
-        self._make_button("Continue", self._finish, cx, 438, width=280)
+        # macOS requires explicit Accessibility + Input Monitoring grants
+        # before tracking works — gate setup on them. Other platforms have no
+        # such permissions, so finish directly.
+        next_step = self._show_permissions if platform.system() == "Darwin" else self._finish
+        self._make_button("Continue", next_step, cx, 438, width=280)
+
+    # ── Permissions Screen (macOS) ───────────────────────────────────
+
+    def _show_permissions(self) -> None:
+        """Gate completion on macOS tracking permissions.
+
+        Prompts for Accessibility + Input Monitoring (registering the app in
+        System Settings), then polls live status. 'Continue' only becomes
+        available once both are granted; closing the window without granting
+        leaves setup incomplete, so the app will not run until approved.
+        """
+        if platform.system() != "Darwin":
+            self._finish()
+            return
+        self._request_permissions_once()
+        self._render_permissions()
+
+    def _request_permissions_once(self) -> None:
+        """Fire the native prompts a single time on first entry."""
+        if getattr(self, "_perm_prompted", False):
+            return
+        self._perm_prompted = True
+        try:
+            from ..ui.permissions import check_input_monitoring, prompt_accessibility
+        except ImportError:
+            from ui.permissions import check_input_monitoring, prompt_accessibility
+        try:
+            prompt_accessibility()
+            check_input_monitoring(prompt=True)
+        except Exception:
+            logger.exception("Permission prompt failed during setup")
+
+    def _render_permissions(self) -> None:
+        """Draw the permissions scene and re-poll until both are granted."""
+        if self._closing or not self._canvas.winfo_exists():
+            return
+        try:
+            from ..ui.permissions import check_accessibility, check_input_monitoring
+        except ImportError:
+            from ui.permissions import check_accessibility, check_input_monitoring
+
+        has_accessibility = check_accessibility()
+        has_input = check_input_monitoring()
+
+        cx = self._draw_scene(
+            title="Grant Permissions",
+            subtitle="Required so BetterFlow can track and protect your hours",
+        )
+
+        self._perm_row(cx, 236, "Accessibility", has_accessibility, "App & window names")
+        self._perm_row(
+            cx, 296, "Input Monitoring", has_input,
+            "Keystrokes & clicks — prevents false fraud flags",
+        )
+
+        if has_accessibility and has_input:
+            self._canvas.create_text(
+                cx, 364,
+                text="All set — you're ready to go.",
+                font=FONT_SMALL, fill=SUCCESS_COLOR, justify=tk.CENTER,
+            )
+            self._make_button("Continue", self._finish, cx, 438, width=280)
+            return
+
+        self._canvas.create_text(
+            cx, 360,
+            text=("Turn BetterFlow ON in System Settings.\n"
+                  "Both permissions are required to continue."),
+            font=FONT_SMALL, fill=TEXT_MUTED, justify=tk.CENTER,
+        )
+        self._make_button(
+            "Open System Settings", self._open_permission_settings,
+            cx - 132, 438, width=236, primary=True,
+        )
+        self._draw_disabled_button(cx + 132, 438, "Waiting…", width=196)
+
+        # Poll until granted. _draw_scene -> _clear cancels this id before the
+        # next redraw, so there's no overlapping callback leak.
+        self._spinner_after_id = self._window.after(1500, self._render_permissions)
+
+    def _perm_row(self, cx: int, y: int, label: str, ok: bool, hint: str) -> None:
+        """Draw one permission status row with a ✓/✗ badge."""
+        color = SUCCESS_COLOR if ok else ERROR_COLOR
+        symbol = "✓" if ok else "✗"
+        left = cx - 210
+        self._canvas.create_oval(left, y - 14, left + 28, y + 14, fill=color, outline="")
+        self._canvas.create_text(
+            left + 14, y, text=symbol, font=(FONT_FAMILY, 15, "bold"), fill=BTN_TEXT
+        )
+        self._canvas.create_text(
+            left + 46, y - 9, text=label, font=(FONT_FAMILY, 13, "bold"),
+            fill=TEXT_COLOR, anchor="w",
+        )
+        self._canvas.create_text(
+            left + 46, y + 11, text=hint, font=FONT_SMALL, fill=TEXT_MUTED, anchor="w",
+        )
+
+    def _draw_disabled_button(self, x: int, y: int, text: str, width: int = 200) -> None:
+        """Draw a non-interactive, greyed-out button placeholder."""
+        x1, y1 = x - (width // 2), y - (BTN_HEIGHT // 2)
+        x2, y2 = x + (width // 2), y + (BTN_HEIGHT // 2)
+        self._create_rounded_rect(
+            x1, y1, x2, y2, radius=BTN_BORDER_RADIUS,
+            fill="#2a2342", outline="#3d2d6b", width=1,
+        )
+        self._canvas.create_text(x, y, text=text, font=FONT_BUTTON, fill="#6f6390")
+
+    def _open_permission_settings(self) -> None:
+        """Open the System Settings pane for whichever grant is still missing."""
+        try:
+            from ..ui.permissions import (
+                check_accessibility,
+                check_input_monitoring,
+                open_accessibility_settings,
+                open_input_monitoring_settings,
+            )
+        except ImportError:
+            from ui.permissions import (
+                check_accessibility,
+                check_input_monitoring,
+                open_accessibility_settings,
+                open_input_monitoring_settings,
+            )
+        try:
+            if not check_input_monitoring():
+                check_input_monitoring(prompt=True)
+                open_input_monitoring_settings()
+            elif not check_accessibility():
+                open_accessibility_settings()
+        except Exception:
+            logger.exception("Failed to open permission settings during setup")
 
     def _finish(self) -> None:
         """Complete and close the wizard only."""

--- a/src/ui/setup_wizard.py
+++ b/src/ui/setup_wizard.py
@@ -80,7 +80,7 @@ class SetupResult:
 class SetupWizard:
     """First-run setup wizard window."""
 
-    def __init__(self, config: Config, login_manager: LoginManager):
+    def __init__(self, config: Config, login_manager: Optional[LoginManager] = None):
         self._config = config
         self._login_manager = login_manager
         self._result = SetupResult()
@@ -91,11 +91,15 @@ class SetupWizard:
         self._spinner_angle: int = 0
         self._button_id = itertools.count(1)
         self._perm_prompted: bool = False
+        # Permission-gate mode: when True, the window shows only the permission
+        # screen and reports its outcome via _gate_result instead of SetupResult.
+        self._gate_only: bool = False
+        self._gate_result: str = "quit"
 
-    def show(self) -> SetupResult:
-        """Show the wizard and return result when closed."""
+    def _build_window(self, title: str = "BetterFlow") -> None:
+        """Create the Tk window + canvas, centered, with the close handler."""
         self._window = tk.Tk()
-        self._window.title("BetterFlow")
+        self._window.title(title)
         self._window.geometry(f"{WINDOW_WIDTH}x{WINDOW_HEIGHT}")
         self._window.resizable(False, False)
         self._window.configure(bg=BG_COLOR)
@@ -130,10 +134,26 @@ class SetupWizard:
         )
         self._canvas.pack(fill=tk.BOTH, expand=True)
 
+    def show(self) -> SetupResult:
+        """Show the wizard and return result when closed."""
+        self._build_window()
         self._show_welcome()
-
         self._window.mainloop()
         return self._result
+
+    def run_permission_gate(self) -> str:
+        """Show only the permission gate; block until resolved.
+
+        Returns 'granted' (both permissions present), 'restart' (the user asked
+        to relaunch so a new grant takes effect) or 'quit' (window closed).
+        """
+        self._gate_only = True
+        self._gate_result = "quit"
+        self._build_window(title="BetterFlow — Permissions")
+        self._request_permissions_once()
+        self._render_permissions()
+        self._window.mainloop()
+        return self._gate_result
 
     def _clear(self) -> None:
         """Clear all canvas items and widgets."""
@@ -152,8 +172,13 @@ class SetupWizard:
     def _on_close(self) -> None:
         """Handle window close — cancel any in-progress login."""
         self._closing = True
-        self._result = SetupResult(completed=False)
-        self._login_manager.cancel_login()
+        if self._gate_only:
+            # Closing the gate means permissions were not approved.
+            self._gate_result = "quit"
+        else:
+            self._result = SetupResult(completed=False)
+            if self._login_manager is not None:
+                self._login_manager.cancel_login()
         self._window.destroy()
 
     def _make_button(self, text: str, command: callable, x: int, y: int, width: int = 248, primary: bool = True) -> str:
@@ -478,27 +503,12 @@ class SetupWizard:
             justify=tk.CENTER,
         )
 
-        # macOS requires explicit Accessibility + Input Monitoring grants
-        # before tracking works — gate setup on them. Other platforms have no
-        # such permissions, so finish directly.
-        next_step = self._show_permissions if platform.system() == "Darwin" else self._finish
-        self._make_button("Continue", next_step, cx, 438, width=280)
+        # Login is done. macOS tracking permissions are enforced separately by
+        # the always-on permission gate (see SetupWizard.run_permission_gate),
+        # which runs after this wizard and on every subsequent launch.
+        self._make_button("Continue", self._finish, cx, 438, width=280)
 
-    # ── Permissions Screen (macOS) ───────────────────────────────────
-
-    def _show_permissions(self) -> None:
-        """Gate completion on macOS tracking permissions.
-
-        Prompts for Accessibility + Input Monitoring (registering the app in
-        System Settings), then polls live status. 'Continue' only becomes
-        available once both are granted; closing the window without granting
-        leaves setup incomplete, so the app will not run until approved.
-        """
-        if platform.system() != "Darwin":
-            self._finish()
-            return
-        self._request_permissions_once()
-        self._render_permissions()
+    # ── Permissions Gate (macOS) ─────────────────────────────────────
 
     def _request_permissions_once(self) -> None:
         """Fire the native prompts a single time on first entry.
@@ -563,24 +573,44 @@ class SetupWizard:
                 text="All set — you're ready to go.",
                 font=FONT_SMALL, fill=SUCCESS_COLOR, justify=tk.CENTER,
             )
-            self._make_button("Continue", self._finish, cx, 438, width=280)
+            self._make_button(
+                "Continue", lambda: self._finish_gate("granted"), cx, 438, width=280
+            )
             return
 
+        # macOS only reveals a newly-granted Input Monitoring permission to a
+        # freshly-launched process, so the user must restart after enabling it —
+        # we can't detect it live. Make Restart the primary action.
         self._canvas.create_text(
-            cx, 360,
+            cx, 356,
             text=("In System Settings, turn BetterFlow ON under both\n"
-                  "“Accessibility” and “Input Monitoring”. Both are required."),
+                  "“Accessibility” and “Input Monitoring”, then Restart."),
             font=FONT_SMALL, fill=TEXT_MUTED, justify=tk.CENTER,
         )
         self._make_button(
             "Open System Settings", self._open_permission_settings,
-            cx - 132, 438, width=236, primary=True,
+            cx - 132, 440, width=236, primary=False,
         )
-        self._draw_disabled_button(cx + 132, 438, "Waiting…", width=196)
+        self._make_button(
+            "Restart", lambda: self._finish_gate("restart"),
+            cx + 132, 440, width=196, primary=True,
+        )
 
-        # Poll until granted. _draw_scene -> _clear cancels this id before the
-        # next redraw, so there's no overlapping callback leak.
+        # Keep polling so the Accessibility badge updates live (Input Monitoring
+        # won't flip until restart). _draw_scene -> _clear cancels this id before
+        # the next redraw, so there's no overlapping callback leak.
         self._spinner_after_id = self._window.after(1500, self._render_permissions)
+
+    def _finish_gate(self, result: str) -> None:
+        """Resolve the permission gate with the given outcome and close it."""
+        self._gate_result = result
+        if self._spinner_after_id is not None:
+            try:
+                self._window.after_cancel(self._spinner_after_id)
+            except tk.TclError as e:
+                logger.debug("after_cancel on gate poll failed: %s", e)
+            self._spinner_after_id = None
+        self._window.destroy()
 
     def _perm_row(self, cx: int, y: int, label: str, ok: bool, hint: str) -> None:
         """Draw one permission status row with a ✓/✗ badge."""
@@ -668,3 +698,12 @@ def show_setup_wizard(config: Config, login_manager: LoginManager) -> SetupResul
     """
     wizard = SetupWizard(config, login_manager)
     return wizard.show()
+
+
+def run_permission_gate(config: Config) -> str:
+    """Show the macOS permission gate, blocking until it is resolved.
+
+    Returns 'granted' (both permissions present), 'restart' (relaunch so a new
+    grant takes effect) or 'quit' (the user closed the window without granting).
+    """
+    return SetupWizard(config).run_permission_gate()

--- a/src/ui/tray.py
+++ b/src/ui/tray.py
@@ -159,6 +159,9 @@ class TrayModel:
 
         # Permissions
         self.needs_permissions: bool = False
+        # macOS Input Monitoring (keystroke/click capture). True until a check
+        # proves otherwise so non-macOS platforms never show the warning.
+        self.input_monitoring_ok: bool = True
 
 
 # On Linux, pystray binds its backend at import time. Choose it explicitly:
@@ -488,6 +491,8 @@ class TrayIcon:
                 "private_interval_minutes": self.model.private_interval_minutes,
                 "auto_categorize": self.model.auto_categorize,
                 "track_display_info": self.model.track_display_info,
+                "needs_permissions": self.model.needs_permissions,
+                "input_monitoring_ok": self.model.input_monitoring_ok,
             }
 
     def _create_menu(self) -> pystray.Menu:
@@ -499,6 +504,16 @@ class TrayIcon:
         s = self._snapshot_model()
         items = []
         logged_in = s["user_email"] is not None
+
+        # ── Permission warning (macOS Input Monitoring) ─────
+        # Surfaced at the very top so a disabled keystroke/click capture — which
+        # makes the day look like a jiggler server-side — is impossible to miss.
+        if not s["input_monitoring_ok"]:
+            items.append(Item(
+                "⚠️  Input tracking off — Fix Permissions",
+                self._handle_fix_permissions,
+            ))
+            items.append(Item("─" * 20, None, enabled=False))
 
         # ── User identity & status ──────────────────────────
         if s["user_email"]:
@@ -701,6 +716,8 @@ class TrayIcon:
             return "Paused"
         elif state == TrayState.WAITING_AUTH:
             return "Waiting for login..."
+        elif state == TrayState.NEEDS_PERMISSIONS:
+            return "Permissions needed"
         else:
             return "Starting..."
 
@@ -740,6 +757,41 @@ class TrayIcon:
         return state not in (TrayState.QUEUED, TrayState.QUEUE_WARNING, TrayState.ERROR)
 
     # -- Menu action handlers ------------------------------------------------
+
+    def _handle_fix_permissions(self, icon, item) -> None:
+        """Open System Settings to the pane for whichever grant is missing.
+
+        Prioritises Input Monitoring (the one that disables keystroke/click
+        capture). Calling the prompt registers the app in the list so the
+        toggle exists. The 60s permission re-check clears the warning once the
+        user flips it on.
+        """
+        try:
+            from .permissions import (
+                check_accessibility,
+                check_input_monitoring,
+                open_accessibility_settings,
+                open_input_monitoring_settings,
+            )
+        except ImportError:
+            from permissions import (  # type: ignore[no-redef]
+                check_accessibility,
+                check_input_monitoring,
+                open_accessibility_settings,
+                open_input_monitoring_settings,
+            )
+        try:
+            if not check_input_monitoring():
+                # prompt=True shows Apple's dialog and registers the app so the
+                # System Settings toggle appears.
+                check_input_monitoring(prompt=True)
+                open_input_monitoring_settings()
+            elif not check_accessibility():
+                open_accessibility_settings()
+            else:
+                open_input_monitoring_settings()
+        except Exception as e:
+            logger.warning("Failed to open permission settings: %s", e)
 
     def _handle_login(self, icon, item) -> None:
         """Handle login menu click."""


### PR DESCRIPTION
## Why
Days show up as **suspicious** on the dashboard because the agent silently stops capturing keystrokes/clicks. An app update changes the code signature → macOS drops the **Input Monitoring** TCC grant → `grant_tcc_permissions()`'s `.tcc_grant_done` marker blocks a re-prompt → the new build runs with window time but **zero input**, which the server reads as a mouse-jiggler.

Confirmed against prod: input was last captured 2026-05-22 (before the latest update); the running app logs `Process does NOT have Input Monitoring permission — keypress tracking disabled`.

## What
1. **Visible runtime error** — `SyncCoordinator._check_permissions` now also checks Input Monitoring, runs on the 60s tick + once ~8s after launch, flips the tray to `NEEDS_PERMISSIONS`, adds a top-of-menu **"⚠️ Input tracking off — Fix Permissions"** action, and fires a throttled notification.
2. **Install-time gate** — the first-run setup wizard gains a macOS permissions screen that prompts for Accessibility + Input Monitoring and only enables **Continue** once both are granted; closing without granting leaves setup incomplete (app won't run).
3. `permissions.prompt_accessibility()` — native AX prompt that registers the app in System Settings.
4. Fixes a latent wizard bug where `_on_login_complete` called `_show_error()` on the success path too.
5. Version bump 1.5.23 → 1.5.24.

## Test
- `py_compile` clean; **331/331** tests pass; no new ruff findings.

## Follow-up (not in this PR)
Backend `suspicious_days` counts per-app **rows**, not distinct days (so 2 input-less days with 3+ apps reads as "suspicious_days:5"). Lives in `betterflow/v1` — `AgentActivityAggregate::isSuspicious()`, `AnomalyDetectionService::getPotentialFraud()`, `AgentManagementController::getDeviceFraudRisk()`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)