### PR TITLE
fix(windows): disable UPX to cut antivirus false positives

### DIFF
--- a/build.spec
+++ b/build.spec
@@ -231,7 +231,12 @@ elif is_windows:
         debug=False,
         bootloader_ignore_signals=False,
         strip=False,
-        upx=True,
+        # UPX OFF on Windows: UPX-packed binaries are the #1 antivirus heuristic
+        # trigger (Avast/Defender flag them on sight). An unsigned + UPX-packed
+        # one-file exe was getting quarantined ("Suspicious file detected",
+        # Claudia 2026-06-16). Dropping UPX trades a slightly larger exe for far
+        # fewer false positives. The durable fix is Authenticode code-signing.
+        upx=False,
         console=False,
         disable_windowed_traceback=False,
         argv_emulation=False,


### PR DESCRIPTION
Claudia (2026-06-16, Windows) had **Avast quarantine `BetterFlow.exe`** ("Suspicious file detected … we'll keep blocking it") plus a follow-on `_MEI…` temp-dir cleanup warning.

The Windows build hits **all three AV heuristic triggers at once**: **unsigned + UPX-packed + one-file**. UPX is the worst — packed executables are malware-associated and get flagged on sight.

**This PR:** `upx=False` for the Windows exe. Slightly larger binary, far fewer false positives.

**This is mitigation, not the cure.** The only thing that *reliably* clears an AV/SmartScreen false positive is **Authenticode code-signing** (separate — needs a cert). The one-file → one-dir switch would also kill the `_MEI` temp-dir error, but it touches the self-updater + resource paths, so it needs real Windows testing.

> Can't Windows-test from here; CI builds the Windows artifact. A release + version bump is needed for it to reach Claudia (and she's currently AV-blocked, so she'll need an Avast exception or a manual download of the new build).

🤖 Generated with [Claude Code](https://claude.com/claude-code)