### PR TITLE
fix(auth): tolerate transient 401/403 instead of instant logout

### DIFF
--- a/src/auth/login.py
+++ b/src/auth/login.py
@@ -2,6 +2,7 @@
 
 import logging
 import threading
+import time
 from dataclasses import dataclass
 from typing import Optional, Callable
 
@@ -82,28 +83,42 @@ class LoginManager:
         # Set credentials on client
         self.bf.set_credentials(credentials.api_token, credentials.device_id)
 
-        # Verify credentials are still valid
-        try:
-            self.bf.get_status()
-            state = LoginState(
-                logged_in=True,
-                user_email=credentials.user_email,
-                user_name=credentials.user_name or None,
-                user_role=credentials.user_role,
-                device_id=credentials.device_id,
-            )
-            logger.info(f"Auto-login successful for {credentials.user_email}")
-            if self._on_login_callback:
-                self._on_login_callback(state)
-            return state
-        except BetterFlowAuthError as e:
-            logger.warning(f"Auto-login failed (auth): {e}")
-            self.bf.clear_credentials()
-            return LoginState(logged_in=False, error="Stored credentials are invalid")
-        except BetterFlowClientError as e:
-            logger.warning(f"Auto-login failed (network): {e}")
-            # Don't clear credentials on network error - might be temporary
-            return LoginState(logged_in=False, error="Network error - check your connection")
+        # Verify credentials are still valid. A single 401 is often transient
+        # (the agent started mid-deploy, or a momentary backend token-lookup
+        # blip) — clearing credentials on the first failure forces a needless
+        # full re-login. Retry a few times with backoff and only treat the token
+        # as genuinely invalid (and clear it) after the failures persist.
+        auth_attempts = 3
+        auth_backoff = [2.0, 4.0]  # waits between the attempts
+        for attempt in range(auth_attempts):
+            try:
+                self.bf.get_status()
+                state = LoginState(
+                    logged_in=True,
+                    user_email=credentials.user_email,
+                    user_name=credentials.user_name or None,
+                    user_role=credentials.user_role,
+                    device_id=credentials.device_id,
+                )
+                logger.info(f"Auto-login successful for {credentials.user_email}")
+                if self._on_login_callback:
+                    self._on_login_callback(state)
+                return state
+            except BetterFlowAuthError as e:
+                if attempt < auth_attempts - 1:
+                    logger.warning(
+                        "Auto-login auth error (attempt %d/%d): %s — retrying",
+                        attempt + 1, auth_attempts, e,
+                    )
+                    time.sleep(auth_backoff[attempt])
+                    continue
+                logger.warning(f"Auto-login failed (auth) after {auth_attempts} attempts: {e}")
+                self.bf.clear_credentials()
+                return LoginState(logged_in=False, error="Stored credentials are invalid")
+            except BetterFlowClientError as e:
+                logger.warning(f"Auto-login failed (network): {e}")
+                # Don't clear credentials on network error - might be temporary
+                return LoginState(logged_in=False, error="Network error - check your connection")
 
     def login_via_browser(self) -> LoginState:
         """Log in via browser-based OAuth flow.

--- a/src/main.py
+++ b/src/main.py
@@ -146,6 +146,15 @@ class SyncCoordinator:
         self._consecutive_sync_failures = 0
         self._SYNC_FAILURE_ALERT_THRESHOLD = 3
 
+        # Consecutive auth (401/403) failures. A single one is almost always
+        # transient — a backend deploy, a momentary token-lookup blip — so
+        # logging out on the first one needlessly stops tracking and leaves the
+        # user "idle" until they re-login. Only treat the session as lost after
+        # this many CONSECUTIVE failures; any successful sync resets the streak.
+        # Mutated only inside _do_sync's call chain (sync thread), no extra lock.
+        self._consecutive_auth_failures = 0
+        self._AUTH_FAILURE_LOGOUT_THRESHOLD = 3
+
         # Flags set by the app layer - protected by _state_lock
         self._logged_in = False
         self._paused_by_network = False
@@ -210,6 +219,10 @@ class SyncCoordinator:
     def logged_in(self, value: bool) -> None:
         with self._state_lock:
             self._logged_in = value
+        # A fresh login starts with a clean auth-failure streak so a later
+        # transient 401 doesn't immediately re-cross the logout threshold.
+        if value:
+            self._consecutive_auth_failures = 0
 
     @property
     def paused_by_network(self) -> bool:
@@ -771,6 +784,9 @@ class SyncCoordinator:
             if stats.success or stats.events_sent > 0:
                 # A successful (or partial) sync clears the failure streak.
                 self._consecutive_sync_failures = 0
+                # A successful authenticated round-trip means the token is fine,
+                # so any earlier 401/403 was transient — clear the auth streak.
+                self._consecutive_auth_failures = 0
                 # Partial success: some buckets may fail but data still syncs
                 if stats.errors:
                     for err in stats.errors:
@@ -860,8 +876,34 @@ class SyncCoordinator:
             )
 
     def _handle_auth_error(self, e: BetterFlowAuthError, *, source: str) -> None:
-        """Trigger re-login on a 401/403 from sync or heartbeat."""
-        logger.warning(f"Auth error during {source}: {e} — triggering re-login")
+        """Handle a 401/403 from sync or heartbeat — tolerating transient ones.
+
+        Logging out on the FIRST auth error is what froze users at "idle" after
+        a backend deploy or a momentary token blip: one 401 → wipe session →
+        tracking stops. We instead require several CONSECUTIVE failures before
+        treating the session as lost. Until the threshold, we keep the session
+        and keep tracking/queuing — the next sync retries, and a success resets
+        the streak (see _do_sync). Only a sustained failure (genuine
+        revoke/logout) crosses the threshold and prompts re-login.
+        """
+        self._consecutive_auth_failures += 1
+        if self._consecutive_auth_failures < self._AUTH_FAILURE_LOGOUT_THRESHOLD:
+            logger.warning(
+                "Auth error during %s (%d/%d consecutive): %s — tolerating as "
+                "likely transient; keeping session, will retry",
+                source,
+                self._consecutive_auth_failures,
+                self._AUTH_FAILURE_LOGOUT_THRESHOLD,
+                e,
+            )
+            return
+
+        logger.warning(
+            "Auth error during %s — %d consecutive failures, session lost: %s",
+            source,
+            self._consecutive_auth_failures,
+            e,
+        )
         self.logged_in = False
         self.tray.set_state(
             TrayState.WAITING_AUTH, "Session expired, re-login required"

--- a/tests/test_auth_tolerance.py
+++ b/tests/test_auth_tolerance.py
@@ -1,0 +1,103 @@
+"""Tests for transient-auth-error tolerance.
+
+A single 401/403 (backend deploy, momentary token-lookup blip) used to log the
+user out immediately and stop tracking → dashboard showed "idle". Now:
+- SyncCoordinator._handle_auth_error tolerates failures below a threshold and
+  only logs out after N consecutive ones; a fresh login resets the streak.
+- LoginManager.try_auto_login retries auth failures with backoff before wiping
+  stored credentials.
+"""
+
+from unittest.mock import MagicMock, patch
+
+from src.auth.login import LoginManager
+from src.main import SyncCoordinator
+from src.sync.http_client import BetterFlowAuthError, BetterFlowClientError
+
+
+def _make_coordinator() -> SyncCoordinator:
+    tray = MagicMock()
+    tray.model = MagicMock()
+    coord = SyncCoordinator(
+        config=MagicMock(),
+        aw=MagicMock(),
+        bf=MagicMock(),
+        queue=MagicMock(),
+        sync_engine=MagicMock(),
+        tray=tray,
+        aw_manager=MagicMock(),
+    )
+    coord.logged_in = True
+    coord._on_auth_error = MagicMock()
+    return coord
+
+
+class TestHandleAuthErrorTolerance:
+    def test_single_auth_error_is_tolerated(self):
+        coord = _make_coordinator()
+        coord._handle_auth_error(BetterFlowAuthError("401"), source="sync")
+        assert coord.logged_in is True
+        coord._on_auth_error.assert_not_called()
+
+    def test_below_threshold_keeps_session(self):
+        coord = _make_coordinator()
+        for _ in range(coord._AUTH_FAILURE_LOGOUT_THRESHOLD - 1):
+            coord._handle_auth_error(BetterFlowAuthError("401"), source="heartbeat")
+        assert coord.logged_in is True
+        coord._on_auth_error.assert_not_called()
+
+    def test_threshold_logs_out_and_triggers_relogin(self):
+        coord = _make_coordinator()
+        for _ in range(coord._AUTH_FAILURE_LOGOUT_THRESHOLD):
+            coord._handle_auth_error(BetterFlowAuthError("401"), source="sync")
+        assert coord.logged_in is False
+        coord._on_auth_error.assert_called_once()
+
+    def test_login_resets_the_streak(self):
+        coord = _make_coordinator()
+        # Two failures (below threshold), then a successful (re)login.
+        coord._handle_auth_error(BetterFlowAuthError("401"), source="sync")
+        coord._handle_auth_error(BetterFlowAuthError("401"), source="sync")
+        coord.logged_in = True  # setter resets the auth streak
+        assert coord._consecutive_auth_failures == 0
+        # Two more failures must still be tolerated (streak restarted).
+        coord._handle_auth_error(BetterFlowAuthError("401"), source="sync")
+        coord._handle_auth_error(BetterFlowAuthError("401"), source="sync")
+        assert coord.logged_in is True
+
+
+class TestTryAutoLoginRetries:
+    def _mgr(self, get_status_side_effect):
+        bf = MagicMock()
+        bf.get_status.side_effect = get_status_side_effect
+        keychain = MagicMock()
+        creds = MagicMock()
+        creds.api_token = "tok"
+        creds.device_id = "dev"
+        creds.user_email = "a@b.co"
+        creds.user_name = "A"
+        creds.user_role = "user"
+        keychain.load.return_value = creds
+        return LoginManager(bf_client=bf, keychain=keychain), bf
+
+    def test_transient_auth_error_then_success_does_not_clear(self):
+        # 401 twice, then OK — should log in and NEVER clear credentials.
+        mgr, bf = self._mgr([BetterFlowAuthError("401"), BetterFlowAuthError("401"), None])
+        with patch("src.auth.login.time.sleep"):
+            state = mgr.try_auto_login()
+        assert state.logged_in is True
+        bf.clear_credentials.assert_not_called()
+
+    def test_persistent_auth_error_clears_after_retries(self):
+        mgr, bf = self._mgr([BetterFlowAuthError("401")] * 3)
+        with patch("src.auth.login.time.sleep"):
+            state = mgr.try_auto_login()
+        assert state.logged_in is False
+        bf.clear_credentials.assert_called_once()
+
+    def test_network_error_never_clears(self):
+        mgr, bf = self._mgr([BetterFlowClientError("network")])
+        with patch("src.auth.login.time.sleep"):
+            state = mgr.try_auto_login()
+        assert state.logged_in is False
+        bf.clear_credentials.assert_not_called()

--- a/tests/test_liveness_heartbeat.py
+++ b/tests/test_liveness_heartbeat.py
@@ -103,10 +103,14 @@ def test_offline_skips():
     coord.sync_engine.send_heartbeat_now.assert_not_called()
 
 
-def test_auth_error_triggers_relogin():
+def test_auth_error_routes_through_handler_and_is_tolerated():
+    # A single auth error from the liveness heartbeat is routed to
+    # _handle_auth_error, which now TOLERATES one transient failure rather than
+    # logging out immediately (see test_auth_tolerance for the threshold).
     coord = _make_coordinator()
     coord.sync_engine.is_paused = True
     coord.sync_engine.send_heartbeat_now.return_value = BetterFlowAuthError("401")
     coord._liveness_heartbeat()
     coord.sync_engine.send_heartbeat_now.assert_called_once()
-    assert coord.logged_in is False  # _handle_auth_error flipped it
+    assert coord.logged_in is True  # tolerated, not an immediate logout
+    assert coord._consecutive_auth_failures == 1


### PR DESCRIPTION
## Problem

Users (incl. Alexandru, and the founder) got **logged out mid-session and dropped to "idle"**. Sanctum tokens never expire server-side (`'expiration' => null`), so it was never a timeout — the agent just **gave up on the first 401/403**:
- `_handle_auth_error` logged out + went WAITING_AUTH on the **first** auth error.
- `try_auto_login` **wiped stored credentials** on the first auth error.

A single transient blip — a backend deploy (we shipped several today), a momentary token-lookup hiccup — was enough to stop tracking for the rest of the session.

## Fix — tolerate transient auth failures

- **`SyncCoordinator`**: only treat the session as lost after **3 consecutive** auth failures. Below that, keep the session and keep tracking/queuing; the next sync retries. A **successful sync** or a **fresh login** resets the streak.
- **`LoginManager.try_auto_login`**: retry auth failures with backoff (3 attempts) before clearing credentials, so starting up during a deploy doesn't force a full re-login. Network errors still never clear creds.

## Tests

`tests/test_auth_tolerance.py` — below-threshold tolerated, logout at threshold (+ re-login triggered), streak reset on login; auto-login retries-then-succeeds without clearing, clears only after sustained failure, never clears on network error. (Updated one liveness test to the new tolerant behavior.) Full suite: **471 passing**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)