### PR TITLE
fix(logs): write UTF-8 + normalize tail so Windows log uploads store

### DIFF
--- a/src/config.py
+++ b/src/config.py
@@ -697,8 +697,13 @@ def setup_logging(debug: bool = False) -> None:
         root.removeHandler(h)
         h.close()
 
+    # encoding="utf-8" is REQUIRED, not cosmetic: without it the handler writes
+    # in the platform locale encoding, which on Windows is cp1252. A cp1252 byte
+    # like \x97 then breaks the remote log upload — the server's INSERT into the
+    # utf8 agent_log_uploads.content column fails with MySQL 1366 "Incorrect
+    # string value", so Windows logs silently never landed (Sachi, 2026-06-18).
     file_handler = RotatingFileHandler(
-        log_file, maxBytes=5 * 1024 * 1024, backupCount=3,
+        log_file, maxBytes=5 * 1024 * 1024, backupCount=3, encoding="utf-8",
     )
     file_handler.setFormatter(formatter)
     root.addHandler(file_handler)

--- a/src/sync/sync_engine.py
+++ b/src/sync/sync_engine.py
@@ -2017,19 +2017,29 @@ class SyncEngine:
 
     @staticmethod
     def _read_log_tail(path, max_bytes: int = 512 * 1024) -> Optional[bytes]:
-        """Return up to the last ``max_bytes`` of a log file (matching the
-        server's per-file tail cap). Returns ``None`` if it can't be read
-        (OSError) and ``b""`` for an empty file — callers treat both as "no
-        content" (``if not tail``), so don't rely on None-vs-b"" to distinguish
-        unreadable from empty."""
+        """Return up to the last ``max_bytes`` of a log file as VALID UTF-8
+        (matching the server's per-file tail cap). Returns ``None`` if it can't
+        be read (OSError) and ``b""`` for an empty file — callers treat both as
+        "no content" (``if not tail``), so don't rely on None-vs-b"" to
+        distinguish unreadable from empty.
+
+        The bytes are normalized to valid UTF-8 (invalid sequences replaced)
+        before returning. Older Windows logs were written in cp1252, so a tail
+        could carry bytes like \\x97 that make the server's INSERT into the utf8
+        `content` column fail with MySQL 1366 — silently dropping the upload.
+        New logs are UTF-8 (handler `encoding`), but logs already on disk and
+        any stray bytes still need this guard so the upload always stores.
+        """
         try:
             size = path.stat().st_size
             with open(path, "rb") as f:
                 if size > max_bytes:
                     f.seek(size - max_bytes)
-                return f.read()
+                raw = f.read()
         except OSError:
             return None
+        # Re-encode so the result is always valid UTF-8 the server can store.
+        return raw.decode("utf-8", errors="replace").encode("utf-8")
 
     @staticmethod
     def _version_below(current: str, minimum: str) -> bool:

--- a/tests/test_sync_engine.py
+++ b/tests/test_sync_engine.py
@@ -482,6 +482,28 @@ class TestSyncEngine:
         self.bf.upload_logs.assert_called_once()
         self.engine.error_reporter.capture.assert_not_called()
 
+    def test_read_log_tail_normalizes_invalid_utf8(self):
+        """A cp1252 byte from a Windows log (e.g. \\x97) must come back as VALID
+        UTF-8. Otherwise the server's INSERT into the utf8 content column fails
+        with MySQL 1366 'Incorrect string value' and the upload is silently
+        dropped — the real reason Windows logs never landed (Sachi, 2026-06-18)."""
+        import os
+        import tempfile
+        from pathlib import Path
+
+        fd, p = tempfile.mkstemp()
+        os.write(fd, b"hello \x97 world")  # \x97 is not valid UTF-8
+        os.close(fd)
+        try:
+            tail = SyncEngine._read_log_tail(Path(p))
+        finally:
+            os.unlink(p)
+
+        assert tail is not None
+        tail.decode("utf-8")  # must not raise — the whole point of the fix
+        assert b"\x97" not in tail
+        assert b"hello" in tail and b"world" in tail
+
     def test_get_category_db_only_returns_none_for_unmapped(self):
         """Test that _get_category only checks DB, returns None for unmapped apps."""
         self.queue.get_all_categories.return_value = {}


### PR DESCRIPTION
## Root cause (found in the ops error stream tonight)

Sachi's win32 agent **did** upload its log — the **server's INSERT failed**:
```
QueryException: SQLSTATE[HY000]: 1366 Incorrect string value: '\x97 onli...'
for column 'content' ... insert into agent_log_uploads (device_id=16, ...)
```
The `RotatingFileHandler` had **no `encoding=`**, so on Windows the log is written in **cp1252**. A byte like `\x97` can't go into the server's **utf8** `agent_log_uploads.content` column, so the row is silently dropped. **That's why no Windows log ever landed** — not the agent, the server insert choking on non-UTF-8 log bytes.

## Fix (two guards)

- **`config.py`** — `RotatingFileHandler(encoding="utf-8")`. Logs are UTF-8 on every platform going forward (Windows stops writing cp1252).
- **`sync_engine._read_log_tail`** — normalize the tail to valid UTF-8 (`decode("utf-8", errors="replace").encode("utf-8")`) before upload, so logs **already on disk** in cp1252 (and any stray bytes) still store instead of 1366-dropping.

## Complementary server fix (separate, Martin / internal-tool2)

Make `agent_log_uploads.content` a **BLOB/binary** — logs are arbitrary bytes, not text. That's the robust backstop; this PR makes the agent send storable content regardless.

## Test

A `\x97` byte in the tail comes back as valid UTF-8. Fails pre-fix (`UnicodeDecodeError` on `0x97`), passes after. Full suite 616 green, no new lint.

🤖 Generated with [Claude Code](https://claude.com/claude-code)