### PR TITLE
fix(heartbeat): read response fields under the data envelope, not top-level

### DIFF
--- a/src/sync/sync_engine.py
+++ b/src/sync/sync_engine.py
@@ -1870,8 +1870,19 @@ class SyncEngine:
         try:
             response = self.bf.heartbeat()
 
+            # The server wraps the heartbeat payload in an envelope: the real
+            # fields live under response["data"], NOT at the top level — the same
+            # convention send_events already accounts for (it had this exact bug
+            # and unwraps with response.get("data", response)). Reading top-level
+            # here made EVERY heartbeat-driven feature a silent no-op: remote
+            # pause/deregister commands, the minimum-version check, clock-skew
+            # detection, config-change refetch, and the admin logs_requested
+            # upload all never fired. Unwrap once, with a fallback so a future
+            # un-enveloped response still works.
+            payload = response.get("data", response) if isinstance(response, dict) else {}
+
             # Handle server commands
-            commands = response.get("commands", [])
+            commands = payload.get("commands", [])
             for cmd in commands:
                 cmd_type = cmd.get("type")
                 if cmd_type == "pause":
@@ -1884,14 +1895,14 @@ class SyncEngine:
                         self._paused = True
 
             # Version compatibility check
-            min_version = response.get("minimum_agent_version")
+            min_version = payload.get("minimum_agent_version")
             if min_version and self._version_below(AGENT_VERSION, min_version):
                 logger.warning(
                     f"Agent {AGENT_VERSION} is below minimum {min_version} — update required"
                 )
 
             # Clock skew detection: compare server time with local time
-            server_time_str = response.get("server_time")
+            server_time_str = payload.get("server_time")
             if server_time_str:
                 try:
                     server_time = datetime.fromisoformat(
@@ -1910,13 +1921,13 @@ class SyncEngine:
                     logger.debug("server_time parse failed: %s", e)
 
             # Re-fetch config if server says it changed
-            if response.get("config_updated"):
+            if payload.get("config_updated"):
                 self.fetch_server_config()
 
             # Admin requested this device's logs for diagnostics. Upload the
             # tail; the server clears the flag only on success, so a failed
             # upload simply retries on the next heartbeat.
-            if response.get("logs_requested"):
+            if payload.get("logs_requested"):
                 self._upload_requested_logs()
 
         except BetterFlowAuthError as e:

--- a/tests/test_sync_engine.py
+++ b/tests/test_sync_engine.py
@@ -390,8 +390,14 @@ class TestSyncEngine:
 
     def test_heartbeat_uploads_logs_when_requested(self):
         """When the heartbeat response sets logs_requested, the agent uploads
-        the betterflow.log tail (relaunch log optional)."""
-        self.bf.heartbeat.return_value = {"logs_requested": True}
+        the betterflow.log tail (relaunch log optional).
+
+        The response MUST be the real server envelope ({"success", "data": {...}}),
+        not a top-level flag — _send_heartbeat reads response["data"]. An earlier
+        version of this test mocked {"logs_requested": True} at the top level,
+        which matched the buggy reader and so passed against code that never
+        actually uploaded (live repro: Emilian's 1.5.57 agent, 2026-06-18)."""
+        self.bf.heartbeat.return_value = {"success": True, "data": {"logs_requested": True}}
 
         def fake_tail(path, max_bytes=512 * 1024):
             return b"log-bytes" if path.name == "betterflow.log" else None
@@ -404,7 +410,7 @@ class TestSyncEngine:
 
     def test_heartbeat_does_not_upload_logs_when_not_requested(self):
         """No logs_requested flag -> no upload (the common case)."""
-        self.bf.heartbeat.return_value = {"logs_requested": False}
+        self.bf.heartbeat.return_value = {"success": True, "data": {"logs_requested": False}}
         self.engine._send_heartbeat()
         self.bf.upload_logs.assert_not_called()
 
@@ -413,11 +419,33 @@ class TestSyncEngine:
         _send_heartbeat (the re-login signal), not be swallowed by the generic
         client-error handler."""
         from src.sync.bf_client import BetterFlowAuthError
-        self.bf.heartbeat.return_value = {"logs_requested": True}
+        self.bf.heartbeat.return_value = {"success": True, "data": {"logs_requested": True}}
         self.bf.upload_logs.side_effect = BetterFlowAuthError("expired")
         with patch.object(SyncEngine, "_read_log_tail", return_value=b"log-bytes"):
             result = self.engine._send_heartbeat()
         assert isinstance(result, BetterFlowAuthError)
+
+    def test_heartbeat_unwraps_envelope_for_commands(self):
+        """Not just logs: every heartbeat-driven field lives under response["data"].
+        A 'pause' command in the enveloped response must reach pause() — proving
+        the unwrap covers remote commands (silently no-op'd before the fix), not
+        only the log upload."""
+        self.bf.heartbeat.return_value = {
+            "success": True,
+            "data": {"commands": [{"type": "pause", "reason": "admin"}]},
+        }
+        with patch.object(self.engine, "pause") as mock_pause:
+            self.engine._send_heartbeat()
+        mock_pause.assert_called_once()
+
+    def test_heartbeat_tolerates_unenveloped_response(self):
+        """Defensive: the response.get("data", response) fallback means a future
+        un-enveloped (top-level) response still works rather than silently
+        no-op'ing again."""
+        self.bf.heartbeat.return_value = {"logs_requested": True}
+        with patch.object(SyncEngine, "_read_log_tail", return_value=b"x"):
+            self.engine._send_heartbeat()
+        self.bf.upload_logs.assert_called_once()
 
     def test_get_category_db_only_returns_none_for_unmapped(self):
         """Test that _get_category only checks DB, returns None for unmapped apps."""


### PR DESCRIPTION
## The bug

`_send_heartbeat` read `commands`, `minimum_agent_version`, `server_time`, `config_updated`, and `logs_requested` at the **top level** of the heartbeat response. But the server wraps every response in `successResponse()` → `{success, message, data: {...}}`. So `response.get("logs_requested")` (and every other field) was **always `None`**, and every heartbeat-driven feature silently no-op'd:

- remote **pause / deregister** commands never reached the agent
- the minimum-version "update required" check never fired
- clock-skew detection never ran
- `config_updated` never triggered a live config refetch
- the admin **`logs_requested` upload never happened** → remote log fetch dead

`send_events` already hit this **exact** envelope bug and fixed it with `response.get("data", response)` (see its in-code comment). `_send_heartbeat` was never given the same unwrap.

## The fix

Unwrap once at the top of `_send_heartbeat` (same proven pattern, with the same fallback so a future un-enveloped response still works), and read all fields from the unwrapped payload.

## How it surfaced

Live repro: Emilian's agent on 1.5.57 had `logs_requested_at` set, kept heartbeating, but never uploaded its logs. The server's heartbeat response carried `logs_requested` under `data` the whole time — the agent just looked in the wrong place.

## Tests

The existing heartbeat tests were **phantoms** (per our test-fixture-discipline rule): they mocked `heartbeat.return_value = {"logs_requested": True}` at the **top level**, matching the buggy reader, so they passed against broken code and could never have caught this. Rewritten to use the real `{"success", "data": {...}}` envelope — 3 fail pre-fix (log upload, auth propagation, and a new **remote-pause-command** case), all pass post-fix (verified via `git stash`). Added a fallback test for the un-enveloped shape. Full suite: 603 passing, no new lint.

🤖 Generated with [Claude Code](https://claude.com/claude-code)