### PR TITLE
fix(autostart): self-heal a stale macOS LaunchAgent plist on startup

### DIFF
--- a/src/__init__.py
+++ b/src/__init__.py
@@ -1,4 +1,4 @@
 """BetterFlow - ActivityWatch to BetterFlow sync companion app."""
 
-__version__ = "1.5.65"
+__version__ = "1.5.66"
 __author__ = "BetterQA"

--- a/src/autostart.py
+++ b/src/autostart.py
@@ -71,6 +71,27 @@ def _plist_path() -> Path:
     return Path.home() / "Library" / "LaunchAgents" / f"{LAUNCHAGENT_LABEL}.plist"
 
 
+def _macos_plist_program_args() -> Optional[list[str]]:
+    """ProgramArguments from the installed plist, or None if missing/unreadable."""
+    import plistlib
+
+    try:
+        with open(_plist_path(), "rb") as f:
+            data = plistlib.load(f)
+    except Exception:
+        return None
+    args = data.get("ProgramArguments")
+    return [str(a) for a in args] if isinstance(args, list) else None
+
+
+def _macos_plist_is_current() -> bool:
+    """True only if the installed plist launches the CURRENT app. A plist left
+    over from a rename/move ("BetterFlow Sync.app" -> "BetterFlow.app", or a
+    relocated bundle) is still "loaded" but launches nothing — it must read as
+    not-current so ensure_synced() rewrites it on the next startup."""
+    return _macos_plist_program_args() == _app_launch_args()
+
+
 def _app_launch_args() -> list[str]:
     """Determine the correct launch command for the current execution context."""
     exe = sys.executable
@@ -156,6 +177,11 @@ def _set_macos(enabled: bool) -> bool:
 
 def _get_macos() -> bool:
     if not _plist_path().exists():
+        return False
+    # A stale plist (points at a renamed/moved app) is "loaded" but launches
+    # nothing. Treat it as not-enabled so ensure_synced() rewrites it with the
+    # current app path instead of leaving auto-start silently broken.
+    if not _macos_plist_is_current():
         return False
     # Confirm it's actually loaded with launchd, not just present on disk.
     rc, _ = _launchctl(["print", f"{_launchctl_domain()}/{LAUNCHAGENT_LABEL}"])

--- a/tests/test_autostart_macos.py
+++ b/tests/test_autostart_macos.py
@@ -1,0 +1,58 @@
+"""macOS auto-start: stale LaunchAgent plist self-heal.
+
+`ensure_synced()` only rewrites the plist when `get_auto_start()` is False, and
+the old `_get_macos()` returned True whenever the plist merely existed + was
+loaded — even if its ProgramArguments pointed at a renamed/moved app that no
+longer launches. These pin that a stale plist is detected as not-current so the
+startup sync rewrites it (Tiberiu, 2026-06-22: auto-start silently stopped)."""
+
+import plistlib
+
+import src.autostart as autostart
+
+
+def _write_plist(path, program_args):
+    with open(path, "wb") as f:
+        plistlib.dump(
+            {"Label": "co.betterqa.betterflow", "ProgramArguments": program_args,
+             "RunAtLoad": True},
+            f,
+        )
+
+
+def test_plist_program_args_reads_installed_args(tmp_path, monkeypatch):
+    pl = tmp_path / "agent.plist"
+    _write_plist(pl, ["open", "-a", "/Applications/BetterFlow.app"])
+    monkeypatch.setattr(autostart, "_plist_path", lambda: pl)
+    assert autostart._macos_plist_program_args() == ["open", "-a", "/Applications/BetterFlow.app"]
+
+
+def test_plist_program_args_none_when_missing(tmp_path, monkeypatch):
+    monkeypatch.setattr(autostart, "_plist_path", lambda: tmp_path / "nope.plist")
+    assert autostart._macos_plist_program_args() is None
+
+
+def test_is_current_true_when_args_match(tmp_path, monkeypatch):
+    pl = tmp_path / "agent.plist"
+    _write_plist(pl, ["open", "-a", "/Applications/BetterFlow.app"])
+    monkeypatch.setattr(autostart, "_plist_path", lambda: pl)
+    monkeypatch.setattr(autostart, "_app_launch_args",
+                        lambda: ["open", "-a", "/Applications/BetterFlow.app"])
+    assert autostart._macos_plist_is_current() is True
+
+
+def test_is_current_false_when_path_is_stale(tmp_path, monkeypatch):
+    # plist points at the OLD app name; the running app is now BetterFlow.app.
+    pl = tmp_path / "agent.plist"
+    _write_plist(pl, ["open", "-a", "/Applications/BetterFlow Sync.app"])
+    monkeypatch.setattr(autostart, "_plist_path", lambda: pl)
+    monkeypatch.setattr(autostart, "_app_launch_args",
+                        lambda: ["open", "-a", "/Applications/BetterFlow.app"])
+    assert autostart._macos_plist_is_current() is False
+
+
+def test_is_current_false_when_plist_missing(tmp_path, monkeypatch):
+    monkeypatch.setattr(autostart, "_plist_path", lambda: tmp_path / "nope.plist")
+    monkeypatch.setattr(autostart, "_app_launch_args",
+                        lambda: ["open", "-a", "/Applications/BetterFlow.app"])
+    assert autostart._macos_plist_is_current() is False


### PR DESCRIPTION
**Bug:** `_get_macos()` returned True whenever the LaunchAgent plist *existed + was loaded*, even if its `ProgramArguments` pointed at a renamed/moved app ("BetterFlow Sync.app" → "BetterFlow.app", or a relocated bundle). Since `ensure_synced()` only rewrites the plist when `get_auto_start()` is False, a stale-path plist was left in place forever — auto-start silently launched nothing.

**Fix:** the plist must match the **current** app path (`_macos_plist_is_current()`). A stale one now reads as not-enabled, so `ensure_synced()` rewrites it on the next startup. Correct/fresh installs are unchanged (no churn — a freshly written plist round-trips to an exact match). 5 new tests + lint clean. → 1.5.66.

**Scope note:** this addresses the **rename/move** case. Tiberiu's report (1.5.57→1.5.65, same `/Applications/BetterFlow.app` path) is more likely the macOS-13+ **'Allow in the Background' login-item approval being reset on update** — a separate path that needs user re-approval (awaiting his diagnostic output to confirm).

🤖 Generated with [Claude Code](https://claude.com/claude-code)