### PR TITLE
fix(sync): global 429 backoff + deterministic idempotency key

### DIFF
--- a/src/sync/bf_client.py
+++ b/src/sync/bf_client.py
@@ -1,8 +1,9 @@
 """BetterFlow API client - syncs events to BetterFlow server."""
 
+import hashlib
+import json
 import logging
 import platform
-import uuid
 from dataclasses import dataclass, field
 from typing import Optional
 from urllib.parse import urlparse
@@ -254,10 +255,16 @@ class BetterFlowClient(BaseApiClient):
             return SyncResult(success=True, events_synced=0)
 
         try:
-            # Idempotency key prevents duplicate processing if the connection
-            # drops after the server processes the batch but before we receive
-            # the response (N1).
-            idempotency_key = str(uuid.uuid4())
+            # Idempotency key prevents duplicate processing when the same batch
+            # is re-sent — either the retry loop after the connection drops once
+            # the server has already processed it (N1), or a re-queue/resend on a
+            # transient failure. It MUST be derived from the batch content (not a
+            # fresh random UUID per call), so every resend of the same events
+            # carries the same key and the server can dedup it. A random key
+            # defeated the whole mechanism and produced duplicate/inflated hours.
+            idempotency_key = hashlib.sha256(
+                json.dumps(events, sort_keys=True, separators=(",", ":")).encode("utf-8")
+            ).hexdigest()
             response = self._request(
                 "POST", "events/batch",
                 data={"events": events},

--- a/src/sync/http_client.py
+++ b/src/sync/http_client.py
@@ -6,6 +6,7 @@ import logging
 import os
 import socket
 import threading
+import time
 from typing import Optional
 from urllib.parse import urlparse
 
@@ -112,6 +113,38 @@ class BaseApiClient:
         self._session = session or requests.Session()
         self._owns_session = session is None  # Track if we created the session
         self._session_lock = threading.Lock()
+        # Global rate-limit backoff. When the server returns 429, ALL outbound
+        # calls (sync, hours, trends, heartbeat) pause until this monotonic
+        # deadline — one coordinated pause instead of each endpoint independently
+        # retrying into the same window (the retry storm that amplified the 429s).
+        self._throttle_until = 0.0
+        self._throttle_lock = threading.Lock()
+
+    # ---- Global rate-limit backoff -------------------------------------------
+
+    # Default backoff when a 429 carries no usable Retry-After header.
+    _DEFAULT_THROTTLE_SECONDS = 30.0
+    # Cap so a hostile/buggy Retry-After can't park the agent for minutes.
+    _MAX_THROTTLE_SECONDS = 60.0
+
+    def _throttle_remaining(self) -> float:
+        """Seconds left in the active global backoff window (0 if not throttled)."""
+        with self._throttle_lock:
+            until = self._throttle_until
+        remaining = until - time.monotonic()
+        return remaining if remaining > 0 else 0.0
+
+    def _enter_throttle(self, retry_after: float) -> None:
+        """Open/extend the global backoff window (thread-safe).
+
+        Only ever pushes the deadline later, never earlier, so concurrent 429s
+        from different endpoints can't shorten an existing backoff.
+        """
+        retry_after = max(0.0, min(retry_after, self._MAX_THROTTLE_SECONDS))
+        until = time.monotonic() + retry_after
+        with self._throttle_lock:
+            if until > self._throttle_until:
+                self._throttle_until = until
 
     @property
     def web_base_url(self) -> str:
@@ -197,6 +230,16 @@ class BaseApiClient:
 
         def do_request() -> dict:
             try:
+                # Global backoff: if a recent 429 opened a backoff window, skip the
+                # network call entirely and fail fast so the caller queues/uses
+                # cache. This is what stops every endpoint from hammering a
+                # server that already told us to wait.
+                backoff = self._throttle_remaining()
+                if backoff > 0:
+                    raise BetterFlowClientError(
+                        f"Rate-limit backoff active, {backoff:.0f}s remaining"
+                    )
+
                 with self._session_lock:
                     session = self._session
                 if session is None:
@@ -208,8 +251,28 @@ class BaseApiClient:
                 if response.status_code == 403:
                     raise BetterFlowAuthError("Device not authorized")
 
-                # Retryable HTTP status codes (N12)
-                if response.status_code in (408, 429, 503, 504):
+                # Rate limited: open a GLOBAL backoff window (pauses every
+                # endpoint, not just this call) and fail fast — non-retryable, so
+                # we don't retry into the very window the server asked us to wait
+                # out. Honors Retry-After, capped, with a sane default.
+                if response.status_code == 429:
+                    retry_after_secs = self._DEFAULT_THROTTLE_SECONDS
+                    retry_after_hdr = response.headers.get("Retry-After")
+                    if retry_after_hdr:
+                        try:
+                            retry_after_secs = min(
+                                float(retry_after_hdr), self._MAX_THROTTLE_SECONDS
+                            )
+                        except (ValueError, TypeError):
+                            pass
+                    self._enter_throttle(retry_after_secs)
+                    raise BetterFlowClientError(
+                        f"Server returned 429 (Retry-After: {retry_after_hdr or 'none'}); "
+                        f"backing off {retry_after_secs:.0f}s"
+                    )
+
+                # Other transient HTTP status codes stay per-call retryable (N12).
+                if response.status_code in (408, 503, 504):
                     retry_after_hdr = response.headers.get("Retry-After")
                     retry_after_secs = None
                     msg = f"Server returned {response.status_code}"

--- a/src/sync/sync_engine.py
+++ b/src/sync/sync_engine.py
@@ -1305,8 +1305,9 @@ class SyncEngine:
                 if result.success:
                     stats.events_sent += result.events_synced
                 else:
-                    # Partial batch: only re-queue events the server didn't accept
                     if result.accepted_ids:
+                        # True partial success: re-queue only the events the
+                        # server did NOT accept.
                         accepted_set = set(result.accepted_ids)
                         failed = [e for e in batch if e.get("id") not in accepted_set]
                         stats.events_sent += len(batch) - len(failed)
@@ -1317,15 +1318,18 @@ class SyncEngine:
                                 e.get("bucket_id", "") for e in failed
                             )
                     else:
-                        # N11: server returned non-success without accepted_ids.
-                        # This branch also covers network failures: bf_client
-                        # catches BetterFlowClientError internally and returns
-                        # SyncResult(success=False), so there is no separate
-                        # network-error except branch — see Important-2 in
-                        # commit history.
+                        # N11: total failure with nothing accepted — a transient
+                        # error (429 rate-limit backoff, network drop, timeout;
+                        # bf_client catches BetterFlowClientError internally and
+                        # returns SyncResult(success=False), so there is no
+                        # separate network-error except branch — see Important-2
+                        # in commit history). Re-queue the whole batch; the
+                        # content-derived idempotency key (bf_client.send_events)
+                        # makes the eventual resend safe against duplicates.
                         logger.warning(
-                            "Server returned partial failure without accepted_ids - "
-                            "re-queuing entire batch"
+                            "Batch not accepted (transient failure: %s) - re-queuing all %d events",
+                            result.error or "unknown",
+                            len(batch),
                         )
                         self.queue.enqueue(batch)
                         stats.events_queued += len(batch)

--- a/tests/test_bf_client.py
+++ b/tests/test_bf_client.py
@@ -2,6 +2,7 @@
 
 import gzip
 import json
+import time
 import pytest
 from unittest.mock import Mock, patch, MagicMock
 
@@ -363,6 +364,145 @@ class TestBetterFlowClient:
 
         assert result.success is False
         assert result.error is not None
+
+    # ---- Deterministic idempotency key ---------------------------------------
+
+    @responses.activate
+    def test_idempotency_key_is_deterministic_for_same_batch(self):
+        """The same batch must carry the SAME idempotency key across resends, so
+        the server can dedup a retried/re-queued batch (a random key per call
+        defeated this and produced duplicate hours)."""
+        responses.add(
+            responses.POST,
+            "https://betterflow.eu/api/agent/events/batch",
+            json={"synced": 2},
+            status=200,
+        )
+
+        events = [
+            {"id": 1, "timestamp": "2026-02-18T10:00:00Z", "duration": 60, "data": {}},
+            {"id": 2, "timestamp": "2026-02-18T10:01:00Z", "duration": 30, "data": {}},
+        ]
+        self.client.send_events(events)
+        self.client.send_events(events)  # identical resend
+
+        key1 = responses.calls[0].request.headers["X-Idempotency-Key"]
+        key2 = responses.calls[1].request.headers["X-Idempotency-Key"]
+        assert key1 == key2
+        assert len(key1) == 64  # sha256 hex digest
+
+    @responses.activate
+    def test_idempotency_key_differs_for_different_batches(self):
+        """Distinct batches must get distinct keys (or the server would wrongly
+        dedup unrelated events)."""
+        responses.add(
+            responses.POST,
+            "https://betterflow.eu/api/agent/events/batch",
+            json={"synced": 1},
+            status=200,
+        )
+
+        self.client.send_events([{"id": 1, "duration": 60, "data": {}}])
+        self.client.send_events([{"id": 2, "duration": 60, "data": {}}])
+
+        key1 = responses.calls[0].request.headers["X-Idempotency-Key"]
+        key2 = responses.calls[1].request.headers["X-Idempotency-Key"]
+        assert key1 != key2
+
+    # ---- Global 429 backoff --------------------------------------------------
+
+    def test_enter_throttle_only_extends_and_caps(self):
+        """The backoff window only moves later, never earlier, and is capped."""
+        assert self.client._throttle_remaining() == 0.0
+
+        self.client._enter_throttle(10)
+        assert 8 < self.client._throttle_remaining() <= 10
+
+        # A shorter backoff must NOT shrink an active longer one.
+        self.client._enter_throttle(1)
+        assert self.client._throttle_remaining() > 5
+
+        # Hostile/buggy Retry-After can't park the agent for minutes.
+        self.client._enter_throttle(9999)
+        assert self.client._throttle_remaining() <= 60
+
+    def test_throttle_clears_after_window(self):
+        """Once the deadline passes, requests are allowed again."""
+        self.client._enter_throttle(10)
+        assert self.client._throttle_remaining() > 0
+
+        # Simulate the window elapsing.
+        with self.client._throttle_lock:
+            self.client._throttle_until = time.monotonic() - 1
+        assert self.client._throttle_remaining() == 0.0
+
+    @responses.activate
+    def test_429_opens_global_backoff_and_pauses_every_endpoint(self):
+        """A 429 on ONE endpoint must back off ALL endpoints — the next call (a
+        different endpoint) fails fast WITHOUT touching the network, instead of
+        each endpoint independently retrying into the same window."""
+        responses.add(
+            responses.POST,
+            "https://betterflow.eu/api/agent/events/batch",
+            status=429,
+            headers={"Retry-After": "30"},
+        )
+        # If the gate didn't work, this would be hit and return 200.
+        responses.add(
+            responses.GET,
+            "https://betterflow.eu/api/agent/events/status",
+            json={"ok": True},
+            status=200,
+        )
+
+        result = self.client.send_events([{"id": 1, "duration": 60, "data": {}}])
+        assert result.success is False
+        assert "429" in (result.error or "")
+        assert self.client._throttle_remaining() > 0
+
+        calls_after_429 = len(responses.calls)
+        # A different endpoint now short-circuits before any network call.
+        with pytest.raises(BetterFlowClientError, match="backoff"):
+            self.client._request("GET", "events/status")
+        assert len(responses.calls) == calls_after_429, "throttled call must not hit the network"
+
+    @responses.activate
+    def test_429_without_retry_after_uses_default_backoff(self):
+        """A 429 with no usable Retry-After still opens a (default) backoff."""
+        responses.add(
+            responses.POST,
+            "https://betterflow.eu/api/agent/events/batch",
+            status=429,
+        )
+
+        self.client.send_events([{"id": 1, "duration": 60, "data": {}}])
+        remaining = self.client._throttle_remaining()
+        assert 0 < remaining <= 60
+
+    @responses.activate
+    def test_requests_resume_after_backoff_clears(self):
+        """After the backoff window elapses, normal requests go through again."""
+        responses.add(
+            responses.POST,
+            "https://betterflow.eu/api/agent/events/batch",
+            status=429,
+            headers={"Retry-After": "30"},
+        )
+        responses.add(
+            responses.GET,
+            "https://betterflow.eu/api/agent/events/status",
+            json={"ok": True},
+            status=200,
+        )
+
+        self.client.send_events([{"id": 1, "duration": 60, "data": {}}])
+        assert self.client._throttle_remaining() > 0
+
+        # Window elapses.
+        with self.client._throttle_lock:
+            self.client._throttle_until = time.monotonic() - 1
+
+        assert self.client._request("GET", "events/status") == {"ok": True}
 
     @responses.activate
     def test_exchange_code_success(self):


### PR DESCRIPTION
Agent-side companion to the backend rate-limit fix. Three linked fixes that cut request volume and stop duplicate events under server-side 429 rate limiting.

## 1. Global 429 backoff (`http_client`)
Each endpoint (sync, hours, trends, heartbeat) ran its **own** retry loop and independently honored `Retry-After`. During a rate-limit window they all kept firing — a retry storm that amplified the 429s and likely drove the `Cannot connect` walls some users saw.

Now a single thread-safe backoff window (`_throttle_until`, guarded by `_throttle_lock`) is opened on any 429; **every** endpoint short-circuits *before* the network call until it clears. 429 is fail-fast (non-retryable) so we don't retry into the very window the server asked us to wait out. `408/503/504` stay per-call retryable. `Retry-After` is clamped to `[0, 60]` with a 30s default.

## 2. Deterministic idempotency key (`bf_client.send_events`)
The key was a fresh `uuid4()` **per call**, so a retried/re-queued batch carried a **different** key and the server couldn't dedup it → **duplicate, inflated hours**. It's now a `sha256` of the batch content, so every resend of the same events presents the same key and is deduped. This is what makes the re-queue-on-failure path safe.

## 3. Clearer re-queue logging (`sync_engine`)
The total-failure branch logged `"partial failure without accepted_ids"` for what are really transient errors (429/network/timeout). Now logs `"Batch not accepted (transient failure: …) - re-queuing all N events"`.

## Tests (`test_bf_client`)
- deterministic key for identical batches; distinct keys for distinct batches
- throttle window extend-only / cap / clear
- a 429 on one endpoint pauses **all** endpoints (asserts no network call while throttled)
- requests resume after the window elapses

`119 passed` on this branch; full suite `437 passed` on the working tree. Verified live: ran the patched agent from source on a real machine — starts clean, trackers up, syncing normally.

## Notes
- Thread-safety (per repo conventions): `_throttle_until` is read/written from the sync, heartbeat, and hours threads — all accesses go through `_throttle_lock`.
- Not reformatted with `ruff format`: these files carry a pre-existing formatting/lint baseline the repo doesn't enforce in CI; reformatting would balloon the diff with unrelated changes. New code matches surrounding style.
- Backend root-cause fix is a separate PR on `internal-tool2`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)