### PR TITLE
ci(release): publish -beta/-rc tags as prereleases for the in-app beta channel

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -266,7 +266,15 @@ jobs:
             artifacts/BetterFlow-Windows.zip
             artifacts/BetterFlow-Windows-Setup.exe
             artifacts/BetterFlow-linux-x86_64.AppImage
-          draft: true
+          # Channel-aware publishing, keyed off the '-' in the tag name:
+          #   v1.5.62        (stable)  -> draft, NOT prerelease  (manual publish
+          #                              gates the all-users / `stable` rollout)
+          #   v1.5.62-beta.1 (beta/rc) -> published prerelease    (delivered to
+          #                              the in-app `beta`/`canary` channels for
+          #                              the dev team; never seen by `stable`)
+          # See update_checker._matches_channel for the consuming logic.
+          prerelease: ${{ contains(github.ref_name, '-') }}
+          draft: ${{ !contains(github.ref_name, '-') }}
           generate_release_notes: true
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Lets the dev team validate builds in-app before a stable rollout, using the update channels the app already supports (`stable`/`beta`/`canary` + tray switcher + `auto_install_updates`).

The release job hardcoded `draft: true` and never set `prerelease`, so every beta needed a manual GitHub-UI toggle. Now it keys off the tag name:

| Tag | Result | Who gets it |
|-----|--------|-------------|
| `v1.5.62` (stable) | draft, not prerelease | nobody until manually published, then all `stable` users |
| `v1.5.62-beta.1` (`-beta`/`-rc`) | **published prerelease** | in-app `beta` + `canary` channels (dev team); never `stable` |

Consumed by `update_checker._matches_channel`. No app-code change needed — the channel system already exists.

🤖 Generated with [Claude Code](https://claude.com/claude-code)