### PR TITLE
chore(release): bump version to 1.5.53

### DIFF
--- a/src/__init__.py
+++ b/src/__init__.py
@@ -1,4 +1,4 @@
 """BetterFlow - ActivityWatch to BetterFlow sync companion app."""
 
-__version__ = "1.5.52"
+__version__ = "1.5.53"
 __author__ = "BetterQA"


### PR DESCRIPTION
Cuts **1.5.53** — the first build to ship the audit follow-ups (#47) on top of 1.5.52, most importantly the canonical AFK read (`AWClient.get_latest_afk_event`, prefers `bf-idle-tracker` over a stale vanilla `aw-watcher-afk` bucket). Combined with the #46 input-watcher idle override (already in 1.5.51), this is the build that addresses the recurring phantom-idle + stale-AFK reports.

🤖 Generated with [Claude Code](https://claude.com/claude-code)