### PR TITLE
feat(tray): "Show My Hours" opens dashboard already authenticated

### DIFF
--- a/src/main.py
+++ b/src/main.py
@@ -1045,6 +1045,7 @@ class BetterFlowApp:
             on_install_update=self._on_install_update,
             on_check_update=lambda: self.update_handler._periodic_update_check(),
             on_tray_died=self._on_tray_died,
+            on_show_hours=self._on_show_hours,
         )
         self.tray.set_config(self.config)
 
@@ -1662,6 +1663,18 @@ class BetterFlowApp:
             return
         logger.info("Manual sync triggered")
         self.coordinator.trigger_sync()
+
+    def _on_show_hours(self) -> Optional[str]:
+        """Mint a one-time authenticated dashboard URL for the tray.
+
+        Returns the URL the browser should open, or None so the tray falls back
+        to the plain /agent/my URL. Network/auth errors propagate to the tray's
+        worker, which logs them and uses the fallback.
+        """
+        url = self.bf.get_web_login_url()
+        if url:
+            logger.info("Show My Hours: minted authenticated dashboard URL")
+        return url
 
     def _on_system_sleep(self) -> None:
         if self._shutdown_event.is_set():

--- a/src/sync/bf_client.py
+++ b/src/sync/bf_client.py
@@ -349,6 +349,24 @@ class BetterFlowClient(BaseApiClient):
         return self._request("GET", "events/trends", retry=False, timeout_override=10)
 
     # =========================================================================
+    # Web login passthrough
+    # =========================================================================
+
+    def get_web_login_url(self) -> Optional[str]:
+        """Mint a one-time URL that opens the web dashboard already authenticated.
+
+        Backs the "Show My Hours" tray action: the server trades this device's
+        token for a short-lived, single-use URL so the user lands on /agent/my
+        without logging in again (a pain for multi-Google-account users).
+
+        Returns the URL, or None if the server response lacks one.
+        """
+        resp = self._request("POST", "web-login-link", retry=False, timeout_override=10)
+        data = resp.get("data") or {}
+        url = data.get("url")
+        return url if isinstance(url, str) and url else None
+
+    # =========================================================================
     # Configuration
     # =========================================================================
 

--- a/src/ui/tray.py
+++ b/src/ui/tray.py
@@ -439,6 +439,7 @@ class TrayIcon:
         on_install_update: Optional[Callable[[str], None]] = None,
         on_check_update: Optional[Callable[[], None]] = None,
         on_tray_died: Optional[Callable[[], None]] = None,
+        on_show_hours: Optional[Callable[[], Optional[str]]] = None,
     ):
         """Initialize tray icon.
 
@@ -478,6 +479,7 @@ class TrayIcon:
         self._on_install_update = on_install_update
         self._on_check_update = on_check_update
         self._on_tray_died = on_tray_died
+        self._on_show_hours = on_show_hours
 
         self.model = TrayModel()
 
@@ -897,10 +899,32 @@ class TrayIcon:
         self._update_menu()
 
     def _handle_show_dashboard(self, icon, item) -> None:
-        """Open dashboard in browser."""
+        """Open the web dashboard in the browser.
+
+        Prefer a one-time authenticated URL (so multi-Google-account users skip
+        the login wall); fall back to the plain /agent/my URL if minting fails
+        or no callback is wired. The mint hits the network, so it runs off the
+        tray thread to keep the menu responsive.
+        """
         with self.model.lock:
-            url = self.model.dashboard_url
-        webbrowser.open(url)
+            fallback_url = self.model.dashboard_url
+        on_show_hours = self._on_show_hours
+
+        def worker() -> None:
+            url = fallback_url
+            if on_show_hours is not None:
+                try:
+                    authenticated = on_show_hours()
+                    if authenticated:
+                        url = authenticated
+                except Exception:
+                    logger.exception(
+                        "Show My Hours: failed to mint authenticated URL; "
+                        "opening plain dashboard instead"
+                    )
+            webbrowser.open(url)
+
+        threading.Thread(target=worker, name="show-my-hours", daemon=True).start()
 
     def _handle_open_privacy(self, icon, item) -> None:
         """Open the public privacy policy in the user's default browser.

--- a/tests/test_bf_client.py
+++ b/tests/test_bf_client.py
@@ -833,3 +833,57 @@ class TestRetryBehavior:
 
         assert result["status"] == "ok"
         assert len(responses.calls) == 2
+
+
+class TestGetWebLoginUrl:
+    """Tests for the "Show My Hours" one-time login URL minting."""
+
+    def setup_method(self):
+        self.client = BetterFlowClient(
+            api_url="https://betterflow.eu/api/agent",
+            token="test-token",
+            device_id="test-device",
+        )
+
+    def teardown_method(self):
+        self.client.close()
+
+    @responses.activate
+    def test_returns_url_from_response(self):
+        """A successful mint returns the authenticated URL."""
+        responses.add(
+            responses.POST,
+            "https://betterflow.eu/api/agent/web-login-link",
+            json={"success": True, "data": {"url": "https://betterflow.eu/agent/auth?ott=abc", "expires_in": 90}},
+            status=200,
+        )
+
+        url = self.client.get_web_login_url()
+
+        assert url == "https://betterflow.eu/agent/auth?ott=abc"
+        # Must POST with the device's bearer token attached.
+        assert responses.calls[0].request.headers["Authorization"] == "Bearer test-token"
+
+    @responses.activate
+    def test_returns_none_when_url_absent(self):
+        """A malformed/empty payload yields None so the tray falls back."""
+        responses.add(
+            responses.POST,
+            "https://betterflow.eu/api/agent/web-login-link",
+            json={"success": True, "data": {}},
+            status=200,
+        )
+
+        assert self.client.get_web_login_url() is None
+
+    @responses.activate
+    def test_returns_none_when_data_missing(self):
+        """No data key at all still yields None, not an exception."""
+        responses.add(
+            responses.POST,
+            "https://betterflow.eu/api/agent/web-login-link",
+            json={"success": True},
+            status=200,
+        )
+
+        assert self.client.get_web_login_url() is None


### PR DESCRIPTION
## What & why

**"Show My Hours"** in the tray opened `https://app.betterflow.eu/agent/my` as a plain URL, so a user whose default browser is signed into a different Google account hit the login wall. Emilian Popescu asked for DeskTime's behaviour: the click uses the app token to open the page **already authenticated**.

This is the **agent half**. It pairs with the backend endpoint in **Better-Quality-Assurance/internal-tool2#1841**.

## Changes
- **`src/sync/bf_client.py`** — `get_web_login_url()`: `POST /api/agent/web-login-link` with the device's existing bearer token; returns the server's one-time URL (or `None`).
- **`src/ui/tray.py`** — `_handle_show_dashboard` mints the authenticated URL **off the UI thread** (network call, keeps the menu responsive) and opens it; **falls back to the plain `/agent/my` URL** on any error or when no callback is wired, so the menu item never dead-ends.
- **`src/main.py`** — wires `on_show_hours → BetterFlowClient.get_web_login_url`.

## Tests
`TestGetWebLoginUrl` — returns URL with bearer attached, `None` on empty/missing payload. Full `test_bf_client.py` suite: **59 passed**.

## Ship order ⚠️
Backend (**internal-tool2#1841**) must deploy **first**. Until then this falls back to the plain `/agent/my` URL — i.e. today's behaviour, so it degrades safely.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
