### PR TITLE
chore(release): bump version to 1.5.55

### DIFF
--- a/src/__init__.py
+++ b/src/__init__.py
@@ -1,4 +1,4 @@
 """BetterFlow - ActivityWatch to BetterFlow sync companion app."""
 
-__version__ = "1.5.54"
+__version__ = "1.5.55"
 __author__ = "BetterQA"


### PR DESCRIPTION
Ships the two changes landed since 1.5.54:
- **#55** — agent-side log upload, completing remote fleet log-fetch (`request_agent_logs` → agent uploads on next heartbeat → `get_agent_logs`).
- **#56** — AFK-event null-duration hardening (follow-up to the 1.5.54 false-idle fix; a `duration: null` from the AW API no longer silently no-ops the idle check).

Both audited to convergence (0 critical/important). Merge → tag `v1.5.55` → publish the draft once the signed build lands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)