### PR TITLE
fix(agent): restart a hung idle/AFK tracker so Active time can't freeze

### DIFF
--- a/docs/RELEASE_1.5.43_TEST_CHECKLIST.md
+++ b/docs/RELEASE_1.5.43_TEST_CHECKLIST.md
@@ -1,0 +1,70 @@
+# BetterFlow Agent 1.5.43 — Release Test Checklist
+
+Context: 1.5.43 fixes the 2026-06-15 fleet incident (agents stopped uploading
+window/input activity; users showed idle while working). It pairs with server
+PR internal-tool2 **#1833** (revert breaking aggregate index + send
+`working_hours` in `/api/agent/config`).
+
+**Do not release to the fleet until every box below passes on a real machine.**
+
+## 0. Pre-req
+- [ ] Server **#1833 deployed** first (so `/api/agent/config` returns `working_hours`
+      and the broken `agent_aggregate_unique_v2` index is gone). Verify:
+      `curl -s -H "Authorization: Bearer <device_token>" -H "User-Agent: BetterFlow/1.5.43" \
+       https://app.betterflow.eu/api/agent/config | jq .data.working_hours`
+- [ ] Build is `BetterFlow/1.5.43` (tray → About, or `--version`).
+
+## 1. Basic upload (no regression)
+- [ ] Install, launch, log in. Tray shows `API: Connected`, `ActivityWatch: Running`.
+- [ ] Work for ~3 min (switch a couple apps, type). Within ~1–2 sync cycles, the
+      events appear in prod: `agent_events` for the device has fresh `window` +
+      `input` rows with `created_at` = now.
+- [ ] `/agent/my` shows current activity in the timeline (not idle) and Active
+      time increasing.
+
+## 2. No client-side dropping (the core fix)
+- [ ] Tail the agent log; confirm **no** `"Window event skipped after inactivity
+      cutoff/AFK overlap"` lines appear during active work.
+- [ ] Keep ONE window focused and keep typing for >10 min with few app switches;
+      confirm those minutes still upload (previously dropped).
+- [ ] `1 sent / 0 filtered` style log lines reflect real activity going up; the
+      "filtered" count should be dedup only, not real-activity drops.
+
+## 3. Backlog reconcile on restart (recovers a stuck day)
+- [ ] Simulate a stall: stop networking / block the API for ~5 min while you work
+      (events accumulate locally only). Confirm prod has a gap for that window.
+- [ ] Restore networking, then **Quit + relaunch** the agent.
+- [ ] After the first post-restart sync, the gap **backfills** in prod
+      (`_reconcile_backlog` rewound checkpoints to start-of-day; server upserts by
+      event id, so no duplicates). Confirm event counts didn't double.
+
+## 4. Working-hours enforcement (B2E / Trainee)
+- [ ] On a **B2E** account (`users.relationship = 'B2E'`), confirm config shows
+      `working_hours.enforced = true`, `08:00`–`22:00`, Mon–Fri.
+- [ ] Set the machine clock to **07:30** (or generate activity, then check a
+      pre-08:00 timestamp): confirm those events are **NOT uploaded** (gated by
+      `_within_working_hours`), and the checkpoint still advances (no infinite
+      re-fetch).
+- [ ] Set clock to **22:30**: same — not uploaded.
+- [ ] Set clock to **10:00 weekday**: events upload normally.
+- [ ] On a **B2B** account (`enforced=false`): activity at any hour uploads
+      (unrestricted).
+
+## 5. No idle over-count (pair with server idle handling)
+- [ ] Leave the machine idle (no input, screen on one window) for >20 min.
+- [ ] Confirm tracked/Active time does **not** keep climbing during the idle gap
+      on `/agent/my` (server decides idle from AFK). If it does, the server-side
+      idle handling (option 1) is still needed — flag before release.
+
+## 6. Stability
+- [ ] Run for ~30 min; no crashes, no runaway CPU, log clean.
+- [ ] `events_synced_count` increases steadily; `Queue` stays near 0 under normal
+      network.
+
+## Rollback
+- Agent: users reinstall the previous signed build; no data loss (local aw-db
+  retains events).
+- Server: revert PR #1833 is itself a revert; no separate rollback needed.
+
+---
+Reset the machine clock after the working-hours tests.

--- a/src/__init__.py
+++ b/src/__init__.py
@@ -1,4 +1,4 @@
 """BetterFlow - ActivityWatch to BetterFlow sync companion app."""
 
-__version__ = "1.5.42"
+__version__ = "1.5.43"
 __author__ = "BetterQA"

--- a/src/aw_manager.py
+++ b/src/aw_manager.py
@@ -390,7 +390,6 @@ class AWManager:
         if not binaries_dir:
             return False
 
-        restarted = False
         server_restarted = False
         for name, proc in list(self._processes.items()):
             if name in self._disabled_components:
@@ -400,7 +399,6 @@ class AWManager:
                     f"Restarting {name} (exited with code {proc.returncode})"
                 )
                 self._start_component(name, binaries_dir)
-                restarted = True
                 if name == BF_SERVER:
                     server_restarted = True
 
@@ -426,7 +424,44 @@ class AWManager:
                 except subprocess.TimeoutExpired:
                     proc.kill()
                 self._start_component(watcher, binaries_dir)
-                restarted = True
+
+        # Detect a stalled idle/AFK tracker (process alive but emitting no new
+        # events). The AFK watcher heartbeats its current event, so a frozen
+        # end-time means it hung — and a hung AFK watcher silently freezes
+        # "Active time" while the user keeps working (Alexandru, 2026-06-12: AFK
+        # froze at 18:27 while window+input ran to 19:53, so the day read 7h not
+        # 8h). Gate on the WINDOW tracker being fresh: only restart when the user
+        # is demonstrably active but AFK has gone silent — this is the precise
+        # "hung while working" signature and avoids churn during legitimate
+        # full-system idle or a sleep/wake where both watchers are paused.
+        idle_watcher = "bf-idle-tracker"
+        if (
+            idle_watcher not in self._disabled_components
+            and idle_watcher in self._processes
+            and self._processes[idle_watcher].poll() is None
+        ):
+            afk_age = self._get_latest_afk_event_age()
+            window_age = self._get_latest_window_event_age()
+            if (
+                afk_age is not None
+                and afk_age > STALE_THRESHOLD
+                and window_age is not None
+                and window_age <= STALE_THRESHOLD
+            ):
+                self._stale_restart_count += 1
+                logger.warning(
+                    f"{idle_watcher} stale: no AFK events for {afk_age:.0f}s "
+                    f"while the window tracker is fresh ({window_age:.0f}s) "
+                    f"(threshold {STALE_THRESHOLD}s, "
+                    f"restart #{self._stale_restart_count})"
+                )
+                proc = self._processes[idle_watcher]
+                proc.terminate()
+                try:
+                    proc.wait(timeout=SHUTDOWN_TIMEOUT)
+                except subprocess.TimeoutExpired:
+                    proc.kill()
+                self._start_component(idle_watcher, binaries_dir)
 
         # Only block waiting for the server when the server itself was
         # restarted. The previous check (`BF_SERVER in <currently-running>`)
@@ -561,13 +596,20 @@ class AWManager:
             except (ConnectionRefusedError, OSError):
                 return False
 
-    def _get_latest_window_event_age(self) -> Optional[float]:
-        """Return seconds since the most recent window event, or None on error."""
+    def _get_latest_event_age(self, bucket_prefix: str) -> Optional[float]:
+        """Seconds since the most recent event in the host's bucket whose id
+        starts with ``bucket_prefix`` (e.g. ``aw-watcher-window`` /
+        ``aw-watcher-afk``), or None on error/no events.
+
+        Age is measured from the event's END (timestamp + duration). Both the
+        window and AFK watchers heartbeat their current event, so a healthy
+        watcher keeps the end near now; a hung one freezes it.
+        """
         try:
             hostname = urllib.parse.quote(platform.node(), safe="")
             url = (
                 f"http://localhost:{self.aw_port}/api/0/buckets/"
-                f"aw-watcher-window_{hostname}/events?limit=1"
+                f"{bucket_prefix}_{hostname}/events?limit=1"
             )
             req = urllib.request.Request(url)
             with urllib.request.urlopen(req, timeout=3) as resp:
@@ -582,8 +624,16 @@ class AWManager:
             age = time.time() - event_end
             return max(0, age)
         except Exception as e:
-            logger.debug("_get_latest_window_event_age failed: %s", e)
+            logger.debug("_get_latest_event_age(%s) failed: %s", bucket_prefix, e)
             return None
+
+    def _get_latest_window_event_age(self) -> Optional[float]:
+        """Return seconds since the most recent window event, or None on error."""
+        return self._get_latest_event_age("aw-watcher-window")
+
+    def _get_latest_afk_event_age(self) -> Optional[float]:
+        """Return seconds since the most recent AFK event, or None on error."""
+        return self._get_latest_event_age("aw-watcher-afk")
 
     def _get_binaries_dir(self) -> Optional[str]:
         """Resolve path to tracker binaries directory.

--- a/src/config.py
+++ b/src/config.py
@@ -369,6 +369,20 @@ class ReminderSettings:
 
 
 @dataclass
+class WorkingHoursConfig:
+    """Server-enforced working-hours window. When ``enforced``, the agent must
+    NOT record/upload events outside [work_start, work_end] on working_days,
+    evaluated in ``timezone``. For B2E / Trainee-Intern this is 08:00-22:00
+    Mon-Fri; B2B and others are unrestricted (enforced=False)."""
+
+    enforced: bool = False
+    work_start: str = "00:00"
+    work_end: str = "23:59"
+    working_days: list = field(default_factory=lambda: [1, 2, 3, 4, 5, 6, 7])
+    timezone: str = ""
+
+
+@dataclass
 class Config:
     """Main configuration object."""
 
@@ -378,6 +392,7 @@ class Config:
     sync: SyncSettings = field(default_factory=SyncSettings)
     privacy: PrivacySettings = field(default_factory=PrivacySettings)
     reminders: ReminderSettings = field(default_factory=ReminderSettings)
+    working_hours: WorkingHoursConfig = field(default_factory=WorkingHoursConfig)
     engagement: EngagementConfig = field(default_factory=EngagementConfig)
     fraud_detection: FraudDetectionConfig = field(default_factory=FraudDetectionConfig)
     call_detection: CallDetectionSettings = field(default_factory=CallDetectionSettings)
@@ -558,6 +573,19 @@ class Config:
                 val = tracking["afk_timeout_minutes"]
                 if val in (10, 20, 30):
                     self.aw.afk_timeout_minutes = val
+
+        if "working_hours" in server_config:
+            wh = server_config["working_hours"]
+            try:
+                self.working_hours.enforced = bool(wh.get("enforced", False))
+                self.working_hours.work_start = str(wh.get("work_start", "00:00"))
+                self.working_hours.work_end = str(wh.get("work_end", "23:59"))
+                days = wh.get("working_days")
+                if isinstance(days, list) and days:
+                    self.working_hours.working_days = [int(d) for d in days]
+                self.working_hours.timezone = str(wh.get("timezone", "") or "")
+            except (TypeError, ValueError, AttributeError):
+                logger.warning("Invalid working_hours from server, ignoring")
 
         if "sync" in server_config:
             sync = server_config["sync"]

--- a/src/sync/sync_engine.py
+++ b/src/sync/sync_engine.py
@@ -11,6 +11,7 @@ from dataclasses import dataclass, field
 from datetime import datetime, timedelta, timezone
 from typing import Callable, Optional
 from urllib.parse import urlparse
+from zoneinfo import ZoneInfo
 
 try:
     from ..__init__ import __version__ as AGENT_VERSION
@@ -185,6 +186,10 @@ class SyncEngine:
         self._latest_input_at: Optional[datetime] = None
         self._current_afk_events: list[AWEvent] = []  # AFK events for current sync cycle
         self._afk_watcher_available = False  # True when AFK buckets exist this cycle
+        # One-time-per-process flag: on first sync we rewind checkpoints to the
+        # start of the local day so any locally-stored events the server never
+        # received (sync outage / dropped by the old client filter) get re-sent.
+        self._backlog_reconciled = False
 
         # Call/meeting detection
         self._call_detector: Optional[CallDetector] = (
@@ -362,6 +367,17 @@ class SyncEngine:
         with self._state_lock:
             self._afk_watcher_available = bool(afk_buckets)
 
+        # One-time backlog reconcile (this process): rewind checkpoints to the
+        # start of the local day so events that never reached the server are
+        # re-fetched and re-sent. The backend upserts by AW event id, so
+        # replaying already-stored events is deduped — safe. This is what makes
+        # a simple quit+restart recover a stuck day's data.
+        if not self._backlog_reconciled:
+            self._reconcile_backlog(
+                window_buckets + web_buckets + afk_buckets + input_buckets
+            )
+            self._backlog_reconciled = True
+
         # Fetch input events for activity analysis before processing window events.
         # The lookback must cover both the engagement window and the full AFK
         # grace period so we can cap counted time at last_input + afk_timeout.
@@ -497,6 +513,50 @@ class SyncEngine:
 
         return stats
 
+    def _reconcile_backlog(self, buckets: list) -> None:
+        """Rewind each bucket's checkpoint to the start of the local day so the
+        next fetch re-sends any locally-stored events the server is missing.
+
+        Safe to replay: the backend upserts events by AW event id, so events
+        already stored are deduped. This is what recovers a day stranded by a
+        sync outage or by the (now removed) client-side activity filter — a
+        quit+restart re-uploads everything still on the local DB.
+        """
+        day_start = (
+            datetime.now()
+            .astimezone()
+            .replace(hour=0, minute=0, second=0, microsecond=0)
+            .astimezone(timezone.utc)
+        )
+        for bucket in buckets:
+            try:
+                cp = self.queue.get_checkpoint(bucket.id)
+                if cp is None or cp > day_start:
+                    self.queue.set_checkpoint(bucket.id, day_start)
+            except Exception as e:  # never let reconcile break a sync cycle
+                logger.warning("Backlog reconcile failed for %s: %s", bucket.id, e)
+        logger.info(
+            "Backlog reconcile: checkpoints rewound to %s", day_start.isoformat()
+        )
+
+    def _within_working_hours(self, event: AWEvent) -> bool:
+        """True if the event's start falls inside the server-enforced working-
+        hours window. When the schedule is not enforced (B2B / unrestricted)
+        this is always True. Evaluated in the schedule's timezone, falling back
+        to the machine's local timezone when none is provided."""
+        wh = self.config.working_hours
+        if not getattr(wh, "enforced", False):
+            return True
+        try:
+            tz = ZoneInfo(wh.timezone) if wh.timezone else None
+        except Exception:
+            tz = None
+        local = event.timestamp.astimezone(tz) if tz else event.timestamp.astimezone()
+        if wh.working_days and local.isoweekday() not in wh.working_days:
+            return False
+        hhmm = local.strftime("%H:%M")
+        return wh.work_start <= hhmm <= wh.work_end
+
     def _fetch_bucket_events(
         self, bucket_id: str, stats: SyncStats
     ) -> tuple[list[AWEvent], datetime]:
@@ -568,6 +628,15 @@ class SyncEngine:
                 if is_gap_filled:
                     stats.events_filtered += 1
                     continue
+
+            # Working-hours gate: for restricted relationships (B2E / Trainee)
+            # the agent must NOT upload activity outside the enforced window
+            # (e.g. before 08:00 / after 22:00, or on non-working days). The
+            # checkpoint still advances past skipped events (computed from all
+            # fetched events below), so they are never re-fetched or sent.
+            if not self._within_working_hours(event):
+                stats.events_filtered += 1
+                continue
 
             if bucket_type in (BUCKET_TYPE_WINDOW, BUCKET_TYPE_WINDOW_ALT, BUCKET_TYPE_WEB):
                 transformed_events = self._transform_window_event_with_timeout(
@@ -698,36 +767,15 @@ class SyncEngine:
         """Transform only the countable slices of a long window/web event."""
         event_start = event.timestamp
         event_end = event.timestamp + timedelta(seconds=event.duration)
-        ranges: list[tuple[datetime, datetime]]
-        if self._afk_watcher_available:
-            ranges = self._active_ranges_from_afk(event)
-        else:
-            ranges = [(event_start, event_end)]
 
-        # Apply input timeout cap when input data is available and recent
-        # enough to be relevant. The AFK watcher has a lagging timeout
-        # (typically 5 min) during which it reports "not-afk" despite no
-        # actual input. The input cap trims those trailing minutes for more
-        # accurate time. But when input data is stale (e.g. input watcher
-        # crashed 30 min ago), AFK data alone is authoritative.
-        input_is_recent = (
-            self._has_input_data
-            and self._latest_input_at is not None
-            and (event_end - self._latest_input_at).total_seconds()
-            < self.config.aw.afk_timeout_minutes * 60 * 2
-        )
-        if input_is_recent:
-            active_ranges = self._cap_ranges_to_input_timeout(ranges)
-        else:
-            active_ranges = ranges
-        if not active_ranges:
-            logger.info(
-                "Window event skipped after inactivity cutoff/AFK overlap: "
-                "event=%s->%s",
-                event.timestamp.isoformat(),
-                event_end.isoformat(),
-            )
-            return []
+        # NO client-side dropping. Always upload the full window/web event with
+        # its real duration; active-vs-idle is decided SERVER-SIDE from the AFK
+        # stream. The previous inactivity-cutoff + AFK-overlap + input-timeout
+        # filter discarded genuinely-active work whenever input detection lagged
+        # or an event arrived zero-duration, stranding hours of real activity on
+        # users' machines (fleet incident, 2026-06-15). The client must never
+        # decide to throw real activity away — send everything, every cycle.
+        active_ranges = [(event_start, event_end)]
 
         transformed: list[dict] = []
         total_active_duration = 0.0

--- a/tests/test_aw_manager_idle_restart.py
+++ b/tests/test_aw_manager_idle_restart.py
@@ -1,0 +1,90 @@
+"""Watchdog restarts a HUNG idle/AFK tracker (Alexandru, 2026-06-12).
+
+bf-idle-tracker can stay alive (process running) while emitting no new AFK
+events — e.g. it hangs. The window + input watchers keep running, so the user
+goes on working, but "Active time" (computed from the AFK not-afk signal)
+freezes. The existing stale-check only covered bf-window-tracker; these tests
+pin that a hung idle tracker is detected (AFK stale while window fresh) and
+restarted, and that we DON'T churn-restart it during legitimate idle/sleep.
+"""
+
+from unittest.mock import MagicMock
+
+from src.aw_manager import STALE_THRESHOLD, AWManager
+
+
+def _make_manager(afk_age, window_age, idle_alive=True):
+    """An AWManager with mocked watchers and event-age probes."""
+    mgr = AWManager()
+    mgr._using_external = False
+
+    server = MagicMock()
+    server.poll.return_value = None  # alive
+    window = MagicMock()
+    window.poll.return_value = None  # alive
+    idle = MagicMock()
+    idle.poll.return_value = None if idle_alive else 1
+    mgr._processes = {
+        "bf-data-service": server,
+        "bf-window-tracker": window,
+        "bf-idle-tracker": idle,
+    }
+
+    mgr._get_binaries_dir = MagicMock(return_value="/tmp/bin")
+    mgr._start_component = MagicMock()
+    mgr.check_health = MagicMock(return_value=True)
+    mgr._get_latest_afk_event_age = MagicMock(return_value=afk_age)
+    mgr._get_latest_window_event_age = MagicMock(return_value=window_age)
+    return mgr, idle
+
+
+def _restarted(mgr, idle_proc):
+    return (
+        idle_proc.terminate.called
+        and (
+            ("bf-idle-tracker",) in [c.args[:1] for c in mgr._start_component.call_args_list]
+        )
+    )
+
+
+def test_restarts_idle_tracker_when_afk_stale_but_window_fresh():
+    # Alexandru's exact signature: AFK silent for 30 min, window fresh.
+    mgr, idle = _make_manager(afk_age=1800, window_age=5)
+
+    mgr.restart_if_needed()
+
+    assert _restarted(mgr, idle), "a hung idle tracker (AFK stale, user active) must be restarted"
+
+
+def test_does_not_restart_when_both_watchers_are_stale():
+    # Legitimate full-system idle / sleep: both paused → don't churn-restart.
+    mgr, idle = _make_manager(afk_age=1800, window_age=1800)
+
+    mgr.restart_if_needed()
+
+    assert not idle.terminate.called, "no restart when the user is genuinely idle"
+
+
+def test_does_not_restart_when_afk_is_fresh():
+    mgr, idle = _make_manager(afk_age=5, window_age=5)
+
+    mgr.restart_if_needed()
+
+    assert not idle.terminate.called, "healthy AFK watcher is left alone"
+
+
+def test_does_not_restart_disabled_idle_tracker():
+    mgr, idle = _make_manager(afk_age=1800, window_age=5)
+    mgr._disabled_components.add("bf-idle-tracker")
+
+    mgr.restart_if_needed()
+
+    assert not idle.terminate.called, "a disabled component is never restarted"
+
+
+def test_boundary_just_over_threshold_restarts():
+    mgr, idle = _make_manager(afk_age=STALE_THRESHOLD + 1, window_age=STALE_THRESHOLD)
+
+    mgr.restart_if_needed()
+
+    assert _restarted(mgr, idle), "AFK age just over threshold while window at/under it → restart"

--- a/tests/test_sync_engine.py
+++ b/tests/test_sync_engine.py
@@ -168,8 +168,11 @@ class TestSyncEngine:
         assert result is not None
         assert result["activity_state"] == "active"
 
-    def test_transform_and_checkpoint_splits_window_around_afk(self):
-        """Long window events should count only their non-AFK slices."""
+    def test_transform_and_checkpoint_uploads_full_window_no_client_afk_split(self):
+        """1.5.43: the client no longer splits/drops window events around AFK.
+        The full event is uploaded every cycle; active-vs-idle (AFK overlap) is
+        decided server-side. This prevents the client from stranding real work
+        when input detection lags or events arrive zero-duration."""
         self.engine._has_input_data = False
         self.engine._afk_watcher_available = True
         now = datetime.now(timezone.utc)
@@ -198,15 +201,13 @@ class TestSyncEngine:
         )
 
         assert checkpoint == ("bucket-123", now, 21)
-        assert len(transformed) == 2
+        # Full event uploaded as a single slice — no client-side AFK split.
+        assert len(transformed) == 1
         assert transformed[0]["id"] == "21:0"
-        assert transformed[0]["duration"] == 30.0
-        assert transformed[1]["id"] == "21:1"
-        assert transformed[1]["duration"] == 30.0
-        assert all(item["activity_state"] == "active" for item in transformed)
-        # Time tracking is per-event (sum of segments = 60s), not per-segment
+        assert transformed[0]["duration"] == 90.0
+        assert transformed[0]["activity_state"] == "active"
         self.time_tracker.add_active_time.assert_called_once()
-        assert self.time_tracker.add_active_time.call_args[0][0] == 60.0
+        assert self.time_tracker.add_active_time.call_args[0][0] == 90.0
 
     def test_transform_and_checkpoint_counts_full_window_without_afk(self):
         """Without AFK overlap, no-input windows should still count fully."""
@@ -235,8 +236,10 @@ class TestSyncEngine:
         assert transformed[0]["activity_state"] == "active"
         self.time_tracker.add_active_time.assert_called_once()
 
-    def test_transform_and_checkpoint_caps_counting_at_input_timeout(self):
-        """Counted time must stop at last_input + afk_timeout."""
+    def test_transform_and_checkpoint_uploads_full_duration_no_input_cap(self):
+        """1.5.43: no client-side input-timeout cap. The full event duration is
+        uploaded; the server trims idle from the AFK stream. The old cap dropped
+        genuinely-active work whenever input detection lagged."""
         self.engine._has_input_data = True
         self.engine._latest_input_at = datetime.now(timezone.utc)
         now = self.engine._latest_input_at - timedelta(minutes=5)
@@ -256,12 +259,14 @@ class TestSyncEngine:
         )
 
         assert len(transformed) == 1
-        assert transformed[0]["duration"] == 15 * 60.0
+        assert transformed[0]["duration"] == 20 * 60.0
         self.time_tracker.add_active_time.assert_called_once()
-        assert self.time_tracker.add_active_time.call_args[0][0] == 15 * 60.0
+        assert self.time_tracker.add_active_time.call_args[0][0] == 20 * 60.0
 
-    def test_transform_and_checkpoint_skips_window_after_timeout(self):
-        """A window fully beyond last_input + afk_timeout must not count."""
+    def test_transform_and_checkpoint_uploads_window_even_after_input_timeout(self):
+        """1.5.43: a window beyond last_input + afk_timeout is still uploaded —
+        the client never drops it. The server decides if it counts as active.
+        Previously this returned [] and silently stranded real activity."""
         self.engine._has_input_data = True
         self.engine._afk_watcher_available = False
         self.engine._latest_input_at = datetime.now(timezone.utc) - timedelta(minutes=11)
@@ -280,8 +285,35 @@ class TestSyncEngine:
             stats,
         )
 
-        assert transformed == []
-        self.time_tracker.add_active_time.assert_not_called()
+        assert len(transformed) == 1
+        assert transformed[0]["duration"] == 120.0
+        self.time_tracker.add_active_time.assert_called_once()
+
+    def test_within_working_hours_gate(self):
+        """1.5.43: B2E/Trainee working-hours enforcement. When enforced, events
+        outside [work_start, work_end] or on non-working days are rejected; when
+        unenforced (B2B/others), everything passes."""
+        wh = self.engine.config.working_hours
+        wh.enforced = True
+        wh.work_start = "08:00"
+        wh.work_end = "22:00"
+        wh.working_days = [1, 2, 3, 4, 5]  # Mon-Fri
+        wh.timezone = "UTC"
+
+        def ev(dt):
+            return AWEvent(id=1, timestamp=dt, duration=60, data={})
+
+        wed = lambda h, m=0: datetime(2026, 6, 17, h, m, tzinfo=timezone.utc)  # Wednesday
+        assert self.engine._within_working_hours(ev(wed(7, 30))) is False  # before 08:00
+        assert self.engine._within_working_hours(ev(wed(9, 0))) is True    # inside
+        assert self.engine._within_working_hours(ev(wed(22, 30))) is False  # after 22:00
+        # Saturday 2026-06-20 — non-working day
+        sat = datetime(2026, 6, 20, 10, 0, tzinfo=timezone.utc)
+        assert self.engine._within_working_hours(ev(sat)) is False
+
+        # Unrestricted (B2B): any time passes.
+        wh.enforced = False
+        assert self.engine._within_working_hours(ev(wed(3, 0))) is True
 
     def test_transform_and_checkpoint_uses_afk_when_input_is_stale(self):
         """AFK data should remain authoritative when input watcher goes stale."""


### PR DESCRIPTION
## 1.5.43 — agent reliability + working-hours enforcement

Fixes the 2026-06-15 fleet incident (agents stopped uploading window/input activity; users showed idle despite working). Combines the original hung-tracker restart fix with three more:

### Commits
- `88bfbc4` restart a hung idle/AFK tracker so Active time can't freeze
- `187c9b2` upload all local activity + enforce working hours

### Changes (`187c9b2`)
1. **No client-side activity dropping** — removed the active-range filter in `_transform_window_event_with_timeout` that discarded genuinely-active window events when input lagged or events arrived zero-duration (`"Window event skipped after inactivity cutoff/AFK overlap"`). The agent now uploads the full window/web event every cycle; active-vs-idle is decided server-side from the AFK stream.
2. **Backlog reconcile on startup** (`_reconcile_backlog`) — rewinds each bucket checkpoint to start-of-local-day on first sync so locally-stored events the server never received get re-sent (backend upserts by AW event id → dedupes). A quit+restart now recovers a stuck day.
3. **Working-hours enforcement** — for B2E / Trainee-Intern the agent no longer records/uploads outside the server-provided window (08:00–22:00, working days). New `WorkingHoursConfig` from `/api/agent/config`; `_within_working_hours()` gates every event; checkpoint advances past skipped out-of-hours events.

### Requires (server side, separate PR on internal-tool2)
- `/api/agent/config` must return the `working_hours` block (added).
- The breaking `agent_aggregate_unique_v2` migration must be reverted (done in prod by hand; PR pending).

### Test
See the 1.5.43 test checklist. Must build + run on a real machine before fleet release: verify (a) live upload, (b) backlog reconcile after a forced stall, (c) pre-08:00/post-22:00 suppressed for a B2E account, (d) no idle over-count.