### PR TITLE
test(tray): stub menu render so state-transition tests pass headless

### DIFF
--- a/tests/test_tray_state_transitions.py
+++ b/tests/test_tray_state_transitions.py
@@ -31,6 +31,14 @@ def _make_tray() -> TrayIcon:
             on_quit=lambda: None,
         )
     tray._icon = MagicMock()
+    # Stub the actual menu rendering. set_state() now rebuilds the menu via
+    # _create_menu() -> pystray.Menu, but pystray's backend can't initialize on
+    # a headless CI box (no display), so the real call returns None and the
+    # rebuild raises "NoneType object is not callable". These tests only assert
+    # on model.status_text / state, not on rendered menu items, so stub the
+    # render to keep them platform-independent.
+    tray._create_menu = MagicMock(return_value=MagicMock())
+    tray._apply_menu = MagicMock()
     return tray
 
 


### PR DESCRIPTION
Tudor's new `test_tray_state_transitions` tests failed the **Linux** release build with `TypeError: 'NoneType' object is not callable`. Cause: `set_state()` now rebuilds the menu via `_create_menu() -> pystray.Menu`, but pystray's backend can't initialize on a headless CI runner (no display), so the real call returns `None`. This blocked the v1.5.39 release.

The tests only assert on `model.status_text` / state — not on rendered menu items — so stub `_create_menu`/`_apply_menu` in the fixture to keep them platform-independent. **Production code unchanged.**

Unblocks the release (→ v1.5.40). Full local suite green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)