### PR TITLE
fix(macos): permission-gate Restart never reopened the app

### DIFF
--- a/src/main.py
+++ b/src/main.py
@@ -2,6 +2,7 @@
 
 import logging
 import os
+import shlex
 import signal
 import subprocess
 import sys
@@ -955,7 +956,20 @@ class BetterFlowApp:
                 exe = Path(sys.executable)
                 bundle = exe.parents[2] if len(exe.parents) >= 3 else None
                 if bundle is not None and bundle.suffix == ".app":
-                    subprocess.Popen(["open", str(bundle)])
+                    # `open` on a still-running app just reactivates the current
+                    # (about-to-exit) instance instead of launching a new one —
+                    # so the app would vanish and never reopen. Wait for THIS
+                    # process to exit, then open a fresh instance. Detached so
+                    # the helper survives our os._exit below.
+                    subprocess.Popen(
+                        [
+                            "/bin/sh",
+                            "-c",
+                            f"while kill -0 {os.getpid()} 2>/dev/null; do sleep 0.2; done; "
+                            f"open {shlex.quote(str(bundle))}",
+                        ],
+                        start_new_session=True,
+                    )
                 else:
                     subprocess.Popen([str(exe)])
             else:

--- a/tests/test_relaunch.py
+++ b/tests/test_relaunch.py
@@ -1,0 +1,34 @@
+"""Tests for BetterFlowApp._relaunch on macOS.
+
+The permission gate's 'restart' outcome calls _relaunch. On a frozen .app it
+must defer `open` until the current process has exited — otherwise `open`
+reactivates the about-to-die instance and the app never reopens.
+"""
+
+from unittest.mock import MagicMock, patch
+
+from src.main import BetterFlowApp
+
+
+class TestRelaunch:
+    def test_macos_frozen_defers_open_until_process_exits(self):
+        fake_exe = "/Applications/BetterFlow.app/Contents/MacOS/BetterFlow"
+        with patch("src.main.sys") as msys, \
+             patch("src.main.subprocess.Popen") as popen, \
+             patch("src.main.os._exit") as exit_mock:
+            msys.frozen = True
+            msys.executable = fake_exe
+
+            BetterFlowApp._relaunch(MagicMock())
+
+        popen.assert_called_once()
+        cmd = popen.call_args.args[0]
+        assert cmd[0] == "/bin/sh" and cmd[1] == "-c"
+        script = cmd[2]
+        # Waits for the current process to exit, THEN opens the bundle.
+        assert "kill -0" in script
+        assert "open " in script
+        assert "BetterFlow.app" in script
+        # Detached so the helper outlives our exit.
+        assert popen.call_args.kwargs.get("start_new_session") is True
+        exit_mock.assert_called_once_with(0)


### PR DESCRIPTION
## Bug
On macOS, clicking **Restart** in the Input Monitoring permission gate made the app disappear and never reopen.

## Cause
`_relaunch()` ran `open <BetterFlow.app>` and then `os._exit(0)` immediately. macOS `open` on an app that's **still running** *reactivates* the existing instance rather than launching a new one — so it 'opened' the instance that was about to exit, the process died, and nothing fresh launched.

## Fix
Defer the `open` until the current process has actually exited (poll our own PID via `kill -0`), then launch a fresh instance — in a detached session (`start_new_session=True`) so the helper survives `os._exit(0)`.

## Test
`tests/test_relaunch.py`: asserts the frozen-.app path spawns a deferred `open` (waits on PID, then opens the bundle, detached) and exits. Passing locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)