### PR TITLE
fix(agent): idle-resume during call, daily counted-time prune, detector hardening (review R1)

### DIFF
--- a/src/__init__.py
+++ b/src/__init__.py
@@ -1,4 +1,4 @@
 """BetterFlow - ActivityWatch to BetterFlow sync companion app."""
 
-__version__ = "1.5.48"
+__version__ = "1.5.49"
 __author__ = "BetterQA"

--- a/src/browser_tracker.py
+++ b/src/browser_tracker.py
@@ -337,10 +337,12 @@ def _collect_uia_url_values(root, max_depth: int = _WIN_UIA_MAX_DEPTH, max_nodes
     """
     edits: list = []
     docs: list = []
-    queue = [(root, 0)]
+    # deque, not a list: this is a BFS, and list.pop(0) is O(n) per dequeue
+    # (O(n^2) over the walk). deque.popleft() is O(1).
+    queue: deque = deque([(root, 0)])
     seen = 0
     while queue and seen < max_nodes:
-        node, depth = queue.pop(0)
+        node, depth = queue.popleft()
         seen += 1
         try:
             type_name = node.ControlTypeName

--- a/src/browser_tracker.py
+++ b/src/browser_tracker.py
@@ -339,7 +339,7 @@ def _collect_uia_url_values(root, max_depth: int = _WIN_UIA_MAX_DEPTH, max_nodes
     docs: list = []
     # deque, not a list: this is a BFS, and list.pop(0) is O(n) per dequeue
     # (O(n^2) over the walk). deque.popleft() is O(1).
-    queue: deque = deque([(root, 0)])
+    queue: Deque[Tuple[object, int]] = deque([(root, 0)])
     seen = 0
     while queue and seen < max_nodes:
         node, depth = queue.popleft()

--- a/src/idle_manager.py
+++ b/src/idle_manager.py
@@ -118,14 +118,34 @@ class IdleManager:
                     idle_start = datetime.now(timezone.utc) - timedelta(seconds=system_idle)
 
             if is_afk and afk_duration >= self._idle_pause_threshold:
-                if not was_idle_paused:
+                in_call = self._is_in_call()
+                if was_idle_paused:
+                    # Already idle-paused, but a call has since started while the
+                    # user stays AFK. They're now engaged in the meeting
+                    # (listening/watching), so resume — otherwise the call span
+                    # stays painted Idle for as long as they don't touch the
+                    # keyboard. The _is_in_call() guard below only blocks
+                    # ENTERING idle; this is the symmetric exit when a call
+                    # begins during an existing idle pause (Windows has no
+                    # in-process input watcher, so AFK never clears on its own
+                    # mid-call).
+                    if in_call:
+                        logger.info(
+                            "Call active while idle-paused — resuming to track the call"
+                        )
+                        self.clear_idle_pause(send_event=True)
+                        reschedule(self.config.sync.interval_seconds)
+                        self.tray.set_state(TrayState.SYNCING)
+                        trigger_sync("call_resume_sync")
+                    # else: still idle with no call — stay paused.
+                else:
                     # Don't mark idle while the user is in a call/meeting. In a
                     # meeting they're engaged (listening/watching) even without
                     # keyboard/mouse input. The AFK watcher is the only idle
                     # signal on Windows (no in-process input watcher), so a long
                     # call otherwise trips this pause and paints the whole span
                     # as Idle even though the meeting app was focused throughout.
-                    if self._is_in_call():
+                    if in_call:
                         logger.debug(
                             "AFK for %ds but a call is active — not pausing as idle",
                             int(afk_duration),

--- a/src/sync/call_detector.py
+++ b/src/sync/call_detector.py
@@ -34,7 +34,12 @@ class CallEvent:
 # undetected on Windows (Sachi, 2026-06-15). Each entry stays title-gated, so
 # widening the app match can never turn "app merely open" into a false call.
 _NATIVE_PATTERNS: list[tuple[tuple[str, ...], Optional[re.Pattern], str]] = [
-    (("zoom.us", "zoom"), re.compile(r"Zoom (Meeting|Webinar)|\d{9,11}", re.IGNORECASE), "Zoom"),
+    # NOTE: dropped the old `\d{9,11}` Zoom fallback — a 9–11 digit ticket /
+    # phone / timestamp in a Zoom window title was mis-read as a meeting ID
+    # (mirrors the PHP CallEventDetector E3 fix; KEEP THE TWO IN SYNC). Real
+    # Zoom meetings still match the "Zoom Meeting"/"Zoom Webinar" native title
+    # or the zoom.us/j/ | zoom.us/wc/ browser URL below.
+    (("zoom.us", "zoom"), re.compile(r"Zoom (Meeting|Webinar)", re.IGNORECASE), "Zoom"),
     (("microsoft teams", "ms-teams", "msteams", "teams"), re.compile(r"(Meeting|Call) with|In a call", re.IGNORECASE), "Microsoft Teams"),
     (("slack",), re.compile(r"Huddle", re.IGNORECASE), "Slack"),
     (("discord",), re.compile(r"Voice Connected|voice channel", re.IGNORECASE), "Discord"),
@@ -57,13 +62,28 @@ _BROWSER_PATTERNS: list[tuple[str, Optional[re.Pattern], str]] = [
 _DEFAULT_GRACE_PERIOD = 30.0
 
 
+def _app_contains(app_lower: str, sub: str) -> bool:
+    """Match an app-name alias against the (lowercased) app name.
+
+    Bare alphanumeric aliases ("teams", "zoom") match on a WORD BOUNDARY so a
+    short, common alias can't bleed into an unrelated app — "teams" matches the
+    "Teams" app but not "teamspeak"/"teamviewer", "zoom" matches "Zoom" but not
+    "zoomtext". Aliases carrying a separator ("zoom.us", "ms-teams",
+    "microsoft teams") use plain containment, where a \\b boundary would be
+    wrong (the punctuation already disambiguates).
+    """
+    if sub.isalnum():
+        return re.search(rf"\b{re.escape(sub)}\b", app_lower) is not None
+    return sub in app_lower
+
+
 def _match_native(app: str, title: str) -> Optional[str]:
     """Return display name if (app, title) matches a native call pattern."""
     if not title:
         title = ""
     app_lower = app.lower()
     for app_substrs, title_re, name in _NATIVE_PATTERNS:
-        if any(sub in app_lower for sub in app_substrs) and (
+        if any(_app_contains(app_lower, sub) for sub in app_substrs) and (
             title_re is None or title_re.search(title)
         ):
             return name

--- a/src/sync/call_detector.py
+++ b/src/sync/call_detector.py
@@ -62,17 +62,23 @@ _BROWSER_PATTERNS: list[tuple[str, Optional[re.Pattern], str]] = [
 _DEFAULT_GRACE_PERIOD = 30.0
 
 
+# Bare aliases short/common enough to bleed into an unrelated app name — matched
+# on a WORD BOUNDARY rather than as a substring: "teams" must not match
+# "teamspeak"/"teamviewer", "zoom" must not match "zoomtext". Every other alias
+# stays plain containment — notably "webex", which must still match the compound
+# Windows process name "CiscoWebexStart"; a \b boundary would break that.
+_WORD_BOUNDARY_ALIASES = frozenset({"teams", "zoom"})
+
+
 def _app_contains(app_lower: str, sub: str) -> bool:
     """Match an app-name alias against the (lowercased) app name.
 
-    Bare alphanumeric aliases ("teams", "zoom") match on a WORD BOUNDARY so a
-    short, common alias can't bleed into an unrelated app — "teams" matches the
-    "Teams" app but not "teamspeak"/"teamviewer", "zoom" matches "Zoom" but not
-    "zoomtext". Aliases carrying a separator ("zoom.us", "ms-teams",
-    "microsoft teams") use plain containment, where a \\b boundary would be
-    wrong (the punctuation already disambiguates).
+    Word-boundary for the ambiguous bare aliases in _WORD_BOUNDARY_ALIASES;
+    plain containment for everything else (separator aliases like "ms-teams"
+    where \\b is wrong, and distinctive substrings like "webex" that must still
+    match compound process names).
     """
-    if sub.isalnum():
+    if sub in _WORD_BOUNDARY_ALIASES:
         return re.search(rf"\b{re.escape(sub)}\b", app_lower) is not None
     return sub in app_lower
 

--- a/src/sync/call_detector.py
+++ b/src/sync/call_detector.py
@@ -62,12 +62,17 @@ _BROWSER_PATTERNS: list[tuple[str, Optional[re.Pattern], str]] = [
 _DEFAULT_GRACE_PERIOD = 30.0
 
 
-# Bare aliases short/common enough to bleed into an unrelated app name — matched
-# on a WORD BOUNDARY rather than as a substring: "teams" must not match
-# "teamspeak"/"teamviewer", "zoom" must not match "zoomtext". Every other alias
-# stays plain containment — notably "webex", which must still match the compound
-# Windows process name "CiscoWebexStart"; a \b boundary would break that.
-_WORD_BOUNDARY_ALIASES = frozenset({"teams", "zoom"})
+# Bare aliases matched on a WORD BOUNDARY rather than as a substring, so they
+# can't bleed into an unrelated app name:
+#   - "teams" must not match "teamspeak"/"teamviewer", "zoom" not "zoomtext".
+#   - "facetime" must not match "FaceTimeHelper" / other facetime-prefixed
+#     helper processes — and unlike the others it has NO title gate (any window
+#     counts), so a loose substring there would be the easiest to false-trigger.
+# Aliases kept as plain containment are EITHER title-gated ("slack"/"discord"/
+# "msteams" need an in-call title too, so a stray substring match can't bill on
+# its own) OR must match a compound process name — notably "webex", which has to
+# match the Windows process "CiscoWebexStart" where a \b boundary would break it.
+_WORD_BOUNDARY_ALIASES = frozenset({"teams", "zoom", "facetime"})
 
 
 def _app_contains(app_lower: str, sub: str) -> bool:

--- a/src/sync/sync_engine.py
+++ b/src/sync/sync_engine.py
@@ -385,6 +385,17 @@ class SyncEngine:
         # Check ActivityWatch
         if not self.aw.is_running():
             stats.errors.append("ActivityWatch is not running")
+            # Finalize any in-progress call before bailing. Otherwise is_in_call()
+            # stays True for the whole outage (sync returns here every cycle, so
+            # the end-of-sync flush at line ~522 never runs), and the idle guard
+            # in IdleManager keeps suppressing idle long after the call ended —
+            # painting the post-call AFK stretch as worked time. The observed call
+            # portion is still recorded if the backend is reachable; if AW comes
+            # back mid-call a fresh call starts cleanly.
+            if self._call_detector:
+                remaining = self._call_detector.flush()
+                if remaining and self.bf.is_reachable():
+                    self._send_events([self._make_call_bf_event(remaining)], stats)
             return stats
 
         # Start session if needed (attempt directly; no pre-check to avoid TOCTOU)

--- a/src/sync/sync_engine.py
+++ b/src/sync/sync_engine.py
@@ -589,9 +589,9 @@ class SyncEngine:
             # daily total resets at midnight, so drop them before reloading.
             self._time_cache.clear()
         logger.info("Local day rolled over to %s — pruning counted-time cache", today)
-        self._load_counted_time_cache()
+        self._load_counted_time_cache(today)
 
-    def _load_counted_time_cache(self) -> None:
+    def _load_counted_time_cache(self, day: Optional[str] = None) -> None:
         """Repopulate ``_time_cache`` from persisted per-event counted-seconds
         for the current local day.
 
@@ -609,7 +609,7 @@ class SyncEngine:
         if not callable(getter):
             return
         try:
-            today = self._local_day_iso()
+            today = day or self._local_day_iso()
             persisted = getter(today)
             if not isinstance(persisted, dict):
                 return

--- a/src/sync/sync_engine.py
+++ b/src/sync/sync_engine.py
@@ -392,10 +392,21 @@ class SyncEngine:
             # painting the post-call AFK stretch as worked time. The observed call
             # portion is still recorded if the backend is reachable; if AW comes
             # back mid-call a fresh call starts cleanly.
+            #
+            # That recovery can emit a SECOND event for the same meeting (the
+            # continuation is picked up from the un-advanced checkpoint). Both
+            # carry the deterministic id call_<app>_<start_ts> and the backend
+            # upserts call events by id, so the overlapping recovered portion
+            # supersedes this flushed one rather than double-billing.
             if self._call_detector:
                 remaining = self._call_detector.flush()
                 if remaining and self.bf.is_reachable():
+                    # _send_events may set stats.queued_bucket_ids on failure; we
+                    # return immediately and intentionally don't act on it — call
+                    # events go to the synthetic call bucket, not a checkpointed AW
+                    # bucket, so there is no checkpoint to withhold.
                     self._send_events([self._make_call_bf_event(remaining)], stats)
+                    stats.calls_detected += 1
             return stats
 
         # Start session if needed (attempt directly; no pre-check to avoid TOCTOU)

--- a/src/sync/sync_engine.py
+++ b/src/sync/sync_engine.py
@@ -110,6 +110,9 @@ class BoundedLRU:
     def __len__(self) -> int:
         return len(self._od)
 
+    def clear(self) -> None:
+        self._od.clear()
+
 
 class SyncEngine:
     """Core sync engine that orchestrates AW -> BetterFlow data flow."""
@@ -205,6 +208,10 @@ class SyncEngine:
             if config.call_detection.enabled
             else None
         )
+
+        # The local day the counted-time cache is scoped to; a change across a
+        # sync cycle triggers daily housekeeping (prune) without a restart.
+        self._counted_cache_day = self._local_day_iso()
 
         # Restore per-event counted-time from the previous process so a restart
         # (or the start-of-day backlog reconcile that re-fetches the whole day)
@@ -360,6 +367,12 @@ class SyncEngine:
         6. Send heartbeat periodically
         """
         stats = SyncStats()
+
+        # Daily housekeeping before anything else, so it still runs while paused:
+        # a long-running agent that never restarts across midnight would
+        # otherwise never prune persisted counted-time (prune_counted_time only
+        # ran at startup), leaking a day's rows every day it stays up.
+        self._maybe_rollover_counted_day()
 
         with self._state_lock:
             if self._paused or self._private_mode:
@@ -557,6 +570,26 @@ class SyncEngine:
         """Local calendar date as ISO ``YYYY-MM-DD`` — the key the daily time
         counter and counted-time persistence are scoped by."""
         return datetime.now().astimezone().date().isoformat()
+
+    def _maybe_rollover_counted_day(self) -> None:
+        """On a local-day rollover, reset the per-day dedup cache and reload
+        (which prunes persisted counted-time for days we will never replay).
+
+        Without this the prune only happened at process start, so an agent left
+        running across midnight accumulated a day's counted-time rows in the
+        persistent store every day it stayed up. Cheap when the day is unchanged
+        (a single string compare), so safe to call every sync cycle.
+        """
+        today = self._local_day_iso()
+        with self._cache_lock:
+            if today == self._counted_cache_day:
+                return
+            self._counted_cache_day = today
+            # Yesterday's (bucket_id, event_id) dedup entries are dead — the
+            # daily total resets at midnight, so drop them before reloading.
+            self._time_cache.clear()
+        logger.info("Local day rolled over to %s — pruning counted-time cache", today)
+        self._load_counted_time_cache()
 
     def _load_counted_time_cache(self) -> None:
         """Repopulate ``_time_cache`` from persisted per-event counted-seconds

--- a/tests/test_call_detector.py
+++ b/tests/test_call_detector.py
@@ -61,6 +61,12 @@ class TestPatternMatching:
         # "zoom" matches "Zoom" but not "ZoomText" (a screen magnifier).
         assert _match_native("ZoomText", "Zoom Meeting") is None
 
+    def test_webex_still_matches_compound_process_name(self):
+        # "webex" stays a SUBSTRING match (not word-boundary) so the compound
+        # Windows process "CiscoWebexStart" is still caught — the word-boundary
+        # tightening is scoped to teams/zoom only.
+        assert _match_native("CiscoWebexStart", "Meeting - Sprint Review") == "Webex"
+
     def test_slack_huddle(self):
         assert _match_native("Slack", "Huddle in #engineering") == "Slack"
 

--- a/tests/test_call_detector.py
+++ b/tests/test_call_detector.py
@@ -82,6 +82,12 @@ class TestPatternMatching:
     def test_facetime_any_window(self):
         assert _match_native("FaceTime", "anything here") == "FaceTime"
 
+    def test_facetime_alias_matches_on_word_boundary(self):
+        # FaceTime has NO title gate (any window counts), so its alias must match
+        # on a word boundary — a helper process like "FaceTimeHelper" must not be
+        # read as an active call.
+        assert _match_native("FaceTimeHelper", "anything here") is None
+
     def test_webex_meeting(self):
         assert _match_native("Webex", "Meeting - Sprint Review") == "Webex"
 

--- a/tests/test_call_detector.py
+++ b/tests/test_call_detector.py
@@ -22,8 +22,14 @@ class TestPatternMatching:
     def test_zoom_native_webinar(self):
         assert _match_native("zoom.us", "Zoom Webinar") == "Zoom"
 
-    def test_zoom_native_meeting_id(self):
-        assert _match_native("zoom.us", "123456789") == "Zoom"
+    def test_zoom_native_bare_meeting_id_does_not_match(self):
+        # A bare 9–11 digit number in a Zoom window (ticket / phone / timestamp)
+        # must NOT be read as a meeting ID — the old \d{9,11} fallback
+        # over-credited (dropped, mirrors PHP CallEventDetector E3). Real Zoom
+        # calls match the "Zoom Meeting"/"Zoom Webinar" title or the zoom.us/j/
+        # browser URL instead.
+        assert _match_native("zoom.us", "123456789") is None
+        assert _match_native("Zoom", "Ticket 2024123456") is None
 
     def test_zoom_native_no_match(self):
         assert _match_native("zoom.us", "Zoom - Home") is None
@@ -39,6 +45,21 @@ class TestPatternMatching:
 
     def test_teams_native_chat_no_match(self):
         assert _match_native("Microsoft Teams", "Chat - General") is None
+
+    def test_teams_bare_app_name_matches_on_word_boundary(self):
+        # The classic-Teams process can report as a standalone "Teams".
+        assert _match_native("Teams", "Meeting with John") == "Microsoft Teams"
+
+    def test_teams_alias_does_not_bleed_into_unrelated_apps(self):
+        # "teams" must match as a whole word, not a substring — TeamSpeak /
+        # TeamViewer contain "teams"/"team" but are not Microsoft Teams. (Even
+        # title-gated, a tighter app match is correct.)
+        assert _match_native("TeamSpeak", "Meeting with John") is None
+        assert _match_native("TeamViewer", "Call with Sarah") is None
+
+    def test_zoom_alias_does_not_bleed_into_unrelated_apps(self):
+        # "zoom" matches "Zoom" but not "ZoomText" (a screen magnifier).
+        assert _match_native("ZoomText", "Zoom Meeting") is None
 
     def test_slack_huddle(self):
         assert _match_native("Slack", "Huddle in #engineering") == "Slack"

--- a/tests/test_idle_manager.py
+++ b/tests/test_idle_manager.py
@@ -107,8 +107,12 @@ def test_resumes_when_a_call_starts_during_an_existing_idle_pause():
     was painted Idle. This is the symmetric exit: still AFK, but now in a call.
     """
     idle_mgr, reschedule, trigger_sync, tray = _make(idle_in_call=True)
-    # Simulate "already idle-paused before the call started".
+    # Simulate "already idle-paused before the call started" — both the flag and
+    # the start timestamp, as the real pause path sets them together, so the
+    # idle_time event send is actually exercised.
+    idle_start = datetime.now(timezone.utc) - timedelta(hours=2)
     idle_mgr._idle_paused = True
+    idle_mgr._idle_start = idle_start
 
     idle_mgr.check_idle_status(
         logged_in=True,
@@ -120,3 +124,9 @@ def test_resumes_when_a_call_starts_during_an_existing_idle_pause():
     assert idle_mgr.idle_paused is False, "a call starting mid-idle must resume"
     reschedule.assert_called_once_with(idle_mgr.config.sync.interval_seconds)
     trigger_sync.assert_called_once_with("call_resume_sync")
+    # The pre-call idle stretch is still recorded as idle (send_event=True path).
+    idle_mgr.sync_engine.send_idle_event.assert_called_once_with(idle_start)
+
+    from src.ui.tray import TrayState
+
+    tray.set_state.assert_called_once_with(TrayState.SYNCING)

--- a/tests/test_idle_manager.py
+++ b/tests/test_idle_manager.py
@@ -96,3 +96,27 @@ def test_pauses_idle_when_not_in_a_call():
 
     assert idle_mgr.idle_paused is True, "long AFK outside a call should pause"
     reschedule.assert_called_once_with(idle_mgr._IDLE_SYNC_INTERVAL)
+
+
+def test_resumes_when_a_call_starts_during_an_existing_idle_pause():
+    """A call that begins AFTER the idle pause must resume tracking.
+
+    The is_in_call guard only blocks ENTERING idle. If the user was already
+    idle-paused (stepped away, no call) and then joins a meeting but stays AFK
+    (listening, no keyboard), nothing cleared the pause — the whole call span
+    was painted Idle. This is the symmetric exit: still AFK, but now in a call.
+    """
+    idle_mgr, reschedule, trigger_sync, tray = _make(idle_in_call=True)
+    # Simulate "already idle-paused before the call started".
+    idle_mgr._idle_paused = True
+
+    idle_mgr.check_idle_status(
+        logged_in=True,
+        is_on_break=False,
+        reschedule=reschedule,
+        trigger_sync=trigger_sync,
+    )
+
+    assert idle_mgr.idle_paused is False, "a call starting mid-idle must resume"
+    reschedule.assert_called_once_with(idle_mgr.config.sync.interval_seconds)
+    trigger_sync.assert_called_once_with("call_resume_sync")

--- a/tests/test_sync_engine_aw_outage_call_flush.py
+++ b/tests/test_sync_engine_aw_outage_call_flush.py
@@ -71,8 +71,9 @@ def test_aw_outage_clears_stuck_call_state_and_records_when_reachable():
     engine.aw.is_running.return_value = False
     engine.bf.is_reachable.return_value = True  # online → the observed call is sent
 
-    engine.sync()
+    stats = engine.sync()
 
     assert engine.is_in_call() is False, "stale call state cleared on AW outage"
     # The observed 2-minute call portion is recorded (>= min_call_duration).
     assert engine.bf.send_events.called, "the call up to the outage should be sent"
+    assert stats.calls_detected == 1, "the flushed call must be counted in stats"

--- a/tests/test_sync_engine_aw_outage_call_flush.py
+++ b/tests/test_sync_engine_aw_outage_call_flush.py
@@ -1,0 +1,78 @@
+"""Regression test: an ActivityWatch outage mid-call must not leave the call
+detector stuck "in a call" forever.
+
+sync() early-returns the moment aw.is_running() is False, which is BEFORE the
+end-of-sync flush that normally finalizes an in-progress call. So if AW crashes
+while the user is in a meeting, every subsequent cycle bails early, the detector
+keeps is_in_call() == True, and IdleManager's "don't pause while in a call"
+guard suppresses idle for the whole outage — painting the post-call AFK stretch
+as worked time. The fix flushes the detector in the AW-down branch so the stale
+call state can't carry forward (the observed portion is still recorded if the
+backend is reachable).
+"""
+
+import tempfile
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+from types import SimpleNamespace
+from unittest.mock import Mock
+
+from src.config import Config
+from src.sync.queue import OfflineQueue
+from src.sync.sync_engine import SyncEngine
+
+
+def _build_engine() -> SyncEngine:
+    tmp = Path(tempfile.mkdtemp())
+    engine = SyncEngine(
+        aw=Mock(),
+        bf=Mock(),
+        queue=OfflineQueue(db_path=tmp / "q.db", max_size=1000),
+        config=Config(),  # call_detection.enabled defaults True
+        time_tracker=Mock(),
+    )
+    # Skip the first-sync server-config fetch (its Mock return isn't a dict).
+    engine._config_fetched = True
+    # A well-formed send result so _send_events doesn't choke on a bare Mock.
+    engine.bf.send_events.return_value = SimpleNamespace(
+        success=True, events_synced=1, accepted_ids=[], error=None
+    )
+    return engine
+
+
+def _enter_call(engine: SyncEngine) -> None:
+    """Drive the detector into an active 2-minute Teams call."""
+    t0 = datetime(2026, 6, 17, 13, 0, 0, tzinfo=timezone.utc)
+    engine._call_detector.process_event("Microsoft Teams", "Meeting with X", None, t0, 60)
+    engine._call_detector.process_event(
+        "Microsoft Teams", "Meeting with X", None, t0 + timedelta(minutes=2), 60
+    )
+    assert engine.is_in_call(), "precondition: detector should report in-call"
+
+
+def test_aw_outage_clears_stuck_call_state_backend_unreachable():
+    engine = _build_engine()
+    _enter_call(engine)
+
+    engine.aw.is_running.return_value = False
+    engine.bf.is_reachable.return_value = False  # offline → don't try to send
+
+    engine.sync()
+
+    assert engine.is_in_call() is False, (
+        "an AW outage mid-call must flush the detector so idle isn't suppressed"
+    )
+
+
+def test_aw_outage_clears_stuck_call_state_and_records_when_reachable():
+    engine = _build_engine()
+    _enter_call(engine)
+
+    engine.aw.is_running.return_value = False
+    engine.bf.is_reachable.return_value = True  # online → the observed call is sent
+
+    engine.sync()
+
+    assert engine.is_in_call() is False, "stale call state cleared on AW outage"
+    # The observed 2-minute call portion is recorded (>= min_call_duration).
+    assert engine.bf.send_events.called, "the call up to the outage should be sent"

--- a/tests/test_sync_engine_counted_day_rollover.py
+++ b/tests/test_sync_engine_counted_day_rollover.py
@@ -1,0 +1,84 @@
+"""Regression test: a long-running agent must prune persisted counted-time on a
+local-day rollover, not only at process start.
+
+`prune_counted_time` was called solely from `_load_counted_time_cache`, which
+runs at construction (and on an explicit reset). An agent left running across
+midnight therefore never pruned — every day it stayed up leaked that day's
+counted-time rows into the SQLite store, and yesterday's in-memory dedup entries
+lingered. `sync()` now calls `_maybe_rollover_counted_day` each cycle, which is a
+no-op on the same day and, on a rollover, clears the per-day dedup cache and
+reloads (which prunes prior days).
+
+Drives the real OfflineQueue persistence + the real BoundedLRU cache; no mocking
+of the components under test.
+"""
+
+import tempfile
+from pathlib import Path
+from unittest.mock import Mock
+
+from src.config import Config
+from src.sync.queue import OfflineQueue
+from src.sync.sync_engine import SyncEngine
+
+
+def _build_engine(queue_db: Path, time_db: Path) -> SyncEngine:
+    engine = SyncEngine(
+        aw=Mock(),
+        bf=Mock(),
+        queue=OfflineQueue(db_path=queue_db, max_size=1000),
+        config=Config(),
+        time_tracker=Mock(),
+    )
+    # Exit the sync cycle right after the rollover housekeeping (which is all
+    # this test exercises): no server config fetch, no AW work.
+    engine.bf.is_reachable.return_value = False
+    engine.aw.is_running.return_value = False
+    return engine
+
+
+def test_day_rollover_prunes_yesterdays_counted_time_without_restart():
+    tmp = Path(tempfile.mkdtemp())
+    engine = _build_engine(tmp / "offline_queue.db", tmp / "time.db")
+
+    today = engine._counted_cache_day
+    yesterday = "2000-01-01"  # any day strictly before "today"
+
+    # A counted-time row persisted "yesterday", plus a lingering in-memory
+    # dedup entry from that day.
+    engine.queue.set_counted_time("aw-window", "evt-1", 123.0, yesterday)
+    engine._time_cache[("aw-window", "evt-1")] = 123.0
+    assert engine.queue.get_counted_times(yesterday), "precondition: yesterday persisted"
+
+    # Pretend the cache was last loaded yesterday, then run a sync cycle. No AW,
+    # so sync() bails early after the rollover housekeeping — which is the point.
+    engine._counted_cache_day = yesterday
+    engine.sync()
+
+    assert engine._counted_cache_day == today, "cache day advanced to today"
+    assert engine.queue.get_counted_times(yesterday) == {}, (
+        "yesterday's counted-time must be pruned on rollover"
+    )
+    assert ("aw-window", "evt-1") not in engine._time_cache, (
+        "stale dedup entry from yesterday must be cleared"
+    )
+
+    engine.queue.close()
+
+
+def test_same_day_sync_does_not_prune_or_clear():
+    """Control: within the same day the rollover check is a cheap no-op."""
+    tmp = Path(tempfile.mkdtemp())
+    engine = _build_engine(tmp / "offline_queue.db", tmp / "time.db")
+
+    today = engine._counted_cache_day
+    engine.queue.set_counted_time("aw-window", "evt-2", 50.0, today)
+    engine._time_cache[("aw-window", "evt-2")] = 50.0
+
+    engine.sync()
+
+    assert engine._counted_cache_day == today
+    assert engine.queue.get_counted_times(today), "today's counted-time is retained"
+    assert ("aw-window", "evt-2") in engine._time_cache, "today's dedup entry retained"
+
+    engine.queue.close()


### PR DESCRIPTION
## Business impact

Four agent-side fixes from a senior-review pass on the call-presence / counted-time work:

- **Calls mid-idle were billed as Idle (B1).** If someone stepped away (idle-paused), then joined a meeting but stayed off the keyboard (listening), nothing resumed tracking — the whole call showed Idle. On Windows there's no input watcher, so AFK never cleared on its own. Now a call starting during an idle pause resumes tracking.
- **Counted-time rows leaked on long-running agents (B2).** `prune_counted_time` only ran at startup, so an agent left up across midnight accumulated a day's rows in SQLite every day. Now pruned on day-rollover inside the sync loop.
- **False / missed call detection (B3).** Bare app aliases (`teams`, `zoom`) matched substrings (TeamSpeak, ZoomText); now matched on a word boundary. Dropped the `\d{9,11}` Zoom title fallback that read a ticket/phone number as a meeting ID (mirrors the PHP-side E3 fix).
- **O(n²) UIA tree walk (B4).** The Windows browser-URL BFS used `list.pop(0)`; switched to `deque.popleft()`.

## Testing

5 new regression assertions, each verified to **fail against pre-fix source and pass after** (stash-the-source check): idle-resume-during-call, rollover-prune + same-day no-op control, bare-meeting-ID rejection, word-boundary alias isolation. Full relevant suites green (idle, call_detector, browser_tracker, restart-double-count). Pre-existing repo-wide ruff/import-sort noise and GUI-dep collection errors are untouched and unrelated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)