### PR TITLE
fix(diagnostics): report log-upload failures to ops (Windows wedge blind spot)

### DIFF
--- a/src/main.py
+++ b/src/main.py
@@ -142,6 +142,9 @@ class SyncCoordinator:
         # sync-failure counter, which the SyncEngine does not — so the provider
         # lives here and is handed to the engine.
         self.sync_engine.health_provider = self._build_health_telemetry
+        # So a failed logs_requested upload surfaces to the ops ingest (it can't
+        # surface via the log itself — that's the file we couldn't fetch).
+        self.sync_engine.error_reporter = self.error_reporter
 
         self.scheduler = BackgroundScheduler()
         self._last_tick: Optional[datetime] = None

--- a/src/sync/sync_engine.py
+++ b/src/sync/sync_engine.py
@@ -191,6 +191,14 @@ class SyncEngine:
         # each heartbeat (set by the SyncCoordinator, which owns the AwManager
         # and the sync-failure counter). Returning None / raising is tolerated.
         self.health_provider: Optional[Callable[[], dict]] = None
+        # Optional error reporter (set by the SyncCoordinator) so a FAILED
+        # logs_requested upload is visible remotely. The whole point of the
+        # remote log fetch is to diagnose a sick agent — but if the upload
+        # itself fails (unreadable log, POST error) the only record is the local
+        # log we can't fetch. Reporting the failure here (a separate ops-ingest
+        # channel) breaks that circular blindness. This is exactly why Windows
+        # wedges were undiagnosable. None / errors tolerated.
+        self.error_reporter = None
 
         # Queue retry backoff
         self._queue_consecutive_failures = 0
@@ -1973,6 +1981,7 @@ class SyncEngine:
                 "logs_requested but betterflow.log is empty/unreadable — "
                 "skipping this cycle (will retry next heartbeat)"
             )
+            self._report_upload_failure("betterflow.log empty/unreadable")
             return
         relaunch_tail = self._read_log_tail(log_dir / "self-update-relaunch.log")
         try:
@@ -1985,6 +1994,26 @@ class SyncEngine:
             raise  # let _send_heartbeat surface re-login
         except BetterFlowClientError as e:
             logger.debug("Log upload failed (will retry next heartbeat): %s", e)
+            self._report_upload_failure(f"upload POST failed: {e}")
+
+    def _report_upload_failure(self, reason: str) -> None:
+        """Surface a logs_requested upload failure to the ops ingest. We can't
+        rely on the local log to carry this — it IS the file we failed to send,
+        and the admin requested it precisely because the agent is sick. The
+        error_reporter is a separate channel that keeps working when the log
+        fetch doesn't, so a wedged/failing agent stays diagnosable. The
+        reporter's own dedup window keeps this from flooding on each retry."""
+        if self.error_reporter is None:
+            return
+        try:
+            self.error_reporter.capture(
+                f"Agent log upload failed: {reason}",
+                level="warning",
+                tags={"component": "log-upload"},
+                fingerprint="log-upload-failed",
+            )
+        except Exception:
+            logger.debug("log-upload-failure report failed", exc_info=True)
 
     @staticmethod
     def _read_log_tail(path, max_bytes: int = 512 * 1024) -> Optional[bytes]:

--- a/tests/test_sync_engine.py
+++ b/tests/test_sync_engine.py
@@ -447,6 +447,41 @@ class TestSyncEngine:
             self.engine._send_heartbeat()
         self.bf.upload_logs.assert_called_once()
 
+    def test_unreadable_log_reports_upload_failure_to_ops(self):
+        """The remote log fetch exists to diagnose a sick agent — so if the
+        upload fails (here: the log is unreadable, the suspected Windows wedge
+        case), the failure must surface via the error_reporter (a channel that
+        works when the log fetch doesn't). Otherwise the failure is only in the
+        local log we couldn't fetch — circular blindness."""
+        self.bf.heartbeat.return_value = {"success": True, "data": {"logs_requested": True}}
+        self.engine.error_reporter = MagicMock()
+        with patch.object(SyncEngine, "_read_log_tail", return_value=None):
+            self.engine._send_heartbeat()
+        self.bf.upload_logs.assert_not_called()
+        self.engine.error_reporter.capture.assert_called_once()
+        assert "unreadable" in self.engine.error_reporter.capture.call_args[0][0]
+
+    def test_failed_upload_post_reports_to_ops(self):
+        """A POST failure on the upload is likewise surfaced to ops, not just
+        logged locally where we can't reach it."""
+        from src.sync.bf_client import BetterFlowClientError
+        self.bf.heartbeat.return_value = {"success": True, "data": {"logs_requested": True}}
+        self.bf.upload_logs.side_effect = BetterFlowClientError("500")
+        self.engine.error_reporter = MagicMock()
+        with patch.object(SyncEngine, "_read_log_tail", return_value=b"log-bytes"):
+            self.engine._send_heartbeat()
+        self.engine.error_reporter.capture.assert_called_once()
+        assert "POST failed" in self.engine.error_reporter.capture.call_args[0][0]
+
+    def test_successful_upload_does_not_report_failure(self):
+        """The happy path must NOT fire a failure report."""
+        self.bf.heartbeat.return_value = {"success": True, "data": {"logs_requested": True}}
+        self.engine.error_reporter = MagicMock()
+        with patch.object(SyncEngine, "_read_log_tail", return_value=b"log-bytes"):
+            self.engine._send_heartbeat()
+        self.bf.upload_logs.assert_called_once()
+        self.engine.error_reporter.capture.assert_not_called()
+
     def test_get_category_db_only_returns_none_for_unmapped(self):
         """Test that _get_category only checks DB, returns None for unmapped apps."""
         self.queue.get_all_categories.return_value = {}


### PR DESCRIPTION
## Why

The remote log fetch (`betterflow_request_agent_logs` / `betterflow_get_agent_logs`) exists to diagnose a sick agent. But when the upload itself fails — the log is unreadable, or the POST errors — the **only** record is the local `betterflow.log`, which is exactly the file we couldn't fetch. **Circular blindness:** the wedge that breaks an agent's tracking also breaks the log upload, so we never learn why.

Seen live today: **Sachi's win32 agent on 1.5.58** (which has the heartbeat-envelope fix) heartbeats fine — `last_seen` stays fresh — but **never uploads its log** despite the flag being armed across many heartbeats. The liveness heartbeat already routes through `_send_heartbeat` and honors `logs_requested`, so the upload *is* attempted; it's failing silently and invisibly. This is why Martin can never get logs from the Windows users who need it most.

## Fix

Surface the upload failure through the **error_reporter** — a separate ops-ingest channel that keeps working when the log fetch doesn't. The `SyncEngine` gets an optional `error_reporter`, injected by the `SyncCoordinator` the same way as `health_provider`. `_upload_requested_logs` now reports both failure modes (unreadable log, POST failure) with a stable fingerprint; the reporter's own dedup window keeps it from flooding on each heartbeat retry.

So a wedged/failing agent now tells us **why** remotely instead of going dark.

## Tests

`unreadable-log` and `failed-POST` both fire a `capture`; the happy path does not. Both report tests fail pre-fix (no capture) and pass after — verified via `git stash`. Full suite 615 green, no new lint.

## Note

This makes the failure *observable*; it does not yet fix whatever specific Windows condition makes Sachi's upload fail (we'll see the reason in ops once she's on this build). Likely candidates once we can see it: a `RotatingFileHandler` read contention or a path issue — but no more guessing in the dark.

🤖 Generated with [Claude Code](https://claude.com/claude-code)