### PR TITLE
fix(telemetry): idle-tracker-only restart count + blind flag on heartbeat

### DIFF
--- a/src/aw_manager.py
+++ b/src/aw_manager.py
@@ -341,7 +341,15 @@ class AWManager:
         self._using_external = False
         # Components intentionally disabled for this app session.
         self._disabled_components: set[str] = set()
+        # Any-tracker force-restart count (window OR idle) — drives the
+        # cross-tracker restart-loop escalation check. NOT a per-tracker figure;
+        # use _idle_stale_restart_count for the idle-specific telemetry.
         self._stale_restart_count: int = 0
+        # bf-idle-tracker-only force-restart count this session. Reported as
+        # idle_tracker_stale_restarts so the "Active time not advancing (N
+        # restarts)" fleet alert reflects idle-tracker churn alone, not a flapping
+        # window tracker bleeding into the figure.
+        self._idle_stale_restart_count: int = 0
         # Consecutive bf-idle-tracker stale-restarts that didn't take; once it
         # crosses IDLE_BLIND_RESTART_THRESHOLD the tracker is treated as blind
         # (missing Input Monitoring) — restarts back off and the app re-prompts.
@@ -594,17 +602,26 @@ class AWManager:
         age stays low is the "active but idle tracker frozen" signature the
         backend uses to mark a device tracking_degraded.
 
-        The restart count is read under the lifecycle lock; the event ages are
+        ``idle_tracker_blind`` lets the backend distinguish a transient restart
+        from a chronically blind tracker (a denied Input Monitoring grant a
+        restart can't fix) so the alert can tell the user to grant permission
+        rather than wait it out.
+
+        The counters/flag are read under the lifecycle lock; the event ages are
         fetched from the local tracker server (no shared mutable state) so they
         sit outside the lock to avoid holding it across network I/O.
         """
         with self._lifecycle_lock:
-            stale_restarts = self._stale_restart_count
+            idle_restarts = self._idle_stale_restart_count
+            blind = self._idle_tracker_blind
 
         afk_age = self._get_latest_afk_event_age()
         window_age = self._get_latest_window_event_age()
         return {
-            "idle_tracker_stale_restarts": stale_restarts,
+            # idle-tracker-only — window-tracker restarts are excluded so this
+            # figure isn't inflated by an unrelated flapping window watcher.
+            "idle_tracker_stale_restarts": idle_restarts,
+            "idle_tracker_blind": blind,
             # Ints are friendlier to JSON / the backend's unsigned columns; the
             # sub-second precision is irrelevant for a staleness signal.
             "afk_event_age_seconds": int(afk_age) if afk_age is not None else None,
@@ -717,6 +734,7 @@ class AWManager:
                     )
                 else:
                     self._stale_restart_count += 1
+                    self._idle_stale_restart_count += 1
                     self._idle_consecutive_stale += 1
                     self._idle_last_restart_mono = now_mono
                     logger.warning(

--- a/src/sync/bf_client.py
+++ b/src/sync/bf_client.py
@@ -365,6 +365,7 @@ class BetterFlowClient(BaseApiClient):
         if health is not None:
             for key in (
                 "idle_tracker_stale_restarts",
+                "idle_tracker_blind",
                 "afk_event_age_seconds",
                 "window_event_age_seconds",
                 "consecutive_sync_failures",

--- a/tests/test_aw_manager_health_snapshot.py
+++ b/tests/test_aw_manager_health_snapshot.py
@@ -10,7 +10,7 @@ from src.aw_manager import AWManager
 
 def _manager_with(monkeypatch, *, afk_age, window_age, restarts):
     mgr = AWManager(aw_port=5600)
-    mgr._stale_restart_count = restarts
+    mgr._idle_stale_restart_count = restarts
     monkeypatch.setattr(mgr, "_get_latest_afk_event_age", lambda: afk_age)
     monkeypatch.setattr(mgr, "_get_latest_window_event_age", lambda: window_age)
     return mgr
@@ -31,3 +31,37 @@ def test_snapshot_tolerates_missing_ages(monkeypatch):
     assert snap["afk_event_age_seconds"] is None
     assert snap["window_event_age_seconds"] is None
     assert snap["idle_tracker_stale_restarts"] == 0
+
+
+def test_idle_restart_count_excludes_window_tracker_restarts(monkeypatch):
+    """idle_tracker_stale_restarts must count ONLY bf-idle-tracker restarts.
+
+    Regression: it was sourced from the shared _stale_restart_count, which the
+    window-tracker stale path also bumps — so a flapping window tracker inflated
+    the idle figure and the "Active time not advancing (N tracker restarts)" fleet
+    alert misattributed window churn to the idle tracker, the exact thing it's
+    meant to diagnose.
+    """
+    mgr = _manager_with(monkeypatch, afk_age=300.0, window_age=5.0, restarts=2)
+    mgr._stale_restart_count = 30  # heavy window-tracker churn this session
+
+    snap = mgr.health_snapshot()
+
+    assert snap["idle_tracker_stale_restarts"] == 2, "idle-only, not window+idle"
+
+
+def test_snapshot_exposes_blind_flag(monkeypatch):
+    """The backend/alert needs to tell a transient restart apart from a
+    chronically blind tracker (missing Input Monitoring → tell the user to grant
+    it, vs. wait it out)."""
+    mgr = _manager_with(monkeypatch, afk_age=4000.0, window_age=3.0, restarts=5)
+    mgr._idle_tracker_blind = True
+
+    snap = mgr.health_snapshot()
+
+    assert snap["idle_tracker_blind"] is True
+
+
+def test_snapshot_blind_defaults_false(monkeypatch):
+    mgr = _manager_with(monkeypatch, afk_age=5.0, window_age=5.0, restarts=0)
+    assert mgr.health_snapshot()["idle_tracker_blind"] is False

--- a/tests/test_aw_manager_idle_restart.py
+++ b/tests/test_aw_manager_idle_restart.py
@@ -179,6 +179,29 @@ def test_blind_idle_tracker_stops_churning_and_flags_for_reprompt():
     )
 
 
+def test_idle_stale_restart_bumps_idle_only_counter():
+    """A real idle-tracker stale restart increments the idle-specific counter
+    that feeds idle_tracker_stale_restarts."""
+    mgr, idle = _make_manager(afk_age=1800, window_age=5)  # AFK stale, window fresh
+
+    mgr.restart_if_needed()
+
+    assert _restarted(mgr, idle)
+    assert mgr._idle_stale_restart_count == 1
+
+
+def test_window_stale_restart_leaves_idle_counter_untouched():
+    """A flapping window tracker must NOT inflate the idle figure — only the
+    shared any-tracker counter moves."""
+    mgr, idle = _make_manager(afk_age=5, window_age=1800)  # window stale, AFK fresh
+
+    mgr.restart_if_needed()
+
+    assert not idle.terminate.called, "idle tracker is healthy here"
+    assert mgr._idle_stale_restart_count == 0, "window churn must not touch idle count"
+    assert mgr._stale_restart_count == 1, "shared any-tracker counter still moves"
+
+
 def test_blind_clears_when_tracker_recovers():
     """If the tracker starts emitting fresh AFK events again (e.g. permission
     granted), the blind flag and the consecutive counter reset so a future

--- a/tests/test_heartbeat_health_telemetry.py
+++ b/tests/test_heartbeat_health_telemetry.py
@@ -40,6 +40,7 @@ def test_heartbeat_forwards_health_telemetry():
         # "idle but bucket has events": AFK silent while window fresh.
         client.heartbeat(health={
             "idle_tracker_stale_restarts": 12,
+            "idle_tracker_blind": True,
             "afk_event_age_seconds": 300,
             "window_event_age_seconds": 5,
             "consecutive_sync_failures": 0,
@@ -50,6 +51,7 @@ def test_heartbeat_forwards_health_telemetry():
     body = _last_heartbeat_body()
     assert body["agent_version"]  # base field still present
     assert body["idle_tracker_stale_restarts"] == 12
+    assert body["idle_tracker_blind"] is True
     assert body["afk_event_age_seconds"] == 300
     assert body["window_event_age_seconds"] == 5
     assert body["consecutive_sync_failures"] == 0


### PR DESCRIPTION
## Problem

The fleet alert **"Active time not advancing while the user works (N tracker restarts)"** sources `N` from `AWManager.health_snapshot()`'s `idle_tracker_stale_restarts` — which read the **shared** `_stale_restart_count`. But that counter is bumped by **both** the window-tracker stale path *and* the idle-tracker stale path. So a flapping window tracker inflates the idle figure, and the alert meant to diagnose a frozen **idle** tracker misattributes unrelated **window** churn to it. On 2026-06-19, Patricia's "36 restarts" and similar high counts can't be trusted to mean idle-tracker churn.

It also doesn't expose whether the tracker is **chronically blind** (a denied Input Monitoring grant the watchdog already detected and backed off from) vs. just transiently restarting — which is exactly the signal needed to tell a user "grant Input Monitoring" instead of "wait."

## Fix

- Add a dedicated `_idle_stale_restart_count`, incremented **only** on the `bf-idle-tracker` stale-restart path. Report it as `idle_tracker_stale_restarts`. The shared `_stale_restart_count` stays for the cross-tracker restart-loop escalation check (unchanged).
- Surface `idle_tracker_blind` on the snapshot and add it to the heartbeat allowlist (`bf_client.heartbeat`), so the backend can distinguish a transient restart from a blind tracker and surface the correct recovery action.

## Tests

- `test_aw_manager_health_snapshot.py` — idle figure excludes window restarts; blind flag present + defaults false.
- `test_aw_manager_idle_restart.py` — drives the **real** `restart_if_needed()`: idle stall bumps the idle counter; a window stall leaves it at 0 while the shared counter moves (non-phantom).
- `test_heartbeat_health_telemetry.py` — `idle_tracker_blind` rides the heartbeat.

Watched RED first (shared count returned, `KeyError: idle_tracker_blind`), GREEN after. Full suite **633 passed**, no new lint.

## Coordination notes

- **No version bump** here, to avoid colliding with #67's `1.5.63` — bump at merge/release time.
- Touches `aw_manager.py` (Martin's active file) — rebased clean on `main` now; may need a re-rebase.
- **Server-side follow-up (internal-tool2):** the backend must store/surface `idle_tracker_blind` for the alert to use it. This PR only gets the signal onto the wire.

## Context

Companion to #67 (which fixes the actual billing loss by synthesizing not-afk on the upload stream). This PR makes the *diagnosis* of the frozen-tracker problem trustworthy. Neither addresses the deepest cause — why `bf-idle-tracker` freezes and restarts don't converge (TCC grant / hung binary), which is tracked separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
