### PR TITLE
feat(agent): capture active browser-tab URL on macOS

### DIFF
--- a/src/browser_tracker.py
+++ b/src/browser_tracker.py
@@ -1,0 +1,234 @@
+"""Active browser-tab URL tracking (macOS).
+
+The bundled ActivityWatch window watcher reports the app + window title but NOT
+the URL of the page in the foreground browser tab. Without a URL, every browser
+event collapses to a generic "Google Chrome" with no domain, so the backend
+can't categorise it (it lands in generic "browsing") and the activity cards have
+nothing to show.
+
+This module fills that gap on macOS without requiring a browser extension: a
+daemon thread polls the frontmost browser's active-tab URL via AppleScript
+(`osascript`) and keeps a short, time-ordered ring buffer of (timestamp, url)
+samples. The sync engine looks up the URL active at a window event's time and
+attaches it, after which the EXISTING privacy logic (domain_only_urls /
+collect_full_urls) applies — so the full URL never leaves this process unless
+the server has explicitly enabled full-URL collection.
+
+Opt-in (privacy.track_browser_urls = False by default). Querying a browser via
+AppleScript needs macOS Automation permission; if it's not granted the query
+fails closed (returns None) and tracking is simply a no-op — never a crash.
+"""
+
+import logging
+import platform
+import subprocess
+import threading
+import time
+from collections import deque
+from typing import Deque, Optional, Tuple
+
+logger = logging.getLogger(__name__)
+
+_system = platform.system()
+
+# How often to sample the active tab, and how long to keep samples. Sync runs
+# on a ~60s loop and only processes recent events, so a few minutes of history
+# is plenty; the cap also bounds memory.
+DEFAULT_POLL_INTERVAL_SECONDS = 2.0
+DEFAULT_RETENTION_SECONDS = 600.0
+# A window event is matched to the most recent URL sample at-or-before its end,
+# but only if that sample is within this tolerance — otherwise we have no
+# trustworthy URL for that moment and attach nothing.
+DEFAULT_MATCH_TOLERANCE_SECONDS = 8.0
+
+# Chromium-family browsers expose `URL of active tab of front window`; Safari
+# uses `URL of front document`. Keys are the macOS application names as seen by
+# System Events (also the window-watcher app name), matched case-insensitively.
+_CHROMIUM_BROWSERS = {
+    "google chrome",
+    "google chrome canary",
+    "brave browser",
+    "microsoft edge",
+    "chromium",
+    "vivaldi",
+    "opera",
+    "arc",
+}
+_SAFARI_BROWSERS = {"safari", "safari technology preview"}
+
+_BROWSER_APPS = _CHROMIUM_BROWSERS | _SAFARI_BROWSERS
+
+
+def is_browser_app(app: Optional[str]) -> bool:
+    """True if ``app`` is a browser whose active-tab URL we know how to read."""
+    return bool(app) and app.strip().lower() in _BROWSER_APPS
+
+
+class BrowserURLTracker:
+    """Null tracker — returns no URL. Base class / unsupported-platform fallback.
+
+    The buffer logic lives here so it is unit-testable without a real browser:
+    feed samples with ``record()`` and read them back with ``url_at()``.
+    """
+
+    def __init__(
+        self,
+        retention_seconds: float = DEFAULT_RETENTION_SECONDS,
+        match_tolerance_seconds: float = DEFAULT_MATCH_TOLERANCE_SECONDS,
+    ) -> None:
+        self._retention = retention_seconds
+        self._tolerance = match_tolerance_seconds
+        # (epoch_seconds, url), kept in ascending time order.
+        self._samples: Deque[Tuple[float, str]] = deque()
+        self._lock = threading.Lock()
+
+    def record(self, ts_epoch: float, url: str) -> None:
+        """Append a sample and evict anything older than the retention window."""
+        if not url:
+            return
+        with self._lock:
+            self._samples.append((ts_epoch, url))
+            cutoff = ts_epoch - self._retention
+            while self._samples and self._samples[0][0] < cutoff:
+                self._samples.popleft()
+
+    def url_at(self, ts_epoch: float) -> Optional[str]:
+        """Return the URL active at ``ts_epoch``.
+
+        Picks the most recent sample at-or-before the timestamp, but only if it
+        is within the match tolerance (a stale sample from minutes ago is not a
+        trustworthy answer). Returns None when there is no close-enough sample.
+        """
+        best: Optional[Tuple[float, str]] = None
+        with self._lock:
+            for sample_ts, url in self._samples:
+                if sample_ts <= ts_epoch:
+                    best = (sample_ts, url)
+                else:
+                    break
+        if best is None:
+            return None
+        if ts_epoch - best[0] > self._tolerance:
+            return None
+        return best[1]
+
+    def stop(self) -> None:
+        pass
+
+
+# ---------------------------------------------------------------------------
+# macOS implementation
+# ---------------------------------------------------------------------------
+
+# Resolve the frontmost app once, then read the URL from the matching browser.
+# `System Events` gives the frontmost process name; we only script a browser we
+# recognise so we never send Apple Events to unrelated apps.
+_FRONTMOST_APP_SCRIPT = (
+    'tell application "System Events" to get name of first application '
+    "process whose frontmost is true"
+)
+
+
+def _osascript(script: str, timeout: float = 2.0) -> Optional[str]:
+    """Run an AppleScript and return its trimmed stdout, or None on any failure.
+
+    Fails closed: a missing Automation permission, a browser with no open
+    window, or a timeout all yield None rather than raising.
+    """
+    try:
+        proc = subprocess.run(
+            ["osascript", "-e", script],
+            capture_output=True,
+            text=True,
+            timeout=timeout,
+            check=False,
+        )
+    except (subprocess.TimeoutExpired, OSError) as e:
+        logger.debug("osascript failed: %s", e)
+        return None
+    if proc.returncode != 0:
+        # e.g. "not allowed assistive access" / "not authorised to send Apple
+        # events" when Automation permission is missing.
+        logger.debug("osascript non-zero (%s): %s", proc.returncode, proc.stderr.strip())
+        return None
+    out = proc.stdout.strip()
+    return out or None
+
+
+def _active_url_script_for(app_name: str) -> Optional[str]:
+    """AppleScript that returns the active-tab URL for a supported browser."""
+    key = app_name.strip().lower()
+    if key in _CHROMIUM_BROWSERS:
+        return f'tell application "{app_name}" to get URL of active tab of front window'
+    if key in _SAFARI_BROWSERS:
+        return f'tell application "{app_name}" to get URL of front document'
+    return None
+
+
+def get_active_browser_url() -> Optional[str]:
+    """Return the frontmost browser's active-tab URL, or None.
+
+    None when the frontmost app isn't a supported browser, has no window, or
+    when Automation permission is unavailable.
+    """
+    app = _osascript(_FRONTMOST_APP_SCRIPT)
+    if not app or not is_browser_app(app):
+        return None
+    script = _active_url_script_for(app)
+    if script is None:
+        return None
+    url = _osascript(script)
+    # Browsers report internal pages (new tab, settings) as empty or non-http;
+    # only keep real web URLs.
+    if url and (url.startswith("http://") or url.startswith("https://")):
+        return url
+    return None
+
+
+def _start_macos_tracker(
+    poll_interval: float,
+    retention_seconds: float,
+    match_tolerance_seconds: float,
+) -> BrowserURLTracker:
+    """Start a macOS tracker polling the active-tab URL via AppleScript."""
+    tracker = BrowserURLTracker(retention_seconds, match_tolerance_seconds)
+    stop_event = threading.Event()
+
+    def _run() -> None:
+        while not stop_event.wait(poll_interval):
+            try:
+                url = get_active_browser_url()
+                if url:
+                    tracker.record(time.time(), url)
+            except Exception as e:  # never let the poll thread die
+                logger.debug("browser url poll failed: %s", e)
+
+    thread = threading.Thread(target=_run, daemon=True, name="browser-url-tracker-macos")
+    thread.start()
+    tracker.stop = stop_event.set  # type: ignore[assignment]
+    return tracker
+
+
+# ---------------------------------------------------------------------------
+# Factory
+# ---------------------------------------------------------------------------
+
+def start_browser_tracker(
+    enabled: bool = True,
+    poll_interval: float = DEFAULT_POLL_INTERVAL_SECONDS,
+    retention_seconds: float = DEFAULT_RETENTION_SECONDS,
+    match_tolerance_seconds: float = DEFAULT_MATCH_TOLERANCE_SECONDS,
+) -> BrowserURLTracker:
+    """Create and start a browser URL tracker.
+
+    Returns a null tracker (no URLs) when disabled, on unsupported platforms,
+    or if initialization fails — callers can always use the result safely.
+    """
+    if not enabled:
+        return BrowserURLTracker(retention_seconds, match_tolerance_seconds)
+    try:
+        if _system == "Darwin":
+            return _start_macos_tracker(poll_interval, retention_seconds, match_tolerance_seconds)
+    except Exception as e:
+        logger.debug("Failed to start browser tracker: %s", e)
+    return BrowserURLTracker(retention_seconds, match_tolerance_seconds)

--- a/src/config.py
+++ b/src/config.py
@@ -231,6 +231,7 @@ class PrivacySettings:
     collect_page_category: bool = True  # Include coarse page category classification
     auto_categorize: bool = True  # Enrich events with app_category from server mappings
     track_display_info: bool = False  # Track monitor name and virtual desktop
+    track_browser_urls: bool = False  # macOS: read active-tab URL via AppleScript (needs Automation permission)
     exclude_apps: list[str] = field(
         default_factory=lambda: [
             "1Password",
@@ -536,6 +537,8 @@ class Config:
                 self.privacy.auto_categorize = self._to_bool(collection["auto_categorize"])
             if "track_display_info" in collection:
                 self.privacy.track_display_info = self._to_bool(collection["track_display_info"])
+            if "track_browser_urls" in collection:
+                self.privacy.track_browser_urls = self._to_bool(collection["track_browser_urls"])
             if "default_categories" in collection:
                 cats = collection["default_categories"]
                 if isinstance(cats, dict):

--- a/src/main.py
+++ b/src/main.py
@@ -24,6 +24,7 @@ try:
     from .aw_manager import AWManager
     from .config import Config, setup_logging
     from . import error_reporter
+    from .browser_tracker import start_browser_tracker
     from .display_info import start_display_tracker
     from .reminders import ReminderManager
     from .sync import AWClient, BetterFlowClient, OfflineQueue, SyncEngine
@@ -48,6 +49,7 @@ except ImportError:
     from aw_manager import AWManager
     from config import Config, setup_logging
     import error_reporter
+    from browser_tracker import start_browser_tracker
     from display_info import start_display_tracker
     from reminders import ReminderManager
     from sync import AWClient, BetterFlowClient, OfflineQueue, SyncEngine
@@ -672,6 +674,13 @@ class BetterFlowApp:
         else:
             self.display_tracker = None
 
+        # Active browser-tab URL tracker (macOS). Off unless enabled; without it
+        # browser events carry no URL and collapse to generic "browsing".
+        if self.config.privacy.track_browser_urls:
+            self.browser_tracker = start_browser_tracker()
+        else:
+            self.browser_tracker = None
+
         # In-process window watcher on macOS (inherits Accessibility permission)
         self.window_watcher = None
         self.input_watcher = None
@@ -694,6 +703,7 @@ class BetterFlowApp:
             config=self.config,
             on_config_updated=self._on_config_updated,
             display_tracker=self.display_tracker,
+            browser_tracker=self.browser_tracker,
         )
 
         logger.info("Sync engine created")
@@ -1574,6 +1584,8 @@ class BetterFlowApp:
             self.input_watcher.stop()
         if self.display_tracker is not None:
             self.display_tracker.stop()
+        if getattr(self, "browser_tracker", None) is not None:
+            self.browser_tracker.stop()
         # Clean up macOS notification observers (M5)
         try:
             if sys.platform == "darwin":

--- a/src/sync/sync_engine.py
+++ b/src/sync/sync_engine.py
@@ -21,6 +21,7 @@ except ImportError:
         AGENT_VERSION = "0.0.0"
 
 try:
+    from ..browser_tracker import is_browser_app
     from ..config import Config
     from .aw_client import AWClientError, AWEvent, BUCKET_TYPE_WINDOW, BUCKET_TYPE_WINDOW_ALT, BUCKET_TYPE_AFK, BUCKET_TYPE_AFK_ALT, BUCKET_TYPE_WEB, BUCKET_TYPE_INPUT, BUCKET_TYPE_CALL
     from .bf_client import BetterFlowClientError, BetterFlowAuthError
@@ -29,6 +30,7 @@ try:
     from .daily_time_tracker import DailyTimeTracker
     from .call_detector import CallDetector, CallEvent
 except ImportError:
+    from browser_tracker import is_browser_app
     from config import Config
     from sync.aw_client import AWClientError, AWEvent, BUCKET_TYPE_WINDOW, BUCKET_TYPE_WINDOW_ALT, BUCKET_TYPE_AFK, BUCKET_TYPE_AFK_ALT, BUCKET_TYPE_WEB, BUCKET_TYPE_INPUT, BUCKET_TYPE_CALL
     from sync.bf_client import BetterFlowClientError, BetterFlowAuthError
@@ -121,6 +123,7 @@ class SyncEngine:
         display_tracker=None,
         activity_analyzer: Optional[ActivityAnalyzer] = None,
         time_tracker: Optional[DailyTimeTracker] = None,
+        browser_tracker=None,
     ):
         self.aw = aw
         self.bf = bf
@@ -128,6 +131,7 @@ class SyncEngine:
         self.config = config
         self._on_config_updated = on_config_updated
         self._display_tracker = display_tracker
+        self._browser_tracker = browser_tracker
         self._paused = False
         self._private_mode = False
         self._private_start: Optional[datetime] = None
@@ -968,8 +972,20 @@ class SyncEngine:
             data["app"] = app[:MAX_APP_LENGTH] if app else app
             title = event.title
             data["title"] = title[:MAX_TITLE_LENGTH] if title else title
-            if event.url:
-                url = event.url
+            # The bundled window watcher carries no URL. On macOS, enrich browser
+            # events with the active-tab URL captured around the event's time by
+            # the browser tracker. Raw URL here; the privacy block below applies
+            # domain-only / full-URL rules exactly as it does for extension URLs.
+            raw_url = event.url
+            if (
+                not raw_url
+                and self._browser_tracker is not None
+                and is_browser_app(app)
+            ):
+                event_end = event.timestamp + timedelta(seconds=event.duration)
+                raw_url = self._browser_tracker.url_at(event_end.timestamp())
+            if raw_url:
+                url = raw_url
                 # When the full URL exceeds MAX_URL_LENGTH we deliberately
                 # fall back to the domain rather than silent mid-string
                 # truncation — truncation can change semantics (e.g. turn a
@@ -982,7 +998,7 @@ class SyncEngine:
                         data["url"] = domain
 
                 if privacy.collect_page_category:
-                    data["page_category"] = self._infer_page_category(event.url, event.title)
+                    data["page_category"] = self._infer_page_category(raw_url, event.title)
 
             if app and privacy.auto_categorize:
                 category = self._get_category(app)

--- a/tests/test_browser_tracker.py
+++ b/tests/test_browser_tracker.py
@@ -1,0 +1,122 @@
+"""Tests for the macOS active-tab URL tracker (src/browser_tracker.py).
+
+The buffer logic and AppleScript plumbing are tested without a real browser:
+samples are fed directly, and osascript is mocked.
+"""
+
+from unittest.mock import MagicMock, patch
+
+import src.browser_tracker as bt
+
+
+class TestIsBrowserApp:
+    def test_recognizes_chromium_and_safari(self):
+        assert bt.is_browser_app("Google Chrome")
+        assert bt.is_browser_app("google chrome")  # case-insensitive
+        assert bt.is_browser_app("Brave Browser")
+        assert bt.is_browser_app("Safari")
+        assert bt.is_browser_app("Arc")
+
+    def test_rejects_non_browsers_and_empty(self):
+        assert not bt.is_browser_app("Terminal")
+        assert not bt.is_browser_app("Slack")
+        assert not bt.is_browser_app("")
+        assert not bt.is_browser_app(None)
+
+
+class TestUrlBuffer:
+    def test_url_at_returns_most_recent_at_or_before(self):
+        t = bt.BrowserURLTracker(match_tolerance_seconds=8.0)
+        t.record(100.0, "https://a.com")
+        t.record(105.0, "https://b.com")
+        t.record(110.0, "https://c.com")
+
+        assert t.url_at(106.0) == "https://b.com"   # most recent <= 106
+        assert t.url_at(110.0) == "https://c.com"   # exact match
+        assert t.url_at(112.0) == "https://c.com"   # within tolerance after last
+
+    def test_url_at_none_before_first_sample(self):
+        t = bt.BrowserURLTracker()
+        t.record(100.0, "https://a.com")
+        assert t.url_at(50.0) is None
+
+    def test_url_at_respects_tolerance(self):
+        t = bt.BrowserURLTracker(match_tolerance_seconds=8.0)
+        t.record(100.0, "https://a.com")
+        # 9s later — beyond tolerance, so the stale sample is not trusted.
+        assert t.url_at(109.0) is None
+        assert t.url_at(107.9) == "https://a.com"
+
+    def test_record_evicts_beyond_retention(self):
+        t = bt.BrowserURLTracker(retention_seconds=60.0)
+        t.record(100.0, "https://old.com")
+        t.record(170.0, "https://new.com")  # 70s later evicts the first
+        assert len(t._samples) == 1
+        assert t._samples[0][1] == "https://new.com"
+
+    def test_record_ignores_empty_url(self):
+        t = bt.BrowserURLTracker()
+        t.record(100.0, "")
+        assert len(t._samples) == 0
+
+    def test_null_tracker_returns_none(self):
+        t = bt.BrowserURLTracker()
+        assert t.url_at(123.0) is None
+
+
+class TestActiveUrlScript:
+    def test_chromium_uses_active_tab(self):
+        script = bt._active_url_script_for("Google Chrome")
+        assert "active tab of front window" in script
+        assert "Google Chrome" in script
+
+    def test_safari_uses_front_document(self):
+        script = bt._active_url_script_for("Safari")
+        assert "front document" in script
+
+    def test_unknown_app_returns_none(self):
+        assert bt._active_url_script_for("Terminal") is None
+
+
+class TestGetActiveBrowserUrl:
+    def test_returns_url_for_frontmost_browser(self):
+        with patch.object(bt, "_osascript", side_effect=["Google Chrome", "https://github.com/foo"]):
+            assert bt.get_active_browser_url() == "https://github.com/foo"
+
+    def test_none_when_frontmost_is_not_a_browser(self):
+        with patch.object(bt, "_osascript", side_effect=["Terminal"]) as m:
+            assert bt.get_active_browser_url() is None
+            # Should not even attempt the URL query for a non-browser.
+            assert m.call_count == 1
+
+    def test_none_for_non_http_url(self):
+        with patch.object(bt, "_osascript", side_effect=["Google Chrome", "chrome://newtab"]):
+            assert bt.get_active_browser_url() is None
+
+    def test_none_when_osascript_fails(self):
+        with patch.object(bt, "_osascript", side_effect=[None]):
+            assert bt.get_active_browser_url() is None
+
+
+class TestOsascript:
+    def test_returns_none_on_nonzero_exit(self):
+        proc = MagicMock(returncode=1, stdout="", stderr="not authorised")
+        with patch("src.browser_tracker.subprocess.run", return_value=proc):
+            assert bt._osascript("whatever") is None
+
+    def test_returns_stdout_on_success(self):
+        proc = MagicMock(returncode=0, stdout="https://x.com\n", stderr="")
+        with patch("src.browser_tracker.subprocess.run", return_value=proc):
+            assert bt._osascript("whatever") == "https://x.com"
+
+    def test_returns_none_on_timeout(self):
+        import subprocess
+        with patch("src.browser_tracker.subprocess.run", side_effect=subprocess.TimeoutExpired("osascript", 2)):
+            assert bt._osascript("whatever") is None
+
+
+class TestStartBrowserTracker:
+    def test_disabled_returns_null_tracker(self):
+        t = bt.start_browser_tracker(enabled=False)
+        assert t.url_at(123.0) is None
+        t.stop()  # no-op, must not raise

--- a/tests/test_sync_engine.py
+++ b/tests/test_sync_engine.py
@@ -501,6 +501,48 @@ class TestSyncEngine:
         assert result is not None
         assert result["data"]["status"] == "not-afk"
 
+    def test_transform_event_enriches_browser_url_from_tracker(self):
+        """A browser window event with no URL is enriched from the browser
+        tracker, then domain-stripped by the default privacy policy."""
+
+        class _StubTracker:
+            def url_at(self, ts):
+                return "https://github.com/Better-Quality-Assurance/x/pull/1"
+
+        self.engine._browser_tracker = _StubTracker()
+        event = AWEvent(
+            id=1,
+            timestamp=datetime.now(timezone.utc),
+            duration=60,
+            data={"app": "Google Chrome", "title": "PR"},
+        )
+
+        result = self.engine._transform_event(event, "bucket-1", BUCKET_TYPE_WINDOW)
+
+        assert result is not None
+        # domain_only_urls=True by default -> domain, not the full URL
+        assert result["data"]["url"] == "github.com"
+
+    def test_transform_event_no_tracker_url_for_non_browser_app(self):
+        """Non-browser apps are never queried for a URL, even with a tracker."""
+
+        class _StubTracker:
+            def url_at(self, ts):
+                raise AssertionError("url_at must not be called for non-browsers")
+
+        self.engine._browser_tracker = _StubTracker()
+        event = AWEvent(
+            id=2,
+            timestamp=datetime.now(timezone.utc),
+            duration=60,
+            data={"app": "Terminal", "title": "zsh"},
+        )
+
+        result = self.engine._transform_event(event, "bucket-1", BUCKET_TYPE_WINDOW)
+
+        assert result is not None
+        assert "url" not in result["data"]
+
     def test_transform_event_adds_activity_state_for_window_events(self):
         """Test that window events include activity state and metrics."""
         self.engine._has_input_data = True


### PR DESCRIPTION
## Why

Browser activity has **no URL**. The bundled window watcher reports only app + title, and we ship no browser/web watcher (`BF_WATCHERS = ["bf-window-tracker", "bf-idle-tracker"]`). So every Chrome event collapses to a generic "Google Chrome" with no domain — the backend can't categorise it (lands in generic **browsing → Personal**) and the activity cards have nothing to show. This is the root cause of "why does browsing show as a personal task."

## What

A macOS browser-URL tracker (`src/browser_tracker.py`) — mirrors the existing `display_info.py` pattern:
- Daemon thread polls the **frontmost browser's active-tab URL** via AppleScript (`osascript`), every ~2s, into a short time-ordered ring buffer of `(timestamp, url)`.
- `SyncEngine._transform_event` looks up the URL active at a browser window event's time and attaches it. The **existing** privacy block (`domain_only_urls` / `collect_full_urls`) then applies unchanged — so the full URL never leaves the machine unless the server enabled full-URL collection.
- **No backend change needed**: URLs flow through the existing event payload, and the backend's domain rules already categorise known work domains (github→development, etc.).

## Safety / privacy

- **Opt-in**: `privacy.track_browser_urls` (default `False`, server-controllable like `track_display_info`).
- Reading a browser via AppleScript needs macOS **Automation permission**; if it isn't granted the query **fails closed** (returns no URL) — never a crash.
- Supported: Chrome family (Chrome/Brave/Edge/Arc/Chromium/Vivaldi/Opera) + Safari. Non-browser apps are never scripted. Only `http(s)` URLs are kept (internal pages like `chrome://newtab` are dropped).

## Tests

`tests/test_browser_tracker.py` (buffer ordering/tolerance/retention, browser detection, `osascript` fail-closed paths) + transform-enrichment tests in `test_sync_engine.py` (browser event gets the domain; non-browser apps are never queried). Full suite: 430 passing.

## Follow-ups
- Enabling it for a device requires the macOS Automation permission prompt UX (separate from Input Monitoring). Worth a brief onboarding nudge before turning it on fleet-wide.
- Windows/Linux URL capture not included (would need the browser extension or per-platform APIs).

🤖 Generated with [Claude Code](https://claude.com/claude-code)