### PR TITLE
fix(startup): pull data immediately after login (no 'Starting…' limbo)

### DIFF
--- a/src/main.py
+++ b/src/main.py
@@ -1110,6 +1110,11 @@ class BetterFlowApp:
         self.coordinator.fetch_projects()
         self._check_stale_session()
         self.coordinator.start()
+        # Pull data immediately instead of waiting for the scheduler's first
+        # 60s tick — otherwise the tray sits at "Starting… / 0h 0m" with greyed
+        # menus for up to a minute after a successful login. This first sync
+        # fetches today's hours and flips the tray to its live state at once.
+        self.coordinator.trigger_sync("post_login_sync")
         self._ensure_update_checks_started()
 
         if send_greeting:


### PR DESCRIPTION
## Problem

After a successful login, the tray sits at **"App status: Starting… / Hours today: 0h 0m"** with greyed-out menu items for up to ~60 seconds before it shows real data.

## Cause

`_finish_logged_in_startup` calls `coordinator.start()`, which schedules the sync as an `IntervalTrigger(seconds=60)` — and APScheduler's **first run is 60s out**. Nothing kicks an immediate sync, so the tray only flips to **"Active"** and fetches today's hours on that first tick. Until then the "App status" line (derived from `TrayState`) reads "Starting…" and hours read `0h 0m`.

## Fix

Trigger one sync immediately after `coordinator.start()`:

```python
self.coordinator.trigger_sync("post_login_sync")
```

`_do_sync` sets the tray state (→ "Active") and fetches today's hours, so the tray reflects live data within seconds of login instead of after a minute. This mirrors the existing immediate-sync triggers on wake / unlock / network-resume.

## Verification

Full agent suite: **464 passing**. Behaviour traced: `tray._get_status_text` maps `TrayState.SYNCING → "Active"`, and `_do_sync` fetches `hours_today`, so the first sync clears "Starting…", populates hours, and re-enables the menus.

🤖 Generated with [Claude Code](https://claude.com/claude-code)