### PR TITLE
fix(idle): in-process input watcher overrides a blind AFK tracker

### DIFF
--- a/src/__init__.py
+++ b/src/__init__.py
@@ -1,4 +1,4 @@
 """BetterFlow - ActivityWatch to BetterFlow sync companion app."""
 
-__version__ = "1.5.50"
+__version__ = "1.5.51"
 __author__ = "BetterQA"

--- a/src/idle_manager.py
+++ b/src/idle_manager.py
@@ -36,6 +36,15 @@ class IdleManager:
         self._idle_pause_threshold = config.sync.idle_pause_minutes * 60
         self._IDLE_SYNC_INTERVAL = 300
 
+        # In-process input watcher (macOS), injected post-construction by the
+        # app after it is created. It holds the MAIN app's Input Monitoring
+        # grant, so it is authoritative over the AFK bucket — which comes from
+        # bf-idle-tracker, a SEPARATE TCC subject that can be blind (missing
+        # the grant) or stuck and report 'afk' while the user is typing. See
+        # _has_recent_input(). None on platforms without an in-process watcher
+        # (Windows/Linux) or before startup wiring — handled defensively.
+        self.input_watcher = None
+
     @property
     def idle_paused(self) -> bool:
         with self._state_lock:
@@ -61,6 +70,33 @@ class IdleManager:
             self._idle_paused = False
         if idle_start:
             self.sync_engine.send_idle_event(idle_start)
+
+    def _has_recent_input(self, within_seconds: float) -> bool:
+        """True if the in-process input watcher observed input within
+        `within_seconds`.
+
+        This is the authoritative override for the AFK bucket. bf-idle-tracker
+        runs under its own TCC subject and can be blind (no Input Monitoring
+        grant) or stuck, emitting 'afk' while the user types — the recurring
+        "shows idle while I'm working" report. The in-process watcher DOES hold
+        the main app's grant, so positive recent input means the user is NOT
+        idle no matter what the AFK bucket claims.
+
+        Conservative by design: no watcher, no observation yet, or any error
+        returns False. It can only SUPPRESS a false idle, never fabricate
+        activity — so a genuinely idle user is still detected via the AFK path.
+        """
+        watcher = self.input_watcher
+        if watcher is None:
+            return False
+        try:
+            last_input = watcher.get_last_input_at()
+        except Exception as e:
+            logger.debug("_has_recent_input: input watcher query failed: %s", e)
+            return False
+        if last_input is None:
+            return False
+        return (datetime.now(timezone.utc) - last_input) <= timedelta(seconds=within_seconds)
 
     def _is_in_call(self) -> bool:
         """Whether a call/meeting is active, via the sync engine. Defensive:
@@ -98,13 +134,40 @@ class IdleManager:
                 return
 
         try:
+            # Authoritative override: if the in-process input watcher (which
+            # holds the main app's Input Monitoring grant) saw input within the
+            # idle threshold, the user is active — regardless of the AFK bucket,
+            # which comes from the separate-TCC-subject bf-idle-tracker and can
+            # be blind/stuck and report 'afk' while the user types. Without this
+            # the blind tracker paints live work as Idle until the health-check
+            # restart lands (v1.5.50 still showed this). Checked BEFORE the AFK
+            # fetch so positive input short-circuits the whole pause decision.
+            if self._has_recent_input(self._idle_pause_threshold):
+                if was_idle_paused:
+                    logger.info(
+                        "Recent in-process input - clearing idle pause "
+                        "(AFK bucket was blind/stale)"
+                    )
+                    self.clear_idle_pause(send_event=True)
+                    reschedule(self.config.sync.interval_seconds)
+                    self.tray.set_state(TrayState.SYNCING)
+                    trigger_sync("idle_resume_sync")
+                return
+
             is_afk = False
             afk_duration = 0.0
             idle_start: Optional[datetime] = None
 
             afk_buckets = self.aw.get_afk_buckets()
             if afk_buckets:
-                events = self.aw.get_events(afk_buckets[0].id, limit=1)
+                # Prefer the bf-idle-tracker bucket. A user migrated from
+                # vanilla ActivityWatch can also carry a stale aw-watcher-afk
+                # bucket frozen at 'afk' forever; taking buckets[0] blindly
+                # could pick it and paint permanent false idle. Mirrors
+                # SyncCoordinator._check_idle_tracker_health's selection.
+                bf_buckets = [b for b in afk_buckets if "bf-idle-tracker" in b.id]
+                bucket = (bf_buckets or afk_buckets)[0]
+                events = self.aw.get_events(bucket.id, limit=1)
                 if events:
                     latest = events[0]
                     is_afk = latest.status == "afk"

--- a/src/main.py
+++ b/src/main.py
@@ -1120,6 +1120,12 @@ class BetterFlowApp:
         )
         self.coordinator._on_auth_error = self._on_session_expired
         self.coordinator._input_watcher = self.input_watcher
+        # The idle manager uses the same in-process watcher as an authoritative
+        # override so a blind/stuck bf-idle-tracker can't paint live work as
+        # Idle (it never consulted the input watcher before — only the health
+        # check did, which left a race where idle was painted before the
+        # blind-tracker restart landed).
+        self.coordinator.idle_mgr.input_watcher = self.input_watcher
         self.coordinator.idle_mgr._on_idle_pause = self._on_idle_pause
 
         # Reminder manager (created after coordinator for clean callback injection)

--- a/tests/test_idle_manager.py
+++ b/tests/test_idle_manager.py
@@ -98,6 +98,95 @@ def test_pauses_idle_when_not_in_a_call():
     reschedule.assert_called_once_with(idle_mgr._IDLE_SYNC_INTERVAL)
 
 
+def _fake_input_watcher(last_input_secs_ago):
+    """An input watcher whose last observed input was N seconds ago (or None)."""
+    w = Mock()
+    if last_input_secs_ago is None:
+        w.get_last_input_at.return_value = None
+    else:
+        w.get_last_input_at.return_value = (
+            datetime.now(timezone.utc) - timedelta(seconds=last_input_secs_ago)
+        )
+    return w
+
+
+def test_blind_afk_tracker_does_not_pause_while_input_is_live():
+    """Phantom-idle regression: AFK bucket says 'afk' (blind/stuck tracker) but
+    the in-process input watcher saw a keystroke 5s ago. The user is typing —
+    must NOT pause as idle even though the AFK event is well over threshold."""
+    idle_mgr, reschedule, trigger_sync, tray = _make(idle_in_call=False)
+    idle_mgr.input_watcher = _fake_input_watcher(last_input_secs_ago=5)
+
+    idle_mgr.check_idle_status(
+        logged_in=True,
+        is_on_break=False,
+        reschedule=reschedule,
+        trigger_sync=trigger_sync,
+    )
+
+    assert idle_mgr.idle_paused is False, "live input must override a blind AFK bucket"
+    reschedule.assert_not_called()
+    tray.set_state.assert_not_called()
+    # Short-circuited before even reading the AFK bucket.
+    idle_mgr.aw.get_events.assert_not_called()
+
+
+def test_recent_input_clears_an_existing_phantom_idle_pause():
+    """If we somehow already entered idle and then the input watcher sees real
+    input within the threshold, resume immediately (don't wait for the
+    blind-tracker restart to flip the AFK bucket)."""
+    idle_mgr, reschedule, trigger_sync, tray = _make(idle_in_call=False)
+    idle_mgr.input_watcher = _fake_input_watcher(last_input_secs_ago=2)
+    idle_start = datetime.now(timezone.utc) - timedelta(minutes=30)
+    idle_mgr._idle_paused = True
+    idle_mgr._idle_start = idle_start
+
+    idle_mgr.check_idle_status(
+        logged_in=True,
+        is_on_break=False,
+        reschedule=reschedule,
+        trigger_sync=trigger_sync,
+    )
+
+    assert idle_mgr.idle_paused is False, "recent input must clear the idle pause"
+    reschedule.assert_called_once_with(idle_mgr.config.sync.interval_seconds)
+    trigger_sync.assert_called_once_with("idle_resume_sync")
+
+
+def test_genuine_idle_still_pauses_when_input_is_old():
+    """Control: no recent input (last keystroke older than the threshold) — the
+    override must NOT fire, so a real idle stretch still pauses as before."""
+    idle_mgr, reschedule, trigger_sync, tray = _make(idle_in_call=False)
+    # idle_pause_minutes defaults to 20 (1200s); last input 2h ago is well past it.
+    idle_mgr.input_watcher = _fake_input_watcher(last_input_secs_ago=2 * 3600)
+
+    idle_mgr.check_idle_status(
+        logged_in=True,
+        is_on_break=False,
+        reschedule=reschedule,
+        trigger_sync=trigger_sync,
+    )
+
+    assert idle_mgr.idle_paused is True, "old input must not suppress genuine idle"
+    reschedule.assert_called_once_with(idle_mgr._IDLE_SYNC_INTERVAL)
+
+
+def test_no_input_watcher_falls_back_to_afk_path():
+    """Windows/Linux have no in-process watcher (input_watcher is None) — the
+    override is a no-op and idle detection works exactly as before."""
+    idle_mgr, reschedule, trigger_sync, tray = _make(idle_in_call=False)
+    assert idle_mgr.input_watcher is None  # default
+
+    idle_mgr.check_idle_status(
+        logged_in=True,
+        is_on_break=False,
+        reschedule=reschedule,
+        trigger_sync=trigger_sync,
+    )
+
+    assert idle_mgr.idle_paused is True, "no watcher -> unchanged AFK-based idle"
+
+
 def test_resumes_when_a_call_starts_during_an_existing_idle_pause():
     """A call that begins AFTER the idle pause must resume tracking.
 


### PR DESCRIPTION
## Symptom
Timeline shows **Idle (gray) while the user is actively working** — reported again on v1.5.50 (Martin's device/14, Jun 17). Menu bar says `App status: Active`, 100% effectiveness, 0m unproductive, yet the timeline paints idle spans.

## Root cause
Two independent readers of the AFK bucket, only one of which trusts the input watcher:
- `SyncCoordinator._check_idle_tracker_health` cross-checks the in-process input watcher and **restarts** a blind `bf-idle-tracker` (shipped in f06d8c4 / v1.5.50).
- `IdleManager.check_idle_status` **never consulted the watcher** — it blindly trusted `afk_buckets[0]`. So during the window before the restart lands, *and* whenever the tracker is permanently blind (missing Input Monitoring on its separate TCC subject — a restart can't fix that), it paints live work as Idle and emits `idle_time` events.

## Fix
Make the in-process input watcher authoritative in the idle path too:
- If it saw input within the idle threshold → user is active. **Short-circuit before the AFK fetch** (prevents entering idle) and **resume immediately if already paused** (exits a phantom pause without waiting for the AFK bucket to flip).
- Conservative: no watcher / no observation / any error → no override, so genuine idle is still detected via the AFK path. **Windows/Linux unchanged** (no in-process watcher).
- Also prefer the `bf-idle-tracker` bucket over a stale `aw-watcher-afk` bucket (frozen at 'afk' for ActivityWatch migrants), mirroring the health check.

## Tests
4 new in `tests/test_idle_manager.py` — blind-tracker-no-pause, recent-input-clears-pause, genuine-idle-still-pauses, no-watcher-fallback. Full idle/tracker suites green (7 + 22 passing). Bump 1.5.50 → 1.5.51.

## Note
Genuinely present-but-no-input time (reading/meetings) is still out of scope here — that's the backend input-presence union (internal-tool2 #1823). This only stops live *input* being misread as idle.

🤖 Generated with [Claude Code](https://claude.com/claude-code)