### PR TITLE
fix(telemetry): suppress external-AFK staleness reporting when in-process AFK active (false frozen-alerts)

### DIFF
--- a/src/__init__.py
+++ b/src/__init__.py
@@ -1,4 +1,4 @@
 """BetterFlow - ActivityWatch to BetterFlow sync companion app."""
 
-__version__ = "1.5.64"
+__version__ = "1.5.65"
 __author__ = "BetterQA"

--- a/src/aw_manager.py
+++ b/src/aw_manager.py
@@ -625,14 +625,24 @@ class AWManager:
         with self._lifecycle_lock:
             idle_restarts = self._idle_stale_restart_count
             blind = self._idle_tracker_blind
+            inproc = self._inproc_afk_active
 
-        afk_age = self._get_latest_afk_event_age()
         window_age = self._get_latest_window_event_age()
+        # When the agent owns the AFK stream in-process, the external
+        # bf-idle-tracker bucket is ignored — do NOT report its (likely stale)
+        # event age. Reporting it makes the backend fire false "Active time not
+        # advancing" alerts for an agent that is billing correctly (the external
+        # tracker is still running but irrelevant). The restart count + blind flag
+        # are already 0/False on this path (the restart loop is suppressed).
+        afk_age = None if inproc else self._get_latest_afk_event_age()
         return {
             # idle-tracker-only — window-tracker restarts are excluded so this
             # figure isn't inflated by an unrelated flapping window watcher.
             "idle_tracker_stale_restarts": idle_restarts,
             "idle_tracker_blind": blind,
+            # True => agent generates its own AFK stream; backend should ignore
+            # external-tracker staleness for this device.
+            "inproc_afk": inproc,
             # Ints are friendlier to JSON / the backend's unsigned columns; the
             # sub-second precision is irrelevant for a staleness signal.
             "afk_event_age_seconds": int(afk_age) if afk_age is not None else None,

--- a/src/sync/bf_client.py
+++ b/src/sync/bf_client.py
@@ -366,6 +366,7 @@ class BetterFlowClient(BaseApiClient):
             for key in (
                 "idle_tracker_stale_restarts",
                 "idle_tracker_blind",
+                "inproc_afk",
                 "afk_event_age_seconds",
                 "window_event_age_seconds",
                 "consecutive_sync_failures",

--- a/tests/test_aw_manager_health_snapshot.py
+++ b/tests/test_aw_manager_health_snapshot.py
@@ -65,3 +65,22 @@ def test_snapshot_exposes_blind_flag(monkeypatch):
 def test_snapshot_blind_defaults_false(monkeypatch):
     mgr = _manager_with(monkeypatch, afk_age=5.0, window_age=5.0, restarts=0)
     assert mgr.health_snapshot()["idle_tracker_blind"] is False
+
+
+def test_snapshot_suppresses_external_afk_age_when_inproc_active(monkeypatch):
+    """When the agent owns the AFK stream in-process, the external bf-idle-tracker
+    bucket is ignored — its staleness must NOT be reported, or the server fires a
+    false "Active time not advancing" alert for an agent that is billing fine."""
+    mgr = _manager_with(monkeypatch, afk_age=3000.0, window_age=2.0, restarts=0)
+    mgr.set_inproc_afk_active(True)
+    snap = mgr.health_snapshot()
+    assert snap["inproc_afk"] is True
+    assert snap["afk_event_age_seconds"] is None  # not the stale external age
+    assert snap["window_event_age_seconds"] == 2
+
+
+def test_snapshot_reports_external_afk_age_when_inproc_inactive(monkeypatch):
+    mgr = _manager_with(monkeypatch, afk_age=3000.0, window_age=2.0, restarts=0)
+    snap = mgr.health_snapshot()
+    assert snap["inproc_afk"] is False
+    assert snap["afk_event_age_seconds"] == 3000

--- a/tests/test_heartbeat_health_telemetry.py
+++ b/tests/test_heartbeat_health_telemetry.py
@@ -41,6 +41,7 @@ def test_heartbeat_forwards_health_telemetry():
         client.heartbeat(health={
             "idle_tracker_stale_restarts": 12,
             "idle_tracker_blind": True,
+            "inproc_afk": True,
             "afk_event_age_seconds": 300,
             "window_event_age_seconds": 5,
             "consecutive_sync_failures": 0,
@@ -52,6 +53,7 @@ def test_heartbeat_forwards_health_telemetry():
     assert body["agent_version"]  # base field still present
     assert body["idle_tracker_stale_restarts"] == 12
     assert body["idle_tracker_blind"] is True
+    assert body["inproc_afk"] is True
     assert body["afk_event_age_seconds"] == 300
     assert body["window_event_age_seconds"] == 5
     assert body["consecutive_sync_failures"] == 0


### PR DESCRIPTION
After 1.5.64, in-process AFK is the sole billing source and the bf-idle-tracker restart loop is suppressed — but `health_snapshot()` still reported the external bucket's `afk_event_age`, so the backend keeps firing **false** "Active time not advancing" alerts for agents billing fine.

**Confirmed live (2026-06-19):** 1.5.64 agents fire the frozen alert with the restart count dropped (suppressed → 0) but AFK age still present (e.g. Enea win32: *"AFK age 386s, window age 7s"*, no restart count). That dropped-count-but-still-firing is the exact false-positive signature.

## Fix
- `AWManager.health_snapshot()`: when in-process AFK is active, report `afk_event_age_seconds=None` (don't surface the ignored tracker's staleness) + add `inproc_afk: true`.
- bf_client heartbeat allowlist forwards `inproc_afk`.

Pairs with the pending **server-side** change (internal-tool2, Martin) to consume `inproc_afk` and stop alerting on those devices. 130 relevant tests pass (tray/auth skipped locally — unrelated PIL-arch env quirk, CI covers). → 1.5.65.

🤖 Generated with [Claude Code](https://claude.com/claude-code)