### PR TITLE
fix(sync): persist counted time so restart/reconcile can't double-count tray hours

### DIFF
--- a/src/sync/queue.py
+++ b/src/sync/queue.py
@@ -185,6 +185,30 @@ class OfflineQueue:
                 """
             )
 
+            # Per-event counted active-seconds, persisted so the in-memory
+            # time-dedup cache survives a restart. Without this, a restart
+            # (or the start-of-day backlog reconcile that re-fetches the whole
+            # day) re-counts already-counted events into the local daily total,
+            # inflating the tray's "active time". Keyed by (bucket_id, event_id);
+            # `day` scopes load/prune to the local day the time belongs to.
+            cursor.execute(
+                """
+                CREATE TABLE IF NOT EXISTS counted_time (
+                    bucket_id TEXT NOT NULL,
+                    event_id TEXT NOT NULL,
+                    day TEXT NOT NULL,
+                    counted_seconds REAL NOT NULL,
+                    updated_at TEXT NOT NULL,
+                    PRIMARY KEY (bucket_id, event_id)
+                )
+                """
+            )
+            cursor.execute(
+                """
+                CREATE INDEX IF NOT EXISTS idx_counted_time_day ON counted_time(day)
+                """
+            )
+
     def check_integrity(self) -> bool:
         """Run periodic SQLite integrity check (N2).
 
@@ -494,6 +518,80 @@ class OfflineQueue:
                 row["bucket_id"]: datetime.fromisoformat(row["last_timestamp"])
                 for row in cursor.fetchall()
             }
+
+    # Per-event counted-time persistence (restart-safe time dedup)
+
+    def get_counted_times(self, day: str) -> dict[tuple[str, str], float]:
+        """Return all counted active-seconds for a given local day.
+
+        Args:
+            day: Local date in ISO format (``YYYY-MM-DD``).
+
+        Returns:
+            Dict mapping ``(bucket_id, event_id)`` -> counted_seconds. Used to
+            repopulate the in-memory time-dedup cache on startup so replayed
+            events are not double-counted into the daily total.
+        """
+        with self._cursor() as cursor:
+            cursor.execute(
+                """
+                SELECT bucket_id, event_id, counted_seconds FROM counted_time
+                WHERE day = ?
+                """,
+                (day,),
+            )
+            return {
+                (row["bucket_id"], row["event_id"]): float(row["counted_seconds"])
+                for row in cursor.fetchall()
+            }
+
+    def set_counted_time(
+        self, bucket_id: str, event_id: str, counted_seconds: float, day: str
+    ) -> None:
+        """Upsert the cumulative counted active-seconds for one event.
+
+        Idempotent: re-counting the same event with the same total is a no-op
+        for the daily figure because the caller only adds the positive delta.
+
+        Args:
+            bucket_id: ActivityWatch bucket ID.
+            event_id: ActivityWatch event ID (stringified).
+            counted_seconds: Cumulative seconds counted for this event so far.
+            day: Local date the time belongs to (ISO ``YYYY-MM-DD``).
+        """
+        now = datetime.now(timezone.utc).isoformat()
+        with self._cursor() as cursor:
+            cursor.execute(
+                """
+                INSERT INTO counted_time
+                    (bucket_id, event_id, day, counted_seconds, updated_at)
+                VALUES (?, ?, ?, ?, ?)
+                ON CONFLICT(bucket_id, event_id) DO UPDATE SET
+                    counted_seconds = excluded.counted_seconds,
+                    day = excluded.day,
+                    updated_at = excluded.updated_at
+                """,
+                (bucket_id, event_id, day, float(counted_seconds), now),
+            )
+
+    def prune_counted_time(self, before_day: str) -> int:
+        """Delete counted-time rows for days strictly before ``before_day``.
+
+        Keeps the table bounded — only recent days are ever replayed.
+
+        Args:
+            before_day: Local date in ISO format; rows with ``day < before_day``
+                are removed.
+
+        Returns:
+            Number of rows deleted.
+        """
+        with self._cursor() as cursor:
+            cursor.execute(
+                "DELETE FROM counted_time WHERE day < ?",
+                (before_day,),
+            )
+            return cursor.rowcount
 
     # App category management
 

--- a/src/sync/sync_engine.py
+++ b/src/sync/sync_engine.py
@@ -198,6 +198,11 @@ class SyncEngine:
             else None
         )
 
+        # Restore per-event counted-time from the previous process so a restart
+        # (or the start-of-day backlog reconcile that re-fetches the whole day)
+        # does not re-count already-counted events into the local daily total.
+        self._load_counted_time_cache()
+
     def _create_engagement_thresholds(self) -> EngagementThresholds:
         """Create EngagementThresholds from config."""
         eng = self.config.engagement
@@ -513,6 +518,63 @@ class SyncEngine:
 
         return stats
 
+    @staticmethod
+    def _local_day_iso() -> str:
+        """Local calendar date as ISO ``YYYY-MM-DD`` — the key the daily time
+        counter and counted-time persistence are scoped by."""
+        return datetime.now().astimezone().date().isoformat()
+
+    def _load_counted_time_cache(self) -> None:
+        """Repopulate ``_time_cache`` from persisted per-event counted-seconds
+        for the current local day.
+
+        Without this, after a restart the in-memory dedup cache is empty, so
+        ``prev_counted`` reads as 0 and the next sync re-adds each replayed
+        event's full duration to the daily total — double-counting the tray's
+        active time (badly so when the start-of-day backlog reconcile replays
+        the whole day). Persisted counts make the replay a no-op (delta == 0)
+        while still re-sending events to the server (which dedups by event id).
+
+        Tolerant of a mocked/partial queue: a non-dict result is ignored so
+        existing unit tests with ``Mock`` queues are unaffected.
+        """
+        getter = getattr(self.queue, "get_counted_times", None)
+        if not callable(getter):
+            return
+        try:
+            today = self._local_day_iso()
+            persisted = getter(today)
+            if not isinstance(persisted, dict):
+                return
+            with self._cache_lock:
+                for (bucket_id, event_id), seconds in persisted.items():
+                    self._time_cache[(bucket_id, event_id)] = float(seconds)
+            # Housekeeping: drop counts from days we will never replay.
+            pruner = getattr(self.queue, "prune_counted_time", None)
+            if callable(pruner):
+                pruner(today)
+            if persisted:
+                logger.info(
+                    "Restored counted-time for %d events (day %s)",
+                    len(persisted),
+                    today,
+                )
+        except Exception as e:  # never let cache restore block startup
+            logger.warning("Counted-time cache restore failed: %s", e)
+
+    def _persist_counted_time(
+        self, bucket_id: str, event_id: str, counted_seconds: float, day: str
+    ) -> None:
+        """Write-through the cumulative counted-seconds for one event so the
+        dedup survives a restart. Best-effort; never raises into the sync loop."""
+        setter = getattr(self.queue, "set_counted_time", None)
+        if not callable(setter):
+            return
+        try:
+            setter(bucket_id, event_id, counted_seconds, day)
+        except Exception as e:
+            logger.debug("Counted-time persist failed for %s/%s: %s", bucket_id, event_id, e)
+
     def _reconcile_backlog(self, buckets: list) -> None:
         """Rewind each bucket's checkpoint to the start of the local day so the
         next fetch re-sends any locally-stored events the server is missing.
@@ -807,7 +869,7 @@ class SyncEngine:
         # across cycles (e.g. AFK splits differ between syncs).
         if transformed and total_active_duration > 0:
             event_date = event.timestamp.astimezone().date()
-            time_key = (bucket_id, event.id)
+            time_key = (bucket_id, str(event.id))
             with self._cache_lock:
                 prev_counted = self._time_cache.get(time_key, 0.0)
                 delta = total_active_duration - prev_counted
@@ -815,6 +877,12 @@ class SyncEngine:
                     self._time_cache[time_key] = total_active_duration
             if delta > 0:
                 self._time_tracker.add_active_time(delta, event_date)
+                # Persist the new cumulative so a restart/reconcile doesn't
+                # re-count this event (write-through, outside the cache lock).
+                self._persist_counted_time(
+                    bucket_id, str(event.id), total_active_duration,
+                    event_date.isoformat(),
+                )
 
         return transformed
 
@@ -1191,7 +1259,8 @@ class SyncEngine:
                 and activity_state != "inactive"
             ):
                 event_date = event.timestamp.astimezone().date()
-                time_key = (bucket_id, result["id"])
+                event_key = str(result["id"])
+                time_key = (bucket_id, event_key)
                 time_delta = 0.0
                 with self._cache_lock:
                     prev_counted = self._time_cache.get(time_key, 0.0)
@@ -1203,6 +1272,10 @@ class SyncEngine:
                 # dedup checks with SQLite I/O
                 if time_delta > 0:
                     self._time_tracker.add_active_time(time_delta, event_date)
+                    # Persist cumulative so a restart/reconcile doesn't re-count.
+                    self._persist_counted_time(
+                        bucket_id, event_key, event.duration, event_date.isoformat()
+                    )
 
         return result
 
@@ -1699,5 +1772,9 @@ class SyncEngine:
             self._sent_cache = BoundedLRU(maxsize=5_000)
             self._gap_filled_originals = BoundedLRU(maxsize=5_000)
             self._time_cache = BoundedLRU(maxsize=5_000)
+        # Re-sending events on re-login is safe (server dedups by id), but the
+        # daily total must NOT be re-counted — restore the persisted per-event
+        # counts so a same-day re-login doesn't double-count the tray's hours.
+        self._load_counted_time_cache()
         # Close time tracker
         self._time_tracker.close()

--- a/tests/test_queue.py
+++ b/tests/test_queue.py
@@ -222,3 +222,47 @@ class TestOfflineQueue:
 
         assert self.queue.is_near_capacity(threshold=0.5) is True
         assert self.queue.is_near_capacity(threshold=0.6) is False
+
+    # Per-event counted-time persistence (restart-safe time dedup)
+
+    def test_counted_time_roundtrip(self):
+        """set_counted_time then get_counted_times returns the value."""
+        self.queue.set_counted_time("aw-watcher-window_host", "42", 600.0, "2026-06-15")
+        got = self.queue.get_counted_times("2026-06-15")
+        assert got == {("aw-watcher-window_host", "42"): 600.0}
+
+    def test_counted_time_upsert_overwrites(self):
+        """Re-writing the same event updates the cumulative, not appends."""
+        self.queue.set_counted_time("b", "1", 100.0, "2026-06-15")
+        self.queue.set_counted_time("b", "1", 250.0, "2026-06-15")
+        got = self.queue.get_counted_times("2026-06-15")
+        assert got == {("b", "1"): 250.0}
+
+    def test_counted_time_scoped_by_day(self):
+        """get_counted_times only returns rows for the requested day."""
+        self.queue.set_counted_time("b", "1", 100.0, "2026-06-14")
+        self.queue.set_counted_time("b", "2", 200.0, "2026-06-15")
+        assert self.queue.get_counted_times("2026-06-15") == {("b", "2"): 200.0}
+        assert self.queue.get_counted_times("2026-06-14") == {("b", "1"): 100.0}
+
+    def test_counted_time_survives_reopen(self):
+        """Counts persist across an OfflineQueue restart (same db file)."""
+        self.queue.set_counted_time("b", "1", 123.0, "2026-06-15")
+        self.queue.close()
+        reopened = OfflineQueue(db_path=self.db_path, max_size=100)
+        try:
+            assert reopened.get_counted_times("2026-06-15") == {("b", "1"): 123.0}
+        finally:
+            reopened.close()
+        # Re-point self.queue so teardown's close() doesn't double-close.
+        self.queue = OfflineQueue(db_path=self.db_path, max_size=100)
+
+    def test_prune_counted_time_drops_older_days(self):
+        """prune_counted_time removes rows strictly before the cutoff day."""
+        self.queue.set_counted_time("b", "1", 1.0, "2026-06-13")
+        self.queue.set_counted_time("b", "2", 2.0, "2026-06-14")
+        self.queue.set_counted_time("b", "3", 3.0, "2026-06-15")
+        removed = self.queue.prune_counted_time("2026-06-15")
+        assert removed == 2
+        assert self.queue.get_counted_times("2026-06-15") == {("b", "3"): 3.0}
+        assert self.queue.get_counted_times("2026-06-14") == {}

--- a/tests/test_sync_engine_restart_double_count.py
+++ b/tests/test_sync_engine_restart_double_count.py
@@ -1,0 +1,113 @@
+"""Regression test: a restart (or the start-of-day backlog reconcile) must not
+re-count already-counted active time into the local daily total.
+
+Fleet incident 2026-06-15: 1.5.43 added `_reconcile_backlog`, which rewinds
+bucket checkpoints to local midnight on first sync so events stranded on the
+local DB during the server outage get re-sent. Re-sending is safe (the backend
+dedups by AW event id). But the *local* daily time counter is deduped only by
+the in-memory `_time_cache`, which is empty after a restart — so every replayed
+event's full duration was being added a second time, inflating the tray's
+"active time". Martin's own recovery instruction is "quit + restart", which
+triggers exactly this path.
+
+This test drives the real counting path (`_transform_window_event_with_timeout`)
+with a real OfflineQueue and a real DailyTimeTracker — no mocking of the
+components under test — across a simulated restart that shares both SQLite
+files. Pre-fix the second pass doubles the total; post-fix it is a no-op.
+"""
+
+import tempfile
+from datetime import datetime, timezone
+from pathlib import Path
+from unittest.mock import Mock
+
+from src.config import Config
+from src.sync.aw_client import BUCKET_TYPE_WINDOW, AWEvent
+from src.sync.daily_time_tracker import DailyTimeTracker
+from src.sync.queue import OfflineQueue
+from src.sync.sync_engine import SyncEngine
+
+WINDOW_BUCKET = "aw-watcher-window_testhost"
+
+
+def _build_engine(queue_db: Path, time_db: Path) -> SyncEngine:
+    """Construct an engine backed by real persistence at the given paths.
+
+    Each call simulates a fresh process: a new OfflineQueue and a new
+    DailyTimeTracker opened on the same files the previous 'process' wrote.
+    """
+    return SyncEngine(
+        aw=Mock(),
+        bf=Mock(),
+        queue=OfflineQueue(db_path=queue_db, max_size=1000),
+        config=Config(),
+        time_tracker=DailyTimeTracker(db_path=time_db),
+    )
+
+
+def test_restart_does_not_double_count_replayed_event():
+    tmp = Path(tempfile.mkdtemp())
+    queue_db = tmp / "offline_queue.db"
+    time_db = tmp / "daily_time.db"
+
+    # A 10-minute window event, "today" in local time.
+    event = AWEvent(
+        id=42,
+        timestamp=datetime.now(timezone.utc),
+        duration=600.0,
+        data={"app": "Code", "title": "main.py"},
+    )
+
+    # --- process 1: count the event once ---
+    engine1 = _build_engine(queue_db, time_db)
+    out1 = engine1._transform_window_event_with_timeout(
+        event, WINDOW_BUCKET, BUCKET_TYPE_WINDOW
+    )
+    assert out1, "window event should have been transformed and counted"
+    total1 = engine1._time_tracker.get_today_active_time().total_seconds()
+    assert abs(total1 - 600.0) < 1.0, f"expected ~600s counted, got {total1}"
+    engine1.queue.close()
+    engine1._time_tracker.close()
+
+    # --- process 2: restart + reconcile replays the SAME event ---
+    engine2 = _build_engine(queue_db, time_db)
+    # The new process starts from the persisted daily total (600s already).
+    assert abs(engine2._time_tracker.get_today_active_time().total_seconds() - 600.0) < 1.0
+    engine2._transform_window_event_with_timeout(
+        event, WINDOW_BUCKET, BUCKET_TYPE_WINDOW
+    )
+    total2 = engine2._time_tracker.get_today_active_time().total_seconds()
+
+    # The replay must be a no-op for the daily total. Pre-fix this was ~1200s.
+    assert abs(total2 - 600.0) < 1.0, (
+        f"replayed event double-counted: total is {total2}s, expected ~600s"
+    )
+    engine2.queue.close()
+    engine2._time_tracker.close()
+
+
+def test_heartbeat_extension_counts_only_growth_across_restart():
+    """An event whose duration grows after restart counts only the new seconds,
+    not the whole grown duration."""
+    tmp = Path(tempfile.mkdtemp())
+    queue_db = tmp / "offline_queue.db"
+    time_db = tmp / "daily_time.db"
+
+    ts = datetime.now(timezone.utc)
+    short = AWEvent(id=7, timestamp=ts, duration=300.0, data={"app": "Code", "title": "x"})
+
+    engine1 = _build_engine(queue_db, time_db)
+    engine1._transform_window_event_with_timeout(short, WINDOW_BUCKET, BUCKET_TYPE_WINDOW)
+    assert abs(engine1._time_tracker.get_today_active_time().total_seconds() - 300.0) < 1.0
+    engine1.queue.close()
+    engine1._time_tracker.close()
+
+    # Restart; the same event id now reports a grown duration (heartbeat).
+    grown = AWEvent(id=7, timestamp=ts, duration=500.0, data={"app": "Code", "title": "x"})
+    engine2 = _build_engine(queue_db, time_db)
+    engine2._transform_window_event_with_timeout(grown, WINDOW_BUCKET, BUCKET_TYPE_WINDOW)
+    total = engine2._time_tracker.get_today_active_time().total_seconds()
+    # 300 (already) + 200 (growth) = 500, not 300 + 500 = 800.
+    assert abs(total - 500.0) < 1.0, f"expected ~500s, got {total}"
+    engine2.queue.close()
+    engine2._time_tracker.close()


### PR DESCRIPTION
## Context

Follow-up to the 1.5.43 fleet-incident fixes (PR #34: `187c9b2` reconcile, `88bfbc4` hung-tracker), now on `main`. This fixes a regression the reconcile introduces.

## The bug

`_reconcile_backlog` (1.5.43) rewinds bucket checkpoints to local midnight on first sync so events stranded on the local DB during the ~1–4pm server outage get re-sent. Re-sending is safe — the **server** dedups by AW event id.

But the **local** daily counter (`DailyTimeTracker`, which drives the tray "active time") is deduped only by the in-memory `_time_cache` — empty after a restart. So replayed events get their full duration added **again**:

- normal restart → re-counts the 2-min lookback (small)
- **reconcile → replays the whole day → tray hours roughly double**

The documented recovery is "quit + restart", which triggers exactly this. The server dashboard is unaffected; this is the tray figure users watch.

## The fix

Persist cumulative counted-seconds per `(bucket_id, event_id)` in a new `counted_time` table in `offline_queue.db`, scoped by local day. `_time_cache` is repopulated from it at startup and after a re-login reset:

| scenario | result |
|---|---|
| fresh launch (no rows) | counts everything once — still recovers a stuck day |
| restart / reconcile replay | `prev == total` → delta 0 → **no re-count** |
| heartbeat-extended event | `prev == old` → only the growth counts |

Old days pruned on load to bound the table. Best-effort + tolerant of a mocked/partial queue, so existing unit tests are unaffected. The `187c9b2` premise (server decides active-vs-idle) is unchanged — this only corrects the local tray number.

## Tests (proof-of-failure handshake)

`tests/test_sync_engine_restart_double_count.py` drives the **real** counting path with a **real** `OfflineQueue` + `DailyTimeTracker` across a simulated restart sharing both SQLite files — no mocking of the components under test.

- **Pre-fix** (source stashed): replay reads **1200s** instead of 600s, and **800s** instead of 500s for the heartbeat case → 2 failed.
- **Post-fix**: both correct → **42 passed** (restart + queue + daily-tracker suites). Plus 5 queue unit tests for the new table.

> Note: `test_sync_engine.py` doesn't collect in my local env (x86_64 PIL on arm64 + PyInstaller-style `from auth import`) — pre-existing, unrelated to this change. Should run in CI.

## Not covered here

The **wrong/random "start time"** complaints (≈ the time the agent restarted) are **server-side** (internal-tool2 / betterflow.eu) — the agent only ever sends real AW timestamps. Looks like the backend derives arrival from event-receipt/insertion time rather than the event's own timestamp; the reconcile re-uploading at noon makes it visible. Needs a separate fix on the server.

🤖 Generated with [Claude Code](https://claude.com/claude-code)