### PR TITLE
feat(agent): upload log tail on server request (completes remote log fetch)

### DIFF
--- a/src/sync/bf_client.py
+++ b/src/sync/bf_client.py
@@ -397,9 +397,15 @@ class BetterFlowClient(BaseApiClient):
         flag (admin diagnostics). POST /api/agent/logs (multipart).
 
         ``log`` (betterflow.log) is required by the server; ``relaunch_log`` is
-        sent only when present. The server keeps the last 512 KB per file and
-        clears logs_requested_at on success. Not retried here — if it fails the
-        flag stays set and the next heartbeat re-attempts.
+        sent only when present (``None`` or empty ``b""`` are both omitted). The
+        server keeps the last 512 KB per file and clears logs_requested_at on
+        success. Not retried here — if it fails the flag stays set and the next
+        heartbeat re-attempts.
+
+        Privacy note: this is an admin-initiated diagnostic pull. The log can
+        contain app names, the device hostname (in bucket ids), and OS usernames
+        in stack-trace paths — but NOT window titles, URLs, or auth tokens
+        (those are never logged). Acceptable within the tenant-admin trust model.
         """
         files: dict = {"log": ("betterflow.log", log_tail, "text/plain")}
         if relaunch_tail:

--- a/src/sync/bf_client.py
+++ b/src/sync/bf_client.py
@@ -392,6 +392,20 @@ class BetterFlowClient(BaseApiClient):
         """Get weekly/monthly trend summaries (non-critical, short timeout)."""
         return self._request("GET", "events/trends", retry=False, timeout_override=10)
 
+    def upload_logs(self, log_tail: bytes, relaunch_tail: Optional[bytes] = None) -> dict:
+        """Upload the agent's log tail(s) in response to a server logs_requested
+        flag (admin diagnostics). POST /api/agent/logs (multipart).
+
+        ``log`` (betterflow.log) is required by the server; ``relaunch_log`` is
+        sent only when present. The server keeps the last 512 KB per file and
+        clears logs_requested_at on success. Not retried here — if it fails the
+        flag stays set and the next heartbeat re-attempts.
+        """
+        files: dict = {"log": ("betterflow.log", log_tail, "text/plain")}
+        if relaunch_tail:
+            files["relaunch_log"] = ("self-update-relaunch.log", relaunch_tail, "text/plain")
+        return self._request("POST", "logs", files=files, retry=False)
+
     # =========================================================================
     # Web login passthrough
     # =========================================================================

--- a/src/sync/sync_engine.py
+++ b/src/sync/sync_engine.py
@@ -1943,13 +1943,23 @@ class SyncEngine:
             return
         log_tail = self._read_log_tail(log_dir / "betterflow.log")
         if not log_tail:
-            logger.debug("logs_requested but betterflow.log is empty/unreadable — skipping")
+            # WARNING (not debug) so the next successful upload carries a record
+            # of why earlier ones were skipped — the admin's flag stays set and
+            # we retry every heartbeat, which is correct for the normal cause
+            # (a transient log-rotation window).
+            logger.warning(
+                "logs_requested but betterflow.log is empty/unreadable — "
+                "skipping this cycle (will retry next heartbeat)"
+            )
             return
         relaunch_tail = self._read_log_tail(log_dir / "self-update-relaunch.log")
         try:
             self.bf.upload_logs(log_tail, relaunch_tail)
             logger.info("Uploaded log tail on server request (%d bytes)", len(log_tail))
         except BetterFlowAuthError:
+            # Make the source explicit — _send_heartbeat's shared handler would
+            # otherwise log this as a plain "Heartbeat auth error".
+            logger.warning("Log-upload auth error — session likely expired")
             raise  # let _send_heartbeat surface re-login
         except BetterFlowClientError as e:
             logger.debug("Log upload failed (will retry next heartbeat): %s", e)

--- a/src/sync/sync_engine.py
+++ b/src/sync/sync_engine.py
@@ -1967,7 +1967,10 @@ class SyncEngine:
     @staticmethod
     def _read_log_tail(path, max_bytes: int = 512 * 1024) -> Optional[bytes]:
         """Return up to the last ``max_bytes`` of a log file (matching the
-        server's per-file tail cap), or None if it can't be read."""
+        server's per-file tail cap). Returns ``None`` if it can't be read
+        (OSError) and ``b""`` for an empty file — callers treat both as "no
+        content" (``if not tail``), so don't rely on None-vs-b"" to distinguish
+        unreadable from empty."""
         try:
             size = path.stat().st_size
             with open(path, "rb") as f:

--- a/src/sync/sync_engine.py
+++ b/src/sync/sync_engine.py
@@ -1913,6 +1913,12 @@ class SyncEngine:
             if response.get("config_updated"):
                 self.fetch_server_config()
 
+            # Admin requested this device's logs for diagnostics. Upload the
+            # tail; the server clears the flag only on success, so a failed
+            # upload simply retries on the next heartbeat.
+            if response.get("logs_requested"):
+                self._upload_requested_logs()
+
         except BetterFlowAuthError as e:
             # Surface auth errors to the caller so re-login can fire.
             # The generic BetterFlowClientError handler below would otherwise
@@ -1922,6 +1928,44 @@ class SyncEngine:
         except BetterFlowClientError as e:
             logger.debug(f"Heartbeat failed: {e}")
         return None
+
+    def _upload_requested_logs(self) -> None:
+        """Upload this device's log tail(s) on server request (admin
+        diagnostics). betterflow.log is required by the server; the relaunch log
+        is included when present. Never clears anything client-side — the server
+        clears its logs_requested flag only on success, so a failed upload just
+        retries on the next heartbeat.
+        """
+        try:
+            log_dir = self.config.get_log_dir()
+        except Exception as e:
+            logger.debug("logs_requested: could not resolve log dir: %s", e)
+            return
+        log_tail = self._read_log_tail(log_dir / "betterflow.log")
+        if not log_tail:
+            logger.debug("logs_requested but betterflow.log is empty/unreadable — skipping")
+            return
+        relaunch_tail = self._read_log_tail(log_dir / "self-update-relaunch.log")
+        try:
+            self.bf.upload_logs(log_tail, relaunch_tail)
+            logger.info("Uploaded log tail on server request (%d bytes)", len(log_tail))
+        except BetterFlowAuthError:
+            raise  # let _send_heartbeat surface re-login
+        except BetterFlowClientError as e:
+            logger.debug("Log upload failed (will retry next heartbeat): %s", e)
+
+    @staticmethod
+    def _read_log_tail(path, max_bytes: int = 512 * 1024) -> Optional[bytes]:
+        """Return up to the last ``max_bytes`` of a log file (matching the
+        server's per-file tail cap), or None if it can't be read."""
+        try:
+            size = path.stat().st_size
+            with open(path, "rb") as f:
+                if size > max_bytes:
+                    f.seek(size - max_bytes)
+                return f.read()
+        except OSError:
+            return None
 
     @staticmethod
     def _version_below(current: str, minimum: str) -> bool:

--- a/tests/test_bf_client.py
+++ b/tests/test_bf_client.py
@@ -167,6 +167,23 @@ class TestBetterFlowClient:
             self.client._request("GET", "config", retry=False)
 
     @responses.activate
+    def test_upload_logs_posts_multipart_to_logs_endpoint(self):
+        """upload_logs POSTs a multipart body (the log tail) to /logs."""
+        responses.add(
+            responses.POST,
+            "https://betterflow.eu/api/agent/logs",
+            json={"data": {"received": 1}},
+            status=200,
+        )
+        self.client.upload_logs(b"some-log-tail", None)
+        assert len(responses.calls) == 1
+        body = responses.calls[0].request.body
+        raw = body if isinstance(body, bytes) else body.encode()
+        assert b"betterflow.log" in raw          # multipart field/filename present
+        assert b"some-log-tail" in raw           # the tail content was sent
+        assert b"relaunch_log" not in raw        # omitted when None
+
+    @responses.activate
     def test_is_reachable_true(self):
         """Test is_reachable when server responds."""
         responses.add(

--- a/tests/test_sync_engine.py
+++ b/tests/test_sync_engine.py
@@ -388,6 +388,26 @@ class TestSyncEngine:
         assert enqueued, "reconcile should enqueue the replayed window event"
         assert all(e["activity_state"] == "active" for e in enqueued)
 
+    def test_heartbeat_uploads_logs_when_requested(self):
+        """When the heartbeat response sets logs_requested, the agent uploads
+        the betterflow.log tail (relaunch log optional)."""
+        self.bf.heartbeat.return_value = {"logs_requested": True}
+
+        def fake_tail(path, max_bytes=512 * 1024):
+            return b"log-bytes" if path.name == "betterflow.log" else None
+
+        with patch.object(SyncEngine, "_read_log_tail", side_effect=fake_tail):
+            result = self.engine._send_heartbeat()
+
+        assert result is None  # no auth error surfaced
+        self.bf.upload_logs.assert_called_once_with(b"log-bytes", None)
+
+    def test_heartbeat_does_not_upload_logs_when_not_requested(self):
+        """No logs_requested flag -> no upload (the common case)."""
+        self.bf.heartbeat.return_value = {"logs_requested": False}
+        self.engine._send_heartbeat()
+        self.bf.upload_logs.assert_not_called()
+
     def test_get_category_db_only_returns_none_for_unmapped(self):
         """Test that _get_category only checks DB, returns None for unmapped apps."""
         self.queue.get_all_categories.return_value = {}

--- a/tests/test_sync_engine.py
+++ b/tests/test_sync_engine.py
@@ -408,6 +408,17 @@ class TestSyncEngine:
         self.engine._send_heartbeat()
         self.bf.upload_logs.assert_not_called()
 
+    def test_heartbeat_log_upload_auth_error_propagates(self):
+        """A BetterFlowAuthError during the log upload must surface from
+        _send_heartbeat (the re-login signal), not be swallowed by the generic
+        client-error handler."""
+        from src.sync.bf_client import BetterFlowAuthError
+        self.bf.heartbeat.return_value = {"logs_requested": True}
+        self.bf.upload_logs.side_effect = BetterFlowAuthError("expired")
+        with patch.object(SyncEngine, "_read_log_tail", return_value=b"log-bytes"):
+            result = self.engine._send_heartbeat()
+        assert isinstance(result, BetterFlowAuthError)
+
     def test_get_category_db_only_returns_none_for_unmapped(self):
         """Test that _get_category only checks DB, returns None for unmapped apps."""
         self.queue.get_all_categories.return_value = {}


### PR DESCRIPTION
Answers "can we fetch the team's logs directly?" — **after this ships, yes.**

The server + MCP halves already shipped (`agent_devices.logs_requested_at`, `POST /api/agent/logs`, `agent_log_uploads` table; MCP `betterflow_request_agent_logs` / `betterflow_get_agent_logs` @1.0.3). The desktop agent never **responded** to the flag — so a request set `logs_requested_at` but nothing uploaded. This is that held piece.

## Change
- **`bf_client.upload_logs()`** — POST `/api/agent/logs` as multipart: `log` (betterflow.log) required, `relaunch_log` optional. Matches the server contract exactly (server keeps last 512KB/file, clears the flag on success).
- **`_send_heartbeat()`** — when the heartbeat response has `logs_requested=true`, read the bounded log tail(s) (512KB via `Path.stat`+seek) and upload. Best-effort: unreadable log → skip; client error → debug + **retry next heartbeat** (server only clears the flag on success); auth error → existing re-login path.

## End-to-end after release
`betterflow_request_agent_logs(device_id)` → agent uploads on its next heartbeat (~60s) → `betterflow_get_agent_logs(device_id)` returns the tail. No more "ask the user to send their betterflow.log" — which is exactly what we hit trying to diagnose Sachi/Emilian.

## Tests
- heartbeat uploads-on-request / no-upload-otherwise
- client posts the multipart tail to `/logs` (omits relaunch_log when absent)

591 pass, lint clean. Ships to the fleet via the next release tag.

🤖 Generated with [Claude Code](https://claude.com/claude-code)