### PR TITLE
fix(idle): don't mark the user idle while in a call/meeting

### DIFF
--- a/src/idle_manager.py
+++ b/src/idle_manager.py
@@ -62,6 +62,15 @@ class IdleManager:
         if idle_start:
             self.sync_engine.send_idle_event(idle_start)
 
+    def _is_in_call(self) -> bool:
+        """Whether a call/meeting is active, via the sync engine. Defensive:
+        any error (or a sync engine without the method) means 'not in a call'
+        so idle detection still works."""
+        try:
+            return bool(self.sync_engine.is_in_call())
+        except Exception:
+            return False
+
     def check_idle_status(
         self,
         *,
@@ -110,6 +119,18 @@ class IdleManager:
 
             if is_afk and afk_duration >= self._idle_pause_threshold:
                 if not was_idle_paused:
+                    # Don't mark idle while the user is in a call/meeting. In a
+                    # meeting they're engaged (listening/watching) even without
+                    # keyboard/mouse input. The AFK watcher is the only idle
+                    # signal on Windows (no in-process input watcher), so a long
+                    # call otherwise trips this pause and paints the whole span
+                    # as Idle even though the meeting app was focused throughout.
+                    if self._is_in_call():
+                        logger.debug(
+                            "AFK for %ds but a call is active — not pausing as idle",
+                            int(afk_duration),
+                        )
+                        return
                     if idle_start is None:
                         idle_start = datetime.now(timezone.utc)
                     logger.info(

--- a/src/sync/call_detector.py
+++ b/src/sync/call_detector.py
@@ -159,6 +159,16 @@ class CallDetector:
             return self._end_call()
         return None
 
+    def is_in_call(self) -> bool:
+        """True while a call/meeting is currently active (incl. grace period).
+
+        Used by idle detection to avoid marking the user idle during a call:
+        in a meeting they're engaged (listening/watching) even with no
+        keyboard/mouse input, which would otherwise trip the AFK-only idle
+        pause — especially on Windows, which has no in-process input watcher.
+        """
+        return self._call_app is not None
+
     def _start_call(
         self, name: str, call_type: Optional[str], timestamp: datetime
     ) -> None:

--- a/src/sync/sync_engine.py
+++ b/src/sync/sync_engine.py
@@ -261,6 +261,18 @@ class SyncEngine:
         with self._state_lock:
             return self._private_mode
 
+    def is_in_call(self) -> bool:
+        """True while the call/meeting detector reports an active call.
+
+        Idle detection consults this so a meeting/call with no keyboard or
+        mouse input is not mistaken for idle. False when call detection is
+        disabled. The detector's state is advanced as window events are
+        processed each sync cycle and persists across cycles until the call
+        ends, so it stays True for the duration of a meeting.
+        """
+        detector = self._call_detector
+        return bool(detector and detector.is_in_call())
+
     def set_current_project(self, project: Optional[dict]) -> None:
         """Set the current project for event tagging."""
         with self._state_lock:

--- a/tests/test_call_detector.py
+++ b/tests/test_call_detector.py
@@ -348,3 +348,21 @@ class TestSyncEngineCallIntegration:
         )
         result = self.engine._make_call_bf_event(ce)
         assert result["project_id"] == 42
+
+
+def test_is_in_call_reflects_active_call_state():
+    """is_in_call() is True from call start until the call ends."""
+    from datetime import datetime, timezone
+    det = CallDetector(min_duration=1)
+    t0 = datetime(2026, 6, 15, 10, 0, 0, tzinfo=timezone.utc)
+    assert det.is_in_call() is False
+    # Enter a Teams meeting.
+    det.process_event("Microsoft Teams", "Meeting with Sachi", None, t0, 60.0)
+    assert det.is_in_call() is True
+    # Still in the call on a later same-call event.
+    det.process_event("Microsoft Teams", "Meeting with Sachi", None,
+                      t0.replace(minute=30), 60.0)
+    assert det.is_in_call() is True
+    # Flushing ends the call.
+    det.flush()
+    assert det.is_in_call() is False

--- a/tests/test_idle_manager.py
+++ b/tests/test_idle_manager.py
@@ -1,0 +1,98 @@
+"""Regression test: a call/meeting must not be marked as Idle.
+
+Sachi (Windows, 2026-06-15) showed ~2h of "Idle" mid-day while actually in a
+meeting. On Windows the agent has no in-process input watcher and no system-idle
+fallback (`_get_system_idle_seconds` is macOS-only), so idle is decided purely
+from the AFK watcher: any stretch with no keyboard/mouse for >= idle_pause_minutes
+(default 20) trips the idle pause, and on resume one idle_time event paints the
+whole span gray — even when a meeting app was focused the entire time.
+
+Fix: `IdleManager.check_idle_status` consults the call/meeting detector (via
+`sync_engine.is_in_call()`) and does not pause while a call is active. This test
+drives the real `check_idle_status` with an AFK event well over threshold and
+asserts: in a call -> no idle pause; not in a call -> idle pause as before.
+"""
+
+import sys
+import types
+from datetime import datetime, timedelta, timezone
+from unittest.mock import Mock
+
+# The real tray module imports PIL at module load; stub it only if that import
+# is broken in this environment (no-op in CI where PIL works). IdleManager
+# imports TrayState lazily inside check_idle_status, so this only needs to
+# satisfy that import.
+try:  # pragma: no cover - environment dependent
+    import src.ui.tray  # noqa: F401
+except Exception:  # pragma: no cover
+    _tray = types.ModuleType("src.ui.tray")
+
+    class TrayState:  # minimal stand-in; identity is all the code needs
+        SYNCING = "syncing"
+        PAUSED = "paused"
+
+    _tray.TrayState = TrayState
+    sys.modules.setdefault("src.ui", types.ModuleType("src.ui"))
+    sys.modules["src.ui"].tray = _tray
+    sys.modules["src.ui.tray"] = _tray
+    sys.modules.setdefault("ui", types.ModuleType("ui"))
+    sys.modules["ui.tray"] = _tray
+
+from src.config import Config
+from src.idle_manager import IdleManager
+
+
+def _make(idle_in_call: bool):
+    """Build an IdleManager whose AFK bucket reports a 2h AFK event.
+
+    Returns (idle_mgr, reschedule_mock, trigger_sync_mock, tray_mock).
+    """
+    config = Config()  # idle_pause_minutes defaults to 20 -> threshold 1200s
+
+    afk_event = types.SimpleNamespace(
+        status="afk",
+        duration=2 * 3600.0,  # 2 hours AFK, well over the 20-min threshold
+        timestamp=datetime.now(timezone.utc) - timedelta(hours=2),
+    )
+    aw = Mock()
+    aw.get_afk_buckets.return_value = [types.SimpleNamespace(id="afk-bucket")]
+    aw.get_events.return_value = [afk_event]
+
+    sync_engine = Mock()
+    sync_engine.is_paused = False
+    sync_engine.is_private = False
+    sync_engine.is_in_call.return_value = idle_in_call
+
+    tray = Mock()
+    idle_mgr = IdleManager(sync_engine, tray, aw, config)
+    return idle_mgr, Mock(), Mock(), tray
+
+
+def test_does_not_pause_idle_during_a_call():
+    idle_mgr, reschedule, trigger_sync, tray = _make(idle_in_call=True)
+
+    idle_mgr.check_idle_status(
+        logged_in=True,
+        is_on_break=False,
+        reschedule=reschedule,
+        trigger_sync=trigger_sync,
+    )
+
+    assert idle_mgr.idle_paused is False, "should not mark idle while in a call"
+    reschedule.assert_not_called()
+    tray.set_state.assert_not_called()
+
+
+def test_pauses_idle_when_not_in_a_call():
+    """Control: outside a call, a long AFK stretch still pauses as before."""
+    idle_mgr, reschedule, trigger_sync, tray = _make(idle_in_call=False)
+
+    idle_mgr.check_idle_status(
+        logged_in=True,
+        is_on_break=False,
+        reschedule=reschedule,
+        trigger_sync=trigger_sync,
+    )
+
+    assert idle_mgr.idle_paused is True, "long AFK outside a call should pause"
+    reschedule.assert_called_once_with(idle_mgr._IDLE_SYNC_INTERVAL)


### PR DESCRIPTION
## The bug (Sachi, Windows, 2026-06-15)

~2 hours of solid **Idle** mid-day while she was actually in a meeting (arrival 08:25, active block before and after).

On Windows the agent decides idle from **one signal — the AFK watcher**:
- `_get_system_idle_seconds()` is macOS-only (`return None` off-darwin), and the Windows build has **no in-process input watcher** (`aw_manager.py` `BF_WATCHERS = ["bf-window-tracker", "bf-idle-tracker"]`).
- `IdleManager.check_idle_status` reads only the AFK bucket. After `idle_pause_minutes` (default **20**) of no keyboard/mouse it pauses and, on resume, emits one `idle_event` spanning the whole stretch → one gray block.

So a meeting/call where she's listening (mouse untouched) for >20 min becomes Idle, even though `bf-window-tracker` saw the meeting app focused the whole time. The earlier "meetings aren't Break" fix (1.5.39) only touched sync-engine **labeling**; the **idle-pause path is separate** and never consulted what she was doing — even though a `CallDetector` already recognizes Zoom/Teams/Meet and is fed window events, its state was used only to emit call events.

## The fix

`IdleManager.check_idle_status` now consults the call detector via new `SyncEngine.is_in_call()` (backed by `CallDetector.is_in_call()`) and **does not pause while a call is active** — a call is genuine engagement even with no input. Best-effort: any error ⇒ "not in a call", so idle detection still works.

## Scope

Fixes the **call/meeting** false-idle (the common Windows complaint). Pure no-input *reading* with no recognizable app is genuinely ambiguous from AFK alone — left to the existing "click an idle gap to log offline time" reclaim UI rather than guessing the user is present (which would risk **over-counting** hours). Secondary follow-up worth doing: widen the Teams native title pattern (`call_detector.py` requires `"Meeting/Call with"` / `"In a call"`; newer Teams titles often don't match).

## Tests (proof-of-failure handshake)

`tests/test_idle_manager.py` drives the **real** `check_idle_status` with a 2h AFK event:
- **Pre-fix** (`idle_manager.py` stashed): in-call case **fails** — `idle_paused` is True (it pauses during the call). Control passes.
- **Post-fix**: in a call → no pause/reschedule; not in a call → pauses at `_IDLE_SYNC_INTERVAL` as before. Plus a `CallDetector.is_in_call()` unit test. **42 passed** across the idle + call-detector suites.

> Tray module imports PIL, broken in my local arch (x86_64 PIL on arm64); the idle test stubs `ui.tray` only when that import is broken (no-op in CI).

🤖 Generated with [Claude Code](https://claude.com/claude-code)