### PR TITLE
chore(release): bump version to 1.5.48

### DIFF
--- a/src/__init__.py
+++ b/src/__init__.py
@@ -1,4 +1,4 @@
 """BetterFlow - ActivityWatch to BetterFlow sync companion app."""
 
-__version__ = "1.5.47"
+__version__ = "1.5.48"
 __author__ = "BetterQA"


### PR DESCRIPTION
Cuts 1.5.48 to ship the `upx=False` Windows build (#41) — reduces Avast/Defender false positives. Mitigation only; durable fix is Authenticode signing.

After merge I'll tag `v1.5.48` to trigger the signed macOS + Windows + Linux build.