### PR TITLE
feat(macos): offer to move app into /Applications on first run

### DIFF
--- a/src/main.py
+++ b/src/main.py
@@ -840,6 +840,11 @@ class BetterFlowApp:
         # newer is staged. Relaunches (os._exit) on success.
         self._apply_staged_update_on_launch()
 
+        # macOS: if launched from the DMG, ~/Downloads, or a Gatekeeper
+        # translocation path, offer to move into /Applications and relaunch
+        # from there. No-op when already installed or on other platforms.
+        self._maybe_relocate_to_applications()
+
         # Self-heal auto-start: if config says it should be on but the OS-level
         # LaunchAgent isn't actually loaded (drift from a prior install,
         # manual launchctl bootout, or migration to a new bundle path),
@@ -956,20 +961,7 @@ class BetterFlowApp:
                 exe = Path(sys.executable)
                 bundle = exe.parents[2] if len(exe.parents) >= 3 else None
                 if bundle is not None and bundle.suffix == ".app":
-                    # `open` on a still-running app just reactivates the current
-                    # (about-to-exit) instance instead of launching a new one —
-                    # so the app would vanish and never reopen. Wait for THIS
-                    # process to exit, then open a fresh instance. Detached so
-                    # the helper survives our os._exit below.
-                    subprocess.Popen(
-                        [
-                            "/bin/sh",
-                            "-c",
-                            f"while kill -0 {os.getpid()} 2>/dev/null; do sleep 0.2; done; "
-                            f"open {shlex.quote(str(bundle))}",
-                        ],
-                        start_new_session=True,
-                    )
+                    self._spawn_deferred_open(bundle)
                 else:
                     subprocess.Popen([str(exe)])
             else:
@@ -979,6 +971,80 @@ class BetterFlowApp:
         except Exception:
             logger.exception("Relaunch failed")
         os._exit(0)
+
+    def _spawn_deferred_open(self, target: Path) -> None:
+        """Spawn a detached helper that runs ``open <target>`` only after THIS
+        process has exited.
+
+        macOS ``open`` on a still-running app reactivates the current
+        (about-to-exit) instance instead of launching a new one, so the caller
+        must ``os._exit`` immediately after calling this.
+        """
+        subprocess.Popen(
+            [
+                "/bin/sh",
+                "-c",
+                f"while kill -0 {os.getpid()} 2>/dev/null; do sleep 0.2; done; "
+                f"open {shlex.quote(str(target))}",
+            ],
+            start_new_session=True,
+        )
+
+    def _maybe_relocate_to_applications(self) -> None:
+        """On macOS, offer to move a non-installed .app into /Applications.
+
+        A frozen bundle launched from the DMG, ~/Downloads, or a Gatekeeper
+        translocation path is not in /Applications, so it never appears under
+        Applications/Launchpad and its code-signing identity (and the TCC
+        grants tied to it) churn across updates. Offer a one-click move, then
+        relaunch from the installed copy. Best-effort: any failure is logged
+        and the app keeps running from its current location.
+        """
+        if sys.platform != "darwin" or not getattr(sys, "frozen", False):
+            return
+        try:
+            exe = Path(sys.executable)
+            bundle = exe.parents[2] if len(exe.parents) >= 3 else None
+            if bundle is None or bundle.suffix != ".app":
+                return
+            if str(bundle).startswith("/Applications/"):
+                return  # already installed
+
+            dest = Path("/Applications") / bundle.name
+
+            try:
+                import tkinter as tk
+                from tkinter import messagebox
+            except Exception:
+                logger.warning("tkinter unavailable; skipping move-to-Applications prompt")
+                return
+
+            root = tk.Tk()
+            root.withdraw()
+            try:
+                move = messagebox.askyesno(
+                    "Move to Applications?",
+                    "BetterFlow works best from your Applications folder.\n\n"
+                    "Move it there now? This keeps permissions and automatic "
+                    "updates working correctly.",
+                )
+            finally:
+                root.destroy()
+            if not move:
+                return
+
+            # ditto preserves the Developer ID signature + notarization ticket
+            # (shutil.copytree strips the xattrs that carry them). Replace any
+            # older copy first so we don't merge two versions.
+            if dest.exists():
+                subprocess.run(["rm", "-rf", str(dest)], check=True)
+            subprocess.run(["ditto", str(bundle), str(dest)], check=True)
+
+            logger.info("Relocated to %s; relaunching from there", dest)
+            self._spawn_deferred_open(dest)
+            os._exit(0)
+        except Exception:
+            logger.exception("Move to Applications failed; continuing from current location")
 
     # -- Event handlers ---------------------------------------------------
 

--- a/tests/test_macos_relocate.py
+++ b/tests/test_macos_relocate.py
@@ -1,0 +1,73 @@
+"""Tests for BetterFlowApp._maybe_relocate_to_applications.
+
+On macOS a frozen .app launched from outside /Applications (DMG, Downloads, or
+a Gatekeeper translocation path) should offer to move into /Applications and
+relaunch from there; everywhere else it's a no-op.
+"""
+
+from unittest.mock import MagicMock, patch
+
+from src.main import BetterFlowApp
+
+
+class TestRelocate:
+    def test_noop_on_non_macos(self):
+        self_mock = MagicMock()
+        with patch("src.main.sys") as msys, \
+             patch("src.main.subprocess.run") as run, \
+             patch("src.main.os._exit") as exit_mock:
+            msys.frozen = True
+            msys.platform = "win32"
+            BetterFlowApp._maybe_relocate_to_applications(self_mock)
+        run.assert_not_called()
+        exit_mock.assert_not_called()
+        self_mock._spawn_deferred_open.assert_not_called()
+
+    def test_noop_when_already_in_applications(self):
+        self_mock = MagicMock()
+        with patch("src.main.sys") as msys, \
+             patch("src.main.subprocess.run") as run, \
+             patch("src.main.os._exit") as exit_mock:
+            msys.frozen = True
+            msys.platform = "darwin"
+            msys.executable = "/Applications/BetterFlow.app/Contents/MacOS/BetterFlow"
+            BetterFlowApp._maybe_relocate_to_applications(self_mock)
+        run.assert_not_called()
+        exit_mock.assert_not_called()
+        self_mock._spawn_deferred_open.assert_not_called()
+
+    def test_declining_keeps_running_in_place(self):
+        self_mock = MagicMock()
+        with patch("src.main.sys") as msys, \
+             patch("src.main.subprocess.run") as run, \
+             patch("src.main.os._exit") as exit_mock, \
+             patch("tkinter.Tk"), \
+             patch("tkinter.messagebox.askyesno", return_value=False):
+            msys.frozen = True
+            msys.platform = "darwin"
+            msys.executable = "/Volumes/BetterFlow/BetterFlow.app/Contents/MacOS/BetterFlow"
+            BetterFlowApp._maybe_relocate_to_applications(self_mock)
+        run.assert_not_called()
+        exit_mock.assert_not_called()
+        self_mock._spawn_deferred_open.assert_not_called()
+
+    def test_accepting_copies_to_applications_and_relaunches(self):
+        self_mock = MagicMock()
+        with patch("src.main.sys") as msys, \
+             patch("src.main.subprocess.run") as run, \
+             patch("src.main.os._exit") as exit_mock, \
+             patch("tkinter.Tk"), \
+             patch("tkinter.messagebox.askyesno", return_value=True):
+            msys.frozen = True
+            msys.platform = "darwin"
+            msys.executable = "/Volumes/BetterFlow/BetterFlow.app/Contents/MacOS/BetterFlow"
+            BetterFlowApp._maybe_relocate_to_applications(self_mock)
+
+        ditto = [c for c in run.call_args_list if c.args and "ditto" in c.args[0]]
+        assert ditto, "expected a ditto copy into /Applications"
+        # ditto src is the running bundle, dest is /Applications/BetterFlow.app
+        assert ditto[0].args[0][1] == "/Volumes/BetterFlow/BetterFlow.app"
+        assert ditto[0].args[0][2] == "/Applications/BetterFlow.app"
+        self_mock._spawn_deferred_open.assert_called_once()
+        assert str(self_mock._spawn_deferred_open.call_args.args[0]) == "/Applications/BetterFlow.app"
+        exit_mock.assert_called_once_with(0)

--- a/tests/test_relaunch.py
+++ b/tests/test_relaunch.py
@@ -1,34 +1,42 @@
-"""Tests for BetterFlowApp._relaunch on macOS.
+"""Tests for BetterFlowApp._relaunch and the shared _spawn_deferred_open helper.
 
-The permission gate's 'restart' outcome calls _relaunch. On a frozen .app it
-must defer `open` until the current process has exited — otherwise `open`
+The permission gate's 'restart' outcome calls _relaunch, which (on a frozen
+.app) must defer `open` until the current process has exited — otherwise `open`
 reactivates the about-to-die instance and the app never reopens.
 """
 
+from pathlib import Path
 from unittest.mock import MagicMock, patch
 
 from src.main import BetterFlowApp
 
 
 class TestRelaunch:
-    def test_macos_frozen_defers_open_until_process_exits(self):
-        fake_exe = "/Applications/BetterFlow.app/Contents/MacOS/BetterFlow"
-        with patch("src.main.sys") as msys, \
-             patch("src.main.subprocess.Popen") as popen, \
-             patch("src.main.os._exit") as exit_mock:
+    def test_macos_frozen_delegates_to_deferred_open(self):
+        self_mock = MagicMock()
+        with patch("src.main.sys") as msys, patch("src.main.os._exit") as exit_mock:
             msys.frozen = True
-            msys.executable = fake_exe
+            msys.executable = "/Applications/BetterFlow.app/Contents/MacOS/BetterFlow"
+            BetterFlowApp._relaunch(self_mock)
 
-            BetterFlowApp._relaunch(MagicMock())
+        self_mock._spawn_deferred_open.assert_called_once()
+        target = self_mock._spawn_deferred_open.call_args.args[0]
+        assert str(target) == "/Applications/BetterFlow.app"
+        exit_mock.assert_called_once_with(0)
+
+
+class TestSpawnDeferredOpen:
+    def test_builds_deferred_open_command(self):
+        with patch("src.main.subprocess.Popen") as popen:
+            BetterFlowApp._spawn_deferred_open(MagicMock(), Path("/Applications/BetterFlow.app"))
 
         popen.assert_called_once()
         cmd = popen.call_args.args[0]
         assert cmd[0] == "/bin/sh" and cmd[1] == "-c"
         script = cmd[2]
-        # Waits for the current process to exit, THEN opens the bundle.
+        # Waits for the current process to exit, THEN opens the target.
         assert "kill -0" in script
         assert "open " in script
         assert "BetterFlow.app" in script
         # Detached so the helper outlives our exit.
         assert popen.call_args.kwargs.get("start_new_session") is True
-        exit_mock.assert_called_once_with(0)


### PR DESCRIPTION
## Problem (your report: "app not under apps on Mac")
A frozen `.app` run from the **DMG**, **~/Downloads**, or a **Gatekeeper translocation** path is not in `/Applications`, so it never shows under Applications/Launchpad — and its code-signing identity (and the TCC grants tied to it) churn on every update.

## Fix
On macOS startup, if the running bundle isn't under `/Applications`, prompt **"Move to Applications?"**. On yes: `ditto` into `/Applications` (preserves the Developer ID signature + notarization ticket, unlike copytree), then relaunch from the installed copy. Best-effort — any failure logs and the app keeps running where it is.

Also extracts the deferred-`open` helper shared with the relaunch fix into `_spawn_deferred_open` (DRY).

## Tests (6, passing locally)
no-op on non-macOS, no-op when already in /Applications, decline keeps running in place, accept → `ditto` to /Applications + deferred relaunch + exit; plus the relaunch/helper command shape.

🤖 Generated with [Claude Code](https://claude.com/claude-code)