### PR TITLE
fix(idle): harden AFK-event freshness against null duration

### DIFF
--- a/src/idle_manager.py
+++ b/src/idle_manager.py
@@ -105,6 +105,17 @@ class IdleManager:
             return False
         return (datetime.now(timezone.utc) - last_input) <= timedelta(seconds=within_seconds)
 
+    def _afk_event_age_seconds(self, event) -> Optional[float]:
+        """Seconds since the AFK event ended (``timestamp + duration``), or None
+        if it can't be computed — a missing/None timestamp or duration (e.g. the
+        AW API returned ``{"duration": null}``) is treated as unusable so the
+        caller falls back to the OS idle clock rather than raising."""
+        try:
+            event_end = event.timestamp + timedelta(seconds=event.duration)
+            return (datetime.now(timezone.utc) - event_end).total_seconds()
+        except (TypeError, AttributeError):
+            return None
+
     def _afk_event_is_current(self, event) -> bool:
         """True if the AFK event still covers ~now.
 
@@ -113,12 +124,11 @@ class IdleManager:
         tracker stops emitting, leaving an old event as "latest" — typically an
         'afk' whose end is well in the past. Trusting that stale 'afk' is what
         marks an active user Idle indefinitely (no fresh not-afk event ever
-        lands to clear it). Returns False for such stale events so the caller
-        falls back to the OS idle clock instead.
+        lands to clear it). Returns False for such stale (or malformed) events so
+        the caller falls back to the OS idle clock instead.
         """
-        event_end = event.timestamp + timedelta(seconds=event.duration)
-        age = (datetime.now(timezone.utc) - event_end).total_seconds()
-        return age <= self._afk_staleness_grace
+        age = self._afk_event_age_seconds(event)
+        return age is not None and age <= self._afk_staleness_grace
 
     def _is_in_call(self) -> bool:
         """Whether a call/meeting is active, via the sync engine. Defensive:
@@ -198,12 +208,12 @@ class IdleManager:
                 # independent of the (possibly dead) bf-idle-tracker. On Windows
                 # this is the ONLY safety net (no in-process input watcher).
                 if latest is not None:
+                    age = self._afk_event_age_seconds(latest)
                     logger.debug(
-                        "AFK event is stale (ended %.0fs ago) — tracker likely "
-                        "frozen; using OS idle clock instead of its '%s' status",
-                        (datetime.now(timezone.utc)
-                         - (latest.timestamp + timedelta(seconds=latest.duration))).total_seconds(),
-                        latest.status,
+                        "AFK event not current (age=%s) — tracker likely frozen; "
+                        "using OS idle clock instead of its '%s' status",
+                        f"{age:.0f}s" if age is not None else "unknown",
+                        getattr(latest, "status", "?"),
                     )
                 system_idle = self._get_system_idle_seconds()
                 if system_idle is not None:
@@ -311,7 +321,10 @@ class IdleManager:
                     return None
                 # Both GetTickCount and dwTime are 32-bit ms tick counts; mask
                 # the difference to 32 bits so it stays correct across the
-                # ~49.7-day GetTickCount wraparound.
+                # ~49.7-day GetTickCount wraparound. Pin restype to unsigned so
+                # the value is explicit (the mask makes the result correct
+                # either way, but this avoids a signed-vs-unsigned footgun).
+                ctypes.windll.kernel32.GetTickCount.restype = ctypes.c_uint32
                 tick = ctypes.windll.kernel32.GetTickCount()
                 elapsed_ms = (tick - info.dwTime) & 0xFFFFFFFF
                 return elapsed_ms / 1000.0

--- a/tests/test_idle_manager.py
+++ b/tests/test_idle_manager.py
@@ -341,3 +341,46 @@ def test_current_afk_event_is_trusted_and_pauses():
     )
 
     assert idle_mgr.idle_paused is True, "a live afk event over threshold should still pause"
+
+
+def test_afk_event_with_none_duration_falls_back_not_crash():
+    """A malformed AFK event (duration=None — AW returned null) must not raise:
+    it's treated as not-current, so the code reaches the OS-idle fallback and
+    does not pause an active user. Pre-fix this raised TypeError before the
+    fallback (swallowed by the outer handler -> idle check silently no-op'd)."""
+    bad = types.SimpleNamespace(
+        status="afk",
+        duration=None,
+        timestamp=datetime.now(timezone.utc) - timedelta(minutes=30),
+    )
+    idle_mgr, reschedule, trigger_sync, tray = _make_with_afk_event(bad)
+    with patch.object(IdleManager, "_get_system_idle_seconds", return_value=5.0) as sysidle:
+        idle_mgr.check_idle_status(
+            logged_in=True,
+            is_on_break=False,
+            reschedule=reschedule,
+            trigger_sync=trigger_sync,
+        )
+    assert idle_mgr.idle_paused is False
+    # Post-fix reaches the OS-idle fallback; pre-fix raised before it.
+    sysidle.assert_called()
+
+
+def test_stale_afk_with_no_os_idle_signal_does_not_pause():
+    """Stale AFK + no OS idle clock (Linux, or a Windows API failure -> None):
+    is_afk stays False and the user is not paused. Guards the None-fallback
+    branch so a future change to the default can't silently re-introduce idle."""
+    stale = types.SimpleNamespace(
+        status="afk",
+        duration=25 * 60.0,
+        timestamp=datetime.now(timezone.utc) - timedelta(minutes=55),  # stale
+    )
+    idle_mgr, reschedule, trigger_sync, tray = _make_with_afk_event(stale)
+    with patch.object(IdleManager, "_get_system_idle_seconds", return_value=None):
+        idle_mgr.check_idle_status(
+            logged_in=True,
+            is_on_break=False,
+            reschedule=reschedule,
+            trigger_sync=trigger_sync,
+        )
+    assert idle_mgr.idle_paused is False


### PR DESCRIPTION
Audit follow-up to the shipped idle fix #53 (1.5.54). Two independent reviews said #53 is **safe-as-shipped**; this is the one real finding worth fixing for the next release.

**Bug:** if the AW API returns an AFK event with `duration: null`, `timedelta(seconds=None)` raised `TypeError` inside `_afk_event_is_current` — swallowed by `check_idle_status`'s outer handler, silently no-op'ing the idle check for that tick.

**Fix:**
- Extract `_afk_event_age_seconds()` → returns `None` for a missing/None timestamp-or-duration; `_afk_event_is_current` treats `None` as "not current" → OS-idle fallback instead of raising. The stale-event debug log reuses it (no second TypeError site).
- Pin `GetTickCount.restype = c_uint32` on the Windows idle path (the `&0xFFFFFFFF` mask already made it correct; this removes the signed/unsigned footgun).

**Tests (proof-of-failure):** the null-duration test fails pre-fix with the exact `TypeError: ...timedelta seconds component: NoneType` (verified via `git stash`); plus a stale-AFK + no-OS-idle-signal case. 590 pass.

Rides the next release alongside #55.

🤖 Generated with [Claude Code](https://claude.com/claude-code)