### PR TITLE
fix(call-detector): match native call apps by Windows process names too

### DIFF
--- a/src/sync/call_detector.py
+++ b/src/sync/call_detector.py
@@ -27,14 +27,19 @@ class CallEvent:
 
 
 # -- Native app patterns ------------------------------------------------
-# Each entry: (app name substring, title regex or None, display name)
-_NATIVE_PATTERNS: list[tuple[str, Optional[re.Pattern], str]] = [
-    ("zoom.us", re.compile(r"Zoom (Meeting|Webinar)|\d{9,11}", re.IGNORECASE), "Zoom"),
-    ("Microsoft Teams", re.compile(r"(Meeting|Call) with|In a call", re.IGNORECASE), "Microsoft Teams"),
-    ("Slack", re.compile(r"Huddle", re.IGNORECASE), "Slack"),
-    ("Discord", re.compile(r"Voice Connected|voice channel", re.IGNORECASE), "Discord"),
-    ("FaceTime", None, "FaceTime"),  # Any active FaceTime window = call
-    ("Webex", re.compile(r"Meeting", re.IGNORECASE), "Webex"),
+# Each entry: (app-name substring aliases, title regex or None, display name).
+# Aliases cover macOS app names AND Windows/Linux process names — e.g. macOS
+# reports "zoom.us" / "Microsoft Teams" while Windows reports "Zoom" / the
+# new-Teams "ms-teams". A single macOS-only substring meant native calls went
+# undetected on Windows (Sachi, 2026-06-15). Each entry stays title-gated, so
+# widening the app match can never turn "app merely open" into a false call.
+_NATIVE_PATTERNS: list[tuple[tuple[str, ...], Optional[re.Pattern], str]] = [
+    (("zoom.us", "zoom"), re.compile(r"Zoom (Meeting|Webinar)|\d{9,11}", re.IGNORECASE), "Zoom"),
+    (("microsoft teams", "ms-teams", "msteams", "teams"), re.compile(r"(Meeting|Call) with|In a call", re.IGNORECASE), "Microsoft Teams"),
+    (("slack",), re.compile(r"Huddle", re.IGNORECASE), "Slack"),
+    (("discord",), re.compile(r"Voice Connected|voice channel", re.IGNORECASE), "Discord"),
+    (("facetime",), None, "FaceTime"),  # Any active FaceTime window = call
+    (("webex",), re.compile(r"Meeting", re.IGNORECASE), "Webex"),
 ]
 
 # -- Browser URL patterns -----------------------------------------------
@@ -56,8 +61,11 @@ def _match_native(app: str, title: str) -> Optional[str]:
     """Return display name if (app, title) matches a native call pattern."""
     if not title:
         title = ""
-    for app_substr, title_re, name in _NATIVE_PATTERNS:
-        if app_substr.lower() in app.lower() and (title_re is None or title_re.search(title)):
+    app_lower = app.lower()
+    for app_substrs, title_re, name in _NATIVE_PATTERNS:
+        if any(sub in app_lower for sub in app_substrs) and (
+            title_re is None or title_re.search(title)
+        ):
             return name
     return None
 

--- a/tests/test_call_detector.py
+++ b/tests/test_call_detector.py
@@ -366,3 +366,29 @@ def test_is_in_call_reflects_active_call_state():
     # Flushing ends the call.
     det.flush()
     assert det.is_in_call() is False
+
+
+class TestWindowsNativeAppNames:
+    """Native call apps report different process names on Windows than macOS.
+
+    macOS: "zoom.us" / "Microsoft Teams". Windows: "Zoom" / "ms-teams". The
+    title gate is unchanged, so widening the app aliases cannot create false
+    positives — a non-call window still won't match.
+    """
+
+    def test_zoom_windows_process_name(self):
+        assert _match_native("Zoom", "Zoom Meeting") == "Zoom"
+
+    def test_teams_windows_new_process_name(self):
+        assert _match_native("ms-teams", "Meeting with John") == "Microsoft Teams"
+        assert _match_native("MSTeams", "In a call") == "Microsoft Teams"
+
+    def test_teams_bare_name_in_call(self):
+        assert _match_native("Teams", "Call with Sarah") == "Microsoft Teams"
+
+    def test_teams_windows_chat_still_no_match(self):
+        # Title gate must still reject a non-call Teams window.
+        assert _match_native("ms-teams", "Chat | Microsoft Teams") is None
+
+    def test_zoom_windows_home_still_no_match(self):
+        assert _match_native("Zoom", "Zoom - Home") is None


### PR DESCRIPTION
## Why

Follow-up to #36. The native call patterns only listed **macOS** app names (`"zoom.us"`, `"Microsoft Teams"`), so on **Windows** — where the process is reported as `Zoom` or the new-Teams `ms-teams` — native Zoom/Teams calls weren't detected at all. Windows is exactly where the AFK-only idle path is weakest (no in-process input watcher), so a missed call meant the meeting still showed as **Idle** (Sachi, 2026-06-15).

## What

Each native pattern now carries app-name **aliases** (macOS + Windows/Linux) and stays **title-gated**. Broadening the app match can't turn "app merely open" into a false call — which matters because a false call would suppress legitimate idle and **over-count** hours.

## Tests

`TestWindowsNativeAppNames`: Windows process names now match (`Zoom`/"Zoom Meeting", `ms-teams`/"Meeting with", `MSTeams`/"In a call"), and the title gate still rejects non-call windows (`ms-teams`/"Chat", `Zoom`/"Home"). 45 pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)