### PR TITLE
chore(release): bump version to 1.5.54

### DIFF
--- a/src/__init__.py
+++ b/src/__init__.py
@@ -1,4 +1,4 @@
 """BetterFlow - ActivityWatch to BetterFlow sync companion app."""
 
-__version__ = "1.5.53"
+__version__ = "1.5.54"
 __author__ = "BetterQA"


### PR DESCRIPTION
Ships **#53** — the false-idle fix — to the fleet.

Active users were being pinned **Idle / not tracked while working** after 1.5.53 (Sachi on Windows, Emilian on macOS). Root cause: `IdleManager` trusted a stale/frozen AFK event as the live idle state. 1.5.54 adds an event-freshness guard + a Windows `GetLastInputInfo` system-idle backstop (was macOS-only).

This is the urgent fix — recommend merge → tag `v1.5.54` to kick the signed/notarized build, then publish the draft release once the build lands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)