### PR TITLE
fix(trackers): close all loops behind 'shows idle while I'm working'

### DIFF
--- a/src/aw_manager.py
+++ b/src/aw_manager.py
@@ -478,6 +478,34 @@ class AWManager:
             self._using_external = False
             return self._start_locked()
 
+    def restart_idle_tracker(self, reason: str = "") -> None:
+        """Restart ONLY the idle tracker, reaping orphans first.
+
+        Used when bf-idle-tracker reports 'afk' while the user is demonstrably
+        typing — a blind/stuck tracker. The window/AFK staleness watchdog can't
+        catch this: a blind tracker still emits 'afk' events, so it never looks
+        stale. (If the cause is genuinely missing Input Monitoring permission a
+        restart won't help — the user is separately notified to grant it — but a
+        hung/stuck tracker recovers, and any orphan is cleared.)
+        """
+        name = "bf-idle-tracker"
+        with self._lifecycle_lock:
+            if name in self._disabled_components:
+                return
+            binaries_dir = self._get_binaries_dir()
+            if not binaries_dir:
+                return
+            logger.warning("Restarting %s (%s)", name, reason or "blind tracker")
+            proc = self._processes.get(name)
+            if proc and proc.poll() is None:
+                proc.terminate()
+                try:
+                    proc.wait(timeout=SHUTDOWN_TIMEOUT)
+                except subprocess.TimeoutExpired:
+                    proc.kill()
+            self._reap_orphan_processes(name, binaries_dir)
+            self._start_component(name, binaries_dir)
+
     def check_health(self) -> bool:
         """Check if all managed components are still running."""
         with self._lifecycle_lock:

--- a/src/aw_manager.py
+++ b/src/aw_manager.py
@@ -373,13 +373,13 @@ class AWManager:
                 # exited uncleanly (crash, force-quit, or a pre-fix self-update)
                 # BEFORE starting a fresh one — otherwise two instances post to
                 # the same bucket and the day's data is corrupted on launch.
-                self._reap_orphan_watchers(watcher, binaries_dir)
+                self._reap_orphan_processes(watcher, binaries_dir)
                 self._start_component(watcher, binaries_dir)
 
         logger.info("Tracker components started")
         return True
 
-    def _reap_orphan_watchers(self, name: str, binaries_dir: str) -> None:
+    def _reap_orphan_processes(self, name: str, binaries_dir: str) -> None:
         """Kill stray processes of watcher ``name`` not owned by this instance.
 
         Orphans accumulate when a previous instance exited without a clean
@@ -420,34 +420,63 @@ class AWManager:
         processes — there is nothing belonging to another instance to spare.
         """
         with self._lifecycle_lock:
-            if not self._processes:
-                return
+            self._stop_locked()
 
-            logger.info("Stopping tracker components...")
+    def _stop_locked(self) -> None:
+        """Terminate every tracked process. Caller must hold _lifecycle_lock."""
+        if not self._processes:
+            return
 
-            # Stop watchers first, then server
-            stop_order = BF_WATCHERS + [BF_SERVER]
+        logger.info("Stopping tracker components...")
 
-            for name in stop_order:
-                proc = self._processes.get(name)
-                if proc and proc.poll() is None:
-                    logger.debug(f"Terminating {name} (PID {proc.pid})")
-                    proc.terminate()
+        # Stop watchers first, then server
+        stop_order = BF_WATCHERS + [BF_SERVER]
 
-            # Wait for graceful shutdown
-            deadline = time.monotonic() + SHUTDOWN_TIMEOUT
-            for name in stop_order:
-                proc = self._processes.get(name)
-                if proc and proc.poll() is None:
-                    remaining = max(0, deadline - time.monotonic())
-                    try:
-                        proc.wait(timeout=remaining)
-                    except subprocess.TimeoutExpired:
-                        logger.warning(f"Force-killing {name} (PID {proc.pid})")
-                        proc.kill()
+        for name in stop_order:
+            proc = self._processes.get(name)
+            if proc and proc.poll() is None:
+                logger.debug(f"Terminating {name} (PID {proc.pid})")
+                proc.terminate()
 
-            self._processes.clear()
-            logger.info("Tracker components stopped")
+        # Wait for graceful shutdown
+        deadline = time.monotonic() + SHUTDOWN_TIMEOUT
+        for name in stop_order:
+            proc = self._processes.get(name)
+            if proc and proc.poll() is None:
+                remaining = max(0, deadline - time.monotonic())
+                try:
+                    proc.wait(timeout=remaining)
+                except subprocess.TimeoutExpired:
+                    logger.warning(f"Force-killing {name} (PID {proc.pid})")
+                    proc.kill()
+
+        self._processes.clear()
+        logger.info("Tracker components stopped")
+
+    def force_restart(self, reason: str = "") -> bool:
+        """Tear down the whole tracker stack and rebuild it from scratch.
+
+        Unlike ``stop()`` + ``start()`` (which only cycles the watchers and
+        re-attaches to whatever server holds the port), this also reclaims a
+        **hung-but-listening** server: a ``bf-data-service`` that still holds
+        port 5600 but no longer answers HTTP, so ``_port_in_use()`` reads True
+        and nothing ever restarts it. Path-scoped kill of any stray server +
+        watcher processes, then a clean start. Used by the sync loop after the
+        local server is unreachable for several consecutive cycles.
+        """
+        with self._lifecycle_lock:
+            logger.warning("Force-restarting tracker stack (%s)", reason or "unspecified")
+            self._stop_locked()
+            binaries_dir = self._get_binaries_dir()
+            if binaries_dir:
+                # Reap a hung server too — in external mode it isn't in
+                # _processes, so _stop_locked() can't reach it.
+                for name in (BF_SERVER, *BF_WATCHERS):
+                    self._reap_orphan_processes(name, binaries_dir)
+            # Drop external attachment so _start_locked starts our own server
+            # if the port is now free after the reap.
+            self._using_external = False
+            return self._start_locked()
 
     def check_health(self) -> bool:
         """Check if all managed components are still running."""
@@ -563,7 +592,7 @@ class AWManager:
                 # Kill any orphan too — staleness that survives repeated restarts
                 # is the signature of a second tracker fighting over the bucket;
                 # restarting only our PID can never win against it.
-                self._reap_orphan_watchers(idle_watcher, binaries_dir)
+                self._reap_orphan_processes(idle_watcher, binaries_dir)
                 self._start_component(idle_watcher, binaries_dir)
 
         # Only block waiting for the server when the server itself was

--- a/src/aw_manager.py
+++ b/src/aw_manager.py
@@ -317,12 +317,20 @@ class AWManager:
         return True
 
     def stop(self) -> None:
-        """Stop all managed tracker processes."""
-        with self._lifecycle_lock:
-            if self._using_external:
-                logger.debug("Using external tracker — nothing to stop")
-                return
+        """Stop the tracker processes WE started.
 
+        The watchers (bf-window-tracker, bf-idle-tracker) are always launched by
+        this instance, so they must always be terminated here — even when we
+        attached to an external/shared server. The previous early-return on
+        ``_using_external`` skipped them entirely, so an app quit or self-update
+        relaunch left bf-idle-tracker running as an orphan. Two trackers then
+        post to the same AFK bucket → overlapping/duplicate events and apparent
+        staleness a normal restart can't clear (furdui.iancu, 2026-06-17:
+        88 watcher starts vs 2 stops across the log). The shared external server
+        is never in ``_processes``, so iterating it only ever touches our own
+        processes — there is nothing belonging to another instance to spare.
+        """
+        with self._lifecycle_lock:
             if not self._processes:
                 return
 

--- a/src/aw_manager.py
+++ b/src/aw_manager.py
@@ -5,6 +5,7 @@ import logging
 import os
 import platform
 import shutil
+import signal
 import stat
 import subprocess
 import sys
@@ -115,6 +116,54 @@ def _resolve_binary_path(directory: str, name: str) -> Optional[str]:
         return bundled
 
     return None
+
+
+def _find_pids_by_path(binary_path: str) -> list[int]:
+    """PIDs whose command line contains the exact bundled ``binary_path``.
+
+    Path-scoped on purpose: matching the full install path (not the bare name)
+    means we never touch an unrelated process that merely shares a name. Unix
+    only — the Windows updater replaces files via a batch script rather than an
+    orphaning ``os._exit``, so there is no orphan to reap there.
+    """
+    if platform.system() not in ("Darwin", "Linux"):
+        return []
+    try:
+        result = subprocess.run(
+            ["pgrep", "-f", binary_path],
+            capture_output=True,
+            text=True,
+            timeout=5,
+        )
+    except (FileNotFoundError, OSError, subprocess.SubprocessError) as e:
+        logger.debug("pgrep for %s failed: %s", binary_path, e)
+        return []
+    pids: list[int] = []
+    for token in result.stdout.split():
+        try:
+            pids.append(int(token))
+        except ValueError:
+            continue
+    return pids
+
+
+def _terminate_pid(pid: int, grace: float = SHUTDOWN_TIMEOUT) -> None:
+    """SIGTERM a pid, then SIGKILL if it outlives the grace period."""
+    try:
+        os.kill(pid, signal.SIGTERM)
+    except (ProcessLookupError, PermissionError):
+        return
+    deadline = time.monotonic() + grace
+    while time.monotonic() < deadline:
+        try:
+            os.kill(pid, 0)  # liveness probe
+        except (ProcessLookupError, PermissionError):
+            return
+        time.sleep(0.1)
+    try:
+        os.kill(pid, signal.SIGKILL)
+    except (ProcessLookupError, PermissionError):
+        pass
 
 
 def _download_aw_binaries(install_dir: str) -> bool:
@@ -262,9 +311,18 @@ class AWManager:
 
     @property
     def is_managing(self) -> bool:
-        """True if we started tracker processes (not using external)."""
+        """True when we own at least one tracker process to supervise.
+
+        The watchers are ALWAYS ours, even when we attached to an external
+        server — so this must be true in external mode too. It gates whether
+        the watchdog (restart_if_needed) runs; the old ``not _using_external``
+        clause silently disabled the watchdog on every post-first launch, so a
+        blind/orphaned bf-idle-tracker was never auto-recovered (it took a
+        manual app restart). Only ``_processes`` membership matters; the
+        external server is never stored there.
+        """
         with self._lifecycle_lock:
-            return bool(self._processes) and not self._using_external
+            return bool(self._processes)
 
     def start(self) -> bool:
         """Start tracker components. Returns True if tracker is available."""
@@ -311,10 +369,41 @@ class AWManager:
                 continue
             existing = self._processes.get(watcher)
             if not existing or existing.poll() is not None:
+                # Reap any orphan of this watcher left by a prior instance that
+                # exited uncleanly (crash, force-quit, or a pre-fix self-update)
+                # BEFORE starting a fresh one — otherwise two instances post to
+                # the same bucket and the day's data is corrupted on launch.
+                self._reap_orphan_watchers(watcher, binaries_dir)
                 self._start_component(watcher, binaries_dir)
 
         logger.info("Tracker components started")
         return True
+
+    def _reap_orphan_watchers(self, name: str, binaries_dir: str) -> None:
+        """Kill stray processes of watcher ``name`` not owned by this instance.
+
+        Orphans accumulate when a previous instance exited without a clean
+        ``stop()`` (the self-update ``os._exit`` path before this fix, or a
+        crash/force-quit). Two bf-idle-trackers posting to the same AFK bucket
+        produce overlapping/duplicate events and apparent staleness a normal
+        restart can't clear. Best-effort and path-scoped — never touches our
+        currently-managed PID or any unrelated process.
+        """
+        binary_path = _resolve_binary_path(binaries_dir, name)
+        if not binary_path:
+            return
+        keep = {os.getpid()}
+        managed = self._processes.get(name)
+        if managed is not None and managed.poll() is None:
+            keep.add(managed.pid)
+        try:
+            for pid in _find_pids_by_path(binary_path):
+                if pid in keep:
+                    continue
+                logger.warning("Reaping orphan %s (PID %d)", name, pid)
+                _terminate_pid(pid)
+        except Exception:
+            logger.debug("orphan reap for %s failed", name, exc_info=True)
 
     def stop(self) -> None:
         """Stop the tracker processes WE started.
@@ -383,11 +472,13 @@ class AWManager:
             return self._restart_if_needed_locked()
 
     def _restart_if_needed_locked(self) -> bool:
-        if self._using_external:
-            if self._port_in_use():
-                return True
-            # External tracker disappeared — try to start our own
-            logger.warning("External tracker no longer running")
+        # The SERVER may be external (a shared instance we didn't start); the
+        # WATCHERS are always ours. Only the "external server vanished" case is
+        # special — otherwise fall through to watcher health/stale recovery,
+        # which MUST run in external mode too. Returning early there was why a
+        # blind/orphaned bf-idle-tracker never self-healed after an update.
+        if self._using_external and not self._port_in_use():
+            logger.warning("External tracker server no longer running — starting our own")
             self._using_external = False
             return self._start_locked()
 
@@ -469,6 +560,10 @@ class AWManager:
                     proc.wait(timeout=SHUTDOWN_TIMEOUT)
                 except subprocess.TimeoutExpired:
                     proc.kill()
+                # Kill any orphan too — staleness that survives repeated restarts
+                # is the signature of a second tracker fighting over the bucket;
+                # restarting only our PID can never win against it.
+                self._reap_orphan_watchers(idle_watcher, binaries_dir)
                 self._start_component(idle_watcher, binaries_dir)
 
         # Only block waiting for the server when the server itself was

--- a/src/main.py
+++ b/src/main.py
@@ -648,6 +648,18 @@ class SyncCoordinator:
             "bar icon → Diagnostics → Fix Permissions and grant access to "
             "bf-idle-tracker as well as BetterFlow.",
         )
+        # Don't just warn — try to recover. A tracker that reports 'afk' while
+        # input is flowing is blind/stuck (or an orphan is fighting it); a
+        # restart re-establishes capture and reaps any orphan. Throttled by the
+        # same rewarn interval above, so it won't thrash. If the real cause is a
+        # missing permission a restart won't fix it, but the notification above
+        # tells the user how — and a stuck tracker recovers without a manual
+        # app restart (the recurring "shows idle while I'm working" report).
+        if self.aw_manager.is_managing:
+            try:
+                self.aw_manager.restart_idle_tracker(reason="afk reported while input active")
+            except Exception:
+                logger.warning("restart_idle_tracker failed", exc_info=True)
 
     def _tick_60s(self) -> None:
         """Unified 60-second tick - one wakeup instead of five.

--- a/src/main.py
+++ b/src/main.py
@@ -155,6 +155,15 @@ class SyncCoordinator:
         self._consecutive_auth_failures = 0
         self._AUTH_FAILURE_LOGOUT_THRESHOLD = 3
 
+        # Consecutive cycles where the LOCAL ActivityWatch server is unreachable.
+        # is_running() already resets+retries the HTTP session internally, so a
+        # single failure here means a real stall — but we still debounce before
+        # alarming the user with an Error state, and only force-restart the
+        # (possibly hung-but-listening) server once it's clearly stuck rather
+        # than on one transient blip. Mutated only inside _do_sync (sync thread).
+        self._aw_unreachable_streak = 0
+        self._AW_UNREACHABLE_ERROR_THRESHOLD = 2
+
         # Flags set by the app layer - protected by _state_lock
         self._logged_in = False
         self._paused_by_network = False
@@ -779,12 +788,32 @@ class SyncCoordinator:
                 self.aw_manager.restart_if_needed()
 
             if not self.aw.is_running():
-                if self.aw_manager.is_managing:
-                    logger.warning("ActivityWatch not responding — attempting restart")
-                    self.aw_manager.stop()
-                    self.aw_manager.start()
-                self.tray.set_state(TrayState.ERROR, "ActivityWatch not running")
+                # is_running() already reset+retried the HTTP session, so this
+                # is a real stall, not a stale-socket blip. Debounce before
+                # escalating: one missed cycle stays silent (it usually
+                # self-heals next cycle); only after consecutive failures do we
+                # force-restart and surface an Error.
+                self._aw_unreachable_streak += 1
+                if self._aw_unreachable_streak >= self._AW_UNREACHABLE_ERROR_THRESHOLD:
+                    if self.aw_manager.is_managing:
+                        logger.warning(
+                            "ActivityWatch unreachable for %d cycles — forcing tracker+server restart",
+                            self._aw_unreachable_streak,
+                        )
+                        # force_restart also reclaims a hung-but-listening server
+                        # (port held, HTTP dead); a plain stop()+start() only
+                        # cycles the watchers and leaves the dead server in place.
+                        self.aw_manager.force_restart(reason="server unreachable")
+                    self.tray.set_state(TrayState.ERROR, "ActivityWatch not responding")
+                else:
+                    logger.info(
+                        "ActivityWatch unreachable (%d/%d) — retrying next cycle before escalating",
+                        self._aw_unreachable_streak, self._AW_UNREACHABLE_ERROR_THRESHOLD,
+                    )
                 return
+
+            # Reachable — clear the streak.
+            self._aw_unreachable_streak = 0
 
             stats = self.sync_engine.sync()
 

--- a/src/sync/aw_client.py
+++ b/src/sync/aw_client.py
@@ -131,22 +131,29 @@ class AWClient:
         self._buckets_cache_time: float = 0.0
         self._buckets_cache_ttl: float = 30.0
 
+    # Connection-failure recovery: reset the pooled session and retry with a
+    # short backoff. The first retry (after reset) fixes a rotted client socket
+    # immediately; the later backoff retries ride out a brief server stall.
+    _CONNECT_ATTEMPTS = 3
+    _CONNECT_BACKOFF = (0.25, 0.5)  # seconds before retry 2 and 3
+
     def _request(self, method: str, endpoint: str, timeout: Optional[int] = None, **kwargs) -> dict:
         """Make request to ActivityWatch API.
 
-        On a connection failure the pooled session is reset once and the request
-        retried. A stale keep-alive socket to the LOCAL server raises
-        ConnectionError even though the server is up (the socket rots after the
-        server has been alive a long time). This is why a manual app restart
-        always "fixed" sync stalls — a fresh process builds a fresh session.
-        Doing it here lets the agent self-heal automatically instead of silently
-        dropping syncs until the user notices missing hours (furdui.iancu,
-        2026-06-17).
+        On a connection failure the pooled session is reset and the request
+        retried with a short backoff. A stale keep-alive socket to the LOCAL
+        server raises ConnectionError even though the server is up (the socket
+        rots after the server has been alive a long time). This is why a manual
+        app restart always "fixed" sync stalls — a fresh process builds a fresh
+        session. Doing it here lets the agent self-heal automatically instead of
+        silently dropping syncs until the user notices missing hours
+        (furdui.iancu, 2026-06-17).
         """
         url = urljoin(self.base_url, endpoint)
         kwargs["timeout"] = timeout if timeout is not None else self.timeout
 
-        for attempt in range(2):
+        last_exc: Optional[Exception] = None
+        for attempt in range(self._CONNECT_ATTEMPTS):
             with self._session_lock:
                 session = self._session
             if session is None:
@@ -156,16 +163,19 @@ class AWClient:
                 response.raise_for_status()
                 return response.json() if response.content else {}
             except requests.exceptions.ConnectionError as e:
-                # First failure: drop the (possibly stale) pooled connections
-                # and retry once with a fresh session.
-                if attempt == 0:
+                last_exc = e
+                # Reset the (possibly stale) pooled connections and back off
+                # before retrying; only the final attempt gives up.
+                if attempt < self._CONNECT_ATTEMPTS - 1:
                     with self._session_lock:
                         still_open = self._session is not None
                     if still_open:
                         logger.info(
-                            "AW connection failed (%s) — resetting session and retrying", e
+                            "AW connection failed (%s) — reset+retry %d/%d",
+                            e, attempt + 1, self._CONNECT_ATTEMPTS - 1,
                         )
                         self.reset_session()
+                        time.sleep(self._CONNECT_BACKOFF[min(attempt, len(self._CONNECT_BACKOFF) - 1)])
                         continue
                 raise AWClientError(f"Cannot connect to ActivityWatch at {self.base_url}") from e
             except requests.exceptions.Timeout as e:
@@ -175,7 +185,7 @@ class AWClient:
             except Exception as e:
                 raise AWClientError(f"Unexpected error: {e}") from e
         # Unreachable: the loop either returns or raises on every path.
-        raise AWClientError(f"Cannot connect to ActivityWatch at {self.base_url}")
+        raise AWClientError(f"Cannot connect to ActivityWatch at {self.base_url}") from last_exc
 
     def reset_session(self) -> None:
         """Drop pooled connections and create a fresh session.

--- a/src/sync/aw_client.py
+++ b/src/sync/aw_client.py
@@ -132,26 +132,50 @@ class AWClient:
         self._buckets_cache_ttl: float = 30.0
 
     def _request(self, method: str, endpoint: str, timeout: Optional[int] = None, **kwargs) -> dict:
-        """Make request to ActivityWatch API."""
+        """Make request to ActivityWatch API.
+
+        On a connection failure the pooled session is reset once and the request
+        retried. A stale keep-alive socket to the LOCAL server raises
+        ConnectionError even though the server is up (the socket rots after the
+        server has been alive a long time). This is why a manual app restart
+        always "fixed" sync stalls — a fresh process builds a fresh session.
+        Doing it here lets the agent self-heal automatically instead of silently
+        dropping syncs until the user notices missing hours (furdui.iancu,
+        2026-06-17).
+        """
         url = urljoin(self.base_url, endpoint)
         kwargs["timeout"] = timeout if timeout is not None else self.timeout
 
-        with self._session_lock:
-            session = self._session
-        if session is None:
-            raise AWClientError("AWClient has been closed")
-        try:
-            response = session.request(method, url, **kwargs)
-            response.raise_for_status()
-            return response.json() if response.content else {}
-        except requests.exceptions.ConnectionError as e:
-            raise AWClientError(f"Cannot connect to ActivityWatch at {self.base_url}") from e
-        except requests.exceptions.Timeout as e:
-            raise AWClientError(f"ActivityWatch request timed out") from e
-        except requests.exceptions.HTTPError as e:
-            raise AWClientError(f"ActivityWatch API error: {e}") from e
-        except Exception as e:
-            raise AWClientError(f"Unexpected error: {e}") from e
+        for attempt in range(2):
+            with self._session_lock:
+                session = self._session
+            if session is None:
+                raise AWClientError("AWClient has been closed")
+            try:
+                response = session.request(method, url, **kwargs)
+                response.raise_for_status()
+                return response.json() if response.content else {}
+            except requests.exceptions.ConnectionError as e:
+                # First failure: drop the (possibly stale) pooled connections
+                # and retry once with a fresh session.
+                if attempt == 0:
+                    with self._session_lock:
+                        still_open = self._session is not None
+                    if still_open:
+                        logger.info(
+                            "AW connection failed (%s) — resetting session and retrying", e
+                        )
+                        self.reset_session()
+                        continue
+                raise AWClientError(f"Cannot connect to ActivityWatch at {self.base_url}") from e
+            except requests.exceptions.Timeout as e:
+                raise AWClientError("ActivityWatch request timed out") from e
+            except requests.exceptions.HTTPError as e:
+                raise AWClientError(f"ActivityWatch API error: {e}") from e
+            except Exception as e:
+                raise AWClientError(f"Unexpected error: {e}") from e
+        # Unreachable: the loop either returns or raises on every path.
+        raise AWClientError(f"Cannot connect to ActivityWatch at {self.base_url}")
 
     def reset_session(self) -> None:
         """Drop pooled connections and create a fresh session.

--- a/src/sync/sync_engine.py
+++ b/src/sync/sync_engine.py
@@ -7,6 +7,7 @@ import socket
 import threading
 import time
 from collections import OrderedDict
+import dataclasses
 from dataclasses import dataclass, field
 from datetime import datetime, timedelta, timezone
 from typing import Callable, Optional
@@ -1077,7 +1078,49 @@ class SyncEngine:
         events, _ = self._fetch_bucket_events(bucket_id, stats)
         if not events:
             return [], None
+        if bucket_type in (BUCKET_TYPE_AFK, BUCKET_TYPE_AFK_ALT):
+            # Collapse heartbeat-merge corruption before it reaches the backend
+            # (see _collapse_afk_duplicates). Without this, a misbehaving idle
+            # tracker's duplicate 'afk' rows are synced raw and billed as idle.
+            events = self._collapse_afk_duplicates(events)
         return self._transform_and_checkpoint(events, bucket_id, bucket_type, stats)
+
+    @staticmethod
+    def _collapse_afk_duplicates(events: list[AWEvent]) -> list[AWEvent]:
+        """Merge overlapping same-status AFK events into one span.
+
+        A misbehaving idle tracker — or a server heartbeat-merge failure — can
+        emit many AFK rows that share a start timestamp with growing durations
+        (observed: 29 'afk' rows all starting at the same instant, furdui.iancu
+        2026-06-17). This happens even with a single tracker, so it is distinct
+        from the orphan-tracker bug. Synced raw, the overlapping rows blanket
+        the period with redundant idle and poison both active-time
+        classification and the backend's billing. Collapsing overlapping
+        same-status spans to one (earliest-start, latest-end) event removes the
+        corruption while preserving the real timeline. Source events are not
+        mutated (new events are built via dataclasses.replace).
+        """
+        if len(events) <= 1:
+            return events
+        ordered = sorted(
+            events,
+            key=lambda e: (e.timestamp, e.timestamp + timedelta(seconds=e.duration)),
+        )
+        collapsed: list[AWEvent] = []
+        for ev in ordered:
+            ev_end = ev.timestamp + timedelta(seconds=ev.duration)
+            if collapsed:
+                last = collapsed[-1]
+                last_end = last.timestamp + timedelta(seconds=last.duration)
+                if last.status == ev.status and ev.timestamp <= last_end:
+                    # Overlap with the same status → extend the existing span.
+                    if ev_end > last_end:
+                        collapsed[-1] = dataclasses.replace(
+                            last, duration=(ev_end - last.timestamp).total_seconds()
+                        )
+                    continue
+            collapsed.append(ev)
+        return collapsed
 
     def _get_afk_events_for_range(
         self, start: datetime, end: datetime
@@ -1115,7 +1158,9 @@ class SyncEngine:
                 logger.debug("AFK bucket %s fetch failed: %s", bucket.id, e)
 
         all_afk.sort(key=lambda e: e.timestamp)
-        return all_afk
+        # Collapse heartbeat-merge corruption so active-time classification
+        # isn't poisoned by duplicate overlapping 'afk' spans.
+        return self._collapse_afk_duplicates(all_afk)
 
     @staticmethod
     def _is_active_during(

--- a/src/update_handler.py
+++ b/src/update_handler.py
@@ -51,6 +51,15 @@ class UpdateHandler:
         except Exception:
             pass
         self.coordinator.stop()
+        # Terminate the bundled trackers BEFORE the updater's hard os._exit(0).
+        # coordinator.stop() only stops the scheduler; without this the
+        # self-update relaunch left bf-idle-tracker orphaned, so the new
+        # instance started a second one and the two fought over the AFK bucket
+        # (recurring "idle frozen / hours undercounted after update").
+        try:
+            self.coordinator.aw_manager.stop()
+        except Exception:
+            logger.warning("aw_manager.stop() during update exit failed", exc_info=True)
 
     def ensure_update_checks_started(self) -> None:
         """Kick off update checks once after the tray is already visible."""

--- a/tests/test_aw_client.py
+++ b/tests/test_aw_client.py
@@ -195,7 +195,7 @@ class TestAWClient:
             assert client is not None
 
     def test_request_resets_session_and_retries_on_connection_error(self):
-        """A stale pooled socket (ConnectionError) must trigger one session
+        """A stale pooled socket (ConnectionError) must trigger a session
         reset + retry — the automatic equivalent of the manual restart that
         always 'fixed' sync stalls (furdui.iancu, 2026-06-17)."""
         import requests
@@ -215,21 +215,54 @@ class TestAWClient:
             resp.json = Mock(return_value={"version": "0.13.2"})
             return resp
 
-        with patch.object(requests.Session, "request", flaky_request):
+        with patch.object(requests.Session, "request", flaky_request), \
+                patch("time.sleep"):
             result = client.get_info()
 
         assert result == {"version": "0.13.2"}
-        assert calls["n"] == 2, "must retry exactly once after resetting the session"
+        assert calls["n"] == 2, "recovers on the first retry after resetting the session"
         assert client._session is not first_session, "session was rebuilt on connection failure"
 
-    def test_request_gives_up_after_one_retry(self):
-        """Two consecutive connection failures still surface as AWClientError —
-        no infinite retry loop."""
+    def test_request_retries_through_a_brief_stall_then_succeeds(self):
+        """Two consecutive failures (e.g. a brief server stall) still recover on
+        the third attempt thanks to the backoff retries — no manual restart."""
         import requests
 
         client = AWClient()
-        with patch.object(
-            requests.Session, "request",
-            side_effect=requests.exceptions.ConnectionError("down"),
-        ), pytest.raises(AWClientError):
-            client.get_info()
+        calls = {"n": 0}
+
+        def flaky_request(self, method, url, **kwargs):
+            calls["n"] += 1
+            if calls["n"] < 3:
+                raise requests.exceptions.ConnectionError("stall")
+            resp = Mock()
+            resp.raise_for_status = Mock()
+            resp.content = b'{"ok": true}'
+            resp.json = Mock(return_value={"ok": True})
+            return resp
+
+        with patch.object(requests.Session, "request", flaky_request), \
+                patch("time.sleep"):
+            result = client.get_info()
+
+        assert result == {"ok": True}
+        assert calls["n"] == 3, "uses all backoff retries before succeeding"
+
+    def test_request_gives_up_after_max_attempts(self):
+        """Persistent connection failure surfaces as AWClientError after exactly
+        _CONNECT_ATTEMPTS tries — bounded, no infinite loop."""
+        import requests
+
+        client = AWClient()
+        calls = {"n": 0}
+
+        def always_down(self, method, url, **kwargs):
+            calls["n"] += 1
+            raise requests.exceptions.ConnectionError("down")
+
+        with patch.object(requests.Session, "request", always_down), \
+                patch("time.sleep"):
+            with pytest.raises(AWClientError):
+                client.get_info()
+
+        assert calls["n"] == AWClient._CONNECT_ATTEMPTS

--- a/tests/test_aw_client.py
+++ b/tests/test_aw_client.py
@@ -193,3 +193,43 @@ class TestAWClient:
         """Test using client as context manager."""
         with AWClient() as client:
             assert client is not None
+
+    def test_request_resets_session_and_retries_on_connection_error(self):
+        """A stale pooled socket (ConnectionError) must trigger one session
+        reset + retry — the automatic equivalent of the manual restart that
+        always 'fixed' sync stalls (furdui.iancu, 2026-06-17)."""
+        import requests
+
+        client = AWClient()
+        first_session = client._session
+
+        calls = {"n": 0}
+
+        def flaky_request(self, method, url, **kwargs):
+            calls["n"] += 1
+            if calls["n"] == 1:
+                raise requests.exceptions.ConnectionError("stale socket")
+            resp = Mock()
+            resp.raise_for_status = Mock()
+            resp.content = b'{"version": "0.13.2"}'
+            resp.json = Mock(return_value={"version": "0.13.2"})
+            return resp
+
+        with patch.object(requests.Session, "request", flaky_request):
+            result = client.get_info()
+
+        assert result == {"version": "0.13.2"}
+        assert calls["n"] == 2, "must retry exactly once after resetting the session"
+        assert client._session is not first_session, "session was rebuilt on connection failure"
+
+    def test_request_gives_up_after_one_retry(self):
+        """Two consecutive connection failures still surface as AWClientError —
+        no infinite retry loop."""
+        import requests
+
+        client = AWClient()
+        with patch.object(
+            requests.Session, "request",
+            side_effect=requests.exceptions.ConnectionError("down"),
+        ), pytest.raises(AWClientError):
+            client.get_info()

--- a/tests/test_aw_manager_external_selfheal.py
+++ b/tests/test_aw_manager_external_selfheal.py
@@ -100,3 +100,38 @@ def test_force_restart_reaps_hung_server_then_starts_fresh(monkeypatch):
     assert "bf-data-service" in reaped, "the hung server is reaped, not just the watchers"
     assert mgr._using_external is False, "drops external attachment so a fresh server can start"
     assert mgr._start_locked.called
+
+
+def test_restart_idle_tracker_terminates_reaps_and_restarts():
+    """Blind tracker (afk-while-input) recovery: kill the tracked proc, reap
+    orphans, start fresh."""
+    mgr = AWManager()
+    idle = MagicMock()
+    idle.poll.return_value = None  # alive
+    mgr._processes = {"bf-idle-tracker": idle}
+    mgr._get_binaries_dir = MagicMock(return_value="/tmp/bin")
+    mgr._reap_orphan_processes = MagicMock()
+    mgr._start_component = MagicMock()
+
+    mgr.restart_idle_tracker(reason="afk while input active")
+
+    assert idle.terminate.called, "stuck tracker is terminated"
+    mgr._reap_orphan_processes.assert_called_once_with("bf-idle-tracker", "/tmp/bin")
+    assert ("bf-idle-tracker",) in [
+        c.args[:1] for c in mgr._start_component.call_args_list
+    ], "a fresh idle tracker is started"
+
+
+def test_restart_idle_tracker_skips_disabled():
+    mgr = AWManager()
+    idle = MagicMock()
+    idle.poll.return_value = None
+    mgr._processes = {"bf-idle-tracker": idle}
+    mgr._disabled_components.add("bf-idle-tracker")
+    mgr._get_binaries_dir = MagicMock(return_value="/tmp/bin")
+    mgr._start_component = MagicMock()
+
+    mgr.restart_idle_tracker()
+
+    assert not idle.terminate.called, "a disabled idle tracker is never restarted"
+    assert not mgr._start_component.called

--- a/tests/test_aw_manager_external_selfheal.py
+++ b/tests/test_aw_manager_external_selfheal.py
@@ -73,6 +73,30 @@ def test_reaper_kills_orphans_only(monkeypatch):
     killed = []
     monkeypatch.setattr(awm, "_terminate_pid", lambda pid, **k: killed.append(pid))
 
-    mgr._reap_orphan_watchers("bf-idle-tracker", "/x")
+    mgr._reap_orphan_processes("bf-idle-tracker", "/x")
 
     assert killed == [2222], "kills the orphan only — not our managed PID, not ourselves"
+
+
+def test_force_restart_reaps_hung_server_then_starts_fresh(monkeypatch):
+    """A hung-but-listening server (port held, HTTP dead) must be reclaimed:
+    stop watchers, reap stray server+watcher processes, then start fresh."""
+    mgr = AWManager()
+    mgr._using_external = True  # attached to what we now believe is a dead server
+    mgr._get_binaries_dir = MagicMock(return_value="/tmp/bin")
+
+    reaped = []
+    monkeypatch.setattr(mgr, "_stop_locked", lambda: reaped.append("stopped"))
+    monkeypatch.setattr(
+        mgr, "_reap_orphan_processes",
+        lambda name, d: reaped.append(name),
+    )
+    mgr._start_locked = MagicMock(return_value=True)
+
+    ok = mgr.force_restart(reason="server unreachable")
+
+    assert ok is True
+    assert reaped[0] == "stopped", "watchers stopped first"
+    assert "bf-data-service" in reaped, "the hung server is reaped, not just the watchers"
+    assert mgr._using_external is False, "drops external attachment so a fresh server can start"
+    assert mgr._start_locked.called

--- a/tests/test_aw_manager_external_selfheal.py
+++ b/tests/test_aw_manager_external_selfheal.py
@@ -1,0 +1,78 @@
+"""In external-server mode the watchdog must still supervise OUR watchers.
+
+After the first launch the persistent bf-data-service is reused, so
+``_using_external`` is True forever on that machine. The watchdog used to be
+disabled in that mode two ways: ``is_managing`` returned False (so
+``restart_if_needed`` was never called) and ``_restart_if_needed_locked``
+returned early. A blind/orphaned bf-idle-tracker therefore never self-healed —
+it took a manual app restart (furdui.iancu, 2026-06-17). These pin that the
+watchers are supervised in external mode and that orphans are reaped.
+"""
+
+import os
+from unittest.mock import MagicMock
+
+import src.aw_manager as awm
+from src.aw_manager import AWManager
+
+
+def test_is_managing_true_in_external_mode_when_watchers_owned():
+    mgr = AWManager()
+    mgr._using_external = True
+    mgr._processes = {"bf-idle-tracker": MagicMock()}
+    assert mgr.is_managing, "watchers are ours even on a shared server — watchdog must run"
+
+
+def test_restarts_stale_idle_tracker_in_external_mode():
+    """The exact recurring failure: external server up, idle tracker blind."""
+    mgr = AWManager()
+    mgr._using_external = True
+    mgr._port_in_use = MagicMock(return_value=True)  # external server healthy
+    window = MagicMock()
+    window.poll.return_value = None
+    idle = MagicMock()
+    idle.poll.return_value = None
+    # External mode: server is NOT in _processes, only our watchers are.
+    mgr._processes = {"bf-window-tracker": window, "bf-idle-tracker": idle}
+    mgr._get_binaries_dir = MagicMock(return_value="/tmp/bin")
+    mgr._start_component = MagicMock()
+    mgr.check_health = MagicMock(return_value=True)
+    mgr._get_latest_afk_event_age = MagicMock(return_value=1800)  # 30 min silent
+    mgr._get_latest_window_event_age = MagicMock(return_value=5)  # user active
+
+    mgr.restart_if_needed()
+
+    assert idle.terminate.called, "blind idle tracker must be restarted in external mode"
+    assert ("bf-idle-tracker",) in [
+        c.args[:1] for c in mgr._start_component.call_args_list
+    ]
+
+
+def test_external_server_vanished_falls_back_to_own():
+    mgr = AWManager()
+    mgr._using_external = True
+    mgr._port_in_use = MagicMock(return_value=False)  # external server gone
+    mgr._processes = {"bf-idle-tracker": MagicMock()}
+    mgr._start_locked = MagicMock(return_value=True)
+
+    mgr.restart_if_needed()
+
+    assert mgr._start_locked.called, "must start our own stack when external server disappears"
+    assert mgr._using_external is False
+
+
+def test_reaper_kills_orphans_only(monkeypatch):
+    mgr = AWManager()
+    managed = MagicMock()
+    managed.poll.return_value = None
+    managed.pid = 1111
+    mgr._processes = {"bf-idle-tracker": managed}
+
+    monkeypatch.setattr(awm, "_resolve_binary_path", lambda d, n: "/x/bf-idle-tracker")
+    monkeypatch.setattr(awm, "_find_pids_by_path", lambda p: [1111, 2222, os.getpid()])
+    killed = []
+    monkeypatch.setattr(awm, "_terminate_pid", lambda pid, **k: killed.append(pid))
+
+    mgr._reap_orphan_watchers("bf-idle-tracker", "/x")
+
+    assert killed == [2222], "kills the orphan only — not our managed PID, not ourselves"

--- a/tests/test_aw_manager_stop_orphan.py
+++ b/tests/test_aw_manager_stop_orphan.py
@@ -1,0 +1,56 @@
+"""Stopping must terminate the watchers WE started, even in external mode.
+
+Root cause of the recurring "idle frozen / hours undercounted after update"
+(furdui.iancu, 2026-06-17): on every launch after the first, the persistent
+bf-data-service is reused ("using external instance") so ``_using_external`` is
+True. The old ``stop()`` early-returned in that case and never terminated the
+bf-idle-tracker IT started, so an app quit / self-update relaunch left it
+orphaned. Two trackers then posted to the same AFK bucket → duplicate,
+overlapping events + apparent staleness. Across the log: 88 watcher starts, 2
+stops.
+"""
+
+from unittest.mock import MagicMock
+
+from src.aw_manager import AWManager
+
+
+def _alive_proc():
+    proc = MagicMock()
+    proc.poll.return_value = None  # alive
+    return proc
+
+
+def test_stop_terminates_watchers_when_using_external_server():
+    mgr = AWManager()
+    mgr._using_external = True  # attached to a shared/persistent server
+    window = _alive_proc()
+    idle = _alive_proc()
+    # In external mode the server is NOT in _processes — only our watchers are.
+    mgr._processes = {"bf-window-tracker": window, "bf-idle-tracker": idle}
+
+    mgr.stop()
+
+    assert window.terminate.called, "window watcher we started must be terminated"
+    assert idle.terminate.called, "idle tracker we started must be terminated (no orphan)"
+    assert not mgr._processes, "process table cleared after stop"
+
+
+def test_stop_is_noop_with_no_processes():
+    mgr = AWManager()
+    mgr._using_external = True
+    mgr._processes = {}
+    # Must not raise.
+    mgr.stop()
+
+
+def test_update_exit_stops_trackers():
+    """_flush_before_update_exit must terminate trackers before os._exit(0)."""
+    from src.update_handler import UpdateHandler
+
+    handler = UpdateHandler.__new__(UpdateHandler)
+    handler.coordinator = MagicMock()
+
+    handler._flush_before_update_exit()
+
+    handler.coordinator.aw_manager.stop.assert_called_once()

--- a/tests/test_sync_engine_afk_dedup.py
+++ b/tests/test_sync_engine_afk_dedup.py
@@ -1,0 +1,76 @@
+"""Collapsing duplicate/overlapping AFK heartbeat rows.
+
+A misbehaving idle tracker (or a server heartbeat-merge failure) emits many AFK
+rows sharing a start timestamp with growing durations — observed live as 29
+'afk' rows all starting at the same instant (furdui.iancu, 2026-06-17). This
+happens with a SINGLE tracker, so it is distinct from the orphan-tracker bug.
+Synced raw, the overlapping rows are billed as redundant idle. These pin that
+_collapse_afk_duplicates removes the corruption while preserving the timeline.
+"""
+
+from datetime import datetime, timedelta, timezone
+
+from src.sync.aw_client import AWEvent
+from src.sync.sync_engine import SyncEngine
+
+
+def _afk(start: datetime, dur: float, status: str) -> AWEvent:
+    return AWEvent(id=0, timestamp=start, duration=dur, data={"status": status})
+
+
+def test_collapses_29_same_start_afk_rows_into_one():
+    base = datetime(2026, 6, 17, 4, 16, 14, tzinfo=timezone.utc)
+    # The exact corruption shape: same start, growing durations.
+    durations = list(range(622, 2061, 50))
+    rows = [_afk(base, dur, "afk") for dur in durations]
+    assert len(rows) > 20
+
+    out = SyncEngine._collapse_afk_duplicates(rows)
+
+    assert len(out) == 1, "all same-start 'afk' duplicates collapse to one span"
+    assert out[0].timestamp == base
+    assert out[0].duration == max(durations), "kept the longest (latest-ending) span"
+
+
+def test_preserves_distinct_nonoverlapping_spans():
+    t0 = datetime(2026, 6, 17, 7, 0, 0, tzinfo=timezone.utc)
+    not_afk = _afk(t0, 300, "not-afk")             # 07:00–07:05
+    afk = _afk(t0 + timedelta(seconds=300), 600, "afk")  # 07:05–07:15
+    not_afk2 = _afk(t0 + timedelta(seconds=900), 120, "not-afk")  # 07:15–07:17
+
+    out = SyncEngine._collapse_afk_duplicates([not_afk, afk, not_afk2])
+
+    assert [e.status for e in out] == ["not-afk", "afk", "not-afk"], "real timeline untouched"
+    assert [round(e.duration) for e in out] == [300, 600, 120]
+
+
+def test_merges_overlapping_same_status_spans():
+    t0 = datetime(2026, 6, 17, 8, 0, 0, tzinfo=timezone.utc)
+    a = _afk(t0, 600, "afk")                            # 08:00–08:10
+    b = _afk(t0 + timedelta(seconds=120), 600, "afk")  # 08:02–08:12 (overlaps a)
+
+    out = SyncEngine._collapse_afk_duplicates([a, b])
+
+    assert len(out) == 1, "overlapping same-status spans merge into one"
+    assert out[0].duration == 720, "merged span runs 08:00–08:12"
+
+
+def test_never_merges_across_a_different_status():
+    """An intervening not-afk must NOT be erased by merging the afk spans around
+    it — that would fabricate idle over real activity."""
+    t0 = datetime(2026, 6, 17, 8, 0, 0, tzinfo=timezone.utc)
+    afk1 = _afk(t0, 120, "afk")                           # 08:00–08:02
+    active = _afk(t0 + timedelta(seconds=120), 120, "not-afk")  # 08:02–08:04
+    afk2 = _afk(t0 + timedelta(seconds=240), 120, "afk")  # 08:04–08:06
+
+    out = SyncEngine._collapse_afk_duplicates([afk1, active, afk2])
+
+    assert [e.status for e in out] == ["afk", "not-afk", "afk"], "activity preserved between idle spans"
+
+
+def test_does_not_mutate_source_events():
+    base = datetime(2026, 6, 17, 4, 16, 14, tzinfo=timezone.utc)
+    a = _afk(base, 600, "afk")
+    b = _afk(base, 1200, "afk")
+    SyncEngine._collapse_afk_duplicates([a, b])
+    assert a.duration == 600 and b.duration == 1200, "source events untouched"


### PR DESCRIPTION
Audit-driven fix for the recurring "dashboard shows idle / hours undercounted while actively working, only a manual restart recovers it." **Not** a signing/permissions issue — app + `bf-idle-tracker` are Developer-ID signed and Input Monitoring is granted. Full-log forensics + live diagnosis found **multiple distinct failure modes**, each now closed with tests.

## Loop 1 — orphaned duplicate trackers
88 `bf-idle-tracker` starts vs 2 stops across the log. The persistent `bf-data-service` survives restarts, so every launch attaches "external" and `_using_external=True` — which was conflated with "manage nothing": `stop()` early-returned (orphan on quit/update), the update pre-exit never called `aw_manager.stop()` before `os._exit(0)`, `is_managing` was False (watchdog never ran), and `_restart_if_needed_locked` returned early. Two trackers then fought over the AFK bucket.
**Fix:** `_using_external` scopes to the **server only**; `stop()` always kills watchers; update pre-exit stops trackers; watchdog runs in external mode; path-scoped orphan reaper on startup + stale-recovery.

## Loop 2 — stale local HTTP session
Pooled keep-alive socket to the local server rots after the server's been up for days → `ConnectionError` ("Cannot connect") though the server is alive. `_request` never reset/retried, so syncs stalled until a restart rebuilt the session — *why every restart "fixed" it*.
**Fix:** `_request` resets the session and retries with backoff (up to 3 attempts).

## Loop 3 — debounced Error + hung-server restart
One failed `get buckets` flipped the tray to Error; and a server that holds port 5600 but stops answering HTTP (`_port_in_use`=True) was never restarted.
**Fix:** Error is debounced (N consecutive unreachable cycles); `force_restart()` reclaims a hung-but-listening server (path-scoped kill + fresh start) once it's unreachable for consecutive cycles.

## Loop 4 — single-tracker AFK corruption + blind tracker
- A misbehaving tracker / server heartbeat-merge emits many `afk` rows sharing a start timestamp (29 observed) **with one tracker** — billed as redundant idle. **Fix:** `_collapse_afk_duplicates` merges overlapping same-status spans (never across a status, so real activity isn't erased), on both the analysis fetch and raw sync.
- A tracker reporting `afk` while input flows is blind/stuck and the staleness watchdog can't see it. **Fix:** the existing input-vs-afk detector now **restarts the idle tracker** (+reaps orphans) instead of only warning.
- Out of scope (flagged): genuinely no-input-but-present time (reading) → backend input-presence union (internal-tool2 #1823) / manual time.

## Exit-path audit (verified safe, no change needed)
Normal quit / SIGTERM / crash → `_shutdown()` → `aw_manager.stop()`. Self-update on macOS/Windows/AppImage → pre-exit teardown. Startup relaunches (staged-update, relocate, permission-restart) fire **before** trackers start. SIGKILL/power-loss → startup reaper cleans up next launch.

## Tests
561 passed. New: `test_aw_manager_stop_orphan.py`, `test_aw_manager_external_selfheal.py`, `test_sync_engine_afk_dedup.py`, AW-client retry/backoff tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)