### PR TITLE
feat(afk): in-process AFK source as sole source (default on, macOS+Windows)

### DIFF
--- a/docs/superpowers/plans/2026-06-19-in-process-afk-source.md
+++ b/docs/superpowers/plans/2026-06-19-in-process-afk-source.md
@@ -1,0 +1,737 @@
+# In-process AFK source — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make the agent generate the authoritative active/idle (AFK) stream in-process from the OS idle clock (+ macOS input watcher) and upload it as the sole AFK source, removing correctness-dependence on the external `bf-idle-tracker`.
+
+**Architecture:** A new pure-logic `AfkSource` turns a log of activity samples into AFK spans. `SyncEngine` records a sample each cycle and, behind a default-on kill-switch flag, uploads the in-process spans instead of the external AFK bucket (Linux / flag-off keeps today's external-bucket + #67 path). `aw_manager` stops alerting on the now-ignored tracker.
+
+**Tech Stack:** Python 3.11, pytest, dataclasses, stdlib `datetime`/`collections.deque`/`threading`.
+
+## Global Constraints
+
+- afk transition occurs at `last_input_at + afk_timeout` (aw-watcher-afk parity — first `afk_timeout` seconds of any pause stay billed active). Copied from spec; the single most important invariant.
+- Never invent activity: any sub-range with no covering sample is emitted as `afk`.
+- Default flag value `Config.sync.in_process_afk = True`; it is a kill-switch, not a staging gate.
+- In-process path active only where `os_idle.get_system_idle_seconds()` returns a value (macOS/Windows); Linux always uses the external path.
+- 4-space indent, snake_case, follow existing `sync/` module patterns. Imports use the `try: from .x import ... except ImportError: from x import ...` dual form already in `sync_engine.py`.
+- Event dict shape: `{"id","timestamp","duration","bucket_id","bucket_type","data":{"status","synthetic":True}[,"project_id"]}`; `bucket_type = BUCKET_TYPE_AFK`.
+- Per fixture discipline: every behavior test must fail on pre-change code and pass after; commit the proof.
+
+---
+
+### Task 1: Config kill-switch flag
+
+**Files:**
+- Modify: `src/config.py:294-302` (`SyncSettings`)
+- Test: `tests/test_config.py`
+
+**Interfaces:**
+- Produces: `Config().sync.in_process_afk: bool` (default `True`).
+
+- [ ] **Step 1: Write the failing test**
+
+```python
+# tests/test_config.py  (add)
+def test_in_process_afk_defaults_on():
+    from src.config import Config
+    assert Config().sync.in_process_afk is True
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `python -m pytest tests/test_config.py::test_in_process_afk_defaults_on -v`
+Expected: FAIL — `AttributeError: 'SyncSettings' object has no attribute 'in_process_afk'`
+
+- [ ] **Step 3: Add the field**
+
+```python
+# src/config.py — inside SyncSettings, after min_window_event_seconds
+    # Generate the AFK/active stream in-process from the OS idle clock + input
+    # watcher instead of the external bf-idle-tracker bucket. Kill-switch: set
+    # False to fall back to the external bucket + stale-synthesis path.
+    in_process_afk: bool = True
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `python -m pytest tests/test_config.py::test_in_process_afk_defaults_on -v`
+Expected: PASS
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/config.py tests/test_config.py
+git commit -m "feat(config): add in_process_afk kill-switch (default on)"
+```
+
+---
+
+### Task 2: `AfkSource` — construction, `available()`, `record_sample()`
+
+**Files:**
+- Create: `src/sync/afk_source.py`
+- Test: `tests/test_afk_source.py`
+
+**Interfaces:**
+- Consumes: `os_idle.get_system_idle_seconds` (existing, returns `Optional[float]`).
+- Produces:
+  - `AfkSource(afk_timeout_seconds: float, hostname: str, *, input_watcher=None, idle_clock=get_system_idle_seconds, retention_seconds: float = 7200.0)`
+  - `.available() -> bool`
+  - `.record_sample(now: datetime) -> None`
+  - `.samples` (read-only list copy, for tests)
+
+- [ ] **Step 1: Write the failing tests**
+
+```python
+# tests/test_afk_source.py
+from datetime import datetime, timedelta, timezone
+
+from src.sync.afk_source import AfkSource
+
+T0 = datetime(2026, 6, 19, 12, 0, 0, tzinfo=timezone.utc)
+
+
+def _src(idle_value, **kw):
+    return AfkSource(afk_timeout_seconds=600, hostname="host",
+                     idle_clock=lambda: idle_value, **kw)
+
+
+def test_available_true_when_idle_clock_returns_value():
+    assert _src(5.0).available() is True
+
+
+def test_available_false_when_idle_clock_returns_none():
+    assert _src(None).available() is False
+
+
+def test_record_sample_appends_last_input_from_idle_clock():
+    src = _src(30.0)
+    src.record_sample(T0)
+    assert src.samples == [(T0, T0 - timedelta(seconds=30))]
+
+
+def test_record_sample_noop_when_clock_unavailable():
+    src = _src(None)
+    src.record_sample(T0)
+    assert src.samples == []
+
+
+def test_record_sample_prefers_fresher_input_watcher():
+    class W:
+        def get_last_input_at(self):
+            return T0 - timedelta(seconds=2)  # fresher than idle clock's 30s
+    src = _src(30.0, input_watcher=W())
+    src.record_sample(T0)
+    assert src.samples == [(T0, T0 - timedelta(seconds=2))]
+
+
+def test_retention_prunes_old_samples():
+    src = _src(0.0, retention_seconds=100)
+    src.record_sample(T0)
+    src.record_sample(T0 + timedelta(seconds=200))  # T0 now older than retention
+    assert [s[0] for s in src.samples] == [T0 + timedelta(seconds=200)]
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `python -m pytest tests/test_afk_source.py -v`
+Expected: FAIL — `ModuleNotFoundError: No module named 'src.sync.afk_source'`
+
+- [ ] **Step 3: Implement construction + sampling**
+
+```python
+# src/sync/afk_source.py
+"""In-process AFK source: builds the authoritative active/idle stream from the
+OS idle clock (+ macOS input watcher), replacing the external bf-idle-tracker
+bucket. See docs/superpowers/specs/2026-06-19-in-process-afk-source-design.md."""
+
+import logging
+import threading
+from collections import deque
+from datetime import datetime, timedelta, timezone
+from typing import Callable, Optional
+
+try:
+    from .aw_client import BUCKET_TYPE_AFK
+    from .os_idle import get_system_idle_seconds
+except ImportError:  # PyInstaller bundle (src/ is import root)
+    from sync.aw_client import BUCKET_TYPE_AFK
+    from sync.os_idle import get_system_idle_seconds
+
+logger = logging.getLogger(__name__)
+
+
+class AfkSource:
+    """Records activity samples and reconstructs AFK spans from them."""
+
+    def __init__(
+        self,
+        afk_timeout_seconds: float,
+        hostname: str,
+        *,
+        input_watcher=None,
+        idle_clock: Callable[[], Optional[float]] = get_system_idle_seconds,
+        retention_seconds: float = 7200.0,
+    ) -> None:
+        self._afk_timeout = float(afk_timeout_seconds)
+        self._hostname = hostname
+        self._input_watcher = input_watcher
+        self._idle_clock = idle_clock
+        self._retention = timedelta(seconds=retention_seconds)
+        self._lock = threading.Lock()
+        # (sample_time, last_input_at)
+        self._samples: deque = deque()
+
+    @property
+    def samples(self) -> list:
+        with self._lock:
+            return list(self._samples)
+
+    def available(self) -> bool:
+        """True when the OS idle clock is readable on this platform."""
+        try:
+            return self._idle_clock() is not None
+        except Exception:
+            return False
+
+    def record_sample(self, now: datetime) -> None:
+        """Observe activity at ``now`` and append (now, last_input_at). No-op when
+        the OS idle clock is unavailable (Linux)."""
+        try:
+            idle = self._idle_clock()
+        except Exception as e:
+            logger.debug("AfkSource idle clock failed: %s", e)
+            return
+        if idle is None:
+            return
+        last_input_at = now - timedelta(seconds=idle)
+        # macOS in-process watcher holds the main app's grant — prefer it when
+        # it reports a *more recent* input than the OS idle clock.
+        watcher = self._input_watcher
+        if watcher is not None:
+            try:
+                wli = watcher.get_last_input_at()
+            except Exception as e:
+                logger.debug("AfkSource input watcher failed: %s", e)
+                wli = None
+            if wli is not None and wli > last_input_at:
+                last_input_at = wli
+        with self._lock:
+            self._samples.append((now, last_input_at))
+            cutoff = now - self._retention
+            while self._samples and self._samples[0][0] < cutoff:
+                self._samples.popleft()
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `python -m pytest tests/test_afk_source.py -v`
+Expected: PASS (6 passed)
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/sync/afk_source.py tests/test_afk_source.py
+git commit -m "feat(afk): AfkSource sampler (record_sample + available)"
+```
+
+---
+
+### Task 3: `AfkSource.build_afk_events` — timeline reconstruction
+
+**Files:**
+- Modify: `src/sync/afk_source.py` (add method)
+- Test: `tests/test_afk_source.py` (add cases)
+
+**Interfaces:**
+- Produces: `.build_afk_events(range_start: datetime, range_end: datetime, project_id: Optional[int] = None) -> list[dict]`
+
+- [ ] **Step 1: Write the failing tests**
+
+```python
+# tests/test_afk_source.py  (add)
+def _seed(src, *pairs):
+    """pairs: (sample_time, last_input_at)."""
+    for st, li in pairs:
+        with src._lock:
+            src._samples.append((st, li))
+
+
+def _spans(events):
+    return [(e["data"]["status"], e["timestamp"],
+             round(e["duration"])) for e in events]
+
+
+def test_continuous_activity_is_one_notafk_span():
+    src = _src(0.0)
+    _seed(src, (T0, T0), (T0 + timedelta(seconds=30), T0 + timedelta(seconds=30)))
+    ev = src.build_afk_events(T0, T0 + timedelta(seconds=30))
+    assert _spans(ev) == [("not-afk", T0.isoformat(), 30)]
+
+
+def test_idle_past_timeout_flips_at_last_input_plus_timeout():
+    # last input at T0; range runs to T0+700. afk must start at T0+600, NOT T0.
+    src = _src(700.0)
+    _seed(src, (T0, T0), (T0 + timedelta(seconds=700), T0))
+    ev = src.build_afk_events(T0, T0 + timedelta(seconds=700))
+    assert _spans(ev) == [
+        ("not-afk", T0.isoformat(), 600),
+        ("afk", (T0 + timedelta(seconds=600)).isoformat(), 100),
+    ]
+
+
+def test_pause_shorter_than_timeout_stays_active():
+    src = _src(599.0)
+    _seed(src, (T0, T0), (T0 + timedelta(seconds=599), T0))
+    ev = src.build_afk_events(T0, T0 + timedelta(seconds=599))
+    assert _spans(ev) == [("not-afk", T0.isoformat(), 599)]
+
+
+def test_no_samples_in_range_is_afk():
+    src = _src(0.0)  # empty log
+    ev = src.build_afk_events(T0, T0 + timedelta(seconds=300))
+    assert _spans(ev) == [("afk", T0.isoformat(), 300)]
+
+
+def test_gap_with_no_samples_billed_afk_not_active():
+    # active at T0, then a 1h hole (machine asleep), active again at T0+3600.
+    src = _src(0.0)
+    _seed(src, (T0, T0), (T0 + timedelta(seconds=3600), T0 + timedelta(seconds=3600)))
+    ev = src.build_afk_events(T0, T0 + timedelta(seconds=3600))
+    statuses = [e["data"]["status"] for e in ev]
+    assert "not-afk" in statuses and "afk" in statuses
+    # the long middle is afk; total not-afk never exceeds 2*timeout (grace at each end)
+    notafk = sum(e["duration"] for e in ev if e["data"]["status"] == "not-afk")
+    assert notafk <= 1200
+
+
+def test_empty_range_returns_nothing():
+    src = _src(0.0)
+    assert src.build_afk_events(T0, T0) == []
+
+
+def test_project_id_attached_when_given():
+    src = _src(0.0)
+    _seed(src, (T0, T0))
+    ev = src.build_afk_events(T0, T0 + timedelta(seconds=10), project_id=42)
+    assert all(e["project_id"] == 42 for e in ev)
+
+
+def test_consecutive_cycles_are_contiguous_and_non_overlapping():
+    src = _src(0.0)
+    _seed(src, (T0, T0), (T0 + timedelta(seconds=30), T0 + timedelta(seconds=30)),
+          (T0 + timedelta(seconds=60), T0 + timedelta(seconds=60)))
+    a = src.build_afk_events(T0, T0 + timedelta(seconds=30))
+    b = src.build_afk_events(T0 + timedelta(seconds=30), T0 + timedelta(seconds=60))
+    a_end = datetime.fromisoformat(a[-1]["timestamp"]) + timedelta(seconds=a[-1]["duration"])
+    b_start = datetime.fromisoformat(b[0]["timestamp"])
+    assert a_end == b_start  # contiguous, no gap, no overlap
+    assert a[-1]["id"] != b[0]["id"]
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `python -m pytest tests/test_afk_source.py -k build_afk -v`
+Expected: FAIL — `AttributeError: 'AfkSource' object has no attribute 'build_afk_events'`
+
+- [ ] **Step 3: Implement the timeline**
+
+```python
+# src/sync/afk_source.py — add to AfkSource
+
+    def build_afk_events(
+        self, range_start: datetime, range_end: datetime,
+        project_id: Optional[int] = None,
+    ) -> list[dict]:
+        """Reconstruct AFK spans over [range_start, range_end] from samples.
+
+        Activity is known only at each sample's last_input_at. Between two
+        activity instants the user is not-afk until last_input + afk_timeout,
+        then afk (aw-watcher-afk parity). Any sub-range with no covering sample
+        is afk (never invent activity)."""
+        if range_end <= range_start:
+            return []
+        timeout = timedelta(seconds=self._afk_timeout)
+        with self._lock:
+            instants = sorted({li for (_, li) in self._samples})
+
+        anchor = None
+        for li in instants:
+            if li <= range_start:
+                anchor = li  # newest instant at/before range_start
+        in_range = [li for li in instants if range_start < li < range_end]
+        activity = ([anchor] if anchor is not None else []) + in_range
+
+        spans: list[tuple] = []
+        if not activity:
+            spans.append((range_start, range_end, "afk"))
+        else:
+            first = activity[0]
+            if first > range_start:
+                spans.append((range_start, first, "afk"))  # leading unknown
+            for a, b in zip(activity, activity[1:]):
+                spans.append((a, min(b, a + timeout), "not-afk"))
+                if b - a > timeout:
+                    spans.append((a + timeout, b, "afk"))
+            last = activity[-1]
+            spans.append((last, min(range_end, last + timeout), "not-afk"))
+            if range_end - last > timeout:
+                spans.append((last + timeout, range_end, "afk"))
+
+        events: list[dict] = []
+        for start, end, status in sorted(spans, key=lambda s: s[0]):
+            s = max(start, range_start)
+            e = min(end, range_end)
+            if e <= s:
+                continue
+            events.append(self._event(s, (e - s).total_seconds(), status, project_id))
+        return events
+
+    def _event(self, start: datetime, duration: float, status: str,
+               project_id: Optional[int]) -> dict:
+        ev = {
+            "id": f"afk-inproc_{self._hostname}_{int(start.timestamp())}",
+            "timestamp": start.isoformat(),
+            "duration": round(duration, 2),
+            "bucket_id": f"bf-afk-inproc_{self._hostname}",
+            "bucket_type": BUCKET_TYPE_AFK,
+            "data": {"status": status, "synthetic": True},
+        }
+        if project_id is not None:
+            ev["project_id"] = project_id
+        return ev
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `python -m pytest tests/test_afk_source.py -v`
+Expected: PASS (all)
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/sync/afk_source.py tests/test_afk_source.py
+git commit -m "feat(afk): build_afk_events timeline (aw-watcher-afk parity, never over-bill)"
+```
+
+---
+
+### Task 4: SyncEngine integration
+
+**Files:**
+- Modify: `src/sync/sync_engine.py` (constructor: `self._afk_source=None`, `self._afk_inproc_checkpoint=None`; `sync()` AFK branch ~line 521-539)
+- Test: `tests/test_sync_engine_inproc_afk.py`
+
+**Interfaces:**
+- Consumes: `AfkSource` (Task 2/3), `Config().sync.in_process_afk` (Task 1).
+- Produces: `SyncEngine.afk_source` attribute (settable post-construction, like `health_provider`); when set + flag on + `available()`, `sync()` uploads in-process AFK and skips the external bucket + `_synthesize_for_stale_afk`.
+
+- [ ] **Step 1: Write the failing tests**
+
+```python
+# tests/test_sync_engine_inproc_afk.py
+from datetime import datetime, timedelta, timezone
+from unittest.mock import Mock
+
+from src.config import Config
+from src.sync.afk_source import AfkSource
+from src.sync.activity_analyzer import ActivityAnalyzer
+from src.sync.daily_time_tracker import DailyTimeTracker
+from src.sync.sync_engine import SyncEngine
+
+
+def _engine(in_process_afk: bool):
+    cfg = Config()
+    cfg.sync.in_process_afk = in_process_afk
+    return SyncEngine(aw=Mock(), bf=Mock(), queue=Mock(), config=cfg,
+                      activity_analyzer=Mock(spec=ActivityAnalyzer),
+                      time_tracker=Mock(spec=DailyTimeTracker))
+
+
+def test_inproc_afk_events_built_for_uploaded_range():
+    eng = _engine(True)
+    eng.afk_source = AfkSource(600, "host", idle_clock=lambda: 5.0)
+    now = datetime(2026, 6, 19, 12, 0, 0, tzinfo=timezone.utc)
+    eng.afk_source.record_sample(now - timedelta(seconds=30))
+    eng.afk_source.record_sample(now)
+    events = eng._build_inproc_afk(now)  # helper under test
+    assert events and all(e["bucket_id"] == "bf-afk-inproc_host" for e in events)
+
+
+def test_external_afk_bucket_skipped_when_inproc_active():
+    eng = _engine(True)
+    eng.afk_source = AfkSource(600, "host", idle_clock=lambda: 5.0)
+    assert eng._should_skip_external_afk() is True
+
+
+def test_external_afk_bucket_used_when_flag_off():
+    eng = _engine(False)
+    eng.afk_source = AfkSource(600, "host", idle_clock=lambda: 5.0)
+    assert eng._should_skip_external_afk() is False
+
+
+def test_inproc_inactive_when_clock_unavailable():
+    eng = _engine(True)
+    eng.afk_source = AfkSource(600, "host", idle_clock=lambda: None)  # Linux
+    assert eng._should_skip_external_afk() is False
+
+
+def test_inproc_inactive_when_no_source_wired():
+    eng = _engine(True)
+    assert eng._should_skip_external_afk() is False
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `python -m pytest tests/test_sync_engine_inproc_afk.py -v`
+Expected: FAIL — `AttributeError: 'SyncEngine' object has no attribute '_should_skip_external_afk'`
+
+- [ ] **Step 3: Implement constructor fields + helpers + sync() branch**
+
+```python
+# src/sync/sync_engine.py — in __init__, near self.health_provider = None
+        self.afk_source = None  # AfkSource; set post-construction by the app
+        self._afk_inproc_checkpoint: Optional[datetime] = None
+```
+
+```python
+# src/sync/sync_engine.py — add methods near _synthesize_for_stale_afk
+    def _inproc_afk_active(self) -> bool:
+        """True when the in-process AFK source should be the sole source."""
+        return (
+            bool(self.config.sync.in_process_afk)
+            and self.afk_source is not None
+            and self.afk_source.available()
+        )
+
+    def _should_skip_external_afk(self) -> bool:
+        return self._inproc_afk_active()
+
+    def _build_inproc_afk(self, now: datetime) -> list[dict]:
+        """Build the in-process AFK events for [checkpoint, now] and advance the
+        checkpoint. Returns [] when not active."""
+        if not self._inproc_afk_active():
+            return []
+        if self._afk_inproc_checkpoint is None:
+            self._afk_inproc_checkpoint = now  # account only while running
+            return []
+        with self._state_lock:
+            project = self._current_project
+        events = self.afk_source.build_afk_events(
+            self._afk_inproc_checkpoint, now,
+            project_id=project["id"] if project else None,
+        )
+        self._afk_inproc_checkpoint = now
+        return events
+```
+
+```python
+# src/sync/sync_engine.py — at the very top of sync()'s real work (after the
+# paused/private guard returns, before fetching buckets ~line 472), sample:
+        if self.afk_source is not None:
+            try:
+                self.afk_source.record_sample(datetime.now(timezone.utc))
+            except Exception as e:
+                logger.debug("afk_source.record_sample failed: %s", e)
+```
+
+```python
+# src/sync/sync_engine.py — replace the non-window bucket loop + synth block
+# (currently ~line 521-539). Skip external AFK buckets when in-process is active,
+# and emit in-process events instead of _synthesize_for_stale_afk.
+        skip_afk = self._should_skip_external_afk()
+        for bucket in web_buckets + afk_buckets + input_buckets:
+            if skip_afk and _is_afk_like(bucket.type):
+                continue
+            try:
+                events, checkpoint = self._sync_bucket(bucket.id, bucket.type, stats, cycle)
+                all_events.extend(events)
+                if checkpoint:
+                    pending_checkpoints.append(checkpoint)
+                stats.buckets_synced += 1
+            except AWClientError as e:
+                stats.errors.append(f"Failed to sync bucket {bucket.id}: {e}")
+
+        if skip_afk:
+            all_events.extend(self._build_inproc_afk(datetime.now(timezone.utc)))
+        else:
+            synth_afk = self._synthesize_for_stale_afk(afk_buckets)
+            if synth_afk:
+                all_events.append(synth_afk)
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `python -m pytest tests/test_sync_engine_inproc_afk.py tests/test_sync_engine_synth_afk.py -v`
+Expected: PASS (synth tests still pass — that path is unchanged when flag off / no source)
+
+- [ ] **Step 5: Run the full sync-engine suite for regressions**
+
+Run: `python -m pytest tests/test_sync_engine.py tests/test_backlog_reconcile_enqueues_day.py -q`
+Expected: PASS (backlog reconcile untouched — it never sees `_afk_inproc_checkpoint`)
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/sync/sync_engine.py tests/test_sync_engine_inproc_afk.py
+git commit -m "feat(sync): upload in-process AFK as sole source when enabled"
+```
+
+---
+
+### Task 5: aw_manager — suppress idle stale/blind alerting when in-process active
+
+**Files:**
+- Modify: `src/aw_manager.py` (`__init__` flag + setter; gate the idle stale path in `_restart_if_needed_locked` ~line 688-695)
+- Test: `tests/test_aw_manager_idle_restart.py`
+
+**Interfaces:**
+- Consumes: nothing new.
+- Produces: `AWManager.set_inproc_afk_active(active: bool)`; when active, the `bf-idle-tracker` stale path is skipped (no restart, no `_idle_stale_restart_count`/blind escalation). Window tracker path unchanged.
+
+- [ ] **Step 1: Write the failing test**
+
+```python
+# tests/test_aw_manager_idle_restart.py  (add)
+def test_inproc_afk_suppresses_idle_tracker_restart():
+    mgr, idle = _make_manager(afk_age=1800, window_age=5)  # would normally restart
+    mgr.set_inproc_afk_active(True)
+
+    mgr.restart_if_needed()
+
+    assert not idle.terminate.called, "ignored tracker must not be restarted"
+    assert mgr._idle_stale_restart_count == 0
+    assert mgr.idle_tracker_blind is False
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `python -m pytest tests/test_aw_manager_idle_restart.py::test_inproc_afk_suppresses_idle_tracker_restart -v`
+Expected: FAIL — `AttributeError: 'AWManager' object has no attribute 'set_inproc_afk_active'`
+
+- [ ] **Step 3: Implement the flag + gate**
+
+```python
+# src/aw_manager.py — in __init__, near self._idle_tracker_blind = False
+        # When the agent uploads its own in-process AFK stream, the external
+        # bf-idle-tracker bucket is ignored — don't restart it or raise blind
+        # alerts about a tracker we no longer consume.
+        self._inproc_afk_active: bool = False
+```
+
+```python
+# src/aw_manager.py — add method near idle_tracker_blind property
+    def set_inproc_afk_active(self, active: bool) -> None:
+        with self._lifecycle_lock:
+            self._inproc_afk_active = bool(active)
+```
+
+```python
+# src/aw_manager.py — in _restart_if_needed_locked, gate the idle-tracker block.
+# Change the existing guard (currently ~line 682):
+#     idle_watcher = "bf-idle-tracker"
+#     if (idle_watcher not in self._disabled_components and ...):
+# to also require not self._inproc_afk_active:
+        idle_watcher = "bf-idle-tracker"
+        if (
+            not self._inproc_afk_active
+            and idle_watcher not in self._disabled_components
+            and idle_watcher in self._processes
+            and self._processes[idle_watcher].poll() is None
+        ):
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `python -m pytest tests/test_aw_manager_idle_restart.py tests/test_aw_manager_health_snapshot.py -v`
+Expected: PASS (existing restart tests unaffected — default `_inproc_afk_active` is False)
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/aw_manager.py tests/test_aw_manager_idle_restart.py
+git commit -m "feat(aw): suppress idle-tracker restart/blind alerts when in-process AFK active"
+```
+
+---
+
+### Task 6: Wire it together in `main.py`
+
+**Files:**
+- Modify: `src/main.py` (construct `AfkSource`, assign `sync_engine.afk_source`, call `aw_manager.set_inproc_afk_active` from config)
+- Test: `tests/test_linux_support.py` (Linux forces external path) + manual smoke
+
+**Interfaces:**
+- Consumes: `AfkSource`, `SyncEngine.afk_source`, `AWManager.set_inproc_afk_active`, the existing `self._input_watcher` and hostname.
+
+- [ ] **Step 1: Write the failing test**
+
+```python
+# tests/test_linux_support.py  (add to the Linux class)
+def test_afk_source_unavailable_on_linux(monkeypatch):
+    import src.sync.afk_source as afk
+    src = afk.AfkSource(600, "host", idle_clock=lambda: None)
+    assert src.available() is False
+```
+
+- [ ] **Step 2: Run test to verify it fails or passes**
+
+Run: `python -m pytest tests/test_linux_support.py::*::test_afk_source_unavailable_on_linux -v`
+Expected: PASS immediately (AfkSource already returns False for None clock) — this is a guard test pinning the Linux contract; keep it.
+
+- [ ] **Step 3: Wire construction in main.py**
+
+```python
+# src/main.py — where SyncEngine + AWManager are constructed and the input
+# watcher is wired (search for `self._input_watcher` assignment and
+# `sync_engine.health_provider`). After the input watcher exists:
+        try:
+            from .sync.afk_source import AfkSource
+        except ImportError:
+            from sync.afk_source import AfkSource
+        afk_source = AfkSource(
+            afk_timeout_seconds=self.config.aw.afk_timeout_minutes * 60,
+            hostname=self.sync_engine._hostname,
+            input_watcher=self._input_watcher,
+        )
+        self.sync_engine.afk_source = afk_source
+        self.aw_manager.set_inproc_afk_active(
+            self.config.sync.in_process_afk and afk_source.available()
+        )
+```
+
+- [ ] **Step 4: Run the full suite**
+
+Run: `python -m pytest -q`
+Expected: PASS (all)
+
+- [ ] **Step 5: Manual smoke (macOS) — billing parity pre-flip check (from spec Risks)**
+
+Run the app locally with `in_process_afk=True` for a short session, then compare the `bf-afk-inproc_*` active-seconds against the live `aw-watcher-afk` bucket for the same window; they must match within sampling noise. If they diverge (server bills from `last_input`, no grace), revisit the grace in `build_afk_events`.
+
+- [ ] **Step 6: Bump version + commit**
+
+```bash
+# bump src/__init__.py to 1.5.64
+git add src/main.py src/__init__.py tests/test_linux_support.py
+git commit -m "feat(afk): wire in-process AFK source (default on, macOS+Windows)"
+```
+
+---
+
+## Self-Review
+
+**Spec coverage:**
+- Sole source / skip external bucket → Task 4 (`_should_skip_external_afk`, loop skip). ✓
+- macOS+Windows via OS idle clock, Linux excluded → Task 2 `available()`, Task 4 gate, Task 6 test. ✓
+- Default-ON kill-switch flag → Task 1. ✓
+- Timeline + aw-watcher-afk parity + never-over-bill → Task 3 (+ boundary tests). ✓
+- Checkpoint init=now, no backlog rewind → Task 4 (`_build_inproc_afk`; backlog path untouched, asserted in Step 5). ✓
+- aw_manager alert suppression → Task 5. ✓
+- Pre-flip parity verification → Task 6 Step 5. ✓
+- Out-of-scope (stop external process, server flag, remove #67) → not in any task. ✓
+
+**Placeholder scan:** none — all steps carry real code/commands.
+
+**Type consistency:** `AfkSource(afk_timeout_seconds, hostname, *, input_watcher, idle_clock, retention_seconds)`, `available()`, `record_sample(now)`, `build_afk_events(range_start, range_end, project_id=None)` consistent across Tasks 2/3/4/6. `set_inproc_afk_active(active)` consistent Task 5/6. `_should_skip_external_afk` / `_build_inproc_afk` / `_inproc_afk_active` consistent within Task 4.

--- a/docs/superpowers/specs/2026-06-19-in-process-afk-source-design.md
+++ b/docs/superpowers/specs/2026-06-19-in-process-afk-source-design.md
@@ -85,9 +85,22 @@ Each emitted event:
   "data": {"status": "not-afk"|"afk", "synthetic": True},
   "project_id": <if set> }
 ```
-The id is keyed on `span_start`, so the current (growing) span re-sends the same id
-each cycle and the server upserts (patches) — same heartbeat-extend contract real
-AW events and #67 rely on. Closed past spans keep their id permanently.
+**Billing parity (critical).** The afk transition at `last_input + afk_timeout`
+(steps 2–3) is deliberate: it matches `aw-watcher-afk` (the binary we replace),
+which heartbeats `not-afk` through pauses shorter than the timeout and only flips
+to `afk` once the timeout elapses. So the first `afk_timeout` seconds of any idle
+gap stay billed active, exactly as today — **steady-state billing for normal users
+does not change.** Marking afk from `last_input` instead (no grace) would silently
+under-bill every reading/thinking pause across the fleet. A pre-flip verification
+step (see Risks) confirms this against a real `aw-watcher-afk` bucket before
+default-ON.
+
+**Ids & no overlap.** Because `_afk_inproc_checkpoint` advances to `now` every
+cycle, `build_afk_events` only ever emits spans for the *new* `[checkpoint, now]`
+slice — consecutive cycles produce **non-overlapping** segments, each uploaded once.
+There is no growing-span / re-emit, so no server-side patching is relied on; the
+`span_start`-keyed id is simply a stable unique key (and lets a re-queued offline
+event dedupe on retry). This is simpler and safer than #67's re-emit model.
 
 ### SyncEngine integration
 
@@ -101,10 +114,18 @@ A single flag-gated branch in `sync()`:
   - **skip** `_synthesize_for_stale_afk` (#67 — subsumed).
 - Else (flag off, or Linux): today's behavior verbatim (external bucket + #67).
 
-Checkpoint: a single `_afk_inproc_checkpoint: datetime` (last covered instant). On
-first cycle, initialize to a short lookback (e.g. `now - afk_timeout`) so a restart
-doesn't claim a huge active span. The server upserts by event id, so re-emitting an
-overlapping current span is safe.
+Checkpoint: a single `_afk_inproc_checkpoint: datetime` (last covered instant),
+**initialized to `now` on the first cycle** — we only account for time while the
+agent is running and sampling, and emit nothing for the unknown pre-start period.
+Failed uploads ride the existing offline queue (events are appended to `all_events`
+→ `_send_and_advance_checkpoints`, which queues on failure), so advancing the
+checkpoint after a failed send never loses data.
+
+**Backlog reconcile does NOT touch `_afk_inproc_checkpoint`.** The day-start
+checkpoint rewind exists to re-fetch stranded events from real AW buckets; the
+in-process AFK stream has no AW bucket and the sample log only retains ~2h, so
+rewinding it would re-emit `afk` over a morning we already billed correctly.
+In-process AFK relies solely on the offline queue for delivery, never on rewind.
 
 The local pause decision (`idle_manager`) already uses the in-process input watcher
 + OS idle clock (`_has_recent_input`, `_get_system_idle_seconds`), so it needs no
@@ -129,7 +150,12 @@ untouched.
 - interleaved active/idle/active → correct alternating spans, no fabricated
   activity over the idle middle;
 - empty log → afk for the whole range;
-- stable id across cycles for the growing current span (server patches in place).
+- **billing-parity boundary**: a pause of `afk_timeout − 1s` is entirely not-afk
+  (grace), a pause of `afk_timeout + 1s` flips to afk exactly at
+  `last_input + afk_timeout` — pins that short pauses stay billed active like
+  aw-watcher-afk;
+- consecutive cycles produce non-overlapping, contiguous segments (no gaps, no
+  double-cover) for a steadily-active user.
 
 `tests/test_sync_engine_inproc_afk.py` — integration on the real sync path:
 - flag ON + readable clock → external afk bucket NOT uploaded; in-process afk
@@ -148,6 +174,13 @@ Proof-of-failure per fixture discipline: each behavior test fails on pre-change 
 ## Risks
 - **Billing correctness of the timeline builder** — mitigated by the conservative
   never-over-bill rule (unknown → afk) and exhaustive pure-function tests.
+- **afk-transition semantics assumption** — the design assumes the server bills the
+  first `afk_timeout` seconds of a pause as active (aw-watcher-afk parity).
+  **Pre-flip verification (do before merging the default-ON):** on one machine, run
+  the in-process source side-by-side with the live `aw-watcher-afk` bucket for a
+  session and diff the resulting active-seconds; they must match within sampling
+  noise. If the server actually bills from `last_input` (no grace), drop the grace
+  in step 2/3 instead. This check is cheap and removes the only unproven assumption.
 - **Default ON, no beta** — any timeline bug bills wrong fleet-wide before it's
   caught; the kill-switch flag is the rollback. (Accepted: Brad, 2026-06-19.)
 - **Coarse Windows granularity** — sampling at sync cadence (~30s) vs the 600s

--- a/docs/superpowers/specs/2026-06-19-in-process-afk-source-design.md
+++ b/docs/superpowers/specs/2026-06-19-in-process-afk-source-design.md
@@ -1,0 +1,154 @@
+# In-process AFK source — design
+
+Date: 2026-06-19
+Status: approved design, pending spec review
+Author: pairing session (Brad + Claude)
+
+## Problem
+
+The server bills active-vs-idle from the uploaded AFK stream. That stream comes
+from the external `bf-idle-tracker` binary (renamed `aw-watcher-afk`), a separate
+process under its own TCC subject that repeatedly freezes / goes blind on macOS,
+and wedges on Windows. When it does, the worked span is billed idle ("Active time
+not advancing" fleet alerts; Razvan 2026-06-19 lost ~2.9h in one bucket).
+
+PR #67 patched the worst symptom by synthesizing a not-afk span on upload when the
+tracker is stale, and PR #68 made the telemetry honest. But the agent still
+*depends* on the flaky binary for the steady-state AFK signal, and recovery from
+"blind" is gated on a user re-granting Input Monitoring. This design removes the
+dependence: the agent itself becomes the authoritative AFK source.
+
+## Decisions (locked)
+
+1. **Sole source.** Stop uploading the external `bf-idle-tracker` bucket; the agent
+   uploads ONE AFK stream built in-process. No server-side conflict between two
+   sources. The external tracker keeps *running* (stopping the process is a
+   follow-up) but its bucket is ignored.
+2. **Platforms: macOS + Windows.** Both have a working OS idle clock
+   (`os_idle.get_system_idle_seconds()` — `HIDIdleTime` / `GetLastInputInfo`).
+   macOS also has the in-process input watcher (holds the main app's grant) for
+   finer transitions. **Linux** has no OS idle clock → keeps the external bucket +
+   #67 synthesis unchanged.
+3. **Rollout: straight to main + prod, default ON.** `Config.sync.in_process_afk`
+   defaults to `True`. The flag is a **kill-switch** back to the exact current
+   behavior (external bucket + #67), not a staging gate. No beta channel.
+
+## Architecture
+
+### `sync/afk_source.py` — `AfkSource`
+
+The only component with real logic. Turns a log of activity observations into AFK
+spans. Pure and isolated → exhaustively unit-testable.
+
+State:
+- `afk_timeout: float` (seconds; from `config.aw.afk_timeout_minutes`).
+- `_samples: deque[(sample_time: datetime, last_input_at: datetime)]`, thread-safe
+  under a leaf lock, retained ~2h (pruned as the checkpoint advances).
+- `_input_watcher` (optional, macOS) for `get_last_input_at()`.
+
+Methods:
+- `record_sample(now)` — `idle = get_system_idle_seconds()`; `last_input_at =
+  now - idle`. On macOS, if the input watcher reports a *more recent* last input,
+  use that. Returns early (records nothing) when the OS idle clock is unavailable
+  (Linux), which is also how callers detect "unsupported platform". Append
+  `(now, last_input_at)`.
+- `build_afk_events(range_start, range_end) -> list[dict]` — pure timeline
+  reconstruction (algorithm below). Returns synthetic AFK bf-event dicts.
+- `available() -> bool` — whether the OS idle clock is readable on this platform
+  (drives the SyncEngine gate).
+
+### Timeline reconstruction (where billing correctness lives)
+
+Activity is known only at each sample's `last_input_at` (the instant of the user's
+most recent input as of that sample). Reconstruct active/idle over
+`[range_start, range_end]`:
+
+1. Collect the distinct `last_input_at` values (activity instants) within or
+   bordering the range, sorted ascending. Prepend the newest activity instant at
+   or before `range_start` so the leading edge is anchored.
+2. Walk consecutive activity instants `a_i -> a_{i+1}`:
+   - The user is **not-afk** from `a_i` until `min(a_{i+1}, a_i + afk_timeout)`.
+   - If `a_{i+1} - a_i > afk_timeout`, an **afk** span covers
+     `[a_i + afk_timeout, a_{i+1}]`.
+3. For the tail after the last activity instant `a_n` up to `range_end`:
+   - not-afk `[a_n, min(range_end, a_n + afk_timeout)]`;
+   - afk `[a_n + afk_timeout, range_end]` if it exceeds the timeout.
+4. Clip every emitted span to `[range_start, range_end]`; drop zero/negative spans.
+5. **No samples covering a sub-range → emit afk** for it. Never invent activity
+   (the conservative, never-over-bill rule).
+
+Each emitted event:
+```
+{ "id": f"afk-inproc_{hostname}_{int(span_start.timestamp())}",
+  "timestamp": span_start.isoformat(), "duration": round(secs, 2),
+  "bucket_id": f"bf-afk-inproc_{hostname}", "bucket_type": BUCKET_TYPE_AFK,
+  "data": {"status": "not-afk"|"afk", "synthetic": True},
+  "project_id": <if set> }
+```
+The id is keyed on `span_start`, so the current (growing) span re-sends the same id
+each cycle and the server upserts (patches) — same heartbeat-extend contract real
+AW events and #67 rely on. Closed past spans keep their id permanently.
+
+### SyncEngine integration
+
+A single flag-gated branch in `sync()`:
+- At sync start, `afk_source.record_sample(now)`.
+- If `config.sync.in_process_afk and afk_source.available()`:
+  - **exclude `afk_buckets`** from the non-window upload loop (don't upload the
+    external tracker's bucket);
+  - `events = afk_source.build_afk_events(self._afk_inproc_checkpoint, now)`;
+    append to `all_events`; advance `_afk_inproc_checkpoint` to `now`;
+  - **skip** `_synthesize_for_stale_afk` (#67 — subsumed).
+- Else (flag off, or Linux): today's behavior verbatim (external bucket + #67).
+
+Checkpoint: a single `_afk_inproc_checkpoint: datetime` (last covered instant). On
+first cycle, initialize to a short lookback (e.g. `now - afk_timeout`) so a restart
+doesn't claim a huge active span. The server upserts by event id, so re-emitting an
+overlapping current span is safe.
+
+The local pause decision (`idle_manager`) already uses the in-process input watcher
++ OS idle clock (`_has_recent_input`, `_get_system_idle_seconds`), so it needs no
+change — it is already in-process-authoritative.
+
+### aw_manager
+
+When in-process AFK is active, **suppress idle-tracker stale/blind detection +
+alerting** (the `bf-idle-tracker` stale path in `_restart_if_needed_locked` and the
+`idle_tracker_blind` flag): we no longer consume that bucket, so it must not raise
+"Active time not advancing" alerts or drive the permission re-prompt. Gate via a
+constructor flag/setter the app sets from config. The window-tracker stale path is
+untouched.
+
+## Testing (billing-critical → heavy)
+
+`tests/test_afk_source.py` — pure-function timeline:
+- continuous activity across the range → one not-afk span, no afk;
+- idle past the timeout → not-afk up to `last_input + timeout`, then afk to end;
+- exact transition boundary (`gap == afk_timeout`, `+1s`);
+- multi-hour offline gap (no samples) → afk for the gap, never not-afk;
+- interleaved active/idle/active → correct alternating spans, no fabricated
+  activity over the idle middle;
+- empty log → afk for the whole range;
+- stable id across cycles for the growing current span (server patches in place).
+
+`tests/test_sync_engine_inproc_afk.py` — integration on the real sync path:
+- flag ON + readable clock → external afk bucket NOT uploaded; in-process afk
+  events present in the sent batch with `bucket_id` `bf-afk-inproc_*`;
+- flag OFF → external afk bucket uploaded + `_synthesize_for_stale_afk` runs (today);
+- `available()` False (Linux / clock unreadable) → forced OFF regardless of flag.
+
+Proof-of-failure per fixture discipline: each behavior test fails on pre-change code
+(no `AfkSource`, external bucket always uploaded) and passes after.
+
+## Out of scope (follow-ups)
+- Stopping the external `bf-idle-tracker` process entirely.
+- Server-controlled flag in the config payload.
+- Removing #67 / the external path (retained for Linux + flag-off).
+
+## Risks
+- **Billing correctness of the timeline builder** — mitigated by the conservative
+  never-over-bill rule (unknown → afk) and exhaustive pure-function tests.
+- **Default ON, no beta** — any timeline bug bills wrong fleet-wide before it's
+  caught; the kill-switch flag is the rollback. (Accepted: Brad, 2026-06-19.)
+- **Coarse Windows granularity** — sampling at sync cadence (~30s) vs the 600s
+  afk_timeout is far finer than needed; sub-sample idle blips are correctly ignored.

--- a/docs/superpowers/specs/2026-06-19-in-process-afk-source-design.md
+++ b/docs/superpowers/specs/2026-06-19-in-process-afk-source-design.md
@@ -66,13 +66,13 @@ most recent input as of that sample). Reconstruct active/idle over
 1. Collect the distinct `last_input_at` values (activity instants) within or
    bordering the range, sorted ascending. Prepend the newest activity instant at
    or before `range_start` so the leading edge is anchored.
-2. Walk consecutive activity instants `a_i -> a_{i+1}`:
-   - The user is **not-afk** from `a_i` until `min(a_{i+1}, a_i + afk_timeout)`.
-   - If `a_{i+1} - a_i > afk_timeout`, an **afk** span covers
-     `[a_i + afk_timeout, a_{i+1}]`.
-3. For the tail after the last activity instant `a_n` up to `range_end`:
-   - not-afk `[a_n, min(range_end, a_n + afk_timeout)]`;
-   - afk `[a_n + afk_timeout, range_end]` if it exceeds the timeout.
+2. Walk consecutive activity instants `a_i -> a_{i+1}` (NO grace):
+   - if `a_{i+1} - a_i <= afk_timeout`: **not-afk** for the whole `[a_i, a_{i+1}]`
+     (a pause that never reached the timeout never went afk);
+   - else: **afk** for the whole `[a_i, a_{i+1}]` (backdated to the last input).
+3. Tail after the last activity instant `a_n` up to `range_end`: **not-afk** if
+   `range_end - a_n <= afk_timeout`, else **afk** (whole tail). The caller passes
+   `range_end = finalize_point(now)` so this tail is only ever the settled region.
 4. Clip every emitted span to `[range_start, range_end]`; drop zero/negative spans.
 5. **No samples covering a sub-range → emit afk** for it. Never invent activity
    (the conservative, never-over-bill rule).
@@ -85,22 +85,29 @@ Each emitted event:
   "data": {"status": "not-afk"|"afk", "synthetic": True},
   "project_id": <if set> }
 ```
-**Billing parity (critical).** The afk transition at `last_input + afk_timeout`
-(steps 2–3) is deliberate: it matches `aw-watcher-afk` (the binary we replace),
-which heartbeats `not-afk` through pauses shorter than the timeout and only flips
-to `afk` once the timeout elapses. So the first `afk_timeout` seconds of any idle
-gap stay billed active, exactly as today — **steady-state billing for normal users
-does not change.** Marking afk from `last_input` instead (no grace) would silently
-under-bill every reading/thinking pause across the fleet. A pre-flip verification
-step (see Risks) confirms this against a real `aw-watcher-afk` bucket before
-default-ON.
+**Billing parity (critical — corrected after live measurement 2026-06-19).**
+`aw-watcher-afk` **backdates `afk` to the last input — there is NO grace.**
+Verified on a live machine: across 8 clean idle transitions, the gap from the
+last real keystroke/click to the start of the stored `afk` span was a **median of
+9 seconds**, not 600s. (Had a grace existed, every gap would cluster near 600s; a
+9s gap is only possible if `afk` starts at the last input.) So the rule is:
 
-**Ids & no overlap.** Because `_afk_inproc_checkpoint` advances to `now` every
-cycle, `build_afk_events` only ever emits spans for the *new* `[checkpoint, now]`
-slice — consecutive cycles produce **non-overlapping** segments, each uploaded once.
-There is no growing-span / re-emit, so no server-side patching is relied on; the
-`span_start`-keyed id is simply a stable unique key (and lets a re-queued offline
-event dedupe on retry). This is simpler and safer than #67's re-emit model.
+- consecutive activity instants `a -> b`: `not-afk [a, b]` iff `b - a <=
+  afk_timeout`; otherwise **`afk` for the entire `[a, b]`** (no 600s of leading
+  not-afk).
+
+The earlier draft assumed a grace and would have credited ~`afk_timeout` of extra
+active time per break across the fleet — an over-bill. The `afk_timeout` only
+governs how long real-time detection waits before *declaring* afk; the stored/
+billed span is backdated to the last input.
+
+**Ids & no overlap.** Each cycle finalizes only up to `finalize_point(now)` (the
+last instant whose afk status is settled — see integration), and the checkpoint
+advances to that point. `build_afk_events` emits spans only for the new
+`[checkpoint, finalize_point]` slice, so consecutive cycles produce
+**non-overlapping** segments uploaded once. No growing-span / re-emit and no
+server-side status-flip patching is relied on; the `span_start`-keyed id is a
+stable unique key (and lets a re-queued offline event dedupe on retry).
 
 ### SyncEngine integration
 
@@ -109,8 +116,11 @@ A single flag-gated branch in `sync()`:
 - If `config.sync.in_process_afk and afk_source.available()`:
   - **exclude `afk_buckets`** from the non-window upload loop (don't upload the
     external tracker's bucket);
-  - `events = afk_source.build_afk_events(self._afk_inproc_checkpoint, now)`;
-    append to `all_events`; advance `_afk_inproc_checkpoint` to `now`;
+  - `finalize_to = afk_source.finalize_point(now)`; if `finalize_to >
+    checkpoint`, `events = afk_source.build_afk_events(checkpoint, finalize_to)`,
+    append to `all_events`, and advance `_afk_inproc_checkpoint` to `finalize_to`
+    (the trailing region within the timeout of the last input stays pending for a
+    later cycle, so it can resolve not-afk OR afk without re-emit);
   - **skip** `_synthesize_for_stale_afk` (#67 — subsumed).
 - Else (flag off, or Linux): today's behavior verbatim (external bucket + #67).
 
@@ -174,13 +184,11 @@ Proof-of-failure per fixture discipline: each behavior test fails on pre-change 
 ## Risks
 - **Billing correctness of the timeline builder** — mitigated by the conservative
   never-over-bill rule (unknown → afk) and exhaustive pure-function tests.
-- **afk-transition semantics assumption** — the design assumes the server bills the
-  first `afk_timeout` seconds of a pause as active (aw-watcher-afk parity).
-  **Pre-flip verification (do before merging the default-ON):** on one machine, run
-  the in-process source side-by-side with the live `aw-watcher-afk` bucket for a
-  session and diff the resulting active-seconds; they must match within sampling
-  noise. If the server actually bills from `last_input` (no grace), drop the grace
-  in step 2/3 instead. This check is cheap and removes the only unproven assumption.
+- **afk-transition semantics** — VERIFIED on a live macOS machine 2026-06-19:
+  `aw-watcher-afk` backdates afk to the last input (median 9s gap from last
+  keystroke/click to afk-span start across 8 transitions; a grace would show
+  ~600s). The design uses the no-grace rule accordingly. An earlier grace draft
+  would have over-billed ~`afk_timeout` per break fleet-wide; caught by this check.
 - **Default ON, no beta** — any timeline bug bills wrong fleet-wide before it's
   caught; the kill-switch flag is the rollback. (Accepted: Brad, 2026-06-19.)
 - **Coarse Windows granularity** — sampling at sync cadence (~30s) vs the 600s

--- a/src/__init__.py
+++ b/src/__init__.py
@@ -1,4 +1,4 @@
 """BetterFlow - ActivityWatch to BetterFlow sync companion app."""
 
-__version__ = "1.5.63"
+__version__ = "1.5.64"
 __author__ = "BetterQA"

--- a/src/aw_manager.py
+++ b/src/aw_manager.py
@@ -357,6 +357,10 @@ class AWManager:
         self._idle_consecutive_stale: int = 0
         self._idle_tracker_blind: bool = False
         self._idle_last_restart_mono: float = 0.0
+        # When the agent uploads its own in-process AFK stream, the external
+        # bf-idle-tracker bucket is ignored — don't restart it or raise blind
+        # alerts about a tracker we no longer consume.
+        self._inproc_afk_active: bool = False
 
     @property
     def idle_tracker_blind(self) -> bool:
@@ -366,6 +370,13 @@ class AWManager:
         restarts. Clears automatically once the tracker emits fresh events."""
         with self._lifecycle_lock:
             return self._idle_tracker_blind
+
+    def set_inproc_afk_active(self, active: bool) -> None:
+        """Mark whether the agent is uploading its own in-process AFK stream. When
+        active, the bf-idle-tracker stale/blind detection is suppressed (we no
+        longer consume its bucket, so it must not restart or raise alerts)."""
+        with self._lifecycle_lock:
+            self._inproc_afk_active = bool(active)
 
     def disable_component(self, name: str) -> None:
         """Prevent a component from being started/restarted."""
@@ -697,7 +708,8 @@ class AWManager:
         # full-system idle or a sleep/wake where both watchers are paused.
         idle_watcher = "bf-idle-tracker"
         if (
-            idle_watcher not in self._disabled_components
+            not self._inproc_afk_active
+            and idle_watcher not in self._disabled_components
             and idle_watcher in self._processes
             and self._processes[idle_watcher].poll() is None
         ):

--- a/src/config.py
+++ b/src/config.py
@@ -300,6 +300,10 @@ class SyncSettings:
     compress: bool = True  # Use gzip compression
     idle_pause_minutes: int = 20  # Pause sync after this many minutes AFK
     min_window_event_seconds: float = 5.0  # Drop window/web events shorter than this
+    # Generate the AFK/active stream in-process from the OS idle clock + input
+    # watcher instead of the external bf-idle-tracker bucket. Kill-switch: set
+    # False to fall back to the external bucket + stale-synthesis path.
+    in_process_afk: bool = True
 
 
 @dataclass

--- a/src/main.py
+++ b/src/main.py
@@ -1290,6 +1290,26 @@ class BetterFlowApp:
         self.coordinator.idle_mgr.input_watcher = self.input_watcher
         self.coordinator.idle_mgr._on_idle_pause = self._on_idle_pause
 
+        # In-process AFK source: the agent generates its own active/idle stream
+        # from the OS idle clock (+ the in-process input watcher on macOS) and
+        # uploads it as the sole AFK source, so a frozen/blind bf-idle-tracker
+        # can't lose billed time. Inert unless config enables it AND the OS idle
+        # clock is readable (macOS/Windows; off on Linux). When active, tell the
+        # AwManager to stop restarting/alerting on the now-ignored tracker.
+        try:
+            from .sync.afk_source import AfkSource
+        except ImportError:
+            from sync.afk_source import AfkSource
+        afk_source = AfkSource(
+            afk_timeout_seconds=self.config.aw.afk_timeout_minutes * 60,
+            hostname=self.coordinator.sync_engine._hostname,
+            input_watcher=self.input_watcher,
+        )
+        self.coordinator.sync_engine.afk_source = afk_source
+        self.coordinator.aw_manager.set_inproc_afk_active(
+            self.config.sync.in_process_afk and afk_source.available()
+        )
+
         # Reminder manager (created after coordinator for clean callback injection)
         self.reminder_manager = ReminderManager(self.config.reminders)
         self.coordinator.reminder_manager = self.reminder_manager

--- a/src/sync/afk_source.py
+++ b/src/sync/afk_source.py
@@ -1,0 +1,80 @@
+"""In-process AFK source: builds the authoritative active/idle stream from the
+OS idle clock (+ macOS input watcher), replacing the external bf-idle-tracker
+bucket. See docs/superpowers/specs/2026-06-19-in-process-afk-source-design.md."""
+
+import logging
+import threading
+from collections import deque
+from datetime import datetime, timedelta
+from typing import Callable, Optional
+
+try:
+    from .aw_client import BUCKET_TYPE_AFK
+    from .os_idle import get_system_idle_seconds
+except ImportError:  # PyInstaller bundle (src/ is import root)
+    from sync.aw_client import BUCKET_TYPE_AFK
+    from sync.os_idle import get_system_idle_seconds
+
+logger = logging.getLogger(__name__)
+
+
+class AfkSource:
+    """Records activity samples and reconstructs AFK spans from them."""
+
+    def __init__(
+        self,
+        afk_timeout_seconds: float,
+        hostname: str,
+        *,
+        input_watcher=None,
+        idle_clock: Callable[[], Optional[float]] = get_system_idle_seconds,
+        retention_seconds: float = 7200.0,
+    ) -> None:
+        self._afk_timeout = float(afk_timeout_seconds)
+        self._hostname = hostname
+        self._input_watcher = input_watcher
+        self._idle_clock = idle_clock
+        self._retention = timedelta(seconds=retention_seconds)
+        self._lock = threading.Lock()
+        # (sample_time, last_input_at)
+        self._samples: deque = deque()
+
+    @property
+    def samples(self) -> list:
+        with self._lock:
+            return list(self._samples)
+
+    def available(self) -> bool:
+        """True when the OS idle clock is readable on this platform."""
+        try:
+            return self._idle_clock() is not None
+        except Exception:
+            return False
+
+    def record_sample(self, now: datetime) -> None:
+        """Observe activity at ``now`` and append (now, last_input_at). No-op when
+        the OS idle clock is unavailable (Linux)."""
+        try:
+            idle = self._idle_clock()
+        except Exception as e:
+            logger.debug("AfkSource idle clock failed: %s", e)
+            return
+        if idle is None:
+            return
+        last_input_at = now - timedelta(seconds=idle)
+        # macOS in-process watcher holds the main app's grant — prefer it when
+        # it reports a *more recent* input than the OS idle clock.
+        watcher = self._input_watcher
+        if watcher is not None:
+            try:
+                wli = watcher.get_last_input_at()
+            except Exception as e:
+                logger.debug("AfkSource input watcher failed: %s", e)
+                wli = None
+            if wli is not None and wli > last_input_at:
+                last_input_at = wli
+        with self._lock:
+            self._samples.append((now, last_input_at))
+            cutoff = now - self._retention
+            while self._samples and self._samples[0][0] < cutoff:
+                self._samples.popleft()

--- a/src/sync/afk_source.py
+++ b/src/sync/afk_source.py
@@ -78,3 +78,65 @@ class AfkSource:
             cutoff = now - self._retention
             while self._samples and self._samples[0][0] < cutoff:
                 self._samples.popleft()
+
+    def build_afk_events(
+        self, range_start: datetime, range_end: datetime,
+        project_id: Optional[int] = None,
+    ) -> list:
+        """Reconstruct AFK spans over [range_start, range_end] from samples.
+
+        Activity is known only at each sample's last_input_at. Between two
+        activity instants the user is not-afk until last_input + afk_timeout,
+        then afk (aw-watcher-afk parity). Any sub-range with no covering sample
+        is afk (never invent activity)."""
+        if range_end <= range_start:
+            return []
+        timeout = timedelta(seconds=self._afk_timeout)
+        with self._lock:
+            instants = sorted({li for (_, li) in self._samples})
+
+        anchor = None
+        for li in instants:
+            if li <= range_start:
+                anchor = li  # newest instant at/before range_start
+        in_range = [li for li in instants if range_start < li < range_end]
+        activity = ([anchor] if anchor is not None else []) + in_range
+
+        spans: list = []
+        if not activity:
+            spans.append((range_start, range_end, "afk"))
+        else:
+            first = activity[0]
+            if first > range_start:
+                spans.append((range_start, first, "afk"))  # leading unknown
+            for a, b in zip(activity, activity[1:], strict=False):
+                spans.append((a, min(b, a + timeout), "not-afk"))
+                if b - a > timeout:
+                    spans.append((a + timeout, b, "afk"))
+            last = activity[-1]
+            spans.append((last, min(range_end, last + timeout), "not-afk"))
+            if range_end - last > timeout:
+                spans.append((last + timeout, range_end, "afk"))
+
+        events: list = []
+        for start, end, status in sorted(spans, key=lambda s: s[0]):
+            s = max(start, range_start)
+            e = min(end, range_end)
+            if e <= s:
+                continue
+            events.append(self._event(s, (e - s).total_seconds(), status, project_id))
+        return events
+
+    def _event(self, start: datetime, duration: float, status: str,
+               project_id: Optional[int]) -> dict:
+        ev = {
+            "id": f"afk-inproc_{self._hostname}_{int(start.timestamp())}",
+            "timestamp": start.isoformat(),
+            "duration": round(duration, 2),
+            "bucket_id": f"bf-afk-inproc_{self._hostname}",
+            "bucket_type": BUCKET_TYPE_AFK,
+            "data": {"status": status, "synthetic": True},
+        }
+        if project_id is not None:
+            ev["project_id"] = project_id
+        return ev

--- a/src/sync/afk_source.py
+++ b/src/sync/afk_source.py
@@ -79,6 +79,23 @@ class AfkSource:
             while self._samples and self._samples[0][0] < cutoff:
                 self._samples.popleft()
 
+    def finalize_point(self, now: datetime) -> datetime:
+        """The latest instant whose afk classification is FINAL.
+
+        While the user is within the timeout of their last input, the trailing
+        region [last_input, now] could still resolve either way — they may return
+        (making it not-afk) or stay idle past the timeout (making the whole region
+        afk, backdated). So we finalize only up to the last confirmed input. Once
+        idle >= timeout, the trailing region is definitively afk and we finalize
+        all the way to `now`. With no samples there is nothing to defer."""
+        with self._lock:
+            last_input = max((li for (_, li) in self._samples), default=None)
+        if last_input is None:
+            return now
+        if (now - last_input).total_seconds() >= self._afk_timeout:
+            return now
+        return last_input
+
     def build_afk_events(
         self, range_start: datetime, range_end: datetime,
         project_id: Optional[int] = None,
@@ -102,6 +119,11 @@ class AfkSource:
         in_range = [li for li in instants if range_start < li < range_end]
         activity = ([anchor] if anchor is not None else []) + in_range
 
+        # NO GRACE (verified against live aw-watcher-afk 2026-06-19): afk is
+        # backdated to the last input. A gap between two inputs is not-afk only if
+        # it never reached the timeout; otherwise the ENTIRE gap is afk. The
+        # afk_timeout governs only how long real-time detection waits before
+        # declaring afk, not how the billed span is classified.
         spans: list = []
         if not activity:
             spans.append((range_start, range_end, "afk"))
@@ -110,13 +132,11 @@ class AfkSource:
             if first > range_start:
                 spans.append((range_start, first, "afk"))  # leading unknown
             for a, b in zip(activity, activity[1:], strict=False):
-                spans.append((a, min(b, a + timeout), "not-afk"))
-                if b - a > timeout:
-                    spans.append((a + timeout, b, "afk"))
+                spans.append((a, b, "not-afk" if (b - a) <= timeout else "afk"))
             last = activity[-1]
-            spans.append((last, min(range_end, last + timeout), "not-afk"))
-            if range_end - last > timeout:
-                spans.append((last + timeout, range_end, "afk"))
+            spans.append(
+                (last, range_end, "not-afk" if (range_end - last) <= timeout else "afk")
+            )
 
         events: list = []
         for start, end, status in sorted(spans, key=lambda s: s[0]):

--- a/src/sync/sync_engine.py
+++ b/src/sync/sync_engine.py
@@ -209,6 +209,16 @@ class SyncEngine:
         # channel) breaks that circular blindness. This is exactly why Windows
         # wedges were undiagnosable. None / errors tolerated.
         self.error_reporter = None
+        # Optional in-process AFK source (set by the SyncCoordinator). When
+        # present, enabled by config, and the OS idle clock is readable, the
+        # agent uploads its own AFK stream and ignores the external bf-idle-tracker
+        # bucket. The checkpoint is the last instant covered by an upload; it is
+        # initialized to `now` on the first cycle (account only while running) and
+        # is NEVER touched by the backlog reconcile (no AW bucket to re-fetch; the
+        # sample log only retains ~2h, so a day-start rewind would re-emit afk over
+        # a morning already billed correctly).
+        self.afk_source = None
+        self._afk_inproc_checkpoint: Optional[datetime] = None
 
         # Queue retry backoff
         self._queue_consecutive_failures = 0
@@ -479,6 +489,15 @@ class SyncEngine:
                     else:
                         logger.warning(f"Failed to start session after retry: {e}")
 
+        # Record an activity sample for the in-process AFK timeline (no-op when
+        # no source is wired or the OS idle clock is unavailable). Done every
+        # cycle so the sample log stays dense regardless of bucket-fetch outcome.
+        if self.afk_source is not None:
+            try:
+                self.afk_source.record_sample(datetime.now(timezone.utc))
+            except Exception as e:
+                logger.debug("afk_source.record_sample failed: %s", e)
+
         # Get buckets to sync
         try:
             window_buckets = self.aw.get_window_buckets()
@@ -520,8 +539,14 @@ class SyncEngine:
         # so AFK events from one window bucket don't leak into unrelated buckets.
         cycle.afk_events = []
 
-        # Sync non-window buckets normally
+        # Sync non-window buckets normally. When the agent is the sole AFK source
+        # (in-process), drop the external bf-idle-tracker bucket entirely — we
+        # upload our own stream below instead, so its (possibly frozen/blind)
+        # events never reach the server.
+        skip_external_afk = self._should_skip_external_afk()
         for bucket in web_buckets + afk_buckets + input_buckets:
+            if skip_external_afk and _is_afk_like(bucket.type):
+                continue
             try:
                 events, checkpoint = self._sync_bucket(bucket.id, bucket.type, stats, cycle)
                 all_events.extend(events)
@@ -531,15 +556,18 @@ class SyncEngine:
             except AWClientError as e:
                 stats.errors.append(f"Failed to sync bucket {bucket.id}: {e}")
 
-        # If bf-idle-tracker has frozen but the OS idle clock shows the user kept
-        # working, upload a synthetic not-afk span. The server bills active-vs-idle
-        # from the AFK stream, so without this a frozen tracker's worked span is
-        # billed idle ("Active time not advancing" fleet alert) — the gap #53/#56
-        # left open on the upload side (their OS-idle fallback only governs the
-        # LOCAL pause decision, never the uploaded stream).
-        synth_afk = self._synthesize_for_stale_afk(afk_buckets)
-        if synth_afk:
-            all_events.append(synth_afk)
+        if skip_external_afk:
+            # Sole-source path: upload the in-process AFK stream for the slice
+            # since the last covered instant. Subsumes _synthesize_for_stale_afk.
+            all_events.extend(self._build_inproc_afk(datetime.now(timezone.utc)))
+        else:
+            # External-bucket path: if bf-idle-tracker has frozen but the OS idle
+            # clock shows the user kept working, upload a synthetic not-afk span so
+            # the frozen tracker's worked span isn't billed idle ("Active time not
+            # advancing" alert) — the gap #53/#56 left open on the upload side.
+            synth_afk = self._synthesize_for_stale_afk(afk_buckets)
+            if synth_afk:
+                all_events.append(synth_afk)
 
         # Flush any ongoing call at sync boundary
         if self._call_detector:
@@ -1819,6 +1847,39 @@ class SyncEngine:
             afk_buckets[0].id,
         )
         return self._synthesize_active_afk_event(latest, bucket_id, now=now)
+
+    def _inproc_afk_active(self) -> bool:
+        """True when the in-process AFK source should be the sole AFK source —
+        config flag on, a source is wired, and the OS idle clock is readable
+        (macOS/Windows; False on Linux)."""
+        return (
+            bool(self.config.sync.in_process_afk)
+            and self.afk_source is not None
+            and self.afk_source.available()
+        )
+
+    def _should_skip_external_afk(self) -> bool:
+        """Whether to drop the external bf-idle-tracker bucket from this cycle's
+        upload (because the agent uploads its own AFK stream instead)."""
+        return self._inproc_afk_active()
+
+    def _build_inproc_afk(self, now: datetime) -> list[dict]:
+        """Build in-process AFK events for [checkpoint, now] and advance the
+        checkpoint. First cycle just seeds the checkpoint at `now` (we only
+        account for time while running). Returns [] when not active."""
+        if not self._inproc_afk_active():
+            return []
+        if self._afk_inproc_checkpoint is None:
+            self._afk_inproc_checkpoint = now
+            return []
+        with self._state_lock:
+            project = self._current_project
+        events = self.afk_source.build_afk_events(
+            self._afk_inproc_checkpoint, now,
+            project_id=project["id"] if project else None,
+        )
+        self._afk_inproc_checkpoint = now
+        return events
 
     def _send_events(self, events: list[dict], stats: SyncStats) -> None:
         """Send events to BetterFlow or queue if offline."""

--- a/src/sync/sync_engine.py
+++ b/src/sync/sync_engine.py
@@ -1872,13 +1872,21 @@ class SyncEngine:
         if self._afk_inproc_checkpoint is None:
             self._afk_inproc_checkpoint = now
             return []
+        # Only finalize up to the point whose afk classification is settled. While
+        # the user is within the timeout of their last input, the trailing region
+        # is still pending (could go not-afk or afk), so it waits for a later cycle
+        # — otherwise we'd commit it not-afk and be unable to flip it to afk if they
+        # stay idle past the timeout.
+        finalize_to = self.afk_source.finalize_point(now)
+        if finalize_to <= self._afk_inproc_checkpoint:
+            return []
         with self._state_lock:
             project = self._current_project
         events = self.afk_source.build_afk_events(
-            self._afk_inproc_checkpoint, now,
+            self._afk_inproc_checkpoint, finalize_to,
             project_id=project["id"] if project else None,
         )
-        self._afk_inproc_checkpoint = now
+        self._afk_inproc_checkpoint = finalize_to
         return events
 
     def _send_events(self, events: list[dict], stats: SyncStats) -> None:

--- a/tests/test_afk_source.py
+++ b/tests/test_afk_source.py
@@ -1,0 +1,46 @@
+from datetime import datetime, timedelta, timezone
+
+from src.sync.afk_source import AfkSource
+
+T0 = datetime(2026, 6, 19, 12, 0, 0, tzinfo=timezone.utc)
+
+
+def _src(idle_value, **kw):
+    return AfkSource(afk_timeout_seconds=600, hostname="host",
+                     idle_clock=lambda: idle_value, **kw)
+
+
+def test_available_true_when_idle_clock_returns_value():
+    assert _src(5.0).available() is True
+
+
+def test_available_false_when_idle_clock_returns_none():
+    assert _src(None).available() is False
+
+
+def test_record_sample_appends_last_input_from_idle_clock():
+    src = _src(30.0)
+    src.record_sample(T0)
+    assert src.samples == [(T0, T0 - timedelta(seconds=30))]
+
+
+def test_record_sample_noop_when_clock_unavailable():
+    src = _src(None)
+    src.record_sample(T0)
+    assert src.samples == []
+
+
+def test_record_sample_prefers_fresher_input_watcher():
+    class W:
+        def get_last_input_at(self):
+            return T0 - timedelta(seconds=2)  # fresher than idle clock's 30s
+    src = _src(30.0, input_watcher=W())
+    src.record_sample(T0)
+    assert src.samples == [(T0, T0 - timedelta(seconds=2))]
+
+
+def test_retention_prunes_old_samples():
+    src = _src(0.0, retention_seconds=100)
+    src.record_sample(T0)
+    src.record_sample(T0 + timedelta(seconds=200))  # T0 now older than retention
+    assert [s[0] for s in src.samples] == [T0 + timedelta(seconds=200)]

--- a/tests/test_afk_source.py
+++ b/tests/test_afk_source.py
@@ -44,3 +44,78 @@ def test_retention_prunes_old_samples():
     src.record_sample(T0)
     src.record_sample(T0 + timedelta(seconds=200))  # T0 now older than retention
     assert [s[0] for s in src.samples] == [T0 + timedelta(seconds=200)]
+
+
+def _seed(src, *pairs):
+    """pairs: (sample_time, last_input_at)."""
+    for st, li in pairs:
+        with src._lock:
+            src._samples.append((st, li))
+
+
+def _spans(events):
+    return [(e["data"]["status"], e["timestamp"], round(e["duration"])) for e in events]
+
+
+def test_continuous_activity_is_one_notafk_span():
+    src = _src(0.0)
+    _seed(src, (T0, T0), (T0 + timedelta(seconds=30), T0 + timedelta(seconds=30)))
+    ev = src.build_afk_events(T0, T0 + timedelta(seconds=30))
+    assert _spans(ev) == [("not-afk", T0.isoformat(), 30)]
+
+
+def test_idle_past_timeout_flips_at_last_input_plus_timeout():
+    src = _src(700.0)
+    _seed(src, (T0, T0), (T0 + timedelta(seconds=700), T0))
+    ev = src.build_afk_events(T0, T0 + timedelta(seconds=700))
+    assert _spans(ev) == [
+        ("not-afk", T0.isoformat(), 600),
+        ("afk", (T0 + timedelta(seconds=600)).isoformat(), 100),
+    ]
+
+
+def test_pause_shorter_than_timeout_stays_active():
+    src = _src(599.0)
+    _seed(src, (T0, T0), (T0 + timedelta(seconds=599), T0))
+    ev = src.build_afk_events(T0, T0 + timedelta(seconds=599))
+    assert _spans(ev) == [("not-afk", T0.isoformat(), 599)]
+
+
+def test_no_samples_in_range_is_afk():
+    src = _src(0.0)
+    ev = src.build_afk_events(T0, T0 + timedelta(seconds=300))
+    assert _spans(ev) == [("afk", T0.isoformat(), 300)]
+
+
+def test_gap_with_no_samples_billed_afk_not_active():
+    src = _src(0.0)
+    _seed(src, (T0, T0), (T0 + timedelta(seconds=3600), T0 + timedelta(seconds=3600)))
+    ev = src.build_afk_events(T0, T0 + timedelta(seconds=3600))
+    statuses = [e["data"]["status"] for e in ev]
+    assert "not-afk" in statuses and "afk" in statuses
+    notafk = sum(e["duration"] for e in ev if e["data"]["status"] == "not-afk")
+    assert notafk <= 1200
+
+
+def test_empty_range_returns_nothing():
+    src = _src(0.0)
+    assert src.build_afk_events(T0, T0) == []
+
+
+def test_project_id_attached_when_given():
+    src = _src(0.0)
+    _seed(src, (T0, T0))
+    ev = src.build_afk_events(T0, T0 + timedelta(seconds=10), project_id=42)
+    assert all(e["project_id"] == 42 for e in ev)
+
+
+def test_consecutive_cycles_are_contiguous_and_non_overlapping():
+    src = _src(0.0)
+    _seed(src, (T0, T0), (T0 + timedelta(seconds=30), T0 + timedelta(seconds=30)),
+          (T0 + timedelta(seconds=60), T0 + timedelta(seconds=60)))
+    a = src.build_afk_events(T0, T0 + timedelta(seconds=30))
+    b = src.build_afk_events(T0 + timedelta(seconds=30), T0 + timedelta(seconds=60))
+    a_end = datetime.fromisoformat(a[-1]["timestamp"]) + timedelta(seconds=a[-1]["duration"])
+    b_start = datetime.fromisoformat(b[0]["timestamp"])
+    assert a_end == b_start
+    assert a[-1]["id"] != b[0]["id"]

--- a/tests/test_afk_source.py
+++ b/tests/test_afk_source.py
@@ -64,21 +64,37 @@ def test_continuous_activity_is_one_notafk_span():
     assert _spans(ev) == [("not-afk", T0.isoformat(), 30)]
 
 
-def test_idle_past_timeout_flips_at_last_input_plus_timeout():
+def test_idle_past_timeout_is_all_afk_no_grace():
+    # NO GRACE (verified on live aw-watcher-afk 2026-06-19): last input at T0,
+    # idle through T0+700 -> the WHOLE gap is afk, backdated to last input. There
+    # is no 600s of leading not-afk.
     src = _src(700.0)
     _seed(src, (T0, T0), (T0 + timedelta(seconds=700), T0))
     ev = src.build_afk_events(T0, T0 + timedelta(seconds=700))
-    assert _spans(ev) == [
-        ("not-afk", T0.isoformat(), 600),
-        ("afk", (T0 + timedelta(seconds=600)).isoformat(), 100),
-    ]
+    assert _spans(ev) == [("afk", T0.isoformat(), 700)]
 
 
 def test_pause_shorter_than_timeout_stays_active():
+    # A gap <= afk_timeout never transitioned to afk in real time, so it stays
+    # not-afk (this is the same under grace or no-grace).
     src = _src(599.0)
     _seed(src, (T0, T0), (T0 + timedelta(seconds=599), T0))
     ev = src.build_afk_events(T0, T0 + timedelta(seconds=599))
     assert _spans(ev) == [("not-afk", T0.isoformat(), 599)]
+
+
+def test_gap_exactly_timeout_is_notafk_boundary():
+    src = _src(0.0)
+    _seed(src, (T0, T0), (T0 + timedelta(seconds=600), T0 + timedelta(seconds=600)))
+    ev = src.build_afk_events(T0, T0 + timedelta(seconds=600))
+    assert _spans(ev) == [("not-afk", T0.isoformat(), 600)]  # gap == timeout -> active
+
+
+def test_gap_just_over_timeout_is_all_afk():
+    src = _src(0.0)
+    _seed(src, (T0, T0), (T0 + timedelta(seconds=601), T0 + timedelta(seconds=601)))
+    ev = src.build_afk_events(T0, T0 + timedelta(seconds=601))
+    assert _spans(ev) == [("afk", T0.isoformat(), 601)]  # gap > timeout -> all idle
 
 
 def test_no_samples_in_range_is_afk():
@@ -91,10 +107,7 @@ def test_gap_with_no_samples_billed_afk_not_active():
     src = _src(0.0)
     _seed(src, (T0, T0), (T0 + timedelta(seconds=3600), T0 + timedelta(seconds=3600)))
     ev = src.build_afk_events(T0, T0 + timedelta(seconds=3600))
-    statuses = [e["data"]["status"] for e in ev]
-    assert "not-afk" in statuses and "afk" in statuses
-    notafk = sum(e["duration"] for e in ev if e["data"]["status"] == "not-afk")
-    assert notafk <= 1200
+    assert _spans(ev) == [("afk", T0.isoformat(), 3600)]  # whole 1h gap is idle
 
 
 def test_empty_range_returns_nothing():
@@ -119,3 +132,27 @@ def test_consecutive_cycles_are_contiguous_and_non_overlapping():
     b_start = datetime.fromisoformat(b[0]["timestamp"])
     assert a_end == b_start
     assert a[-1]["id"] != b[0]["id"]
+
+
+def test_finalize_point_is_last_input_while_within_timeout():
+    # User active 5s ago (idle < timeout): the trailing region isn't final yet
+    # (they might return -> not-afk, or go idle -> afk), so finalize only up to
+    # the last confirmed input.
+    src = _src(5.0)
+    now = T0 + timedelta(seconds=100)
+    src.record_sample(now)  # last_input = now - 5
+    assert src.finalize_point(now) == now - timedelta(seconds=5)
+
+
+def test_finalize_point_is_now_once_idle_past_timeout():
+    # Idle >= timeout: the whole trailing region is definitively afk, so it's
+    # safe to finalize all the way to now.
+    src = _src(700.0)
+    now = T0 + timedelta(seconds=1000)
+    src.record_sample(now)  # last_input = now - 700
+    assert src.finalize_point(now) == now
+
+
+def test_finalize_point_is_now_with_no_samples():
+    src = _src(5.0)
+    assert src.finalize_point(T0) == T0

--- a/tests/test_aw_manager_idle_restart.py
+++ b/tests/test_aw_manager_idle_restart.py
@@ -220,3 +220,14 @@ def test_blind_clears_when_tracker_recovers():
 
     assert mgr.idle_tracker_blind is False
     assert mgr._idle_consecutive_stale == 0
+
+
+def test_inproc_afk_suppresses_idle_tracker_restart():
+    mgr, idle = _make_manager(afk_age=1800, window_age=5)  # would normally restart
+    mgr.set_inproc_afk_active(True)
+
+    mgr.restart_if_needed()
+
+    assert not idle.terminate.called, "ignored tracker must not be restarted"
+    assert mgr._idle_stale_restart_count == 0
+    assert mgr.idle_tracker_blind is False

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -187,3 +187,8 @@ class TestUuidRegex:
 
     def test_rejects_empty(self):
         assert not _UUID_RE.match("")
+
+
+def test_in_process_afk_defaults_on():
+    from src.config import Config
+    assert Config().sync.in_process_afk is True

--- a/tests/test_linux_support.py
+++ b/tests/test_linux_support.py
@@ -170,3 +170,11 @@ class TestSelfUpdaterLinux:
         monkeypatch.setattr(self_updater.sys, "platform", "linux")
         monkeypatch.delenv("APPIMAGE", raising=False)
         assert self_updater._get_app_bundle_path() is None
+
+
+def test_afk_source_unavailable_on_linux():
+    """Linux has no OS idle clock → AfkSource.available() is False, so the engine
+    keeps the external bf-idle-tracker path regardless of the config flag."""
+    from src.sync.afk_source import AfkSource
+    src = AfkSource(600, "host", idle_clock=lambda: None)
+    assert src.available() is False

--- a/tests/test_sync_engine_inproc_afk.py
+++ b/tests/test_sync_engine_inproc_afk.py
@@ -1,0 +1,50 @@
+from datetime import datetime, timedelta, timezone
+from unittest.mock import Mock
+
+from src.config import Config
+from src.sync.activity_analyzer import ActivityAnalyzer
+from src.sync.afk_source import AfkSource
+from src.sync.daily_time_tracker import DailyTimeTracker
+from src.sync.sync_engine import SyncEngine
+
+
+def _engine(in_process_afk: bool):
+    cfg = Config()
+    cfg.sync.in_process_afk = in_process_afk
+    return SyncEngine(aw=Mock(), bf=Mock(), queue=Mock(), config=cfg,
+                      activity_analyzer=Mock(spec=ActivityAnalyzer),
+                      time_tracker=Mock(spec=DailyTimeTracker))
+
+
+def test_inproc_afk_events_built_for_uploaded_range():
+    eng = _engine(True)
+    eng.afk_source = AfkSource(600, "host", idle_clock=lambda: 5.0)
+    now = datetime(2026, 6, 19, 12, 0, 0, tzinfo=timezone.utc)
+    eng.afk_source.record_sample(now - timedelta(seconds=30))
+    eng.afk_source.record_sample(now)
+    eng._build_inproc_afk(now)  # first call seeds the checkpoint, returns []
+    events = eng._build_inproc_afk(now + timedelta(seconds=30))
+    assert events and all(e["bucket_id"] == "bf-afk-inproc_host" for e in events)
+
+
+def test_external_afk_bucket_skipped_when_inproc_active():
+    eng = _engine(True)
+    eng.afk_source = AfkSource(600, "host", idle_clock=lambda: 5.0)
+    assert eng._should_skip_external_afk() is True
+
+
+def test_external_afk_bucket_used_when_flag_off():
+    eng = _engine(False)
+    eng.afk_source = AfkSource(600, "host", idle_clock=lambda: 5.0)
+    assert eng._should_skip_external_afk() is False
+
+
+def test_inproc_inactive_when_clock_unavailable():
+    eng = _engine(True)
+    eng.afk_source = AfkSource(600, "host", idle_clock=lambda: None)  # Linux
+    assert eng._should_skip_external_afk() is False
+
+
+def test_inproc_inactive_when_no_source_wired():
+    eng = _engine(True)
+    assert eng._should_skip_external_afk() is False

--- a/tests/test_sync_engine_inproc_afk.py
+++ b/tests/test_sync_engine_inproc_afk.py
@@ -22,7 +22,10 @@ def test_inproc_afk_events_built_for_uploaded_range():
     now = datetime(2026, 6, 19, 12, 0, 0, tzinfo=timezone.utc)
     eng.afk_source.record_sample(now - timedelta(seconds=30))
     eng.afk_source.record_sample(now)
-    eng._build_inproc_afk(now)  # first call seeds the checkpoint, returns []
+    eng._build_inproc_afk(now)  # first call seeds the checkpoint at now, returns []
+    # User stays active — a fresh input pushes the finalize point past the
+    # checkpoint so the settled slice uploads.
+    eng.afk_source.record_sample(now + timedelta(seconds=30))
     events = eng._build_inproc_afk(now + timedelta(seconds=30))
     assert events and all(e["bucket_id"] == "bf-afk-inproc_host" for e in events)
 


### PR DESCRIPTION
## What

Makes the agent generate its own active/idle (AFK) stream in-process from the OS idle clock (+ the macOS input watcher) and upload it as the **sole AFK source**, so a frozen/blind `bf-idle-tracker` can no longer lose billed time. Behind a default-on `in_process_afk` kill-switch; macOS + Windows (Linux keeps the external path).

## Why

`bf-idle-tracker` is a separate TCC subject that repeatedly freezes/goes blind on macOS and wedges on Windows. #67 patched the worst symptom (synthesize not-afk on a stale tracker) and #68 made the telemetry honest, but the agent still *depended* on the flaky binary, and recovery was gated on the user re-granting a permission. This removes the dependence. It also **suppresses the "BetterFlow idle tracker needs a refresh" alert** (the one Sachi screenshotted on Windows, where its macOS-specific text was un-actionable anyway).

## How

- **`sync/afk_source.py`** — `AfkSource`: samples `(now, last_input_at)` each cycle and reconstructs AFK spans (`build_afk_events`) + a `finalize_point`.
- **SyncEngine** — when active, uploads the in-process stream, skips the external `afk` bucket, and skips #67's synthesis; finalizes only up to the last confirmed input so a pending trailing region can resolve either way.
- **aw_manager** — `set_inproc_afk_active(True)` stops restarting/alerting on the ignored tracker.
- **main.py** — wires it up; **`Config.sync.in_process_afk` (default True)** is the kill-switch. Version → 1.5.64.

## Billing semantics — verified on a live machine (the important part)

The spec originally assumed `aw-watcher-afk` applied a "grace" (first `afk_timeout` of a pause billed active). The live parity smoke check **disproved that**: across 8 clean idle transitions on a real macOS machine, the gap from the last keystroke/click to the start of the stored `afk` span was a **median of 9s**, not 600s — i.e. **afk is backdated to the last input, NO grace.** The grace model would have **over-billed ~10min per break fleet-wide**.

Corrected to no-grace, then re-validated by replaying real input history through `build_afk_events`:

| source | active hours (18h window) |
|---|---|
| live `aw-watcher-afk` (server bills this today) | 2.83h |
| in-process (no-grace) | 2.80h |
| diff | **−1.0%** (within noise, conservative) |

## Tests

`test_afk_source.py` (19) — timeline incl. the no-grace boundary + `finalize_point`; `test_sync_engine_inproc_afk.py` (5) — sole-source skip / flag-off / Linux-off; `aw_manager` suppression; Linux guard. Full suite **673 passed**. Spec + plan in `docs/superpowers/`.

## Rollout

Straight to main + a stable prod release, default-ON (no beta). The `in_process_afk` flag is the kill-switch. Stopping the external tracker process and a server-controlled flag are deliberate follow-ups.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
