### PR TITLE
fix(sync): heartbeat while paused so long breaks don't crash the session

### DIFF
--- a/src/main.py
+++ b/src/main.py
@@ -181,6 +181,14 @@ class SyncCoordinator:
         self._input_tracking_ok: Optional[bool] = None  # None = not yet checked
         self._last_perm_warn_at: Optional[datetime] = None
 
+        # Liveness heartbeat while paused. The normal heartbeat rides _do_sync,
+        # which is skipped when paused (break / lock / manual), so a break longer
+        # than the server's 30-min stale-session cleanup gets its session marked
+        # "crashed" and tracking doesn't resume on return. Send a lightweight
+        # heartbeat from the 60s tick while paused-but-running to keep the
+        # session alive. monotonic-throttled so it's at most one per interval.
+        self._last_liveness_heartbeat: Optional[float] = None
+
         # Auth-warn throttle (Emilian, 2026-06-11): after his laptop restart
         # auto-login silently failed and the tray went to WAITING_AUTH without
         # any system notification — he could have worked a full day untracked.
@@ -625,6 +633,7 @@ class SyncCoordinator:
         for fn, label in (
             (self.tray.tick_clock, "tick_clock"),
             (self._check_idle_status, "idle_check"),
+            (self._liveness_heartbeat, "liveness_heartbeat"),
             (self._refresh_hours_today, "hours_refresh"),
             (self._check_permissions, "permissions"),
             (self._check_auth_warn, "auth_warn"),
@@ -647,6 +656,47 @@ class SyncCoordinator:
             reschedule=self.reschedule,
             trigger_sync=self.trigger_sync,
         )
+
+    # Keep the server session alive at least this often while paused. Well under
+    # the server's 30-min stale-session cleanup so a long break never trips it.
+    _LIVENESS_HEARTBEAT_INTERVAL = 300  # seconds
+
+    def _liveness_heartbeat(self) -> None:
+        """Heartbeat while paused-but-running so the server keeps the session.
+
+        The normal heartbeat rides _do_sync, which early-returns when paused
+        (break / screen lock / manual / private), so during a break longer than
+        the server's 30-min cleanup the device's last_seen_at goes stale and the
+        session is marked 'crashed' — then tracking doesn't resume on return.
+        A paused agent is alive, not crashed: send a lightweight heartbeat to
+        keep the session open. It only refreshes last_seen_at, never active time.
+
+        Skipped while actively syncing (that path already heartbeats) and while
+        offline (no server to reach). Throttled to one per interval.
+        """
+        if not self.logged_in:
+            return
+        if self.paused_by_network:
+            return  # offline — the heartbeat would just fail; resume on reconnect
+        paused = (
+            self.sync_engine.is_paused
+            or self.sync_engine.is_private
+            or self.is_on_break
+        )
+        if not paused:
+            return  # active sync already sends heartbeats
+
+        now = time.monotonic()
+        if (
+            self._last_liveness_heartbeat is not None
+            and now - self._last_liveness_heartbeat < self._LIVENESS_HEARTBEAT_INTERVAL
+        ):
+            return
+        self._last_liveness_heartbeat = now
+
+        auth_err = self.sync_engine.send_heartbeat_now()
+        if auth_err is not None:
+            self._handle_auth_error(auth_err, source="liveness_heartbeat")
 
     _DO_SYNC_DEADLINE = 120  # seconds — must exceed request_timeout * (max_retries + 1)
 

--- a/src/sync/sync_engine.py
+++ b/src/sync/sync_engine.py
@@ -1443,6 +1443,21 @@ class SyncEngine:
             return self._send_heartbeat()
         return None
 
+    def send_heartbeat_now(self) -> Optional["BetterFlowAuthError"]:
+        """Send a heartbeat immediately, bypassing the sync-cycle counter.
+
+        Used to keep the device alive on the server while the agent is PAUSED
+        (break / screen lock / manual pause). The normal heartbeat rides the
+        sync cycle, which is skipped while paused — so without this the device's
+        last_seen_at goes stale and the server's 30-minute stale-session cleanup
+        marks a long break as a 'crashed' session, and tracking doesn't resume
+        when the user returns. A paused-but-running agent is alive, not crashed.
+        Heartbeats only refresh last_seen_at; they never add active/tracked time.
+
+        Returns a BetterFlowAuthError on 401/403 so the caller can re-login.
+        """
+        return self._send_heartbeat()
+
     def _send_heartbeat(self) -> Optional["BetterFlowAuthError"]:
         """Send heartbeat to server and process commands.
 

--- a/tests/test_liveness_heartbeat.py
+++ b/tests/test_liveness_heartbeat.py
@@ -1,0 +1,112 @@
+"""Tests for the paused-state liveness heartbeat.
+
+The normal heartbeat rides _do_sync, which is skipped while the agent is
+paused (break / screen lock / manual). A break longer than the server's
+30-minute stale-session cleanup then gets its session marked "crashed", so
+tracking does not resume when the user returns. _liveness_heartbeat keeps the
+session alive by heartbeating from the 60s tick while paused-but-running.
+
+Mirrors test_auth_warn.py: a SyncCoordinator with mocked deps, exercising one
+60s-tick helper directly (no scheduler / AW / tray loop).
+"""
+
+import time
+from unittest.mock import MagicMock
+
+from src.main import SyncCoordinator
+from src.sync.http_client import BetterFlowAuthError
+
+
+def _make_coordinator() -> SyncCoordinator:
+    tray = MagicMock()
+    tray.model = MagicMock()
+
+    coord = SyncCoordinator(
+        config=MagicMock(),
+        aw=MagicMock(),
+        bf=MagicMock(),
+        queue=MagicMock(),
+        sync_engine=MagicMock(),
+        tray=tray,
+        aw_manager=MagicMock(),
+    )
+    coord.logged_in = True
+    coord.paused_by_network = False
+    # MagicMock attrs are truthy by default — pin the states we branch on.
+    coord.sync_engine.is_paused = False
+    coord.sync_engine.is_private = False
+    coord.sync_engine.send_heartbeat_now.return_value = None
+    coord.break_mgr = MagicMock()
+    coord.break_mgr.is_on_break = False
+    return coord
+
+
+def test_no_heartbeat_while_actively_syncing():
+    coord = _make_coordinator()  # not paused
+    coord._liveness_heartbeat()
+    coord.sync_engine.send_heartbeat_now.assert_not_called()
+
+
+def test_heartbeat_when_paused():
+    coord = _make_coordinator()
+    coord.sync_engine.is_paused = True
+    coord._liveness_heartbeat()
+    coord.sync_engine.send_heartbeat_now.assert_called_once()
+
+
+def test_heartbeat_when_on_break():
+    coord = _make_coordinator()
+    coord.break_mgr.is_on_break = True
+    coord._liveness_heartbeat()
+    coord.sync_engine.send_heartbeat_now.assert_called_once()
+
+
+def test_heartbeat_when_private():
+    coord = _make_coordinator()
+    coord.sync_engine.is_private = True
+    coord._liveness_heartbeat()
+    coord.sync_engine.send_heartbeat_now.assert_called_once()
+
+
+def test_throttled_within_interval():
+    coord = _make_coordinator()
+    coord.sync_engine.is_paused = True
+    coord._liveness_heartbeat()
+    coord._liveness_heartbeat()
+    coord._liveness_heartbeat()
+    coord.sync_engine.send_heartbeat_now.assert_called_once()
+
+
+def test_refires_after_interval_elapses():
+    coord = _make_coordinator()
+    coord.sync_engine.is_paused = True
+    coord._liveness_heartbeat()
+    # Pretend the throttle clock advanced past the interval.
+    coord._last_liveness_heartbeat = time.monotonic() - coord._LIVENESS_HEARTBEAT_INTERVAL - 1
+    coord._liveness_heartbeat()
+    assert coord.sync_engine.send_heartbeat_now.call_count == 2
+
+
+def test_not_logged_in_skips():
+    coord = _make_coordinator()
+    coord.logged_in = False
+    coord.sync_engine.is_paused = True
+    coord._liveness_heartbeat()
+    coord.sync_engine.send_heartbeat_now.assert_not_called()
+
+
+def test_offline_skips():
+    coord = _make_coordinator()
+    coord.sync_engine.is_paused = True
+    coord.paused_by_network = True  # offline — server unreachable
+    coord._liveness_heartbeat()
+    coord.sync_engine.send_heartbeat_now.assert_not_called()
+
+
+def test_auth_error_triggers_relogin():
+    coord = _make_coordinator()
+    coord.sync_engine.is_paused = True
+    coord.sync_engine.send_heartbeat_now.return_value = BetterFlowAuthError("401")
+    coord._liveness_heartbeat()
+    coord.sync_engine.send_heartbeat_now.assert_called_once()
+    assert coord.logged_in is False  # _handle_auth_error flipped it


### PR DESCRIPTION
## Problem (recurring)

After a break **longer than ~30 minutes**, tracking doesn't resume on the user's return — even though they stay logged in.

## Root cause (cross-side interaction)

- **Server:** `agent:cleanup-sessions --timeout=30` marks a session **`crashed`** once the device's `last_seen_at` is >30 min stale.
- **Agent:** `last_seen_at` is only refreshed while actively syncing. The heartbeat rides `_do_sync`, which **early-returns whenever paused** (break / screen lock / manual / private). So during a break >30 min the agent goes completely silent → the server marks the session crashed → on return the agent keeps its sticky session and tracking doesn't pick back up cleanly.

Pure *idle* isn't affected (`_do_sync` still runs every ~5 min while idle and touches `last_seen_at`). It's specifically **break / lock / manual-pause** that go silent — matching the reports.

## Fix

Send a lightweight **liveness heartbeat from the 60s tick while paused-but-running** (`SyncEngine.send_heartbeat_now()`), throttled to once per 5 min — comfortably under the 30-min cleanup. A paused agent is *alive, not crashed*; keeping the session open means tracking resumes seamlessly on return.

- Heartbeat only refreshes `last_seen_at` (device online) — it **never** adds active/tracked time.
- Skipped while actively syncing (that path already heartbeats) and while **offline** (`paused_by_network`).
- Auth errors from it route through the existing `_handle_auth_error` (re-login).

System **sleep** is intentionally not kept alive — the agent thread is suspended while the machine sleeps, so the session correctly lapses and the backend self-heals a new one on wake.

## Tests

`tests/test_liveness_heartbeat.py` (9): heartbeats when paused / on break / private; throttle + refire-after-interval; skips when actively syncing, logged-out, or offline; auth error triggers re-login. Full suite: **442 passing**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)