### PR TITLE
fix(tracker): auto-reinstall ad-hoc trackers + honest blind re-prompt

### DIFF
--- a/src/aw_manager.py
+++ b/src/aw_manager.py
@@ -34,6 +34,13 @@ BF_SERVER = "bf-data-service"
 BF_WATCHERS = ["bf-window-tracker", "bf-idle-tracker"]
 ALL_COMPONENTS = [BF_SERVER] + BF_WATCHERS
 
+# Our Apple Developer Team. The build signs the bundled trackers with this
+# (Developer ID, hardened runtime, stable identifier). A persistent tracker that
+# is NOT signed with this team is a stale ad-hoc copy from a pre-signing build:
+# its TCC (Input Monitoring) grant is fragile and gets silently denied, so the
+# tracker runs but stays blind. See _should_reinstall_trackers.
+BETTERQA_TEAM_ID = "87NVC57J44"
+
 AW_VERSION = "v0.13.2"
 RELEASE_BASE = (
     f"https://github.com/ActivityWatch/activitywatch/releases/download/{AW_VERSION}"
@@ -702,10 +709,12 @@ class AWManager:
                     ):
                         self._idle_tracker_blind = True
                         logger.warning(
-                            "%s has stayed stale across %d restarts — it is almost "
-                            "certainly missing Input Monitoring permission (a separate "
-                            "TCC subject from the main app). Backing off restarts and "
-                            "flagging for a permission re-prompt.",
+                            "%s has stayed stale across %d restarts — a restart "
+                            "can't fix it. Likely a stale or denied Input Monitoring "
+                            "grant on the tracker (a separate TCC subject from the "
+                            "main app). Backing off restarts and flagging for a "
+                            "permission re-prompt; tracking continues via the OS "
+                            "idle clock meanwhile.",
                             idle_watcher,
                             self._idle_consecutive_stale,
                         )
@@ -957,6 +966,29 @@ class AWManager:
         # Persistent install directory (auto-downloaded, permissions survive updates)
         install_dir = _get_install_dir()
         if os.path.isdir(install_dir) and _binaries_present(install_dir):
+            # Heal a stale ad-hoc tracker left by a pre-signing build. Such a
+            # copy keeps its fragile ad-hoc TCC grant, which macOS silently
+            # denies → the tracker runs but never sees input (blind, no AFK
+            # heartbeat → false idle). If the bundle ships a properly
+            # Developer-ID-signed tracker, reinstall it so the grant becomes
+            # stable across updates. The user must re-grant Input Monitoring
+            # once (the new signing identity is a fresh TCC subject), but it
+            # then survives every future update instead of breaking on each one.
+            if getattr(sys, "frozen", False):
+                base = os.path.join(sys._MEIPASS, "resources", "trackers", plat)
+                if (
+                    os.path.isdir(base)
+                    and _binaries_present(base)
+                    and self._should_reinstall_trackers(install_dir, base)
+                ):
+                    logger.warning(
+                        "Persistent bf-idle-tracker is ad-hoc/mis-signed while the "
+                        "bundled copy is Developer-ID signed (Team %s) — reinstalling "
+                        "so its Input Monitoring grant is stable. Re-grant Input "
+                        "Monitoring for bf-idle-tracker once after this update.",
+                        BETTERQA_TEAM_ID,
+                    )
+                    self._install_to_persistent(base, install_dir)
             return install_dir
 
         # Development: relative to project root (already has permissions)
@@ -976,6 +1008,57 @@ class AWManager:
                 return base
 
         return None
+
+    @staticmethod
+    def _tracker_team_identifier(binary_path: str) -> Optional[str]:
+        """Return the Apple Developer Team Identifier the binary is signed with,
+        or None if it is ad-hoc / unsigned / unreadable.
+
+        macOS only — codesign does not exist elsewhere, so other platforms
+        always return None (the caller treats that as "can't tell", which never
+        triggers a reinstall). codesign writes its details to stderr.
+        """
+        if platform.system() != "Darwin":
+            return None
+        try:
+            result = subprocess.run(
+                ["codesign", "-dv", "--verbose=2", binary_path],
+                capture_output=True,
+                text=True,
+                timeout=10,
+            )
+        except Exception as e:
+            logger.debug("codesign check failed for %s: %s", binary_path, e)
+            return None
+        for line in (result.stderr or "").splitlines():
+            if line.startswith("TeamIdentifier="):
+                team = line.split("=", 1)[1].strip()
+                return None if team in ("", "not set") else team
+        return None
+
+    @classmethod
+    def _should_reinstall_trackers(cls, install_dir: str, bundle_dir: str) -> bool:
+        """True when the installed bf-idle-tracker is NOT signed with our
+        Developer ID team but the bundled one IS.
+
+        That's the stale-ad-hoc case: a tracker copied to the persistent dir by
+        a pre-signing build keeps its ad-hoc signature, whose Input Monitoring
+        grant macOS silently denies (the tracker is alive but blind — no AFK
+        heartbeat). Replacing it with the Developer-ID-signed bundle copy fixes
+        it for good. We deliberately do NOT reinstall when the bundle is also
+        un-teamed (an old build): swapping ad-hoc for ad-hoc would only churn
+        the binary and force a needless re-grant. Returns False off macOS.
+        """
+        idle = "bf-idle-tracker"
+        bundle_team = cls._tracker_team_identifier(
+            os.path.join(bundle_dir, idle, idle)
+        )
+        if bundle_team != BETTERQA_TEAM_ID:
+            return False
+        installed_team = cls._tracker_team_identifier(
+            os.path.join(install_dir, idle, idle)
+        )
+        return installed_team != BETTERQA_TEAM_ID
 
     @staticmethod
     def _install_to_persistent(source_dir: str, install_dir: str) -> bool:

--- a/src/main.py
+++ b/src/main.py
@@ -646,11 +646,19 @@ class SyncCoordinator:
                 logger.warning("restart_idle_tracker failed", exc_info=True)
 
     def _reprompt_idle_tracker_permission(self) -> None:
-        """bf-idle-tracker is blind across repeated restarts → re-prompt the user
-        for Input Monitoring. Requests the grant (re-registers the app + shows the
-        system prompt), opens the Input Monitoring pane so the user can also add
-        the separate `bf-idle-tracker` binary, and notifies. Throttled to the
-        same rewarn window as the disagreement warning so the two never spam."""
+        """bf-idle-tracker has stayed unresponsive across repeated restarts. A
+        restart can't fix that — the usual cause is a stale or denied Input
+        Monitoring grant on the tracker (a separate TCC subject from the main
+        app, e.g. after the tracker's signing identity changed). Surface an
+        honest, actionable nudge and open the Input Monitoring pane.
+
+        We deliberately do NOT assert "missing permission" as fact: the main app
+        often already has the grant, and tracking keeps working via the OS idle
+        clock regardless (idle_manager's freshness fallback). So the message
+        leads with "still being tracked" and points at the real remedy
+        (enable / re-toggle bf-idle-tracker). Throttled to the same rewarn
+        window as the disagreement warning so the two never spam.
+        """
         now = datetime.now(timezone.utc)
         with self._idle_tracker_warn_lock:
             recently_warned = (
@@ -661,27 +669,52 @@ class SyncCoordinator:
                 return
             self._last_idle_tracker_warn_at = now
 
-        logger.warning(
-            "bf-idle-tracker blind across repeated restarts — re-prompting for "
-            "Input Monitoring (separate TCC subject from the main app)"
-        )
         try:
             from .ui import permissions
         except ImportError:
             from ui import permissions
+
+        # Whether the MAIN app holds Input Monitoring tells us how to phrase this.
+        # If the app itself lacks it, "grant Input Monitoring" is the honest ask.
+        # If the app HAS it, the tracker is a distinct subject whose grant is
+        # stale/denied — telling the user to "grant Input Monitoring" they already
+        # granted reads as broken; "re-toggle bf-idle-tracker" is the real fix.
         try:
-            # Re-request for the main app (re-registers it + system prompt), then
-            # open the pane so the user can enable bf-idle-tracker too.
-            permissions.input_monitoring_active(prompt=True)
+            app_has_grant = permissions.input_monitoring_active()
+        except Exception:
+            logger.debug("Input Monitoring status check failed", exc_info=True)
+            app_has_grant = False
+
+        logger.warning(
+            "bf-idle-tracker unresponsive across repeated restarts (app Input "
+            "Monitoring grant=%s) — opening Input Monitoring so the user can "
+            "enable/refresh the tracker; tracking continues via the OS idle clock",
+            app_has_grant,
+        )
+        try:
+            if not app_has_grant:
+                # The app itself needs the grant — request it (system prompt).
+                permissions.input_monitoring_active(prompt=True)
             permissions.open_input_monitoring_settings()
         except Exception:
             logger.debug("Input Monitoring re-prompt failed", exc_info=True)
-        send_notification(
-            "BetterFlow needs Input Monitoring",
-            "BetterFlow's idle tracker can't see your activity — it needs Input "
-            "Monitoring permission. Opening Settings: please enable BetterFlow "
-            "AND bf-idle-tracker under Input Monitoring.",
-        )
+
+        if app_has_grant:
+            send_notification(
+                "BetterFlow idle tracker needs a refresh",
+                "The idle tracker stopped responding. Your work time is still "
+                "being recorded via the system idle clock. To fix it, open Input "
+                "Monitoring and enable bf-idle-tracker — if it already looks "
+                "enabled, toggle it off and back on to refresh the permission.",
+            )
+        else:
+            send_notification(
+                "BetterFlow needs Input Monitoring",
+                "BetterFlow's idle tracker can't see your activity. Tracking "
+                "continues via the system idle clock for now. Opening Settings: "
+                "please enable BetterFlow and bf-idle-tracker under Input "
+                "Monitoring.",
+            )
 
     def _tick_60s(self) -> None:
         """Unified 60-second tick - one wakeup instead of five.

--- a/tests/test_aw_manager_tracker_reinstall.py
+++ b/tests/test_aw_manager_tracker_reinstall.py
@@ -1,0 +1,62 @@
+"""bf-idle-tracker self-heal: a stale ad-hoc tracker left by a pre-signing
+build keeps a fragile TCC grant that macOS silently denies (blind tracker, no
+AFK heartbeat -> false idle). The app must reinstall the Developer-ID-signed
+bundle copy so the Input Monitoring grant is stable across updates.
+
+Proven live on a fleet machine 2026-06-18: the persistent tracker was ad-hoc
+(Identifier=bf-idle-tracker-5555..., TeamIdentifier=not set) while the bundled
+copy was Developer ID (Team 87NVC57J44). Removing the persistent copy made the
+app reinstall a working, signed, self-contained tracker; a one-time re-grant
+restored the heartbeat. These tests pin the reinstall DECISION.
+"""
+
+from unittest.mock import patch
+
+from src.aw_manager import BETTERQA_TEAM_ID, AWManager
+
+
+def _teams(install, bundle):
+    """Patch the codesign reader so the install/bundle binaries report fixed
+    team identifiers (None = ad-hoc / unsigned)."""
+
+    def fake(binary_path):
+        if binary_path.startswith("/install/"):
+            return install
+        if binary_path.startswith("/bundle/"):
+            return bundle
+        return None
+
+    return patch.object(AWManager, "_tracker_team_identifier", staticmethod(fake))
+
+
+def test_reinstall_when_installed_adhoc_and_bundle_signed():
+    """The real-world bug: ad-hoc persistent copy, Developer-ID bundle."""
+    with _teams(install=None, bundle=BETTERQA_TEAM_ID):
+        assert AWManager._should_reinstall_trackers("/install", "/bundle") is True
+
+
+def test_no_reinstall_when_both_signed_with_our_team():
+    """Already healed (or shipped signed from the start) — leave it alone."""
+    with _teams(install=BETTERQA_TEAM_ID, bundle=BETTERQA_TEAM_ID):
+        assert AWManager._should_reinstall_trackers("/install", "/bundle") is False
+
+
+def test_no_reinstall_when_bundle_also_adhoc():
+    """Old build whose bundle is ad-hoc too — swapping ad-hoc for ad-hoc would
+    only churn the binary and force a needless re-grant for no gain."""
+    with _teams(install=None, bundle=None):
+        assert AWManager._should_reinstall_trackers("/install", "/bundle") is False
+
+
+def test_reinstall_when_installed_is_foreign_team_but_bundle_ours():
+    """Defensive: a tracker signed by some other team still gets replaced by our
+    properly-signed bundle copy."""
+    with _teams(install="OTHERTEAM9", bundle=BETTERQA_TEAM_ID):
+        assert AWManager._should_reinstall_trackers("/install", "/bundle") is True
+
+
+def test_team_identifier_is_none_off_macos():
+    """On non-macOS there is no codesign, so the reader returns None and the
+    decision never triggers a reinstall (no TCC subject to heal)."""
+    with patch("src.aw_manager.platform.system", return_value="Linux"):
+        assert AWManager._tracker_team_identifier("/anything") is None

--- a/tests/test_aw_manager_tracker_reinstall.py
+++ b/tests/test_aw_manager_tracker_reinstall.py
@@ -17,12 +17,17 @@ from src.aw_manager import BETTERQA_TEAM_ID, AWManager
 
 def _teams(install, bundle):
     """Patch the codesign reader so the install/bundle binaries report fixed
-    team identifiers (None = ad-hoc / unsigned)."""
+    team identifiers (None = ad-hoc / unsigned).
+
+    Match on a substring rather than a leading slash so this is independent of
+    the path separator — os.path.join uses backslashes on Windows CI, which a
+    `startswith("/install/")` check would miss.
+    """
 
     def fake(binary_path):
-        if binary_path.startswith("/install/"):
+        if "install" in binary_path:
             return install
-        if binary_path.startswith("/bundle/"):
+        if "bundle" in binary_path:
             return bundle
         return None
 

--- a/tests/test_idle_tracker_health.py
+++ b/tests/test_idle_tracker_health.py
@@ -8,7 +8,7 @@ keeps seeing keystrokes. These tests pin the disagreement detection.
 """
 
 from datetime import datetime, timedelta, timezone
-from unittest.mock import MagicMock, patch
+from unittest.mock import MagicMock, call, patch
 
 from src.main import SyncCoordinator
 from src.sync.aw_client import AWBucket, AWEvent
@@ -284,25 +284,47 @@ def test_aw_unreachable_falls_through_silently(mock_send):
 
 
 @patch("src.main.send_notification")
-def test_reprompts_for_permission_when_idle_tracker_blind(mock_send):
-    """When the watchdog has flagged bf-idle-tracker as chronically blind
-    (stale across repeated restarts = missing Input Monitoring grant, which a
-    restart can't fix), the health check re-prompts the user for permission:
-    re-requests the grant, opens the Settings pane, and notifies. No
-    input_watcher is needed — the blind flag alone drives the re-prompt."""
+def test_reprompt_when_app_lacks_grant_requests_permission(mock_send):
+    """The watchdog flagged the tracker blind AND the main app itself lacks
+    Input Monitoring — the honest ask is "grant Input Monitoring", with a real
+    system prompt. The blind flag alone drives this; no input_watcher needed."""
     coord = _make_coordinator(input_watcher=None)
     coord.aw_manager.idle_tracker_blind = True
 
-    with patch("src.ui.permissions.input_monitoring_active") as req, patch(
-        "src.ui.permissions.open_input_monitoring_settings"
-    ) as open_settings:
+    with patch(
+        "src.ui.permissions.input_monitoring_active", return_value=False
+    ) as im, patch("src.ui.permissions.open_input_monitoring_settings") as open_settings:
         coord._check_idle_tracker_health()
 
-    req.assert_called_once_with(prompt=True)
+    # One status check (no prompt), then one grant request (prompt=True).
+    assert im.call_args_list == [call(), call(prompt=True)]
     open_settings.assert_called_once()
     mock_send.assert_called_once()
-    title = mock_send.call_args[0][0]
-    assert title == "BetterFlow needs Input Monitoring"
+    assert mock_send.call_args[0][0] == "BetterFlow needs Input Monitoring"
+
+
+@patch("src.main.send_notification")
+def test_reprompt_when_app_has_grant_says_refresh_not_missing(mock_send):
+    """The blind tracker's own grant is stale, but the MAIN app already holds
+    Input Monitoring. Telling the user to grant what they already granted reads
+    as broken — and live testing (2026-06-18) showed this is the common case
+    (an ad-hoc tracker whose TCC grant macOS silently denies). So: say
+    "refresh", lead with the OS-idle-clock fallback, and do NOT fire a
+    redundant system prompt for a grant the app already holds."""
+    coord = _make_coordinator(input_watcher=None)
+    coord.aw_manager.idle_tracker_blind = True
+
+    with patch(
+        "src.ui.permissions.input_monitoring_active", return_value=True
+    ) as im, patch("src.ui.permissions.open_input_monitoring_settings") as open_settings:
+        coord._check_idle_tracker_health()
+
+    # Only the status check — never a prompt=True for a grant we already have.
+    assert im.call_args_list == [call()]
+    open_settings.assert_called_once()
+    mock_send.assert_called_once()
+    assert mock_send.call_args[0][0] == "BetterFlow idle tracker needs a refresh"
+    assert "system idle clock" in mock_send.call_args[0][1]
 
 
 @patch("src.main.send_notification")
@@ -326,17 +348,19 @@ def test_no_reprompt_when_idle_tracker_not_blind(mock_send):
 @patch("src.main.send_notification")
 def test_reprompt_throttled_within_window(mock_send):
     """Repeated blind ticks collapse into a single re-prompt within the rewarn
-    window — the Settings pane must not pop on every 60s tick."""
+    window — the Settings pane must not pop on every 60s tick. Ticks 2 and 3
+    return before touching permissions at all, so even the status check runs
+    only once."""
     coord = _make_coordinator(input_watcher=None)
     coord.aw_manager.idle_tracker_blind = True
 
-    with patch("src.ui.permissions.input_monitoring_active") as req, patch(
-        "src.ui.permissions.open_input_monitoring_settings"
-    ) as open_settings:
+    with patch(
+        "src.ui.permissions.input_monitoring_active", return_value=True
+    ) as im, patch("src.ui.permissions.open_input_monitoring_settings") as open_settings:
         coord._check_idle_tracker_health()
         coord._check_idle_tracker_health()
         coord._check_idle_tracker_health()
 
-    assert req.call_count == 1
+    assert im.call_count == 1
     assert open_settings.call_count == 1
     assert mock_send.call_count == 1


### PR DESCRIPTION
## Why

Live testing on a fleet machine (2026-06-18) **disproved the assumption baked into 1.5.56** that a chronically-stale `bf-idle-tracker` means "missing Input Monitoring."

The real root cause: the persistent tracker was an **ad-hoc signed** copy left by a pre-signing build. macOS TCC grants for ad-hoc helpers are fragile — Input Monitoring shows "✓ enabled" but the kernel silently denies the HID tap, so the tracker runs **but never heartbeats** (no AFK events → false idle). Diagnostic: the AFK event's `end_age` grows 1:1 with the clock while the user is actively typing.

The build **already signs** the bundled tracker with Developer ID (Team `87NVC57J44`, stable identifier, hardened runtime). But `_get_binaries_dir` prefers the existing persistent copy and never overwrites it — so the stale ad-hoc binary (mtime months old) persisted and its broken TCC grant never healed.

This was validated end-to-end on the machine: removing the persistent copy → the app reinstalled a working, signed, self-contained tracker → a one-time re-grant restored the heartbeat (`dur` growing, `end_age` small).

## Fix #1 — auto-reinstall (`aw_manager`)

On startup, if the persistent `bf-idle-tracker` is **not** signed with our Developer ID team but the **bundled** copy is, reinstall from the bundle (`_should_reinstall_trackers` + `_tracker_team_identifier`). The app's installer reassembles the split PyInstaller layout (code in `Contents/Frameworks/…`, data symlinked into `Contents/Resources/…`) into a self-contained signed tracker. The user re-grants Input Monitoring **once** for the new *stable* identity, which then survives every future update. macOS-only; never swaps ad-hoc→ad-hoc (old bundle), so no needless churn.

## Fix #2 — honest re-prompt (`main`)

Stop asserting "missing Input Monitoring" as fact. If the main app already holds the grant, the tracker's grant is stale — say **"idle tracker needs a refresh"**, lead with the OS-idle-clock fallback (*tracking continues*), point at enable/re-toggle `bf-idle-tracker`, and **don't** fire a redundant system prompt for a grant we already hold. Only ask to "grant Input Monitoring" when the app genuinely lacks it. Softened the `aw_manager` blind warning to match.

## Tests

- Reinstall decision matrix: ad-hoc→signed reinstalls; signed→signed and ad-hoc→ad-hoc don't; foreign team replaced; `None` off-macOS.
- Two messaging branches: app-has-grant → refresh wording + no prompt; app-lacks-grant → grant ask + prompt.

Both new families **fail pre-fix** (no `BETTERQA_TEAM_ID`/`_should_reinstall_trackers`; old unconditional wording) and pass after — verified via `git stash`. Full suite: 601 passing, no new lint.

## Not in this PR

**Stable-hostname (bucket fragmentation)** is deferred — it's a separate decision. The AW tracker binaries self-determine hostname via their own `platform.node()` and accept no `--hostname` override, so pinning a stable bucket name needs either patching/rebuilding the AW binaries or setting a stable macOS HostName. Tracked separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)