### PR TITLE
fix(idle): synthesize not-afk on the uploaded stream when bf-idle-tracker freezes

### DIFF
--- a/src/__init__.py
+++ b/src/__init__.py
@@ -1,4 +1,4 @@
 """BetterFlow - ActivityWatch to BetterFlow sync companion app."""
 
-__version__ = "1.5.62"
+__version__ = "1.5.63"
 __author__ = "BetterQA"

--- a/src/idle_manager.py
+++ b/src/idle_manager.py
@@ -1,7 +1,6 @@
 """Idle detection: pause/resume sync based on AFK status."""
 
 import logging
-import sys
 import threading
 from datetime import datetime, timedelta, timezone
 from typing import Callable, Optional
@@ -286,50 +285,11 @@ class IdleManager:
         macOS: HIDIdleTime via ioreg. Windows: GetLastInputInfo via ctypes —
         this is Windows' safety net against a frozen bf-idle-tracker (Windows
         has no in-process input watcher), giving it the same real-activity
-        signal macOS gets. Returns None on Linux / on any error.
-        """
-        if sys.platform == "darwin":
-            try:
-                import subprocess as _sp
-                out = _sp.check_output(
-                    ["ioreg", "-c", "IOHIDSystem", "-d", "4"],
-                    timeout=5,
-                    text=True,
-                )
-                for line in out.splitlines():
-                    if "HIDIdleTime" in line and "=" in line:
-                        val = line.split("=")[-1].strip()
-                        try:
-                            return int(val) / 1_000_000_000
-                        except ValueError:
-                            logger.debug(f"_get_system_idle_seconds: unexpected HIDIdleTime value {val!r}")
-                            return None
-            except Exception as e:
-                logger.debug(f"_get_system_idle_seconds failed: {e}")
-            return None
-
-        if sys.platform == "win32":
-            try:
-                import ctypes
-
-                class _LASTINPUTINFO(ctypes.Structure):
-                    _fields_ = [("cbSize", ctypes.c_uint), ("dwTime", ctypes.c_uint)]
-
-                info = _LASTINPUTINFO()
-                info.cbSize = ctypes.sizeof(info)
-                if not ctypes.windll.user32.GetLastInputInfo(ctypes.byref(info)):
-                    return None
-                # Both GetTickCount and dwTime are 32-bit ms tick counts; mask
-                # the difference to 32 bits so it stays correct across the
-                # ~49.7-day GetTickCount wraparound. Pin restype to unsigned so
-                # the value is explicit (the mask makes the result correct
-                # either way, but this avoids a signed-vs-unsigned footgun).
-                ctypes.windll.kernel32.GetTickCount.restype = ctypes.c_uint32
-                tick = ctypes.windll.kernel32.GetTickCount()
-                elapsed_ms = (tick - info.dwTime) & 0xFFFFFFFF
-                return elapsed_ms / 1000.0
-            except Exception as e:
-                logger.debug(f"_get_system_idle_seconds (win) failed: {e}")
-            return None
-
-        return None
+        signal macOS gets. Returns None on Linux / on any error. Implementation
+        is shared with SyncEngine via sync.os_idle (single source of the
+        platform syscalls)."""
+        try:
+            from .sync.os_idle import get_system_idle_seconds
+        except ImportError:
+            from sync.os_idle import get_system_idle_seconds
+        return get_system_idle_seconds()

--- a/src/sync/os_idle.py
+++ b/src/sync/os_idle.py
@@ -1,0 +1,75 @@
+"""OS-level idle clock — seconds since the last real keyboard/mouse input.
+
+This reads the operating system's own input-idle timer, independent of the
+external bf-idle-tracker (a separate process / TCC subject that can freeze or go
+blind). Two consumers rely on it as the safety net when bf-idle-tracker can't be
+trusted:
+
+  * IdleManager — the LOCAL pause decision (don't pause an active user).
+  * SyncEngine  — synthesizing a not-afk span for the UPLOADED stream so the
+    server (which bills active-vs-idle from that stream) doesn't count a worked
+    span as idle while the tracker is frozen.
+
+Shared here so the platform syscalls live in exactly one place.
+"""
+
+import logging
+import sys
+from typing import Optional
+
+logger = logging.getLogger(__name__)
+
+
+def get_system_idle_seconds() -> Optional[float]:
+    """OS-level idle duration (seconds since last keyboard/mouse input).
+
+    macOS: HIDIdleTime via ioreg. Windows: GetLastInputInfo via ctypes — this is
+    Windows' safety net against a frozen bf-idle-tracker (Windows has no
+    in-process input watcher), giving it the same real-activity signal macOS
+    gets. Returns None on Linux / on any error.
+    """
+    if sys.platform == "darwin":
+        try:
+            import subprocess as _sp
+            out = _sp.check_output(
+                ["ioreg", "-c", "IOHIDSystem", "-d", "4"],
+                timeout=5,
+                text=True,
+            )
+            for line in out.splitlines():
+                if "HIDIdleTime" in line and "=" in line:
+                    val = line.split("=")[-1].strip()
+                    try:
+                        return int(val) / 1_000_000_000
+                    except ValueError:
+                        logger.debug(f"get_system_idle_seconds: unexpected HIDIdleTime value {val!r}")
+                        return None
+        except Exception as e:
+            logger.debug(f"get_system_idle_seconds failed: {e}")
+        return None
+
+    if sys.platform == "win32":
+        try:
+            import ctypes
+
+            class _LASTINPUTINFO(ctypes.Structure):
+                _fields_ = [("cbSize", ctypes.c_uint), ("dwTime", ctypes.c_uint)]
+
+            info = _LASTINPUTINFO()
+            info.cbSize = ctypes.sizeof(info)
+            if not ctypes.windll.user32.GetLastInputInfo(ctypes.byref(info)):
+                return None
+            # Both GetTickCount and dwTime are 32-bit ms tick counts; mask the
+            # difference to 32 bits so it stays correct across the ~49.7-day
+            # GetTickCount wraparound. Pin restype to unsigned so the value is
+            # explicit (the mask makes the result correct either way, but this
+            # avoids a signed-vs-unsigned footgun).
+            ctypes.windll.kernel32.GetTickCount.restype = ctypes.c_uint32
+            tick = ctypes.windll.kernel32.GetTickCount()
+            elapsed_ms = (tick - info.dwTime) & 0xFFFFFFFF
+            return elapsed_ms / 1000.0
+        except Exception as e:
+            logger.debug(f"get_system_idle_seconds (win) failed: {e}")
+        return None
+
+    return None

--- a/src/sync/sync_engine.py
+++ b/src/sync/sync_engine.py
@@ -31,6 +31,7 @@ try:
     from .activity_analyzer import ActivityAnalyzer, EngagementThresholds
     from .daily_time_tracker import DailyTimeTracker
     from .call_detector import CallDetector, CallEvent
+    from .os_idle import get_system_idle_seconds
 except ImportError:
     from browser_tracker import is_browser_app
     from config import Config
@@ -40,6 +41,7 @@ except ImportError:
     from sync.activity_analyzer import ActivityAnalyzer, EngagementThresholds
     from sync.daily_time_tracker import DailyTimeTracker
     from sync.call_detector import CallDetector, CallEvent
+    from sync.os_idle import get_system_idle_seconds
 
 logger = logging.getLogger(__name__)
 
@@ -58,6 +60,14 @@ def _is_window_like(bucket_type: str) -> bool:
 def _is_afk_like(bucket_type: str) -> bool:
     """AFK/idle buckets that drive the active-vs-idle decision."""
     return bucket_type in (BUCKET_TYPE_AFK, BUCKET_TYPE_AFK_ALT)
+
+
+# Seconds the latest AFK event may lag "now" before the tracker is presumed
+# frozen. A healthy bf-idle-tracker heartbeats its current event continuously,
+# so its end-time tracks now; a larger gap means it hung/went blind and its last
+# event must not be trusted as the live idle state. Mirrors IdleManager's
+# _afk_staleness_grace and aw_manager's STALE_THRESHOLD (all 120s).
+_AFK_STALENESS_GRACE = 120.0
 
 
 @dataclass
@@ -520,6 +530,16 @@ class SyncEngine:
                 stats.buckets_synced += 1
             except AWClientError as e:
                 stats.errors.append(f"Failed to sync bucket {bucket.id}: {e}")
+
+        # If bf-idle-tracker has frozen but the OS idle clock shows the user kept
+        # working, upload a synthetic not-afk span. The server bills active-vs-idle
+        # from the AFK stream, so without this a frozen tracker's worked span is
+        # billed idle ("Active time not advancing" fleet alert) — the gap #53/#56
+        # left open on the upload side (their OS-idle fallback only governs the
+        # LOCAL pause decision, never the uploaded stream).
+        synth_afk = self._synthesize_for_stale_afk(afk_buckets)
+        if synth_afk:
+            all_events.append(synth_afk)
 
         # Flush any ongoing call at sync boundary
         if self._call_detector:
@@ -1706,6 +1726,99 @@ class SyncEngine:
         if project:
             result["project_id"] = project["id"]
         return result
+
+    def _synthesize_active_afk_event(
+        self, latest_afk, afk_bucket_id: str, now: Optional[datetime] = None
+    ) -> Optional[dict]:
+        """Emit a synthetic ``not-afk`` span when bf-idle-tracker has frozen but
+        the OS idle clock shows the user kept working.
+
+        The server bills active-vs-idle from the uploaded AFK stream
+        (see ``_transform_window_event_with_timeout``). A frozen tracker stops
+        emitting fresh not-afk events, so the worked span has no AFK coverage and
+        the server counts it as idle — the "Active time not advancing while the
+        user works" fleet alert. #53/#56 added an OS-idle-clock fallback, but only
+        in IdleManager's LOCAL pause decision; it never reaches the uploaded
+        stream, so server-side active time still freezes. This closes that loop:
+        when the latest AFK event is stale AND the OS idle clock proves recent
+        input, we upload a not-afk span covering [freeze point, last input].
+
+        Conservative by construction — returns None and fabricates nothing when:
+          * there is no AFK event to extend from,
+          * the tracker is fresh (latest event still ~covers now),
+          * the OS idle clock is unavailable (Linux / ioreg failure), or
+          * the OS clock says the user is genuinely idle, or the last input
+            predates the freeze point (no active span to claim).
+
+        The id is keyed on the freeze point, so while the tracker stays stuck the
+        same id is re-sent with a growing duration and the server upserts (patches
+        in place) rather than accumulating overlapping spans — the same heartbeat-
+        extend contract real AW events rely on.
+        """
+        if latest_afk is None:
+            return None
+        if now is None:
+            now = datetime.now(timezone.utc)
+        try:
+            freeze_end = latest_afk.timestamp + timedelta(seconds=latest_afk.duration)
+        except (TypeError, AttributeError):
+            return None
+
+        if (now - freeze_end).total_seconds() <= _AFK_STALENESS_GRACE:
+            return None  # tracker still heartbeating — not frozen
+
+        system_idle = self._get_system_idle_seconds()
+        if system_idle is None or system_idle >= _AFK_STALENESS_GRACE:
+            # Can't confirm activity, or the OS clock agrees the user is idle.
+            return None
+
+        last_input = now - timedelta(seconds=system_idle)
+        duration = (last_input - freeze_end).total_seconds()
+        if duration <= 0:
+            return None  # last input predates the freeze — nothing active to claim
+
+        synth_id = f"synth-active_{self._hostname}_{int(freeze_end.timestamp())}"
+        result: dict = {
+            "id": synth_id,
+            "timestamp": freeze_end.isoformat(),
+            "duration": round(duration, 2),
+            "bucket_id": afk_bucket_id,
+            "bucket_type": BUCKET_TYPE_AFK,
+            "data": {"status": "not-afk", "synthetic": True},
+        }
+        with self._state_lock:
+            project = self._current_project
+        if project:
+            result["project_id"] = project["id"]
+        return result
+
+    @staticmethod
+    def _get_system_idle_seconds() -> Optional[float]:
+        """OS idle clock (seconds since last input), or None. Delegates to the
+        shared implementation also used by IdleManager."""
+        return get_system_idle_seconds()
+
+    def _synthesize_for_stale_afk(
+        self, afk_buckets: list, now: Optional[datetime] = None
+    ) -> Optional[dict]:
+        """Cycle-level wrapper around ``_synthesize_active_afk_event``: gathers
+        the latest AFK event and the target bucket, then synthesizes a not-afk
+        span if the tracker is frozen while the user is active. Returns None when
+        there is nothing to synthesize.
+        """
+        if not afk_buckets:
+            return None
+        try:
+            latest = self.aw.get_latest_afk_event()
+        except AWClientError:
+            return None
+        # Attach to the BetterFlow-owned AFK bucket so the server folds the span
+        # into the same AFK stream it bills from; fall back to the first bucket.
+        bucket_id = next(
+            (b.id for b in afk_buckets if "bf-idle-tracker" in b.id),
+            afk_buckets[0].id,
+        )
+        return self._synthesize_active_afk_event(latest, bucket_id, now=now)
 
     def _send_events(self, events: list[dict], stats: SyncStats) -> None:
         """Send events to BetterFlow or queue if offline."""

--- a/tests/test_sync_engine_synth_afk.py
+++ b/tests/test_sync_engine_synth_afk.py
@@ -1,0 +1,165 @@
+"""Synthesizing a not-afk span when the idle tracker has frozen.
+
+The SERVER decides active-vs-idle from the uploaded AFK stream
+(sync_engine.py: "active-vs-idle is decided SERVER-SIDE from the AFK stream").
+When bf-idle-tracker freezes, the agent uploads NO fresh not-afk events, so the
+server bills the worked span as idle — the recurring "Active time not advancing
+while the user works" fleet alert (Razvan, 2026-06-19: ~2.9h of a clicking/typing
+user billed idle while his AFK age read 37,159s).
+
+#53/#56 added an OS-idle-clock fallback, but only inside idle_manager's LOCAL
+pause decision — it never injects a not-afk event into the uploaded stream, so
+server-side active time still freezes. These tests cover the missing piece: when
+the AFK event is stale AND the OS idle clock shows the user was active since the
+freeze, the engine emits a synthetic not-afk span so the server counts it active.
+"""
+
+from datetime import datetime, timedelta, timezone
+from unittest.mock import Mock
+
+from src.config import Config
+from src.sync.activity_analyzer import ActivityAnalyzer
+from src.sync.aw_client import BUCKET_TYPE_AFK, AWEvent
+from src.sync.daily_time_tracker import DailyTimeTracker
+from src.sync.sync_engine import SyncEngine
+
+
+def _make_engine():
+    engine = SyncEngine(
+        aw=Mock(),
+        bf=Mock(),
+        queue=Mock(),
+        config=Config(),
+        activity_analyzer=Mock(spec=ActivityAnalyzer),
+        time_tracker=Mock(spec=DailyTimeTracker),
+    )
+    return engine
+
+
+def _afk(start: datetime, dur: float, status: str = "afk") -> AWEvent:
+    return AWEvent(id=0, timestamp=start, duration=dur, data={"status": status})
+
+
+NOW = datetime(2026, 6, 19, 12, 0, 0, tzinfo=timezone.utc)
+
+
+def test_synthesizes_notafk_when_tracker_frozen_and_user_active():
+    """Stale AFK (froze 1h ago) + OS clock says active 5s ago -> not-afk span
+    covering [freeze point, last input], so the server stops billing it idle."""
+    engine = _make_engine()
+    engine._get_system_idle_seconds = lambda: 5.0  # user active 5s ago
+    # Tracker froze at 11:00 (event ended), now is 12:00 -> 3600s stale.
+    frozen = _afk(NOW - timedelta(seconds=3660), 60, "afk")  # ends 11:00:00
+
+    ev = engine._synthesize_active_afk_event(frozen, "aw-watcher-afk_host", now=NOW)
+
+    assert ev is not None, "must emit a not-afk span to cover the worked gap"
+    assert ev["data"]["status"] == "not-afk"
+    assert ev["bucket_type"] == BUCKET_TYPE_AFK
+    assert ev["bucket_id"] == "aw-watcher-afk_host"
+    # Span: from the freeze point (11:00:00) to the last real input (now-5s).
+    assert ev["timestamp"] == (NOW - timedelta(seconds=3600)).isoformat()
+    assert round(ev["duration"]) == 3595  # 3600s gap minus the trailing 5s idle
+
+
+def test_no_synth_when_tracker_fresh():
+    """A live tracker heartbeats; a recent AFK event is not stale -> nothing."""
+    engine = _make_engine()
+    engine._get_system_idle_seconds = lambda: 1.0
+    fresh = _afk(NOW - timedelta(seconds=30), 20, "afk")  # ends 30s ago, < grace
+
+    assert engine._synthesize_active_afk_event(fresh, "b", now=NOW) is None
+
+
+def test_no_synth_when_os_clock_says_idle():
+    """Tracker stale but the OS idle clock confirms the user is genuinely idle
+    -> never fabricate activity."""
+    engine = _make_engine()
+    engine._get_system_idle_seconds = lambda: 4000.0  # idle well past grace
+    frozen = _afk(NOW - timedelta(seconds=3660), 60, "afk")
+
+    assert engine._synthesize_active_afk_event(frozen, "b", now=NOW) is None
+
+
+def test_no_synth_when_os_clock_unavailable():
+    """No OS idle clock (Linux / ioreg failure) -> can't confirm activity, so
+    don't synthesize (conservative; never invent billable time)."""
+    engine = _make_engine()
+    engine._get_system_idle_seconds = lambda: None
+    frozen = _afk(NOW - timedelta(seconds=3660), 60, "afk")
+
+    assert engine._synthesize_active_afk_event(frozen, "b", now=NOW) is None
+
+
+def test_no_synth_when_no_activity_after_freeze_point():
+    """The last input predates the freeze point (user idle through the whole
+    stale span, tracker just lagged) -> nothing to claim as active."""
+    engine = _make_engine()
+    # Froze 100s ago but last input was 200s ago -> last_input < freeze end.
+    engine._get_system_idle_seconds = lambda: 200.0
+    frozen = _afk(NOW - timedelta(seconds=160), 60, "afk")  # ends 100s ago
+
+    assert engine._synthesize_active_afk_event(frozen, "b", now=NOW) is None
+
+
+def test_no_synth_when_no_afk_event_at_all():
+    """No AFK stream to extend from -> conservative no-op."""
+    engine = _make_engine()
+    engine._get_system_idle_seconds = lambda: 5.0
+
+    assert engine._synthesize_active_afk_event(None, "b", now=NOW) is None
+
+
+def _bucket(bucket_id: str):
+    b = Mock()
+    b.id = bucket_id
+    return b
+
+
+def test_gather_synthesizes_for_betterflow_afk_bucket():
+    """The cycle-level gather pulls the latest AFK event + the bf-idle-tracker
+    bucket id and produces the not-afk span the server bills from."""
+    engine = _make_engine()
+    engine._get_system_idle_seconds = lambda: 5.0
+    engine.aw.get_latest_afk_event.return_value = _afk(
+        NOW - timedelta(seconds=3660), 60, "afk"
+    )
+    buckets = [_bucket("aw-watcher-afk_host"), _bucket("bf-idle-tracker_host")]
+
+    ev = engine._synthesize_for_stale_afk(buckets, now=NOW)
+
+    assert ev is not None
+    assert ev["data"]["status"] == "not-afk"
+    assert ev["bucket_id"] == "bf-idle-tracker_host", "prefer the BetterFlow bucket"
+
+
+def test_gather_returns_none_without_afk_buckets():
+    engine = _make_engine()
+    engine._get_system_idle_seconds = lambda: 5.0
+    assert engine._synthesize_for_stale_afk([], now=NOW) is None
+
+
+def test_engine_exposes_real_os_idle_clock():
+    """Production wiring: SyncEngine must have a real OS-idle-clock method (not
+    only the monkeypatched test stub) returning seconds or None — otherwise the
+    synthesizer can never fire on a real machine."""
+    engine = _make_engine()
+    result = engine._get_system_idle_seconds()
+    assert result is None or isinstance(result, (int, float))
+
+
+def test_synth_id_is_stable_across_cycles_so_server_patches_in_place():
+    """While the tracker stays frozen at the same point, the synthetic event's
+    id must stay constant so the server upserts (patches the growing duration)
+    instead of accumulating overlapping not-afk spans."""
+    engine = _make_engine()
+    engine._get_system_idle_seconds = lambda: 5.0
+    frozen = _afk(NOW - timedelta(seconds=3660), 60, "afk")  # freeze point fixed
+
+    first = engine._synthesize_active_afk_event(frozen, "b", now=NOW)
+    later = engine._synthesize_active_afk_event(
+        frozen, "b", now=NOW + timedelta(seconds=600)
+    )
+
+    assert first["id"] == later["id"], "stable id keyed on the freeze point"
+    assert later["duration"] > first["duration"], "duration grows as freeze persists"


### PR DESCRIPTION
## Problem

The fleet kept firing "Active time not advancing while the user works" alerts on the latest build (1.5.61) — ~15 darwin users on 2026-06-19, restart counts not converging (22–36). It's real billed-hours loss, not noise:

**Razvan (user 40), 2026-06-19:** one category bucket read **130s active / 10,455s idle (~2.9h)** with **102 clicks + 4 keystrokes** in that span — billed idle while demonstrably working. His day showed 3.64h instead of ~6.5h. AFK age at the time: 37,159s.

## Root cause

The server decides active-vs-idle from the **uploaded AFK stream** (`sync_engine.py`: *"active-vs-idle is decided SERVER-SIDE from the AFK stream"*). When `bf-idle-tracker` freezes, the agent uploads **no fresh not-afk events**, so the worked span has no AFK coverage and the server bills it idle.

#53/#56 added an OS-idle-clock fallback (HIDIdleTime / GetLastInputInfo), but **only inside `IdleManager`'s local pause decision** — it keeps the tray green and stops sync backing off, yet never injects a not-afk event into the uploaded stream. So the agent locally *knows* (via HIDIdleTime) the user is active but never tells the server. Two independent layers; #53/#56 patched one.

## Fix

Close the loop on the upload side:

- `SyncEngine._synthesize_active_afk_event()` — when the latest AFK event is stale (>120s grace) **and** the OS idle clock proves recent input, emit a synthetic `not-afk` span `[freeze point → last input]`. Id is keyed on the freeze point, so a persisting stall re-sends the same id with a growing duration and the server upserts (patches) rather than accumulating overlapping spans — the same heartbeat-extend contract real AW events use.
- Conservative by construction: fabricates nothing when there's no AFK event, the tracker is fresh, the OS clock is unavailable, the user is genuinely idle, or the last input predates the freeze point.
- `_synthesize_for_stale_afk()` gathers the latest AFK event + the bf-idle-tracker bucket and wires into `sync()` after the AFK bucket loop, attaching the span to the BetterFlow bucket so the server folds it into the AFK stream it bills from.
- `src/sync/os_idle.py` — extracted the HIDIdleTime/GetLastInputInfo syscalls to one shared module; `IdleManager` and `SyncEngine` both delegate (DRY).

## Tests

`tests/test_sync_engine_synth_afk.py` — 10 tests covering the synthesis span, the stable id (server patches in place), and every conservative no-op. Watched them fail RED first (no synthesis path existed → stale-AFK + active-user produced no not-afk event = the bug), GREEN after. Full suite **638 passed**, lint clean.

## Not addressed (follow-up)

*Why* `bf-idle-tracker` keeps freezing on macOS and restarts don't converge — likely a denied/stale Input-Monitoring TCC grant on the tracker subject, or the binary hanging. This fix makes active-time correct **regardless** of why the tracker froze; the convergence problem itself still warrants a separate fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
