### PR TITLE
fix(tray): show Offline (not Error) when the network is down

### DIFF
--- a/src/main.py
+++ b/src/main.py
@@ -807,9 +807,8 @@ class SyncCoordinator:
             else:
                 for err in stats.errors:
                     logger.warning(f"Sync failed: {err}")
-                self.tray.set_state(
-                    TrayState.ERROR,
-                    stats.errors[0] if stats.errors else "Sync failed",
+                self._set_sync_failure_state(
+                    stats.errors[0] if stats.errors else "Sync failed"
                 )
                 self._note_sync_failure(
                     stats.errors[0] if stats.errors else "Sync failed"
@@ -838,7 +837,7 @@ class SyncCoordinator:
             self._handle_auth_error(e, source="sync")
         except Exception as e:
             logger.exception(f"Sync error: {e}")
-            self.tray.set_state(TrayState.ERROR, "Sync error")
+            self._set_sync_failure_state("Sync error")
             self._note_sync_failure("Sync error", exc=e)
         finally:
             watchdog_cancelled.set()
@@ -853,6 +852,24 @@ class SyncCoordinator:
         auth_err = self.sync_engine.send_heartbeat_if_due(stats)
         if auth_err is not None:
             self._handle_auth_error(auth_err, source="heartbeat")
+
+    def _set_sync_failure_state(self, error_message: str) -> None:
+        """Pick the right tray state for a failed sync.
+
+        No internet should read "Offline", not "Error" — including the common
+        case where Wi-Fi is "connected" but has no route (NO_INTERNET), which
+        the OS network monitor doesn't always report, so paused_by_network never
+        gets set. Probe reachability: unreachable -> Offline (we're still
+        tracking and queuing locally); reachable but failed -> a real Error.
+        """
+        try:
+            reachable = self.bf.is_reachable()
+        except Exception:
+            reachable = False
+        if not reachable:
+            self.tray.set_state(TrayState.QUEUED, "Offline")
+        else:
+            self.tray.set_state(TrayState.ERROR, error_message)
 
     def _note_sync_failure(self, reason: str, *, exc: Optional[BaseException] = None) -> None:
         """Track a hard sync failure and report once it becomes a streak.

--- a/tests/test_offline_status.py
+++ b/tests/test_offline_status.py
@@ -1,0 +1,47 @@
+"""A failed sync while offline must read "Offline", not "Error".
+
+When there's no internet (incl. Wi-Fi "connected" but no route, which the OS
+network monitor doesn't always flag), a sync failure should put the tray into
+the queued/Offline state — we're still tracking and queuing locally — instead
+of a scary "App status: Error".
+"""
+
+from unittest.mock import MagicMock
+
+from src.main import SyncCoordinator
+from src.ui.tray import TrayState
+
+
+def _make_coordinator() -> SyncCoordinator:
+    tray = MagicMock()
+    tray.model = MagicMock()
+    return SyncCoordinator(
+        config=MagicMock(),
+        aw=MagicMock(),
+        bf=MagicMock(),
+        queue=MagicMock(),
+        sync_engine=MagicMock(),
+        tray=tray,
+        aw_manager=MagicMock(),
+    )
+
+
+def test_unreachable_shows_offline_not_error():
+    coord = _make_coordinator()
+    coord.bf.is_reachable.return_value = False
+    coord._set_sync_failure_state("Sync failed")
+    coord.tray.set_state.assert_called_once_with(TrayState.QUEUED, "Offline")
+
+
+def test_reachable_failure_shows_error():
+    coord = _make_coordinator()
+    coord.bf.is_reachable.return_value = True
+    coord._set_sync_failure_state("Boom")
+    coord.tray.set_state.assert_called_once_with(TrayState.ERROR, "Boom")
+
+
+def test_reachability_probe_raising_is_treated_as_offline():
+    coord = _make_coordinator()
+    coord.bf.is_reachable.side_effect = RuntimeError("dns")
+    coord._set_sync_failure_state("Sync error")
+    coord.tray.set_state.assert_called_once_with(TrayState.QUEUED, "Offline")


### PR DESCRIPTION
## Problem

With no internet, the tray showed **`App status: Error`** — but the agent was still tracking (1h 6m) and queuing locally. It should read **Offline**.

## Cause

A sync failure fell through to the generic `set_state(TrayState.ERROR, …)`. `paused_by_network` (which would show Offline) is only set from the **OS network monitor**, which doesn't flag the common *"Wi-Fi connected but no route"* case (`NO_INTERNET`/`ERR_INTERNET_DISCONNECTED`). So a real connectivity failure looked like an app error.

## Fix

Route sync failures through `_set_sync_failure_state(msg)`: probe `bf.is_reachable()` (no-retry health check) and show **QUEUED/"Offline"** when unreachable, **ERROR** only when the server is reachable but the request genuinely failed. Both the failed-stats branch and the catch-all `except` in `_do_sync` go through it.

Tests: unreachable → Offline; reachable failure → Error; probe raising → treated as Offline. Full local suite green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)