### PR TITLE
feat(browser-tracker): read active-tab URL on Windows via UI Automation

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -8,6 +8,11 @@ Pillow>=10.0
 pyobjc-framework-SystemConfiguration>=10.0; sys_platform == "darwin"
 pyobjc-framework-ApplicationServices>=10.0; sys_platform == "darwin"
 
+# Windows-only dependencies
+# uiautomation -> read the foreground browser's omnibox URL via UI Automation
+# (opt-in active-tab tracking, privacy.track_browser_urls). Fail-closed if absent.
+uiautomation>=2.0; sys_platform == "win32"
+
 # Linux-only dependencies
 # PyGObject -> AppIndicator tray backend; python-xlib -> XOrg fallback backend;
 # jeepney -> systemd-logind sleep/wake D-Bus signals; SecretStorage -> keyring

--- a/src/browser_tracker.py
+++ b/src/browser_tracker.py
@@ -1,4 +1,4 @@
-"""Active browser-tab URL tracking (macOS).
+"""Active browser-tab URL tracking (macOS + Windows).
 
 The bundled ActivityWatch window watcher reports the app + window title but NOT
 the URL of the page in the foreground browser tab. Without a URL, every browser
@@ -6,17 +6,24 @@ event collapses to a generic "Google Chrome" with no domain, so the backend
 can't categorise it (it lands in generic "browsing") and the activity cards have
 nothing to show.
 
-This module fills that gap on macOS without requiring a browser extension: a
-daemon thread polls the frontmost browser's active-tab URL via AppleScript
-(`osascript`) and keeps a short, time-ordered ring buffer of (timestamp, url)
-samples. The sync engine looks up the URL active at a window event's time and
-attaches it, after which the EXISTING privacy logic (domain_only_urls /
-collect_full_urls) applies — so the full URL never leaves this process unless
-the server has explicitly enabled full-URL collection.
+This module fills that gap without a browser extension. A daemon thread polls
+the frontmost browser's active-tab URL and keeps a short, time-ordered ring
+buffer of (timestamp, url) samples; the sync engine looks up the URL active at a
+window event's time and attaches it, after which the EXISTING privacy logic
+(domain_only_urls / collect_full_urls) applies — so the full URL never leaves
+this process unless the server has explicitly enabled full-URL collection.
 
-Opt-in (privacy.track_browser_urls = False by default). Querying a browser via
-AppleScript needs macOS Automation permission; if it's not granted the query
-fails closed (returns None) and tracking is simply a no-op — never a crash.
+Per-platform readers:
+  - macOS:   AppleScript (`osascript`) asks the frontmost browser for its
+             active-tab URL. Needs macOS Automation permission.
+  - Windows: UI Automation reads the foreground Chromium browser's omnibox
+             value. Needs the `uiautomation` package (bundled in the Windows
+             build); the foreground process is checked so Electron apps that
+             share Chromium's window class aren't mis-read as browsers.
+
+Opt-in (privacy.track_browser_urls = False by default). Every reader is
+fail-closed: a missing permission/library or any error returns None and
+tracking is simply a no-op — never a crash.
 """
 
 import logging
@@ -210,6 +217,203 @@ def _start_macos_tracker(
 
 
 # ---------------------------------------------------------------------------
+# Windows implementation (UI Automation, no extension)
+# ---------------------------------------------------------------------------
+#
+# The bundled window watcher gives the browser's app + title but not the URL.
+# On Windows we read the foreground Chromium browser's address bar via UI
+# Automation (UIA) — the same no-extension approach DeskTime used. UIA querying
+# also nudges Chromium to expose its accessibility tree, where the omnibox Edit
+# control's value holds the current URL.
+#
+# Two guards keep this honest:
+#   1. Process gate — Chromium browsers AND Electron apps (Slack, VS Code,
+#      Teams) share the "Chrome_WidgetWin_1" window class, so matching on class
+#      would mis-read chat apps as browsers. We resolve the foreground window's
+#      process name and only proceed for a known browser executable.
+#   2. Value gate — we accept a value only if it normalizes to an http(s) URL,
+#      so a focused/empty omnibox, a typed search query, or an internal page
+#      (chrome://, edge://) yields nothing rather than garbage.
+#
+# Everything is fail-closed: missing UIA libs, no permission, or any traversal
+# error returns None. Opt-in via privacy.track_browser_urls, same as macOS.
+
+# Foreground process basenames (lowercased) we treat as Chromium browsers.
+_WINDOWS_BROWSER_PROCS = {
+    "chrome.exe",
+    "msedge.exe",
+    "brave.exe",
+    "vivaldi.exe",
+    "opera.exe",
+    "arc.exe",
+    "chromium.exe",
+}
+
+# Bound the UIA tree walk so we never scan a huge page DOM. The omnibox lives in
+# the toolbar near the top of the window tree, so a shallow, capped search reaches
+# it quickly while staying cheap.
+_WIN_UIA_MAX_DEPTH = 8
+_WIN_UIA_MAX_NODES = 400
+
+
+def _normalize_windows_url(raw: Optional[str]) -> Optional[str]:
+    """Turn an address-bar value into a real http(s) URL, or None.
+
+    Chromium hides the scheme in the omnibox, so "github.com/x" must become
+    "https://github.com/x". Rejects empty values, internal pages, and typed
+    search queries (which contain spaces / no dotted host).
+    """
+    if not raw:
+        return None
+    s = raw.strip()
+    if not s:
+        return None
+    if s.startswith(("http://", "https://")):
+        return s
+    low = s.lower()
+    if low.startswith(("chrome://", "edge://", "brave://", "about:", "view-source:", "file://", "chrome-extension://")):
+        return None
+    # A typed search query (spaces) is not a URL.
+    if " " in s:
+        return None
+    # Must look like a host: the part before the first slash needs a dot.
+    host = s.split("/", 1)[0]
+    if "." not in host or host.startswith(".") or host.endswith("."):
+        return None
+    return "https://" + s
+
+
+def _first_url_from_values(values) -> Optional[str]:
+    """Return the first value that normalizes to an http(s) URL, or None."""
+    for v in values:
+        url = _normalize_windows_url(v)
+        if url:
+            return url
+    return None
+
+
+def _foreground_browser_proc() -> Optional[tuple]:
+    """Return (hwnd, proc_basename) for the foreground window when it belongs to
+    a known Chromium browser, else None. Pure ctypes — no third-party deps."""
+    import ctypes
+    import os
+    from ctypes import wintypes
+
+    user32 = ctypes.windll.user32
+    kernel32 = ctypes.windll.kernel32
+
+    hwnd = user32.GetForegroundWindow()
+    if not hwnd:
+        return None
+    pid = wintypes.DWORD()
+    user32.GetWindowThreadProcessId(hwnd, ctypes.byref(pid))
+    if not pid.value:
+        return None
+
+    PROCESS_QUERY_LIMITED_INFORMATION = 0x1000  # noqa: N806 — Win32 constant name
+    handle = kernel32.OpenProcess(PROCESS_QUERY_LIMITED_INFORMATION, False, pid.value)
+    if not handle:
+        return None
+    try:
+        buf = ctypes.create_unicode_buffer(512)
+        size = wintypes.DWORD(len(buf))
+        if not kernel32.QueryFullProcessImageNameW(handle, 0, buf, ctypes.byref(size)):
+            return None
+        proc = os.path.basename(buf.value).lower()
+    finally:
+        kernel32.CloseHandle(handle)
+
+    if proc not in _WINDOWS_BROWSER_PROCS:
+        return None
+    return hwnd, proc
+
+
+def _collect_uia_url_values(root, max_depth: int = _WIN_UIA_MAX_DEPTH, max_nodes: int = _WIN_UIA_MAX_NODES):
+    """Bounded breadth-first walk collecting Edit/Document control values.
+
+    Edit controls (the omnibox) come first so a real URL is preferred over a
+    page Document value. Bounded by depth and node count so we never traverse a
+    full page DOM. Defensive: any per-node failure is skipped.
+    """
+    edits: list = []
+    docs: list = []
+    queue = [(root, 0)]
+    seen = 0
+    while queue and seen < max_nodes:
+        node, depth = queue.pop(0)
+        seen += 1
+        try:
+            type_name = node.ControlTypeName
+        except Exception:
+            type_name = ""
+        if type_name in ("EditControl", "DocumentControl"):
+            try:
+                value = node.GetValuePattern().Value
+            except Exception:
+                value = None
+            if value:
+                (edits if type_name == "EditControl" else docs).append(value)
+        if depth < max_depth:
+            try:
+                children = node.GetChildren()
+            except Exception:
+                children = []
+            for child in children:
+                queue.append((child, depth + 1))
+    return edits + docs
+
+
+def get_active_browser_url_windows() -> Optional[str]:
+    """Read the foreground Chromium browser's active-tab URL via UIA, or None.
+
+    Fail-closed: returns None when the foreground app isn't a known browser, the
+    UIA library isn't bundled, accessibility is unavailable, or no control yields
+    a value that normalizes to an http(s) URL.
+    """
+    found = _foreground_browser_proc()
+    if found is None:
+        return None
+    hwnd, _proc = found
+    try:
+        import uiautomation as auto  # lazy: absent in builds without the dep
+    except Exception:
+        return None
+    try:
+        control = auto.ControlFromHandle(hwnd)
+        if control is None:
+            return None
+        values = _collect_uia_url_values(control)
+        return _first_url_from_values(values)
+    except Exception as e:  # never raise into the poll thread
+        logger.debug("windows browser url read failed: %s", e)
+        return None
+
+
+def _start_windows_tracker(
+    poll_interval: float,
+    retention_seconds: float,
+    match_tolerance_seconds: float,
+) -> BrowserURLTracker:
+    """Start a Windows tracker polling the active-tab URL via UI Automation."""
+    tracker = BrowserURLTracker(retention_seconds, match_tolerance_seconds)
+    stop_event = threading.Event()
+
+    def _run() -> None:
+        while not stop_event.wait(poll_interval):
+            try:
+                url = get_active_browser_url_windows()
+                if url:
+                    tracker.record(time.time(), url)
+            except Exception as e:  # never let the poll thread die
+                logger.debug("browser url poll failed: %s", e)
+
+    thread = threading.Thread(target=_run, daemon=True, name="browser-url-tracker-windows")
+    thread.start()
+    tracker.stop = stop_event.set  # type: ignore[assignment]
+    return tracker
+
+
+# ---------------------------------------------------------------------------
 # Factory
 # ---------------------------------------------------------------------------
 
@@ -229,6 +433,8 @@ def start_browser_tracker(
     try:
         if _system == "Darwin":
             return _start_macos_tracker(poll_interval, retention_seconds, match_tolerance_seconds)
+        if _system == "Windows":
+            return _start_windows_tracker(poll_interval, retention_seconds, match_tolerance_seconds)
     except Exception as e:
         logger.debug("Failed to start browser tracker: %s", e)
     return BrowserURLTracker(retention_seconds, match_tolerance_seconds)

--- a/src/config.py
+++ b/src/config.py
@@ -231,7 +231,7 @@ class PrivacySettings:
     collect_page_category: bool = True  # Include coarse page category classification
     auto_categorize: bool = True  # Enrich events with app_category from server mappings
     track_display_info: bool = False  # Track monitor name and virtual desktop
-    track_browser_urls: bool = False  # macOS: read active-tab URL via AppleScript (needs Automation permission)
+    track_browser_urls: bool = False  # read active-tab URL without an extension (macOS: AppleScript / Windows: UI Automation)
     exclude_apps: list[str] = field(
         default_factory=lambda: [
             "1Password",

--- a/tests/test_browser_tracker.py
+++ b/tests/test_browser_tracker.py
@@ -120,3 +120,114 @@ class TestStartBrowserTracker:
         t = bt.start_browser_tracker(enabled=False)
         assert t.url_at(123.0) is None
         t.stop()  # no-op, must not raise
+
+
+# ---------------------------------------------------------------------------
+# Windows UI Automation reader (logic that is testable off-Windows)
+# ---------------------------------------------------------------------------
+
+
+class TestNormalizeWindowsUrl:
+    def test_passes_through_http_and_https(self):
+        assert bt._normalize_windows_url("https://github.com/x") == "https://github.com/x"
+        assert bt._normalize_windows_url("http://example.com") == "http://example.com"
+
+    def test_adds_scheme_to_bare_host(self):
+        # Chromium hides the scheme in the omnibox.
+        assert bt._normalize_windows_url("github.com/issues") == "https://github.com/issues"
+        assert bt._normalize_windows_url("  app.betterflow.eu  ") == "https://app.betterflow.eu"
+
+    def test_rejects_search_queries(self):
+        assert bt._normalize_windows_url("how to test windows") is None
+
+    def test_rejects_internal_and_non_web(self):
+        assert bt._normalize_windows_url("chrome://settings") is None
+        assert bt._normalize_windows_url("edge://flags") is None
+        assert bt._normalize_windows_url("about:blank") is None
+        assert bt._normalize_windows_url("file:///C:/x.txt") is None
+
+    def test_rejects_empty_and_non_hosts(self):
+        assert bt._normalize_windows_url("") is None
+        assert bt._normalize_windows_url("   ") is None
+        assert bt._normalize_windows_url(None) is None
+        assert bt._normalize_windows_url("localhost") is None  # no dot
+        assert bt._normalize_windows_url("newtab") is None
+
+
+class TestFirstUrlFromValues:
+    def test_returns_first_valid_url(self):
+        assert bt._first_url_from_values(["", "search terms", "github.com"]) == "https://github.com"
+
+    def test_none_when_no_valid(self):
+        assert bt._first_url_from_values(["", "chrome://x", "just text here"]) is None
+
+
+class _FakeControl:
+    """Minimal stand-in for a uiautomation Control for the BFS walk."""
+
+    def __init__(self, type_name="PaneControl", value=None, children=None):
+        self._type = type_name
+        self._value = value
+        self._children = children or []
+
+    @property
+    def ControlTypeName(self):  # noqa: N802
+        return self._type
+
+    def GetChildren(self):  # noqa: N802
+        return self._children
+
+    def GetValuePattern(self):  # noqa: N802
+        v = self._value
+
+        class _VP:
+            Value = v
+
+        return _VP()
+
+
+class TestCollectUiaUrlValues:
+    def test_edits_come_before_documents(self):
+        tree = _FakeControl(children=[
+            _FakeControl("DocumentControl", value="example.org/page"),
+            _FakeControl("ToolbarControl", children=[
+                _FakeControl("EditControl", value="github.com/x"),
+            ]),
+        ])
+        values = bt._collect_uia_url_values(tree)
+        # Edit value precedes Document value so a real URL is preferred.
+        assert values == ["github.com/x", "example.org/page"]
+
+    def test_depth_bound_stops_descent(self):
+        deep = _FakeControl("EditControl", value="deep.com")
+        # Nest the edit far below the depth bound.
+        node = deep
+        for _ in range(12):
+            node = _FakeControl("PaneControl", children=[node])
+        values = bt._collect_uia_url_values(node, max_depth=3)
+        assert "deep.com" not in values
+
+    def test_node_cap_is_respected(self):
+        wide = _FakeControl(children=[_FakeControl("PaneControl") for _ in range(1000)])
+        # Should not raise / hang; just returns what it scanned within the cap.
+        assert bt._collect_uia_url_values(wide, max_nodes=10) == []
+
+
+class TestWindowsTrackerPoll:
+    def test_poll_records_url_into_buffer(self):
+        with patch.object(bt, "get_active_browser_url_windows", return_value="https://x.com"):
+            tracker = bt._start_windows_tracker(
+                poll_interval=0.01, retention_seconds=600.0, match_tolerance_seconds=8.0
+            )
+            try:
+                import time as _t
+                deadline = _t.time() + 2.0
+                got = None
+                while _t.time() < deadline:
+                    got = tracker.url_at(_t.time())
+                    if got:
+                        break
+                    _t.sleep(0.02)
+                assert got == "https://x.com"
+            finally:
+                tracker.stop()


### PR DESCRIPTION
## Why

macOS already captures the foreground browser's active-tab URL (AppleScript, opt-in), so browser events get a real domain instead of a generic "Google Chrome". On **Windows** there was only the null tracker — browser activity collapsed to the browser name. This is the DeskTime parity gap you asked about.

## What

A Windows reader mirroring the macOS `BrowserURLTracker` interface, so the sync engine is **unchanged**:

- **Process gate (ctypes):** resolves the foreground window's process and only proceeds for a known browser executable. Chromium browsers *and* Electron apps (Slack, VS Code, Teams) share the `Chrome_WidgetWin_1` window class, so matching on class alone would mis-read chat apps as browsers — the process gate prevents that.
- **UIA read:** bounded BFS over the browser window (depth + node caps) reads Edit/Document control values; the first that normalizes to an http(s) URL wins, omnibox (Edit) preferred over Document.
- **Normalization:** adds the scheme Chromium hides (`github.com` → `https://github.com`), rejects internal pages (`chrome://`, `about:`) and typed search queries.
- **Fail-closed everywhere:** non-browser foreground, missing `uiautomation` package, no accessibility, or any traversal error → `None` (no-op). **Opt-in** via `privacy.track_browser_urls` (default off). Existing privacy logic (`domain_only_urls` default) still strips to domain unless the server enables full URLs.

Adds `uiautomation` to `requirements.txt` under a `win32` marker (bundled in the Windows build; absent elsewhere).

## Tests

Off-Windows-testable logic is covered: URL normalization, omnibox-vs-document selection, the bounded BFS (depth/node caps), and the poll loop recording into the buffer with the UIA read stubbed. **30 browser-tracker tests pass; 77 across browser+call+idle.**

## ⚠️ Needs Windows validation before enabling

I can't run the **live UIA read** from macOS — the omnibox traversal (control types, depth needed to reach Chrome/Edge's address bar, value format) should be validated and tuned on a real Windows machine. The feature is **default-off and fail-closed**, so merging is safe (no-op until enabled), but don't flip `track_browser_urls` on for Windows users until the read is confirmed against current Chrome/Edge. Easiest check: enable it on one Windows box, browse a few sites, confirm domains show on the activity cards.

🤖 Generated with [Claude Code](https://claude.com/claude-code)