### PR TITLE
fix(sync): decouple per-bucket sends and make checkpoints monotonic

### DIFF
--- a/src/__init__.py
+++ b/src/__init__.py
@@ -1,4 +1,4 @@
 """BetterFlow - ActivityWatch to BetterFlow sync companion app."""
 
-__version__ = "1.5.66"
+__version__ = "1.5.67"
 __author__ = "BetterQA"

--- a/src/sync/queue.py
+++ b/src/sync/queue.py
@@ -506,6 +506,39 @@ class OfflineQueue:
                 (bucket_id, event_id, timestamp.isoformat(), now),
             )
 
+    def set_checkpoint_forward(
+        self, bucket_id: str, timestamp: datetime, event_id: Optional[int] = None
+    ) -> None:
+        """Advance a bucket's checkpoint, but only forward (monotonic).
+
+        Identical to ``set_checkpoint`` except the write is a no-op when the
+        bucket already has a checkpoint at or after ``timestamp``. The guard is
+        a ``WHERE`` on the existing row inside a single statement, so two sync
+        threads can't race a checkpoint backward (no read-then-write). Use this
+        on the normal per-cycle advance path; reserve the raw ``set_checkpoint``
+        for intentional resets (first-sync seed, pause skip-forward).
+
+        The comparison is lexical on the stored ISO-8601 strings. Every writer
+        passes a tz-aware UTC datetime (``isoformat()`` -> ``...+00:00``), so the
+        fixed-width prefix compares chronologically; sub-second format
+        differences only ever bias toward NOT rewinding, which is the safe
+        direction.
+        """
+        now = datetime.now(timezone.utc).isoformat()
+        with self._cursor() as cursor:
+            cursor.execute(
+                """
+                INSERT INTO sync_checkpoints (bucket_id, last_event_id, last_timestamp, updated_at)
+                VALUES (?, ?, ?, ?)
+                ON CONFLICT(bucket_id) DO UPDATE SET
+                    last_event_id = excluded.last_event_id,
+                    last_timestamp = excluded.last_timestamp,
+                    updated_at = excluded.updated_at
+                WHERE excluded.last_timestamp > sync_checkpoints.last_timestamp
+                """,
+                (bucket_id, event_id, timestamp.isoformat(), now),
+            )
+
     def get_all_checkpoints(self) -> dict[str, datetime]:
         """Get all sync checkpoints."""
         with self._cursor() as cursor:

--- a/src/sync/sync_engine.py
+++ b/src/sync/sync_engine.py
@@ -690,17 +690,17 @@ class SyncEngine:
             if stats.events_queued == pre_queued:
                 # Full success — advance all checkpoints
                 for bucket_id, ts, event_id in pending_checkpoints:
-                    self.queue.set_checkpoint(bucket_id, ts, event_id)
+                    self.queue.set_checkpoint_forward(bucket_id, ts, event_id)
             else:
                 # Partial failure — advance only buckets whose events
                 # were all sent (none queued).
                 for bucket_id, ts, event_id in pending_checkpoints:
                     if bucket_id not in stats.queued_bucket_ids:
-                        self.queue.set_checkpoint(bucket_id, ts, event_id)
+                        self.queue.set_checkpoint_forward(bucket_id, ts, event_id)
         elif pending_checkpoints:
             # All events were dedup-filtered (already sent); safe to advance.
             for bucket_id, ts, event_id in pending_checkpoints:
-                self.queue.set_checkpoint(bucket_id, ts, event_id)
+                self.queue.set_checkpoint_forward(bucket_id, ts, event_id)
 
     @staticmethod
     def _local_day_iso() -> str:
@@ -947,7 +947,7 @@ class SyncEngine:
         # checkpoint): advance past it so we don't re-poll the same empty span
         # forever while a backlog waits beyond it.
         if not events and fetch_end < now:
-            self.queue.set_checkpoint(bucket_id, fetch_end)
+            self.queue.set_checkpoint_forward(bucket_id, fetch_end)
             return [], lookback_start
 
         if len(events) > self.config.sync.batch_size:
@@ -1890,7 +1890,43 @@ class SyncEngine:
         return events
 
     def _send_events(self, events: list[dict], stats: SyncStats) -> None:
-        """Send events to BetterFlow or queue if offline."""
+        """Send events to BetterFlow, grouped by bucket (#4 decouple buckets).
+
+        Each bucket's events are batched and sent in their own sequence so a
+        transient failure in one bucket (e.g. a frozen/duplicate AFK stream)
+        re-queues and back-off-marks ONLY that bucket. Previously all buckets
+        shared one batch list, so a single transient failure with no
+        ``accepted_ids`` re-queued the whole mixed batch and tainted every
+        bucket's ``queued_bucket_ids`` — withholding the window checkpoint over
+        an unrelated AFK failure. Grouping confines the blast radius to the
+        failing bucket; ``_send_and_advance_checkpoints`` then advances the
+        healthy buckets normally.
+        """
+        # Preserve insertion order (dict is ordered in 3.7+) so behaviour is
+        # deterministic and single-bucket cycles are unchanged.
+        by_bucket: dict[str, list[dict]] = {}
+        for event in events:
+            by_bucket.setdefault(event.get("bucket_id", ""), []).append(event)
+
+        bucket_groups = list(by_bucket.values())
+        for idx, group in enumerate(bucket_groups):
+            try:
+                self._send_bucket_events(group, stats)
+            except BetterFlowAuthError:
+                # A 401 means the server rejected the request — every bucket not
+                # yet attempted is also unsent. Queue them all before
+                # propagating so nothing is silently dropped (the per-bucket
+                # handler already queued this bucket's remaining batches).
+                for remaining in bucket_groups[idx + 1:]:
+                    self.queue.enqueue(remaining)
+                    stats.events_queued += len(remaining)
+                    stats.queued_bucket_ids.update(
+                        e.get("bucket_id", "") for e in remaining
+                    )
+                raise
+
+    def _send_bucket_events(self, events: list[dict], stats: SyncStats) -> None:
+        """Batch and send a single bucket's events (or queue on failure)."""
         # Batch events
         batch_size = self.config.sync.batch_size
         batches = [events[i : i + batch_size] for i in range(0, len(events), batch_size)]

--- a/tests/test_bf_client.py
+++ b/tests/test_bf_client.py
@@ -521,7 +521,13 @@ class TestBetterFlowClient:
         assert self.client._throttle_remaining() == 0.0
 
         self.client._enter_throttle(10)
-        assert 8 < self.client._throttle_remaining() <= 10
+        # Upper bound tolerates a float epsilon: _throttle_remaining computes
+        # (monotonic() + 10) - monotonic(), and on a coarse clock (Windows
+        # returns the same value for both reads) float cancellation can land a
+        # hair above 10 (e.g. 10.000000000000028). Only the _MAX_THROTTLE_SECONDS
+        # cap is a hard invariant (clamped in _throttle_remaining); 10 is just
+        # this call's input, so allow the rounding slack.
+        assert 8 < self.client._throttle_remaining() <= 10 + 1e-6
 
         # A shorter backoff must NOT shrink an active longer one.
         self.client._enter_throttle(1)

--- a/tests/test_queue.py
+++ b/tests/test_queue.py
@@ -152,6 +152,57 @@ class TestOfflineQueue:
         loaded = self.queue.get_checkpoint(bucket_id)
         assert loaded.replace(microsecond=0) == new_time.replace(microsecond=0)
 
+    def test_checkpoint_forward_advances_on_newer(self):
+        """set_checkpoint_forward moves the checkpoint forward (#5a)."""
+        bucket_id = "aw-watcher-window_test"
+        old_time = datetime.now(timezone.utc) - timedelta(hours=1)
+        new_time = datetime.now(timezone.utc)
+
+        self.queue.set_checkpoint_forward(bucket_id, old_time)
+        self.queue.set_checkpoint_forward(bucket_id, new_time)
+
+        loaded = self.queue.get_checkpoint(bucket_id)
+        assert loaded.replace(microsecond=0) == new_time.replace(microsecond=0)
+
+    def test_checkpoint_forward_is_noop_on_older(self):
+        """set_checkpoint_forward never rewinds a checkpoint backward (#5a).
+
+        Guards the doc's "silently re-scan from a 2-day-old checkpoint" class:
+        a lookback re-fetch whose last event end predates the stored checkpoint
+        must not drag it back.
+        """
+        bucket_id = "aw-watcher-window_test"
+        new_time = datetime.now(timezone.utc)
+        old_time = new_time - timedelta(days=2)
+
+        self.queue.set_checkpoint_forward(bucket_id, new_time)
+        self.queue.set_checkpoint_forward(bucket_id, old_time)  # must be ignored
+
+        loaded = self.queue.get_checkpoint(bucket_id)
+        assert loaded.replace(microsecond=0) == new_time.replace(microsecond=0)
+
+    def test_checkpoint_forward_seeds_when_absent(self):
+        """First forward write creates the row (no existing checkpoint)."""
+        bucket_id = "aw-watcher-window_test"
+        ts = datetime.now(timezone.utc)
+
+        self.queue.set_checkpoint_forward(bucket_id, ts)
+
+        loaded = self.queue.get_checkpoint(bucket_id)
+        assert loaded is not None
+        assert loaded.replace(microsecond=0) == ts.replace(microsecond=0)
+
+    def test_checkpoint_forward_equal_is_noop(self):
+        """An equal timestamp is not 'forward' — keeps the stored event_id."""
+        bucket_id = "aw-watcher-window_test"
+        ts = datetime(2026, 6, 20, 10, 0, 0, tzinfo=timezone.utc)
+
+        self.queue.set_checkpoint_forward(bucket_id, ts, event_id=1)
+        self.queue.set_checkpoint_forward(bucket_id, ts, event_id=2)
+
+        loaded = self.queue.get_checkpoint(bucket_id)
+        assert loaded.replace(microsecond=0) == ts.replace(microsecond=0)
+
     def test_get_nonexistent_checkpoint(self):
         """Test getting a checkpoint that doesn't exist."""
         loaded = self.queue.get_checkpoint("nonexistent_bucket")

--- a/tests/test_sync_engine.py
+++ b/tests/test_sync_engine.py
@@ -1,17 +1,18 @@
 """Tests for sync engine."""
 
 import threading
-import pytest
 from datetime import datetime, timedelta, timezone
-from unittest.mock import Mock, MagicMock, patch
+from unittest.mock import MagicMock, Mock, patch
 
-from src.config import Config, PrivacySettings
-from src.sync.aw_client import AWEvent, BUCKET_TYPE_WINDOW, BUCKET_TYPE_AFK, BUCKET_TYPE_INPUT
-from src.sync.sync_engine import SyncEngine, _SyncCycleContext
-from src.sync.activity_analyzer import ActivityAnalyzer
-from src.sync.daily_time_tracker import DailyTimeTracker
+import pytest
+
+from src.config import Config
 from src.main import SyncCoordinator
 from src.reminders import ReminderManager
+from src.sync.activity_analyzer import ActivityAnalyzer
+from src.sync.aw_client import BUCKET_TYPE_AFK, BUCKET_TYPE_INPUT, BUCKET_TYPE_WINDOW, AWEvent
+from src.sync.daily_time_tracker import DailyTimeTracker
+from src.sync.sync_engine import SyncEngine, _SyncCycleContext
 from src.ui.tray import TrayState
 
 
@@ -1047,6 +1048,124 @@ class TestSyncEngine:
         # _cache_lock should have been acquired for _time_cache operations
         # _transform_event accesses _time_cache when activity_state is "active"
         assert acquire_count >= 1, f"Expected >= 1 lock acquisition for _time_cache, got {acquire_count}"
+
+
+class TestSendEventsDecoupleBuckets:
+    """#4: a transient failure in one bucket must not taint another."""
+
+    def setup_method(self):
+        self.aw = Mock()
+        self.bf = Mock()
+        self.queue = Mock()
+        self.queue.get_checkpoint.return_value = None
+        self.config = Config()
+        self.engine = SyncEngine(
+            aw=self.aw,
+            bf=self.bf,
+            queue=self.queue,
+            config=self.config,
+            activity_analyzer=Mock(spec=ActivityAnalyzer),
+            time_tracker=Mock(spec=DailyTimeTracker),
+        )
+
+    @staticmethod
+    def _ev(bucket_id, eid):
+        return {"id": f"{bucket_id}_{eid}", "bucket_id": bucket_id, "duration": 60}
+
+    def test_afk_failure_does_not_taint_window(self):
+        """AFK send fails transiently; window send succeeds → only AFK is
+        queued/back-off-marked. Previously the mixed batch re-queued both."""
+        from src.sync.bf_client import SyncResult
+        from src.sync.sync_engine import SyncStats
+
+        def fake_send(batch):
+            if any("afk" in e.get("bucket_id", "") for e in batch):
+                return SyncResult(success=False, error="transient failure")
+            return SyncResult(success=True, events_synced=len(batch))
+
+        self.bf.send_events.side_effect = fake_send
+
+        events = [
+            self._ev("aw-watcher-window_host", 1),
+            self._ev("bf-afk-inproc_host", 2),
+            self._ev("aw-watcher-window_host", 3),
+        ]
+        stats = SyncStats()
+        self.engine._send_events(events, stats)
+
+        # Only the AFK bucket is queued/tainted.
+        assert "bf-afk-inproc_host" in stats.queued_bucket_ids
+        assert "aw-watcher-window_host" not in stats.queued_bucket_ids
+        # Exactly the two AFK events were enqueued, window events were not.
+        enqueued = [e for call in self.queue.enqueue.call_args_list for e in call.args[0]]
+        assert {e["id"] for e in enqueued} == {"bf-afk-inproc_host_2"}
+        assert stats.events_queued == 1
+        assert stats.events_sent == 2
+
+    def test_no_batch_mixes_buckets(self):
+        """Each send_events call carries a single bucket's events only."""
+        from src.sync.bf_client import SyncResult
+        from src.sync.sync_engine import SyncStats
+
+        self.bf.send_events.return_value = SyncResult(success=True, events_synced=1)
+        events = [
+            self._ev("aw-watcher-window_host", 1),
+            self._ev("bf-afk-inproc_host", 2),
+            self._ev("aw-watcher-input_host", 3),
+        ]
+        self.engine._send_events(events, SyncStats())
+
+        for call in self.bf.send_events.call_args_list:
+            buckets = {e["bucket_id"] for e in call.args[0]}
+            assert len(buckets) == 1, f"batch mixed buckets: {buckets}"
+
+    def test_single_bucket_transient_failure_unchanged(self):
+        """Regression: a single-bucket cycle still queues that whole bucket."""
+        from src.sync.bf_client import SyncResult
+        from src.sync.sync_engine import SyncStats
+
+        self.bf.send_events.return_value = SyncResult(success=False, error="down")
+        events = [self._ev("aw-watcher-window_host", i) for i in range(3)]
+        stats = SyncStats()
+        self.engine._send_events(events, stats)
+
+        assert stats.queued_bucket_ids == {"aw-watcher-window_host"}
+        assert stats.events_queued == 3
+        assert stats.events_sent == 0
+
+    def test_afk_failure_advances_window_checkpoint(self):
+        """End-to-end goal: with AFK failing and window succeeding, the window
+        checkpoint advances while the AFK checkpoint is withheld. This is the
+        actual decouple win — exercises _send_and_advance_checkpoints, not just
+        _send_events."""
+        from src.sync.bf_client import SyncResult
+        from src.sync.sync_engine import SyncStats
+
+        def fake_send(batch):
+            if any("afk" in e.get("bucket_id", "") for e in batch):
+                return SyncResult(success=False, error="transient failure")
+            return SyncResult(success=True, events_synced=len(batch))
+
+        self.bf.send_events.side_effect = fake_send
+
+        win_ts = datetime(2026, 6, 22, 10, 0, 0, tzinfo=timezone.utc)
+        afk_ts = datetime(2026, 6, 22, 10, 0, 5, tzinfo=timezone.utc)
+        all_events = [
+            self._ev("aw-watcher-window_host", 1),
+            self._ev("bf-afk-inproc_host", 2),
+        ]
+        pending = [
+            ("aw-watcher-window_host", win_ts, 1),
+            ("bf-afk-inproc_host", afk_ts, 2),
+        ]
+        stats = SyncStats()
+        self.engine._send_and_advance_checkpoints(all_events, pending, stats)
+
+        advanced = {
+            call.args[0] for call in self.queue.set_checkpoint_forward.call_args_list
+        }
+        assert "aw-watcher-window_host" in advanced  # healthy bucket advances
+        assert "bf-afk-inproc_host" not in advanced  # failed bucket withheld
 
 
 class TestStatusSpanEvents:

--- a/tests/test_sync_engine_decouple_buckets_e2e.py
+++ b/tests/test_sync_engine_decouple_buckets_e2e.py
@@ -1,0 +1,170 @@
+"""End-to-end pipeline test for #4 (decouple buckets) + #5a (monotonic checkpoints).
+
+Drives the REAL ``SyncEngine.sync()`` across multiple cycles with a REAL on-disk
+SQLite ``OfflineQueue`` and ``DailyTimeTracker``; only the two external
+boundaries are faked (the AW client serves events, the BetterFlow client accepts
+window sends but fails afk sends transiently, then recovers). Assertions are made
+against the checkpoint state read back off disk between cycles — the same state
+the live agent keeps.
+
+Regression context: a transient failure in one bucket (e.g. a frozen/duplicate
+AFK stream) used to re-queue the whole mixed batch and withhold every bucket's
+checkpoint, stalling unrelated window sync (the doc's "one type failing re-queues
++ backs off everything"). #4 confines the blast radius to the failing bucket; #5a
+guarantees a checkpoint can never be dragged backward.
+"""
+import tempfile
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+
+from src.config import Config
+from src.sync.aw_client import BUCKET_TYPE_AFK, BUCKET_TYPE_WINDOW, AWBucket, AWEvent
+from src.sync.bf_client import SyncResult
+from src.sync.daily_time_tracker import DailyTimeTracker
+from src.sync.queue import OfflineQueue
+from src.sync.sync_engine import SyncEngine
+
+WIN = "aw-watcher-window_smoke"
+AFK = "aw-watcher-afk_smoke"
+
+
+def _bucket(now, bid, btype):
+    return AWBucket(id=bid, name=bid, type=btype, client="", hostname="smoke", created=now)
+
+
+class _FakeAW:
+    """Serves one window + one afk event, both ~4 min old (past the checkpoint,
+    inside the lookback), filtered by the requested [start, end) window."""
+
+    def __init__(self, now):
+        self._now = now
+        t = now - timedelta(minutes=4)
+        self._events = {
+            WIN: [AWEvent(id=1, timestamp=t, duration=60.0,
+                          data={"app": "Terminal", "title": "work"})],
+            AFK: [AWEvent(id=2, timestamp=t, duration=60.0,
+                          data={"status": "not-afk"})],
+        }
+
+    def is_running(self):
+        return True
+
+    def get_window_buckets(self):
+        return [_bucket(self._now, WIN, BUCKET_TYPE_WINDOW)]
+
+    def get_web_buckets(self):
+        return []
+
+    def get_afk_buckets(self):
+        return [_bucket(self._now, AFK, BUCKET_TYPE_AFK)]
+
+    def get_input_buckets(self):
+        return []
+
+    def get_events(self, bid, start=None, end=None, limit=1000):
+        return [
+            e for e in self._events.get(bid, [])
+            if (start is None or e.timestamp >= start)
+            and (end is None or e.timestamp < end)
+        ]
+
+    def get_events_since(self, bid, since, limit=1000):
+        return [e for e in self._events.get(bid, []) if e.timestamp >= since]
+
+    def get_latest_afk_event(self):
+        evs = self._events.get(AFK, [])
+        return evs[-1] if evs else None
+
+
+class _FakeBF:
+    """Window sends succeed; afk sends fail transiently until ``afk_ok`` flips."""
+
+    def __init__(self):
+        self.afk_ok = False
+        self.sent_window = 0
+        self.sent_afk = 0
+
+    def is_reachable(self):
+        return True
+
+    def get_config(self):
+        return {}
+
+    def start_session(self):
+        return {}
+
+    def end_session(self, reason="app_quit"):
+        return {}
+
+    def heartbeat(self, agent_version="0"):
+        return {}
+
+    def get_trends(self):
+        return {}
+
+    def send_events(self, events):
+        is_afk = any("afk" in e.get("bucket_id", "") for e in events)
+        if is_afk and not self.afk_ok:
+            return SyncResult(success=False, error="transient failure")
+        if is_afk:
+            self.sent_afk += len(events)
+        else:
+            self.sent_window += len(events)
+        return SyncResult(success=True, events_synced=len(events))
+
+
+def test_decouple_and_monotonic_checkpoints_end_to_end():
+    tmp = Path(tempfile.mkdtemp())
+    now = datetime.now(timezone.utc)
+    q = OfflineQueue(db_path=tmp / "q.db", max_size=100000)
+    tt = DailyTimeTracker(db_path=tmp / "t.db")
+    aw, bf = _FakeAW(now), _FakeBF()
+
+    engine = SyncEngine(aw=aw, bf=bf, queue=q, config=Config(), time_tracker=tt)
+    # Exercise the STEADY-STATE path: skip the one-time whole-day backlog replay.
+    engine._backlog_reconciled = True
+    # Suppress the stale-AFK synthesizer: on a genuinely-active CI/dev machine it
+    # would add an extra synthetic not-afk span (real, correct behaviour) and
+    # muddy the event count this test asserts on. Report "idle" so it stays quiet.
+    engine._get_system_idle_seconds = lambda: 9999.0
+
+    # Seed both checkpoints to 10 min ago so the 4-min-old events are fetched.
+    t0 = now - timedelta(minutes=10)
+    q.set_checkpoint(WIN, t0)
+    q.set_checkpoint(AFK, t0)
+
+    try:
+        # --- Cycle 1: window OK, afk fails transiently -------------------------
+        engine.sync()
+        win_cp1, afk_cp1 = q.get_checkpoint(WIN), q.get_checkpoint(AFK)
+        # #4: the healthy window bucket advances even though afk failed.
+        assert win_cp1 > t0, "window checkpoint must advance despite afk failure"
+        # The failed afk bucket is withheld.
+        assert afk_cp1 == t0, "afk checkpoint must be withheld on failure"
+        # Its event is durably queued, window was delivered.
+        assert q.size() == 1
+        assert bf.sent_window == 1
+
+        # --- Cycle 2: afk still failing; verify monotonicity -------------------
+        engine.sync()
+        win_cp2, afk_cp2 = q.get_checkpoint(WIN), q.get_checkpoint(AFK)
+        # #5a: neither checkpoint is ever dragged backward.
+        assert win_cp2 >= win_cp1, "window checkpoint must be monotonic"
+        assert afk_cp2 >= afk_cp1, "afk checkpoint must be monotonic"
+        # The afk event is dedup-cached after cycle 1, so its checkpoint may
+        # advance — but the undelivered event must still live in the durable
+        # queue (no loss); the recovery cycle below delivers it.
+        assert q.size() >= 1, "undelivered afk event must not be lost"
+
+        # --- Cycle 3: afk recovers; queue drains -------------------------------
+        bf.afk_ok = True
+        # Clear the exponential backoff armed by the prior failures so the queue
+        # drains this cycle (otherwise _process_queue correctly waits it out).
+        engine._queue_backoff_until = datetime.min.replace(tzinfo=timezone.utc)
+        engine._queue_consecutive_failures = 0
+        engine.sync()
+        assert q.size() == 0, "offline queue must drain after recovery"
+        assert bf.sent_afk >= 1, "afk event must eventually be delivered"
+    finally:
+        q.close()
+        tt.close()


### PR DESCRIPTION
## What & why

Two agent-side robustness fixes from the DeskTime comparison design note (`docs/desktime-vs-betterflow-sync.md`), items **#4** and **#5a**. Both are **recurrence-prevention** for the false-idle / stalled-checkpoint class — **not** a fix for any live incident (the live `tracked:2h / active:0` symptom remains the **#1850 backend deploy**).

### #4 — Decouple buckets
`_send_events` merged every bucket's events into one list. On a transient failure with no `accepted_ids` (the N11 branch), the **whole mixed batch** was re-queued and **every** `bucket_id` in it marked queued — so a transient AFK failure withheld the **window** checkpoint too (the doc's "one type failing re-queues + backs off everything").

Fix: group events by `bucket_id` and send each bucket in its own batch sequence. A transient failure now confines its blast radius to the failing bucket; `_send_and_advance_checkpoints` advances the healthy buckets normally. Auth-error contract preserved — a 401 still queues every not-yet-attempted bucket before re-raising.

### #5a — Monotonic checkpoints
New `OfflineQueue.set_checkpoint_forward()`: an **atomic** upsert guarded by `WHERE excluded.last_timestamp > sync_checkpoints.last_timestamp` (no read-then-write race) that never moves a checkpoint backward. The normal advance paths now use it; raw `set_checkpoint` stays only on the intentional-reset paths (first-sync seed, pause skip-to-now). A 2-min lookback re-fetch can no longer drag a checkpoint back and trigger a re-scan.

## Testing
- **Unit** — monotonic-checkpoint tests (`test_queue.py`); decouple-bucket tests (`test_sync_engine.py`).
- **Integration** — checkpoint-advance test through `_send_and_advance_checkpoints` (window advances while AFK is withheld).
- **End-to-end** — `test_sync_engine_decouple_buckets_e2e.py` drives the real `SyncEngine.sync()` across 3 cycles (fail → monotonic hold → recover/drain) with a real on-disk SQLite queue.
- **Mutation-verified** — removing the `WHERE` guard fails the no-op test; defeating the grouping fails 3 decouple tests (incl. the integration one) with the original-bug log line.
- Full suite: **684 passed**. Ruff clean on changed files.

## Scope notes
- Offline-queue draining (`_process_queue`) left as-is — it already does per-id partial handling.
- The fully server-acknowledged checkpoint (#5b/#5c) and explicit active/idle payload (#3) are **out of scope** here; #5c/#3 need a backend envelope contract.
- Surfaced (pre-existing, not changed): the dedup cache marks an event "sent" at transform time before delivery is confirmed, so a failed-then-queued event's checkpoint can advance on the next cycle — safe because the event lives durably in the offline queue (the e2e test proves it drains), and the monotonic guard is compatible.

🤖 Generated with [Claude Code](https://claude.com/claude-code)