### PR TITLE
fix(tray): show running version in hover tooltip (Windows hidden-icons)

### DIFF
--- a/src/ui/tray.py
+++ b/src/ui/tray.py
@@ -33,6 +33,11 @@ except ImportError:
             _APP_VERSION = "unknown"
         BUILD_DATE = "dev"
 
+# Tray hover tooltip base. Surfaces the running version on hover even when the
+# icon sits in the Windows hidden-icons overflow, where the right-click menu
+# (and its Preferences > version item) isn't reachable.
+_BASE_TOOLTIP = f"BetterFlow v{_APP_VERSION}"
+
 from PIL import Image, ImageDraw, ImageFont
 
 if TYPE_CHECKING:
@@ -1138,7 +1143,7 @@ class TrayIcon:
         minutes = (total_seconds % 3600) // 60
         with self.model.lock:
             self.model.hours_today = f"{hours}h {minutes}m"
-        self._update_tooltip(f"BetterFlow - Today: {hours}h {minutes}m active")
+        self._update_tooltip(f"{_BASE_TOOLTIP} - Today: {hours}h {minutes}m active")
         self._update_menu()
 
     def set_update_available(self, version: str, url: str, asset_url: Optional[str] = None) -> None:
@@ -1382,7 +1387,7 @@ class TrayIcon:
         self._icon = pystray.Icon(
             "BetterFlow",
             create_icon_image(color),
-            "BetterFlow",
+            _BASE_TOOLTIP,
             self._create_menu(),
         )
 
@@ -1413,7 +1418,7 @@ class TrayIcon:
                 self._icon = pystray.Icon(
                     "BetterFlow",
                     create_icon_image(color),
-                    "BetterFlow",
+                    _BASE_TOOLTIP,
                     self._create_menu(),
                 )
 


### PR DESCRIPTION
## Problem
On Windows, when the tray icon is in the **hidden-icons overflow**, there's no way to see the running version — the version only lived in the right-click **Preferences** submenu, which isn't reachable from the overflow flyout. (Reported during rollout.)

## Fix
Put the version in the **tooltip** (shown on hover, even in the overflow):
- New `_BASE_TOOLTIP = "BetterFlow v<version>"` constant.
- Both `pystray.Icon` titles use it → hover shows `BetterFlow v1.5.x`.
- Daily active-time tooltip becomes `BetterFlow v1.5.x - Today: Xh Ym active`.

Single source for the string (DRY); `py_compile` clean; no tests assert tooltip text.

> Reaches users only via a **new release** (e.g. 1.5.29) built+signed through CI — existing installs won't show it until they update. Immediate workaround today: right-click tray → Preferences.

🤖 Generated with [Claude Code](https://claude.com/claude-code)