### PR TITLE
fix(startup): don't force re-login on update — gate wizard on credentials

### DIFF
--- a/src/main.py
+++ b/src/main.py
@@ -1233,8 +1233,30 @@ class BetterFlowApp:
             except Exception as e:
                 logger.warning("Auto-start sync failed (non-fatal): %s", e)
 
-        # First-run setup wizard
+        # First-run setup wizard.
+        #
+        # Gate on stored CREDENTIALS, not on the setup_complete flag alone. The
+        # flag has been observed to get knocked false across self-update
+        # relaunches; keying the wizard on it alone forced already-onboarded
+        # users to re-sign-in after every auto-update. So: only show the wizard
+        # when the user genuinely isn't set up (no credentials in the keychain).
+        # If credentials exist but the flag is false, it was spuriously reset —
+        # repair it and continue straight to auto-login below.
         wizard_login_state = None
+        has_credentials = False
+        try:
+            has_credentials = self.keychain.load() is not None
+        except Exception as e:
+            logger.warning("Could not read stored credentials at startup: %s", e)
+
+        if not self.config.setup_complete and has_credentials:
+            logger.info(
+                "setup_complete was false but credentials exist — repairing flag "
+                "and skipping the setup wizard (likely reset across an update)"
+            )
+            self.config.setup_complete = True
+            self.config.save()
+
         if not self.config.setup_complete:
             try:
                 from .ui.setup_wizard import show_setup_wizard


### PR DESCRIPTION
## Problem

Users (repeatedly) landed on the **"Welcome / Install and Connect"** setup wizard after auto-updates and had to **sign in again**. With 4 releases shipped today, anyone on the bleeding edge ate a re-login per update.

## Root cause

The setup wizard is gated **only** on the config `setup_complete` flag, which gets **knocked false across self-update relaunches** (confirmed in logs: every reset lines up with `Applying staged update → relaunch`). Keyed on that flag alone, every auto-update forces an already-onboarded user to re-authenticate — and the re-login **rotates the device token** server-side, cascading into further logouts.

## Fix

Gate on **stored credentials**, not the flag. If the keychain has valid credentials, the user is set up → **skip the wizard and auto-login**, even if the flag was spuriously reset. If the flag is false but credentials exist, **repair it** (set true + save). The wizard now only shows on a genuine first run (no credentials). **Self-heals regardless of why the flag flipped** — so we don't have to chase every reset path.

This makes auto-updates seamless: relaunch into the new version → credentials present → no wizard → straight back to tracking.

Full suite: **486 passing**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)