### PR TITLE
fix(tls): bundle certifi + resolve CA bundle so a missing cacert can't black out all sync

### DIFF
--- a/build.spec
+++ b/build.spec
@@ -73,6 +73,19 @@ from PyInstaller.utils.hooks import collect_data_files, collect_dynamic_libs
 tcl_tk_datas = collect_data_files("tkinter")
 tcl_tk_binaries = collect_dynamic_libs("_tkinter")
 
+# Certifi CA bundle. requests verifies TLS against certifi.where(), which in a
+# frozen build resolves to _internal/certifi/cacert.pem. If that file isn't
+# collected (PyInstaller hook didn't run) — or an antivirus clips it from the
+# install — EVERY HTTPS sync dies with "Could not find a suitable TLS CA
+# certificate bundle" and tracking silently stops uploading (reported on
+# Windows 2026-06-18: ~1h40m total sync blackout, recovered only on restart).
+# Collect it explicitly so the canonical copy is deterministic, AND ship a
+# redundant copy under resources/ so a single clipped file doesn't take down
+# all sync — sync/http_client._resolve_ca_bundle() falls back to it at runtime.
+import certifi as _certifi
+certifi_datas = collect_data_files("certifi")
+certifi_fallback = [(str(Path(_certifi.where())), "resources")]
+
 # Platform-specific hidden imports (tray backend, keyring backend, native libs).
 if is_mac:
     platform_hiddenimports = [
@@ -115,6 +128,8 @@ hiddenimports = [
     "PIL._tkinter_finder",
     "apscheduler.triggers.interval",
     "apscheduler.schedulers.background",
+    "certifi",  # TLS CA bundle for requests; data file collected via certifi_datas
+
     # Our modules (absolute imports from src/)
     "config",
     "sync",
@@ -153,7 +168,7 @@ a = Analysis(
     [str(src_dir / "entry_point.py")],
     pathex=[str(root_dir), str(src_dir)],
     binaries=aw_binaries + tcl_tk_binaries,
-    datas=datas + tcl_tk_datas,
+    datas=datas + tcl_tk_datas + certifi_datas + certifi_fallback,
     hiddenimports=hiddenimports,
     hookspath=[],
     hooksconfig={},

--- a/src/__init__.py
+++ b/src/__init__.py
@@ -1,4 +1,4 @@
 """BetterFlow - ActivityWatch to BetterFlow sync companion app."""
 
-__version__ = "1.5.61"
+__version__ = "1.5.62"
 __author__ = "BetterQA"

--- a/src/error_reporter.py
+++ b/src/error_reporter.py
@@ -35,6 +35,11 @@ from urllib.parse import urlparse
 
 import requests
 
+try:
+    from .sync.http_client import resolve_ca_bundle
+except ImportError:  # PyInstaller bundle (src/ is import root)
+    from sync.http_client import resolve_ca_bundle
+
 logger = logging.getLogger(__name__)
 
 # betterqa-bot error ingest. Overridable for staging/self-host; the production
@@ -206,6 +211,7 @@ class ErrorReporter:
                 json=payload,
                 headers={"Authorization": f"Bearer {self._dsn}"},
                 timeout=self._timeout,
+                verify=resolve_ca_bundle(),
             )
             if resp.status_code >= 400:
                 logger.warning(

--- a/src/self_updater.py
+++ b/src/self_updater.py
@@ -34,9 +34,11 @@ import requests
 
 try:
     from .config import Config
+    from .sync.http_client import resolve_ca_bundle
     from .update_checker import _version_tuple
 except ImportError:  # PyInstaller bundle (src/ is import root)
     from config import Config
+    from sync.http_client import resolve_ca_bundle
     from update_checker import _version_tuple
 
 logger = logging.getLogger(__name__)
@@ -111,7 +113,13 @@ def _download_to_file(
     Caps the body at ``_MAX_DOWNLOAD_BYTES`` so a misconfigured redirect or a
     malicious release asset can't fill the disk (our installers are ~60-80 MB).
     """
-    with requests.get(download_url, stream=True, timeout=120) as resp:
+    # Pin TLS verification to a resolved CA bundle: a missing/clipped certifi
+    # copy must not also break the self-updater, or the app can't download its
+    # own fix. resolve_ca_bundle() returns None only when no bundle exists, in
+    # which case verify=None falls back to the requests default (logged loudly).
+    with requests.get(
+        download_url, stream=True, timeout=120, verify=resolve_ca_bundle()
+    ) as resp:
         resp.raise_for_status()
         try:
             # `or 0` guards an empty-string header; the except guards garbage.

--- a/src/sync/http_client.py
+++ b/src/sync/http_client.py
@@ -5,11 +5,13 @@ import json
 import logging
 import os
 import socket
+import sys
 import threading
 import time
 from typing import Optional
 from urllib.parse import urlparse
 
+import certifi
 import requests
 
 try:
@@ -22,9 +24,105 @@ __all__ = [
     "BaseApiClient",
     "BetterFlowClientError",
     "BetterFlowAuthError",
+    "resolve_ca_bundle",
 ]
 
 logger = logging.getLogger(__name__)
+
+
+# ---- TLS CA bundle resolution -----------------------------------------------
+#
+# requests verifies HTTPS against certifi.where(), which in a PyInstaller build
+# resolves to _internal/certifi/cacert.pem. If that file is missing — not
+# collected into the bundle, or clipped by antivirus after install — every
+# HTTPS request raises OSError("Could not find a suitable TLS CA certificate
+# bundle, invalid path: ...cacert.pem") and ALL sync silently fails until the
+# app is restarted (reported on Windows 2026-06-18: ~1h40m sync blackout while
+# the user kept working, surfacing as false idle on the dashboard). build.spec
+# now ships a redundant copy under resources/; this resolver picks whichever CA
+# bundle actually exists and logs loudly if none do, instead of letting requests
+# fail the same way on every call.
+_CACHED_CA_BUNDLE: Optional[str] = None
+_CA_BUNDLE_RESOLVED = False
+
+
+def _bundled_cacert_fallback() -> Optional[str]:
+    """Path to the redundant cacert.pem shipped under resources/, if present."""
+    if getattr(sys, "frozen", False):
+        meipass = getattr(sys, "_MEIPASS", None)
+        if meipass:
+            return os.path.join(meipass, "resources", "cacert.pem")
+    # Dev run: src/sync/http_client.py -> src/ -> repo root -> resources/
+    return os.path.join(
+        os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__)))),
+        "resources",
+        "cacert.pem",
+    )
+
+
+def resolve_ca_bundle() -> Optional[str]:
+    """Return a usable CA bundle path for TLS verification, or None.
+
+    Resolution order (first existing file wins):
+      1. REQUESTS_CA_BUNDLE / SSL_CERT_FILE env overrides (operator escape hatch)
+      2. certifi.where() — the bundle requests would use by default
+      3. resources/cacert.pem — the redundant copy build.spec ships
+
+    Cached after the first call. Returns None only when no bundle exists at all,
+    after logging an error — we never silently disable verification (that would
+    trade a sync outage for a MITM risk); callers fall back to the requests
+    default, which now fails loudly with a logged cause instead of silently.
+
+    Called from several threads (sync scheduler, update-checker, error-report
+    daemon). Intentionally lock-free: resolution is idempotent — every caller
+    inspects the same filesystem/env and arrives at the identical result, and
+    the string/bool assignments are atomic under the GIL, so a first-use race
+    only recomputes the same value, never tears or returns a wrong one.
+    """
+    global _CACHED_CA_BUNDLE, _CA_BUNDLE_RESOLVED
+    if _CA_BUNDLE_RESOLVED:
+        return _CACHED_CA_BUNDLE
+
+    candidates = []
+    for env in ("REQUESTS_CA_BUNDLE", "SSL_CERT_FILE"):
+        val = os.environ.get(env)
+        if val:
+            candidates.append(val)
+    try:
+        candidates.append(certifi.where())
+    except Exception as e:  # pragma: no cover - certifi.where() is pure pathjoin
+        logger.warning("certifi.where() raised while resolving CA bundle: %s", e)
+    fallback = _bundled_cacert_fallback()
+    if fallback:
+        candidates.append(fallback)
+
+    for path in candidates:
+        try:
+            if path and os.path.isfile(path):
+                _CACHED_CA_BUNDLE = path
+                _CA_BUNDLE_RESOLVED = True
+                return path
+        except OSError:
+            continue
+
+    logger.error(
+        "No TLS CA bundle found (checked: %s). HTTPS verification will fail; "
+        "reinstall the app to restore the certifi bundle.",
+        ", ".join(p for p in candidates if p) or "none",
+    )
+    _CACHED_CA_BUNDLE = None
+    _CA_BUNDLE_RESOLVED = True
+    return None
+
+
+def _new_verified_session() -> requests.Session:
+    """Create a requests.Session with TLS verification pinned to a resolved CA
+    bundle, so a missing/clipped certifi copy can't silently break all sync."""
+    session = requests.Session()
+    ca_bundle = resolve_ca_bundle()
+    if ca_bundle:
+        session.verify = ca_bundle
+    return session
 
 
 class BetterFlowClientError(Exception):
@@ -110,7 +208,7 @@ class BaseApiClient:
         self.compress = compress
         self.timeout = timeout
         self.retry_config = retry_config or self.DEFAULT_RETRY_CONFIG
-        self._session = session or requests.Session()
+        self._session = session or _new_verified_session()
         self._owns_session = session is None  # Track if we created the session
         self._session_lock = threading.Lock()
         # Global rate-limit backoff. When the server returns 429, ALL outbound
@@ -363,7 +461,7 @@ class BaseApiClient:
         with self._session_lock:
             old = self._session
             was_owned = self._owns_session
-            self._session = requests.Session()
+            self._session = _new_verified_session()
             self._owns_session = True
         # Close outside lock to avoid holding it during I/O.
         # Only close the old session if we owned it - don't destroy

--- a/src/update_checker.py
+++ b/src/update_checker.py
@@ -7,6 +7,11 @@ from typing import Callable, Optional
 
 import requests
 
+try:
+    from .sync.http_client import resolve_ca_bundle
+except ImportError:  # PyInstaller bundle (src/ is import root)
+    from sync.http_client import resolve_ca_bundle
+
 logger = logging.getLogger(__name__)
 
 GITHUB_REPO = "Better-Quality-Assurance/betterflow-sync"
@@ -132,6 +137,7 @@ def check_for_update(
                     f"{RELEASES_URL}/latest",
                     headers={"Accept": "application/vnd.github+json"},
                     timeout=10,
+                    verify=resolve_ca_bundle(),
                 )
                 if resp.status_code != 200:
                     logger.debug(f"Update check: GitHub API returned {resp.status_code}")
@@ -148,6 +154,7 @@ def check_for_update(
                     headers={"Accept": "application/vnd.github+json"},
                     params={"per_page": 20},
                     timeout=10,
+                    verify=resolve_ca_bundle(),
                 )
                 if resp.status_code != 200:
                     logger.debug(f"Update check: GitHub API returned {resp.status_code}")

--- a/tests/test_ca_bundle.py
+++ b/tests/test_ca_bundle.py
@@ -1,0 +1,76 @@
+"""Tests for TLS CA bundle resolution (sync.http_client.resolve_ca_bundle).
+
+Regression cover for the Windows 2026-06-18 sync blackout: the bundled certifi
+cacert.pem went missing and every HTTPS request failed with "Could not find a
+suitable TLS CA certificate bundle", silently stopping all sync. The resolver
+must fall back to an env override or the shipped redundant copy, and must log
+loudly (not raise) when nothing exists.
+"""
+
+import os
+
+import pytest
+
+import src.sync.http_client as http_client
+from src.sync.http_client import resolve_ca_bundle
+
+
+@pytest.fixture(autouse=True)
+def _reset_cache():
+    """resolve_ca_bundle() memoizes — clear it around every test."""
+    http_client._CACHED_CA_BUNDLE = None
+    http_client._CA_BUNDLE_RESOLVED = False
+    yield
+    http_client._CACHED_CA_BUNDLE = None
+    http_client._CA_BUNDLE_RESOLVED = False
+
+
+def test_uses_certifi_when_present():
+    """Default path: certifi's bundle exists, so it is returned."""
+    path = resolve_ca_bundle()
+    assert path is not None
+    assert os.path.isfile(path)
+
+
+def test_env_override_takes_precedence(tmp_path, monkeypatch):
+    """REQUESTS_CA_BUNDLE wins over certifi (operator escape hatch)."""
+    custom = tmp_path / "custom-ca.pem"
+    custom.write_text("-----BEGIN CERTIFICATE-----\n")
+    monkeypatch.setenv("REQUESTS_CA_BUNDLE", str(custom))
+    assert resolve_ca_bundle() == str(custom)
+
+
+def test_falls_back_when_certifi_missing(tmp_path, monkeypatch):
+    """If certifi.where() points at a missing file, fall back to the shipped
+    redundant copy rather than handing requests a dead path."""
+    fallback = tmp_path / "cacert.pem"
+    fallback.write_text("-----BEGIN CERTIFICATE-----\n")
+    monkeypatch.delenv("REQUESTS_CA_BUNDLE", raising=False)
+    monkeypatch.delenv("SSL_CERT_FILE", raising=False)
+    monkeypatch.setattr(http_client.certifi, "where", lambda: str(tmp_path / "gone.pem"))
+    monkeypatch.setattr(http_client, "_bundled_cacert_fallback", lambda: str(fallback))
+    assert resolve_ca_bundle() == str(fallback)
+
+
+def test_returns_none_and_logs_when_nothing_exists(tmp_path, monkeypatch, caplog):
+    """No bundle anywhere → None (never raises), and an error is logged so the
+    failure is visible instead of silently breaking every request."""
+    monkeypatch.delenv("REQUESTS_CA_BUNDLE", raising=False)
+    monkeypatch.delenv("SSL_CERT_FILE", raising=False)
+    monkeypatch.setattr(http_client.certifi, "where", lambda: str(tmp_path / "gone.pem"))
+    monkeypatch.setattr(
+        http_client, "_bundled_cacert_fallback", lambda: str(tmp_path / "also-gone.pem")
+    )
+    with caplog.at_level("ERROR"):
+        assert resolve_ca_bundle() is None
+    assert any("No TLS CA bundle found" in r.message for r in caplog.records)
+
+
+def test_new_session_pins_verify(monkeypatch):
+    """_new_verified_session sets session.verify to the resolved bundle."""
+    monkeypatch.setattr(http_client, "resolve_ca_bundle", lambda: "/tmp/some-ca.pem")
+    session = http_client._new_verified_session()
+    try:
+        assert session.verify == "/tmp/some-ca.pem"
+    finally:
+        session.close()


### PR DESCRIPTION
## Problem

Windows agents could lose **every** HTTPS sync with:

```
Sync error: Could not find a suitable TLS CA certificate bundle,
invalid path: C:\Users\...\BetterFlow\_internal\certifi\cacert.pem
```

when the bundled certifi `cacert.pem` was absent or clipped by antivirus. `requests` then failed identically on every call with **no fallback**, silently stopping all uploads until an app restart.

**Field report (2026-06-18):** ~1h40m total sync blackout while the user kept working — surfaced on the dashboard as false idle (~3h "idle" while windows were active). Recovered only when the app was restarted, flushing 470 queued events at once.

## Fix (defense in depth)

- **`build.spec`** — collect certifi explicitly (`collect_data_files`) so the bundled copy is deterministic (not reliant on the hook firing), add `certifi` to hiddenimports, and ship a **redundant copy under `resources/`** so a single clipped file can't take down sync.
- **`http_client.resolve_ca_bundle()`** — pick the first CA bundle that actually exists: `REQUESTS_CA_BUNDLE`/`SSL_CERT_FILE` → `certifi.where()` → `resources/cacert.pem`. Cached; **logs loudly** if none found. Never disables verification (returns `None` → requests default), so we don't trade a sync outage for a MITM risk.
- Pin `session.verify` in both session-creation paths (`__init__`, `reset_session`), and apply the same resolver to the other HTTPS callers — `self_updater` (so a clipped cert can't block the self-healing download), `update_checker`, `error_reporter`.

## Tests

- `tests/test_ca_bundle.py` — resolution order, env override precedence, fallback when certifi is missing, `None`+loud-log when nothing exists, and session pinning.
- Full suite: **628 passed**.

## Notes

- Bumps version **1.5.61 → 1.5.62**.
- Fixes the TLS blackout only. The separate chronic AFK-watcher hang (the other half of the 2026-06-18 reports) is tracked independently.
- On release: the download-page version reference is a separate repo and still needs its own bump + deploy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)