### PR TITLE
test(macos): skip relocate tests on non-macOS (hung Windows CI)

### DIFF
--- a/tests/test_macos_relocate.py
+++ b/tests/test_macos_relocate.py
@@ -5,9 +5,21 @@ a Gatekeeper translocation path) should offer to move into /Applications and
 relaunch from there; everywhere else it's a no-op.
 """
 
+import sys
 from unittest.mock import MagicMock, patch
 
+import pytest
+
 from src.main import BetterFlowApp
+
+# These tests force sys.platform="darwin" to exercise the macOS-only relocate
+# path. On Windows that path falls through to a real tkinter modal (pathlib
+# uses backslashes, so the "/Applications/" guard never matches), which blocks
+# CI forever. Production gates this on `sys.platform != "darwin"`, so the
+# logic never runs off macOS anyway — skip the tests there.
+pytestmark = pytest.mark.skipif(
+    sys.platform != "darwin", reason="exercises macOS-only relocate logic"
+)
 
 
 class TestRelocate:


### PR DESCRIPTION
The relocate tests force `sys.platform=darwin`; on Windows that path falls through to a real `tkinter.messagebox.askyesno` modal (backslash paths defeat the `/Applications/` guard), hanging the Windows 'Run tests' step indefinitely. Production gates the logic on `sys.platform != 'darwin'`, so it never runs off macOS — skip the tests there. macOS still runs all 4 (verified locally).

🤖 Generated with [Claude Code](https://claude.com/claude-code)