### PR TITLE
fix(sync): stop relabeling AFK as "break" (phantom breaks)

### DIFF
--- a/src/sync/sync_engine.py
+++ b/src/sync/sync_engine.py
@@ -961,7 +961,7 @@ class SyncEngine:
             return None
 
         # Build data object
-        result_bucket_type = bucket_type  # may be overridden for AFK-as-break
+        result_bucket_type = bucket_type
         data = {}
 
         if bucket_type in (BUCKET_TYPE_WINDOW, BUCKET_TYPE_WINDOW_ALT, BUCKET_TYPE_WEB):
@@ -1015,11 +1015,15 @@ class SyncEngine:
                     data["desktop_index"] = ds.desktop_index
         elif bucket_type in (BUCKET_TYPE_AFK, BUCKET_TYPE_AFK_ALT):
             data["status"] = event.status
-            # Send AFK periods as "break" bucket_type for chart display.
-            # Use a separate variable so the original bucket_type is preserved
-            # for the activity classification logic below.
-            if event.status == "afk":
-                result_bucket_type = "break"
+            # AFK periods are sent with their real AFK bucket_type — NOT relabeled
+            # as "break". A break is an intentional, user-initiated pause
+            # (_send_break_event -> "break_time"); blanket-relabeling every
+            # away-from-keyboard stretch as a break turned ordinary no-input work
+            # (reading, meetings, watching a screen) into phantom "Break" cards
+            # for people who never took a break. The backend already classifies
+            # long AFK spans as Idle (TimelineCardBuilder::appendIdleFromAfk) and
+            # uses AFK status for active-hours, so leaving bucket_type untouched
+            # routes this to the correct "Idle" category.
         elif bucket_type == BUCKET_TYPE_INPUT:
             # Input events track keystrokes, clicks, scrolls for fraud detection.
             # The MacOSInputWatcher tags each batch with the frontmost app so the

--- a/tests/test_sync_engine.py
+++ b/tests/test_sync_engine.py
@@ -501,6 +501,29 @@ class TestSyncEngine:
         assert result is not None
         assert result["data"]["status"] == "not-afk"
 
+    def test_transform_event_afk_status_not_relabeled_as_break(self):
+        """AFK (away-from-keyboard) must NOT be sent as a 'break'.
+
+        A break is an intentional user-initiated pause (break_time). Blanket-
+        relabeling AFK as break turned ordinary no-input work (reading, meetings,
+        watching a screen) into phantom 'Break' cards for people who took no
+        break. AFK keeps its real bucket_type so the backend classifies long
+        spans as Idle.
+        """
+        event = AWEvent(
+            id=1,
+            timestamp=datetime.now(timezone.utc),
+            duration=600,
+            data={"status": "afk"},
+        )
+
+        result = self.engine._transform_event(event, "bucket-123", BUCKET_TYPE_AFK)
+
+        assert result is not None
+        assert result["data"]["status"] == "afk"
+        assert result["bucket_type"] == BUCKET_TYPE_AFK
+        assert result["bucket_type"] != "break"
+
     def test_transform_event_adds_activity_state_for_window_events(self):
         """Test that window events include activity state and metrics."""
         self.engine._has_input_data = True


### PR DESCRIPTION
## Problem

Users who took **no breaks** see multiple "Break" cards in the dashboard (e.g. 10m / 11m / 10m). Those durations are the **10-minute AFK timeout** firing — not actual breaks.

## Cause

`SyncEngine._transform_event` relabeled every AFK (away-from-keyboard / no-input) period as `bucket_type = "break"`:

```python
# src/sync/sync_engine.py (before)
if event.status == "afk":
    result_bucket_type = "break"
```

The backend's `AgentEvent::inferEventType()` maps `"break"` → `EVENT_TYPE_BREAK` → a **Break** card. But reading, meetings, calls, and watching a screen all generate **no keyboard/mouse input**, so ordinary work was logged as a break.

A genuine break is an intentional, user-initiated pause — a **separate** path (`_send_break_event` → `"break_time"`), which is unchanged.

## Fix

Remove **only** the AFK→`"break"` relabel. AFK events now keep their real bucket_type, and the backend already handles them correctly:

- `TimelineCardBuilder::appendIdleFromAfk()` classifies long AFK spans as **Idle** (with its own minimum-gap threshold), and
- AFK status feeds the active-hours calculation.

**Net effect:** phantom Break cards become **Idle**; user-initiated breaks still show as **Break**. No backend change needed — this re-enables logic the backend was already built for.

## Test

`test_transform_event_afk_status_not_relabeled_as_break`: an AFK `status=afk` event keeps its AFK bucket_type and is never relabeled to `"break"`. Full suite: 396 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)