### PR TITLE
fix(telemetry): audit follow-ups for PR #61

### DIFF
--- a/src/error_reporter.py
+++ b/src/error_reporter.py
@@ -31,6 +31,7 @@ import threading
 import time
 import traceback
 from typing import Callable, Optional
+from urllib.parse import urlparse
 
 import requests
 
@@ -187,6 +188,18 @@ class ErrorReporter:
 
     def _post(self, payload: dict) -> None:
         """POST the report. Swallows all transport errors (logged, never raised)."""
+        # The DSN rides in `Authorization: Bearer ...` on every report, so refuse
+        # to send it over plaintext. The default endpoint is HTTPS, but
+        # BETTERFLOW_ERROR_ENDPOINT (env or baked) could point elsewhere; mirror
+        # bf_client's token-exchange guard (HTTPS, or loopback for dev).
+        parsed = urlparse(self._endpoint)
+        if parsed.scheme != "https" and parsed.hostname not in ("localhost", "127.0.0.1"):
+            logger.warning(
+                "Error report skipped — endpoint is not HTTPS (won't send the DSN "
+                "in clear): %s",
+                self._endpoint,
+            )
+            return
         try:
             resp = requests.post(
                 self._endpoint,

--- a/src/main.py
+++ b/src/main.py
@@ -21,7 +21,7 @@ from apscheduler.triggers.interval import IntervalTrigger
 try:
     from .__init__ import __version__
     from .auth import KeychainManager, LoginManager
-    from .aw_manager import AWManager
+    from .aw_manager import IDLE_BLIND_RESTART_THRESHOLD, AWManager
     from .config import Config, setup_logging
     from . import error_reporter
     from .browser_tracker import start_browser_tracker
@@ -46,7 +46,7 @@ try:
 except ImportError:
     from src import __version__
     from auth import KeychainManager, LoginManager
-    from aw_manager import AWManager
+    from aw_manager import IDLE_BLIND_RESTART_THRESHOLD, AWManager
     from config import Config, setup_logging
     import error_reporter
     from browser_tracker import start_browser_tracker
@@ -207,8 +207,13 @@ class SyncCoordinator:
         self._blind_tracker_window = 0
         # Forced tracker restarts past this (in one session) means the restart
         # isn't converging (orphan tracker / missing Input Monitoring perm) —
-        # escalate via a captured report instead of looping silently.
-        self._RESTART_LOOP_ALERT_THRESHOLD = 5
+        # escalate via a captured report instead of looping silently. Reuse the
+        # aw_manager threshold (the same point at which it flags the tracker
+        # blind) so the two can't drift out of sync.
+        self._RESTART_LOOP_ALERT_THRESHOLD = IDLE_BLIND_RESTART_THRESHOLD
+        # Latch so the escalation captures once per session, not on every sync
+        # cycle once the (monotonic) restart count crosses the threshold.
+        self._restart_loop_escalated = False
 
         # macOS permission-warning throttle. Input Monitoring can be revoked
         # silently (e.g. a new build changes the code signature and macOS drops
@@ -669,7 +674,12 @@ class SyncCoordinator:
                 tags={"component": "idle-tracker"},
                 context={
                     "detections": self._blind_tracker_detections,
-                    "last_input": last_input.isoformat(),
+                    # Age, not the wall-clock timestamp: a precise "last typed at
+                    # HH:MM:SS" anchors a high-resolution activity timeline for the
+                    # end user in the ops error-ingest, which the privacy model
+                    # (hashed titles, domain-only URLs) is meant to avoid. Age
+                    # conveys "input was N seconds ago" without that anchor.
+                    "last_input_age_seconds": int((now - last_input).total_seconds()),
                 },
                 fingerprint="idle-tracker-blind",
             )
@@ -903,6 +913,7 @@ class SyncCoordinator:
                     restarts = self.aw_manager.stale_restart_count()
                     if (
                         restarts >= self._RESTART_LOOP_ALERT_THRESHOLD
+                        and not self._restart_loop_escalated
                         and self.error_reporter is not None
                     ):
                         self.error_reporter.capture(
@@ -912,8 +923,15 @@ class SyncCoordinator:
                             context={"stale_restarts": restarts},
                             fingerprint="idle-tracker-restart-loop",
                         )
+                        # Once per session — the restart count is monotonic, so
+                        # without this latch the capture would re-fire every cycle
+                        # (only the reporter's dedup window kept it from flooding).
+                        self._restart_loop_escalated = True
                 except Exception:
-                    logger.debug("restart-loop escalation check failed", exc_info=True)
+                    # WARNING, not debug: if the reporter itself is broken (bad
+                    # DSN, etc.) the escalation we built to surface this loop must
+                    # not fail silently every cycle.
+                    logger.warning("restart-loop escalation check failed", exc_info=True)
 
             if not self.aw.is_running():
                 # is_running() already reset+retried the HTTP session, so this

--- a/src/sync/bf_client.py
+++ b/src/sync/bf_client.py
@@ -362,7 +362,7 @@ class BetterFlowClient(BaseApiClient):
             "agent_version": agent_version,
             "timezone": self._detect_timezone(),
         }
-        if health:
+        if health is not None:
             for key in (
                 "idle_tracker_stale_restarts",
                 "afk_event_age_seconds",

--- a/tests/test_error_reporter.py
+++ b/tests/test_error_reporter.py
@@ -40,6 +40,30 @@ class TestDisabled:
         assert from_env(release="1.0.0").enabled is False
 
 
+class TestEndpointScheme:
+    """The DSN rides in `Authorization: Bearer ...` on every report, so a
+    non-HTTPS endpoint must be refused (it would send the token in clear).
+    Loopback is exempt for local dev. Pre-fix, _post sent over any scheme."""
+
+    def test_http_endpoint_is_refused(self) -> None:
+        r = _reporter(endpoint="http://bot.example/notify/error")
+        with patch("src.error_reporter.requests.post") as post:
+            r.capture("boom", block=True)
+            post.assert_not_called()
+
+    def test_loopback_http_is_allowed_for_dev(self) -> None:
+        r = _reporter(endpoint="http://127.0.0.1:8080/notify/error")
+        with patch("src.error_reporter.requests.post") as post:
+            r.capture("boom", block=True)
+            post.assert_called_once()
+
+    def test_https_endpoint_posts(self) -> None:
+        r = _reporter(endpoint="https://bot.example/notify/error")
+        with patch("src.error_reporter.requests.post") as post:
+            r.capture("boom", block=True)
+            post.assert_called_once()
+
+
 class TestPayload:
     def test_builds_expected_payload_and_auth(self) -> None:
         r = _reporter(

--- a/tests/test_idle_tracker_health.py
+++ b/tests/test_idle_tracker_health.py
@@ -117,6 +117,28 @@ def test_warns_when_input_recent_but_afk_bucket_says_afk(mock_send):
 
 
 @patch("src.main.send_notification")
+def test_blind_capture_uses_coarse_input_age_not_timestamp(mock_send):
+    """The blind-tracker error report (sent to ops ingest) must NOT carry a
+    precise last-input wall-clock timestamp — that anchors a high-resolution
+    activity timeline for the end user. It should send a coarse age in seconds."""
+    input_watcher = MagicMock()
+    input_watcher.get_last_input_at.return_value = datetime.now(timezone.utc) - timedelta(seconds=30)
+
+    coord = _make_coordinator(
+        input_watcher=input_watcher,
+        latest_afk_event=_afk_event("afk", age_seconds=3600, duration=300),
+    )
+    coord.error_reporter = MagicMock()
+
+    coord._check_idle_tracker_health()
+
+    coord.error_reporter.capture.assert_called_once()
+    ctx = coord.error_reporter.capture.call_args.kwargs["context"]
+    assert "last_input" not in ctx, "must not leak the precise wall-clock timestamp"
+    assert isinstance(ctx.get("last_input_age_seconds"), int)
+
+
+@patch("src.main.send_notification")
 def test_silent_when_afk_bucket_says_not_afk(mock_send):
     """The tracker agrees with the input watcher — no warning."""
     input_watcher = MagicMock()


### PR DESCRIPTION
## Context

After PR #61 (agent health telemetry + blind-tracker notice + shutdown-race fix + baked ERROR_DSN) landed on `main`, I ran it through three senior reviews (correctness/concurrency, SOLID/error-handling, security/privacy).

**Verdict: no critical issues.** The shutdown-race fix is correct, the blind-tracker notice correctly shares the throttle lock with the existing re-prompt (no double-fire), the tests aren't phantoms, and the **PR #60 heartbeat-envelope fix is intact** (telemetry rides the heartbeat *request*; the response is still unwrapped via `payload = response.get("data", response)`). The `ERROR_DSN` baking is clean — injected from a GitHub secret into a gitignored `_build_secrets.py`, never committed, and it's a low-sensitivity project-scoped ingest token.

This PR addresses the real findings the reviews converged on.

## Security / privacy
- **`error_reporter._post` now refuses a non-HTTPS endpoint** (loopback exempt for dev). The DSN rides in `Authorization: Bearer …` on every report; an HTTP override via `BETTERFLOW_ERROR_ENDPOINT` would have sent it in clear. Mirrors `bf_client`'s existing token-exchange guard.
- **Blind-tracker capture no longer sends a precise timestamp.** It sent `last_input.isoformat()` — an exact "employee last typed at HH:MM:SS" that anchors a high-resolution activity timeline in the ops ingest. Replaced with `last_input_age_seconds` (same signal, no anchor), consistent with the privacy model.

## Maintainability / correctness
- `main.py` now reuses `IDLE_BLIND_RESTART_THRESHOLD` instead of redefining `5` locally, so the escalation threshold can't drift from where `aw_manager` flags the tracker blind.
- The restart-loop escalation **latches** (fires once/session). The restart count is monotonic, so without the latch only the reporter's dedup kept it from re-capturing every cycle. Its `except` now logs at **WARNING** — a broken reporter must not silently swallow the escalation meant to surface the loop.
- `bf_client` heartbeat: `if health is not None` (was truthiness) — explicit guard against a future empty-dict regression.

## Tests
HTTPS-guard (http refused / loopback allowed / https posts) and the coarse-age blind capture. Both fail pre-fix — the pre-fix run literally leaks the `last_input` ISO timestamp in the assertion output — and pass after. Full suite **612 green**, no new lint.

## Not changed (flag for you)
Now that error reporting is live, confirm the privacy policy discloses that crash reports carry `user_email`/`user_name` (pre-existing code, but #61 activates it).

🤖 Generated with [Claude Code](https://claude.com/claude-code)