### PR TITLE
feat: agent health telemetry + blind-tracker notice + shutdown-race fix + bake ERROR_DSN

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -74,6 +74,10 @@ jobs:
         run: pyinstaller build.spec --clean
         env:
           TARGET_ARCH: ${{ matrix.target_arch }}
+          # Baked into _build_secrets.py by build.spec so the shipped app reports
+          # in-app errors/crashes. Without this the error reporter is a no-op.
+          BETTERFLOW_ERROR_DSN: ${{ secrets.BETTERFLOW_ERROR_DSN }}
+          BETTERFLOW_ERROR_ENDPOINT: ${{ secrets.BETTERFLOW_ERROR_ENDPOINT }}
 
       - name: List dist contents (macOS)
         if: runner.os == 'macOS'

--- a/src/aw_manager.py
+++ b/src/aw_manager.py
@@ -578,6 +578,39 @@ class AWManager:
                     return False
             return True
 
+    def stale_restart_count(self) -> int:
+        """Idle/window tracker force-restart count this session (lock-safe).
+
+        Cheap counterpart to health_snapshot() — no tracker-server I/O — for the
+        restart-loop escalation check that runs every sync cycle."""
+        with self._lifecycle_lock:
+            return self._stale_restart_count
+
+    def health_snapshot(self) -> dict:
+        """Public read-only view of tracker health for telemetry/heartbeat.
+
+        Returns the idle-tracker force-restart count plus the age (seconds) of
+        the most recent AFK and window events. A high AFK age while the window
+        age stays low is the "active but idle tracker frozen" signature the
+        backend uses to mark a device tracking_degraded.
+
+        The restart count is read under the lifecycle lock; the event ages are
+        fetched from the local tracker server (no shared mutable state) so they
+        sit outside the lock to avoid holding it across network I/O.
+        """
+        with self._lifecycle_lock:
+            stale_restarts = self._stale_restart_count
+
+        afk_age = self._get_latest_afk_event_age()
+        window_age = self._get_latest_window_event_age()
+        return {
+            "idle_tracker_stale_restarts": stale_restarts,
+            # Ints are friendlier to JSON / the backend's unsigned columns; the
+            # sub-second precision is irrelevant for a staleness signal.
+            "afk_event_age_seconds": int(afk_age) if afk_age is not None else None,
+            "window_event_age_seconds": int(window_age) if window_age is not None else None,
+        }
+
     def restart_if_needed(self) -> bool:
         """Restart crashed or stalled components. Returns True if tracker is healthy."""
         with self._lifecycle_lock:

--- a/src/main.py
+++ b/src/main.py
@@ -137,6 +137,12 @@ class SyncCoordinator:
         self.reminder_manager = reminder_manager
         self.error_reporter = error_reporter
 
+        # Let the heartbeat carry agent-health telemetry. We own the AwManager
+        # (idle-tracker restart count + AFK/window event ages) and the
+        # sync-failure counter, which the SyncEngine does not — so the provider
+        # lives here and is handed to the engine.
+        self.sync_engine.health_provider = self._build_health_telemetry
+
         self.scheduler = BackgroundScheduler()
         self._last_tick: Optional[datetime] = None
 
@@ -190,6 +196,19 @@ class SyncCoordinator:
         # _PERM_REWARN_INTERVAL while the disagreement persists.
         self._idle_tracker_warn_lock = threading.Lock()
         self._last_idle_tracker_warn_at: Optional[datetime] = None
+        # Count of "afk reported while input active" (blind-tracker) detections
+        # this session — the literal "idle but the bucket has events" case.
+        # Reported via heartbeat telemetry so the backend can flag the device.
+        # Mutated under _idle_tracker_warn_lock. _detections is cumulative (for
+        # the captured report's context); _window resets each heartbeat so the
+        # reported telemetry is "detected since last heartbeat" — a recovered
+        # tracker clears, instead of a cumulative count flagging it all session.
+        self._blind_tracker_detections = 0
+        self._blind_tracker_window = 0
+        # Forced tracker restarts past this (in one session) means the restart
+        # isn't converging (orphan tracker / missing Input Monitoring perm) —
+        # escalate via a captured report instead of looping silently.
+        self._RESTART_LOOP_ALERT_THRESHOLD = 5
 
         # macOS permission-warning throttle. Input Monitoring can be revoked
         # silently (e.g. a new build changes the code signature and macOS drops
@@ -315,10 +334,15 @@ class SyncCoordinator:
             replace_existing=True,
         )
 
-    def stop(self) -> None:
-        """Shut down the scheduler if running."""
+    def stop(self, wait: bool = False) -> None:
+        """Shut down the scheduler if running.
+
+        wait=True blocks until any in-flight _do_sync finishes — used by the
+        final app shutdown so a scheduled sync can't keep running after the
+        offline queue is closed (the 'OfflineQueue has been closed' race,
+        2026-06-17). The watchdog/30s drain cap in _do_sync bounds the wait."""
         if self.scheduler.running:
-            self.scheduler.shutdown(wait=False)
+            self.scheduler.shutdown(wait=wait)
 
     def reschedule(self, interval_seconds: int) -> None:
         """Change the sync interval on the fly."""
@@ -609,8 +633,12 @@ class SyncCoordinator:
         if afk_end > last_input - timedelta(seconds=30):
             return
 
-        # Disagreement detected. Throttled warn.
+        # Disagreement detected: the tracker submits 'afk' while the bucket has
+        # fresh input — the literal "idle but bucket has events". Count every
+        # detection (reported via telemetry) but throttle the warn+capture.
         with self._idle_tracker_warn_lock:
+            self._blind_tracker_detections += 1
+            self._blind_tracker_window += 1
             recently_warned = (
                 self._last_idle_tracker_warn_at is not None
                 and (now - self._last_idle_tracker_warn_at) < self._PERM_REWARN_INTERVAL
@@ -632,6 +660,20 @@ class SyncCoordinator:
             "bar icon → Diagnostics → Fix Permissions and grant access to "
             "bf-idle-tracker as well as BetterFlow.",
         )
+        # Surface as a (non-exception) captured report so it shows up in error
+        # tracking, not just local logs. error_reporter has its own dedup window.
+        if self.error_reporter is not None:
+            self.error_reporter.capture(
+                "Idle tracker reporting AFK while input is active (blind tracker)",
+                level="warning",
+                tags={"component": "idle-tracker"},
+                context={
+                    "detections": self._blind_tracker_detections,
+                    "last_input": last_input.isoformat(),
+                },
+                fingerprint="idle-tracker-blind",
+            )
+
         # Don't just warn — try to recover. A tracker that reports 'afk' while
         # input is flowing is blind/stuck (or an orphan is fighting it); a
         # restart re-establishes capture and reaps any orphan. Throttled by the
@@ -853,6 +895,25 @@ class SyncCoordinator:
 
             if self.aw_manager.is_managing:
                 self.aw_manager.restart_if_needed()
+                # Escalate a non-converging restart loop: repeated forced
+                # restarts mean the restart isn't fixing it (orphan tracker /
+                # missing Input Monitoring permission). Capture so it surfaces
+                # instead of looping silently; error_reporter dedup throttles.
+                try:
+                    restarts = self.aw_manager.stale_restart_count()
+                    if (
+                        restarts >= self._RESTART_LOOP_ALERT_THRESHOLD
+                        and self.error_reporter is not None
+                    ):
+                        self.error_reporter.capture(
+                            f"Idle-tracker restart loop not converging ({restarts} restarts this session)",
+                            level="warning",
+                            tags={"component": "idle-tracker"},
+                            context={"stale_restarts": restarts},
+                            fingerprint="idle-tracker-restart-loop",
+                        )
+                except Exception:
+                    logger.debug("restart-loop escalation check failed", exc_info=True)
 
             if not self.aw.is_running():
                 # is_running() already reset+retried the HTTP session, so this
@@ -973,6 +1034,31 @@ class SyncCoordinator:
             self.tray.set_state(TrayState.QUEUED, "Offline")
         else:
             self.tray.set_state(TrayState.ERROR, error_message)
+
+    def _build_health_telemetry(self) -> dict:
+        """Assemble agent-health telemetry for the heartbeat.
+
+        Combines the AwManager's tracker view (idle-tracker restart count, AFK
+        and window event ages) with our own consecutive-sync-failure counter.
+        Best-effort: any failure here is swallowed by the caller so it can never
+        block the heartbeat. Reading the int counter without a lock is fine — a
+        torn read of a single int can't happen in CPython, and a slightly stale
+        value is harmless for a telemetry signal.
+        """
+        # Read-and-reset the per-heartbeat blind-tracker window so the reported
+        # value reflects "detected since the last heartbeat" (clears on recovery).
+        with self._idle_tracker_warn_lock:
+            blind_window = self._blind_tracker_window
+            self._blind_tracker_window = 0
+        telemetry: dict = {
+            "consecutive_sync_failures": self._consecutive_sync_failures,
+            "idle_while_active_detections": blind_window,
+        }
+        try:
+            telemetry.update(self.aw_manager.health_snapshot())
+        except Exception as e:  # noqa: BLE001
+            logger.debug("aw_manager.health_snapshot failed: %s", e)
+        return telemetry
 
     def _note_sync_failure(self, reason: str, *, exc: Optional[BaseException] = None) -> None:
         """Track a hard sync failure and report once it becomes a streak.
@@ -2098,7 +2184,9 @@ class BetterFlowApp:
         # Flush idle event before stopping (otherwise idle period is lost)
         self.coordinator.flush_idle_event()
         clear_notifications()
-        self.coordinator.stop()
+        # wait=True so an in-flight scheduled sync completes BEFORE we close the
+        # offline queue below — otherwise it dies on a closed SQLite handle.
+        self.coordinator.stop(wait=True)
         self.sync_engine.shutdown()
         if self.window_watcher:
             self.window_watcher.stop()

--- a/src/sync/bf_client.py
+++ b/src/sync/bf_client.py
@@ -341,19 +341,40 @@ class BetterFlowClient(BaseApiClient):
     # Lightweight retry for heartbeat (N14): 1 retry, 5s timeout
     _HEARTBEAT_RETRY = RetryConfig(max_retries=1, base_delay=1.0, max_delay=5.0)
 
-    def heartbeat(self, agent_version: str = AGENT_VERSION) -> dict:
+    def heartbeat(
+        self,
+        agent_version: str = AGENT_VERSION,
+        health: Optional[dict] = None,
+    ) -> dict:
         """Send heartbeat to server.
 
         Uses a shorter timeout (5s) and fewer retries (1) to avoid
         blocking the sync loop when the server is slow (N14).
 
+        ``health`` carries optional agent-health telemetry (idle-tracker
+        restart count, AFK/window event ages, consecutive sync failures) so the
+        backend can mark a device tracking_degraded even while it reports
+        "Active". Only known keys are forwarded; everything else is ignored.
+
         Returns server commands (pause/deregister) and config update flag.
         """
+        data = {
+            "agent_version": agent_version,
+            "timezone": self._detect_timezone(),
+        }
+        if health:
+            for key in (
+                "idle_tracker_stale_restarts",
+                "afk_event_age_seconds",
+                "window_event_age_seconds",
+                "consecutive_sync_failures",
+                "idle_while_active_detections",
+            ):
+                if key in health:
+                    data[key] = health[key]
+
         return self._request(
-            "POST", "heartbeat", data={
-                "agent_version": agent_version,
-                "timezone": self._detect_timezone(),
-            },
+            "POST", "heartbeat", data=data,
             timeout_override=5,
             retry_config_override=self._HEARTBEAT_RETRY,
         )

--- a/src/sync/sync_engine.py
+++ b/src/sync/sync_engine.py
@@ -187,6 +187,10 @@ class SyncEngine:
         self._heartbeat_count = 0
         # Send heartbeat every 5 sync cycles (5 * 60s = 5 min default)
         self._heartbeat_interval = 5
+        # Optional callable returning agent-health telemetry to ride along with
+        # each heartbeat (set by the SyncCoordinator, which owns the AwManager
+        # and the sync-failure counter). Returning None / raising is tolerated.
+        self.health_provider: Optional[Callable[[], dict]] = None
 
         # Queue retry backoff
         self._queue_consecutive_failures = 0
@@ -1868,7 +1872,14 @@ class SyncEngine:
         a transient heartbeat failure should not surface as a user error.
         """
         try:
-            response = self.bf.heartbeat()
+            health = None
+            if self.health_provider is not None:
+                try:
+                    health = self.health_provider()
+                except Exception as e:  # noqa: BLE001
+                    # Telemetry is best-effort; never let it block the heartbeat.
+                    logger.debug("health_provider failed: %s", e)
+            response = self.bf.heartbeat(health=health)
 
             # The server wraps the heartbeat payload in an envelope: the real
             # fields live under response["data"], NOT at the top level — the same

--- a/tests/test_aw_manager_health_snapshot.py
+++ b/tests/test_aw_manager_health_snapshot.py
@@ -1,0 +1,33 @@
+"""Smoke tests for AWManager.health_snapshot — the read side of option B.
+
+health_snapshot() is what feeds the heartbeat: the idle-tracker restart count
+plus the AFK and window event ages. The "idle but bucket has events" signature
+is a high AFK age with a low window age.
+"""
+
+from src.aw_manager import AWManager
+
+
+def _manager_with(monkeypatch, *, afk_age, window_age, restarts):
+    mgr = AWManager(aw_port=5600)
+    mgr._stale_restart_count = restarts
+    monkeypatch.setattr(mgr, "_get_latest_afk_event_age", lambda: afk_age)
+    monkeypatch.setattr(mgr, "_get_latest_window_event_age", lambda: window_age)
+    return mgr
+
+
+def test_snapshot_reports_idle_frozen_signature(monkeypatch):
+    mgr = _manager_with(monkeypatch, afk_age=300.7, window_age=5.2, restarts=12)
+    snap = mgr.health_snapshot()
+    assert snap["idle_tracker_stale_restarts"] == 12
+    # Coerced to int for the backend's unsigned columns.
+    assert snap["afk_event_age_seconds"] == 300
+    assert snap["window_event_age_seconds"] == 5
+
+
+def test_snapshot_tolerates_missing_ages(monkeypatch):
+    mgr = _manager_with(monkeypatch, afk_age=None, window_age=None, restarts=0)
+    snap = mgr.health_snapshot()
+    assert snap["afk_event_age_seconds"] is None
+    assert snap["window_event_age_seconds"] is None
+    assert snap["idle_tracker_stale_restarts"] == 0

--- a/tests/test_heartbeat_health_telemetry.py
+++ b/tests/test_heartbeat_health_telemetry.py
@@ -1,0 +1,95 @@
+"""Smoke tests for agent-health telemetry riding the heartbeat (option B).
+
+The heartbeat is the channel that lets the backend mark a device
+tracking_degraded while it still reports "Active" — the Martin/Sachi
+2026-06-17 "idle but bucket has events" case. These pin that the health dict
+reaches the wire, that the payload stays backward-compatible without it, and
+that only whitelisted keys are forwarded.
+"""
+
+import json
+
+import responses
+
+from src.sync.bf_client import BetterFlowClient
+
+
+def _make_client():
+    return BetterFlowClient(
+        api_url="https://betterflow.eu/api/agent",
+        token="test-token",
+        device_id="test-device",
+    )
+
+
+def _last_heartbeat_body():
+    # responses records each call; the heartbeat is the only POST here.
+    return json.loads(responses.calls[-1].request.body)
+
+
+@responses.activate
+def test_heartbeat_forwards_health_telemetry():
+    responses.add(
+        responses.POST,
+        "https://betterflow.eu/api/agent/heartbeat",
+        json={"status": "active", "commands": []},
+        status=200,
+    )
+    client = _make_client()
+    try:
+        # "idle but bucket has events": AFK silent while window fresh.
+        client.heartbeat(health={
+            "idle_tracker_stale_restarts": 12,
+            "afk_event_age_seconds": 300,
+            "window_event_age_seconds": 5,
+            "consecutive_sync_failures": 0,
+        })
+    finally:
+        client.close()
+
+    body = _last_heartbeat_body()
+    assert body["agent_version"]  # base field still present
+    assert body["idle_tracker_stale_restarts"] == 12
+    assert body["afk_event_age_seconds"] == 300
+    assert body["window_event_age_seconds"] == 5
+    assert body["consecutive_sync_failures"] == 0
+
+
+@responses.activate
+def test_heartbeat_without_health_is_backward_compatible():
+    responses.add(
+        responses.POST,
+        "https://betterflow.eu/api/agent/heartbeat",
+        json={"status": "active"},
+        status=200,
+    )
+    client = _make_client()
+    try:
+        client.heartbeat()
+    finally:
+        client.close()
+
+    body = _last_heartbeat_body()
+    assert set(body.keys()) == {"agent_version", "timezone"}
+
+
+@responses.activate
+def test_heartbeat_drops_unknown_health_keys():
+    responses.add(
+        responses.POST,
+        "https://betterflow.eu/api/agent/heartbeat",
+        json={"status": "active"},
+        status=200,
+    )
+    client = _make_client()
+    try:
+        client.heartbeat(health={
+            "afk_event_age_seconds": 300,
+            "evil": "DROP TABLE agent_devices",  # not whitelisted
+        })
+    finally:
+        client.close()
+
+    body = _last_heartbeat_body()
+    assert body["afk_event_age_seconds"] == 300
+    assert "evil" not in body


### PR DESCRIPTION
Ships the three follow-ups to the device-health work. These surface the silent-degradation failures the error reporter can't catch (they don't throw) and turn on in-app error capture in prod.

## #1 Blind-tracker "idle while active" notice
The literal "submits idle but the bucket has events". The agent already detected "afk reported while input active" and restarted; now it also **counts** it (per-heartbeat-window counter that resets on report, so a recovered tracker clears) and **captures** it (error_reporter, deduped). Heartbeat telemetry carries `idle_while_active_detections`.

## #2 Non-exception captures (option C)
- **OfflineQueue shutdown race**: `stop(wait=True)` on final shutdown so an in-flight scheduled sync finishes before the SQLite queue closes (the `OfflineQueue has been closed` error, 2026-06-17).
- **Restart-loop escalation**: capture a non-converging idle-tracker restart loop instead of looping silently.

## #3 Bake ERROR_DSN
`build.yml` now passes `BETTERFLOW_ERROR_DSN`/`ENDPOINT` secrets into `build.spec` so shipped builds report in-app errors. Capture was a silent no-op in prod (only 1 manual smoke-test row ever). The `BETTERFLOW_ERROR_DSN` repo secret is set.

Complementary to the recent blind-tracker recovery work (#58/#59): that recovers, this reports. Telemetry rides the existing ~5-min heartbeat (no new network calls). Full suite green (154). Pairs with betterflow backend PR for the `idle_while_active` reason.

Note: builds on merge to main but does NOT roll out to users until a `v*` release tag.

🤖 Generated with [Claude Code](https://claude.com/claude-code)