### PR TITLE
feat(setup): Windows/Linux first-run consent & transparency screen

### DIFF
--- a/src/ui/setup_wizard.py
+++ b/src/ui/setup_wizard.py
@@ -427,7 +427,14 @@ class SetupWizard:
 
         if state.logged_in:
             self._login_state = state
-            self._show_success(state.user_email or "")
+            # macOS surfaces the tracking boundary via the Input Monitoring
+            # permission gate (after this wizard). Windows/Linux have no OS
+            # permission to grant, so show a one-time transparency + consent
+            # screen here before tracking starts.
+            if sys.platform == "darwin":
+                self._show_success(state.user_email or "")
+            else:
+                self._show_consent(state.user_email or "")
         else:
             safe_error = (state.error or "Login failed")[:200]
             self._show_error(safe_error)
@@ -508,6 +515,60 @@ class SetupWizard:
         # the always-on permission gate (see SetupWizard.run_permission_gate),
         # which runs after this wizard and on every subsequent launch.
         self._make_button("Continue", self._finish, cx, 438, width=280)
+
+    # ── Consent / Transparency (Windows / Linux) ─────────────────────
+
+    def _show_consent(self, email: str) -> None:
+        """First-run tracking transparency + consent screen.
+
+        Shown only on platforms without an OS permission gate (Windows/Linux);
+        macOS uses the Input Monitoring gate as the equivalent boundary. The
+        window close handler aborts setup, so tracking never starts without an
+        explicit acknowledgement.
+        """
+        cx = self._draw_scene(
+            title="How BetterFlow Tracks Time",
+            subtitle="Please review before tracking starts",
+        )
+
+        if email:
+            self._canvas.create_text(
+                cx,
+                210,
+                text=f"Signed in as {email}",
+                font=(FONT_FAMILY, 12, "bold"),
+                fill=SUCCESS_COLOR,
+            )
+
+        self._canvas.create_text(
+            cx,
+            262,
+            text=(
+                "BetterFlow records which apps and windows are active\n"
+                "while you work, to build your automatic timesheet."
+            ),
+            font=FONT_BODY,
+            fill=TEXT_MUTED,
+            justify=tk.CENTER,
+        )
+
+        self._canvas.create_text(
+            cx,
+            344,
+            text=(
+                "Your privacy is protected by default:\n"
+                "•  Window titles are hashed on your device\n"
+                "•  URLs are reduced to the domain only\n"
+                "•  Excluded apps are never tracked"
+            ),
+            font=FONT_SMALL,
+            fill="#9a87c4",
+            justify=tk.LEFT,
+        )
+
+        self._make_button(
+            "I Agree & Continue", lambda: self._show_success(email), cx, 446, width=280
+        )
 
     # ── Permissions Gate (macOS) ─────────────────────────────────────
 

--- a/tests/test_setup_wizard_consent.py
+++ b/tests/test_setup_wizard_consent.py
@@ -1,0 +1,73 @@
+"""Tests for the first-run consent/transparency screen.
+
+On non-macOS platforms (no OS permission gate) a successful login routes to
+the consent screen before success; on macOS it goes straight to success.
+No real Tk event loop is started — _window/_canvas are mocked.
+"""
+
+from unittest.mock import MagicMock, patch
+
+from src.ui.setup_wizard import SetupWizard
+
+
+def _make_wizard() -> SetupWizard:
+    w = SetupWizard()
+    w._window = MagicMock()
+    w._canvas = MagicMock()
+    w._spinner_after_id = None
+    w._show_success = MagicMock()
+    w._show_consent = MagicMock()
+    return w
+
+
+class TestConsentRouting:
+    def test_non_macos_login_routes_to_consent(self):
+        w = _make_wizard()
+        state = MagicMock(logged_in=True, user_email="cati@betterqa.co")
+        with patch("src.ui.setup_wizard.sys.platform", "win32"):
+            w._on_login_complete(state)
+        w._show_consent.assert_called_once_with("cati@betterqa.co")
+        w._show_success.assert_not_called()
+
+    def test_linux_login_routes_to_consent(self):
+        w = _make_wizard()
+        state = MagicMock(logged_in=True, user_email="x@y.co")
+        with patch("src.ui.setup_wizard.sys.platform", "linux"):
+            w._on_login_complete(state)
+        w._show_consent.assert_called_once()
+        w._show_success.assert_not_called()
+
+    def test_macos_login_skips_consent(self):
+        w = _make_wizard()
+        state = MagicMock(logged_in=True, user_email="x@y.co")
+        with patch("src.ui.setup_wizard.sys.platform", "darwin"):
+            w._on_login_complete(state)
+        w._show_success.assert_called_once_with("x@y.co")
+        w._show_consent.assert_not_called()
+
+    def test_failed_login_shows_neither(self):
+        w = _make_wizard()
+        w._show_error = MagicMock()
+        state = MagicMock(logged_in=False, error="nope")
+        with patch("src.ui.setup_wizard.sys.platform", "win32"):
+            w._on_login_complete(state)
+        w._show_consent.assert_not_called()
+        w._show_success.assert_not_called()
+        w._show_error.assert_called_once()
+
+
+class TestConsentRender:
+    def test_consent_screen_draws_and_offers_continue(self):
+        w = _make_wizard()
+        # Render against mocked canvas; isolate from _draw_scene/_make_button.
+        w._draw_scene = MagicMock(return_value=300)
+        w._make_button = MagicMock()
+        # Use the real method (un-mock it for this render test).
+        SetupWizard._show_consent(w, "cati@betterqa.co")
+        w._draw_scene.assert_called_once()
+        w._make_button.assert_called_once()
+        # The action button forwards to the success screen on acknowledgement.
+        label, action = w._make_button.call_args.args[0], w._make_button.call_args.args[1]
+        assert "Agree" in label
+        action()
+        w._show_success.assert_called_once_with("cati@betterqa.co")


### PR DESCRIPTION
## Why
macOS shows the Input Monitoring permission gate (the moment the user is told tracking is starting). Windows/Linux have **no OS permission**, so they jumped straight from login to tracking with no acknowledgement. This adds the equivalent transparency/consent step.

## What
- New `_show_consent` scene in the first-run setup wizard, shown **only on non-macOS** after login.
- Explains what's tracked + privacy defaults (hashed titles, domain-only URLs, excluded apps) and requires **"I Agree & Continue"**.
- Closing the window aborts setup (`completed=False` → app exits), so tracking never starts without consent.
- Shown **once** — it's inside the first-run wizard (guarded by `setup_complete`); macOS flow unchanged.

## Tests
`tests/test_setup_wizard_consent.py` (5, all passing locally): non-macOS/Linux route to consent, macOS skips it, failed login shows neither, and the consent render offers an 'I Agree' button that forwards to success.

## Notes
- Reaches users only in a **new release** (held at 1.5.28 for now). 
- Scope: new installs. Users who already completed setup on a prior version won't be re-prompted (no retroactive flag) — can add one if you want existing users to re-consent.

🤖 Generated with [Claude Code](https://claude.com/claude-code)