### PR TITLE
fix(macos): detect Accessibility loss honestly (stop trusting Automation)

### DIFF
--- a/src/ui/permissions.py
+++ b/src/ui/permissions.py
@@ -35,15 +35,56 @@ _ALLOWED_TCC_SERVICES = frozenset({
 _BUNDLE_ID_RE = re.compile(r"^[A-Za-z0-9][A-Za-z0-9._-]{1,127}$")
 
 
+# AXError code: the Accessibility API is disabled for this process (i.e. NOT
+# granted). Any other result from an AXUIElement query means the AX subsystem
+# is servicing our requests = granted. From <HIServices/AXError.h>.
+_kAXErrorAPIDisabled = -25211
+
+
+def _ax_api_works() -> bool:
+    """Authoritative Accessibility test: exercise the real in-process AX API.
+
+    Asks the system-wide AX element for the focused application — the same
+    Accessibility machinery the window watcher relies on to read titles. If the
+    grant is present the call is serviced (success, or no-value when nothing is
+    focused); if it is absent macOS returns ``kAXErrorAPIDisabled``. This is the
+    only honest practical probe: it tests *this process's own* Accessibility
+    grant, and it succeeds even when ``AXIsProcessTrusted()`` returns a false
+    negative for unsigned x86_64 binaries under Rosetta.
+
+    Crucially it does NOT shell out to AppleScript/System Events — that path
+    only proves *Automation* permission, so after a reinstall dropped the AX
+    grant it reported Accessibility as present and the watcher silently emitted
+    empty titles with no re-prompt.
+    """
+    try:
+        from ApplicationServices import (
+            AXUIElementCopyAttributeValue,
+            AXUIElementCreateSystemWide,
+        )
+
+        system_wide = AXUIElementCreateSystemWide()
+        err, _value = AXUIElementCopyAttributeValue(
+            system_wide, "AXFocusedApplication", None,
+        )
+        return err != _kAXErrorAPIDisabled
+    except Exception as e:
+        logger.debug("AX system-wide probe failed: %s", e)
+        return False
+
+
 def check_accessibility() -> bool:
     """Check if Accessibility permission is granted.
 
-    Tries pyobjc ApplicationServices first (more reliable in PyInstaller
-    bundles), falls back to ctypes, then to a practical AppleScript test.
+    Tries pyobjc ``AXIsProcessTrusted`` first (most reliable in PyInstaller
+    bundles), falls back to ctypes, then confirms a negative with a real
+    in-process AX read (``_ax_api_works``).
 
-    The practical test is needed because AXIsProcessTrusted() can return
-    False for unsigned x86_64 PyInstaller binaries running under Rosetta
-    even when the System Settings toggle is ON.
+    The final AX read is needed because ``AXIsProcessTrusted()`` can return
+    False for unsigned x86_64 PyInstaller binaries running under Rosetta even
+    when the System Settings toggle is ON. It replaces a former AppleScript
+    probe that only exercised Automation permission and so falsely reported
+    Accessibility as granted after a signature change dropped the grant.
 
     Returns True on non-macOS platforms.
     """
@@ -73,21 +114,10 @@ def check_accessibility() -> bool:
     except Exception as e:
         logger.debug("ctypes AXIsProcessTrusted probe failed: %s", e)
 
-    # Practical test: try reading the frontmost app name via AppleScript.
-    # This actually exercises the Accessibility API and works even when
-    # AXIsProcessTrusted() lies (Rosetta/unsigned binary edge case).
-    try:
-        result = subprocess.run(
-            ["osascript", "-e", 'tell application "System Events" to get name of first process whose frontmost is true'],
-            capture_output=True, text=True, timeout=3,
-        )
-        if result.returncode == 0 and result.stdout.strip():
-            logger.debug("AXIsProcessTrusted=False but AppleScript works, treating as granted")
-            return True
-    except Exception as e:
-        logger.debug("AppleScript accessibility probe failed: %s", e)
-
-    return False
+    # AXIsProcessTrusted() said False — confirm against the real AX API rather
+    # than trusting it (Rosetta false-negative) or AppleScript (Automation
+    # false-positive). This is the authoritative, watcher-matching test.
+    return _ax_api_works()
 
 
 def check_input_monitoring(prompt: bool = False) -> bool:

--- a/tests/test_permissions.py
+++ b/tests/test_permissions.py
@@ -1,0 +1,107 @@
+"""Tests for macOS Accessibility permission detection (src/ui/permissions.py).
+
+Regression context: check_accessibility() used an AppleScript / System Events
+call as its practical fallback. That call only proves *Automation* permission,
+not the process's own *Accessibility* grant — so after a reinstall changed the
+code signature and macOS dropped the Accessibility grant, the probe still
+returned True. The window watcher (which uses the real in-process AX API) then
+silently emitted empty titles, and the startup re-grant/notification never
+fired. The fallback now exercises the real AX API instead.
+
+These tests inject a fake ``ApplicationServices`` module so the macOS-only code
+paths run deterministically on any CI platform (Linux/Windows included).
+"""
+import ctypes.util
+import sys
+import types
+from unittest.mock import MagicMock
+
+import src.ui.permissions as permissions
+
+# AXError codes (from <HIServices/AXError.h>)
+AX_SUCCESS = 0
+AX_ERROR_NO_VALUE = -25212
+AX_ERROR_API_DISABLED = -25211  # accessibility disabled for this process
+
+
+def _install_fake_app_services(monkeypatch, *, trusted, ax_err):
+    """Install a fake ApplicationServices module and force the macOS path.
+
+    Also makes the ctypes AXIsProcessTrusted fallback fail, so the outcome is
+    determined solely by the fake pyobjc result + the AX probe — never the
+    host's real Accessibility state.
+    """
+    mod = types.ModuleType("ApplicationServices")
+    mod.AXIsProcessTrusted = lambda: trusted
+    mod.AXUIElementCreateSystemWide = lambda: object()
+    mod.AXUIElementCopyAttributeValue = lambda element, attr, none: (ax_err, None)
+    monkeypatch.setitem(sys.modules, "ApplicationServices", mod)
+    monkeypatch.setattr(ctypes.util, "find_library", lambda name: "/nonexistent/lib")
+    monkeypatch.setattr(permissions, "_IS_MACOS", True)
+
+
+def test_returns_true_when_axisprocesstrusted_true(monkeypatch):
+    """Fast path: a positive AXIsProcessTrusted short-circuits to granted."""
+    _install_fake_app_services(monkeypatch, trusted=True, ax_err=AX_ERROR_API_DISABLED)
+    assert permissions.check_accessibility() is True
+
+
+def test_rosetta_false_negative_confirmed_by_ax_read(monkeypatch):
+    """AXIsProcessTrusted lies (False) but the real AX read is serviced →
+    granted. Preserves the Rosetta/unsigned-binary handling the old AppleScript
+    fallback was added for."""
+    _install_fake_app_services(monkeypatch, trusted=False, ax_err=AX_SUCCESS)
+    assert permissions.check_accessibility() is True
+
+
+def test_real_loss_detected_not_masked(monkeypatch):
+    """The bug: AXIsProcessTrusted False AND the AX API disabled must report
+    MISSING. The old AppleScript probe returned True here (Automation), masking
+    the loss and suppressing the re-grant."""
+    _install_fake_app_services(monkeypatch, trusted=False, ax_err=AX_ERROR_API_DISABLED)
+    assert permissions.check_accessibility() is False
+
+
+def test_granted_but_nothing_focused_counts_as_granted(monkeypatch):
+    """No focused app (kAXErrorNoValue) still means the AX subsystem serviced
+    the request — that's a grant, not a denial."""
+    _install_fake_app_services(monkeypatch, trusted=False, ax_err=AX_ERROR_NO_VALUE)
+    assert permissions.check_accessibility() is True
+
+
+def test_never_shells_out_to_applescript(monkeypatch):
+    """The Automation-based AppleScript probe is gone: check_accessibility must
+    not invoke subprocess, even on the negative path."""
+    _install_fake_app_services(monkeypatch, trusted=False, ax_err=AX_ERROR_API_DISABLED)
+    run = MagicMock()
+    monkeypatch.setattr(permissions.subprocess, "run", run)
+    assert permissions.check_accessibility() is False
+    run.assert_not_called()
+
+
+def test_non_macos_returns_true(monkeypatch):
+    """Non-macOS platforms are always 'granted' (no AX model)."""
+    monkeypatch.setattr(permissions, "_IS_MACOS", False)
+    assert permissions.check_accessibility() is True
+
+
+def test_ax_api_works_maps_error_codes(monkeypatch):
+    """_ax_api_works: only kAXErrorAPIDisabled means not-granted."""
+    for err, expected in [
+        (AX_SUCCESS, True),
+        (AX_ERROR_NO_VALUE, True),
+        (AX_ERROR_API_DISABLED, False),
+    ]:
+        mod = types.ModuleType("ApplicationServices")
+        mod.AXUIElementCreateSystemWide = lambda: object()
+        mod.AXUIElementCopyAttributeValue = lambda e, a, n, _e=err: (_e, None)
+        monkeypatch.setitem(sys.modules, "ApplicationServices", mod)
+        assert permissions._ax_api_works() is expected
+
+
+def test_ax_api_works_false_when_binding_unavailable(monkeypatch):
+    """If the AX binding can't be imported, fail safe (report not-granted
+    rather than falsely granting)."""
+    broken = types.ModuleType("ApplicationServices")  # missing AX symbols
+    monkeypatch.setitem(sys.modules, "ApplicationServices", broken)
+    assert permissions._ax_api_works() is False


### PR DESCRIPTION
## Problem (found while verifying the v1.5.67-beta.1 install live)

After reinstalling the app, the macOS window watcher logged *\"does NOT have Accessibility permission — window titles will be empty\"* — yet `check_accessibility()` returned **True**. Titles were silently blank and nothing re-prompted.

Root cause: `check_accessibility()`'s practical fallback ran an AppleScript probe —
```python
osascript -e 'tell application "System Events" to get name of first process whose frontmost is true'
```
That only proves **Automation** permission (scripting System Events), **not this process's own Accessibility grant** — System Events performs the AX work on our behalf. A reinstall changes the code signature, macOS drops the Accessibility TCC grant, but Automation survives → the probe returns True → the startup re-grant (`_start_watchers → grant_tcc_permissions`) and any warning are skipped, and the in-process window watcher (real AX APIs) emits empty titles.

Reproduced live on this machine: `check_accessibility() == True` while the watcher reported the permission missing.

## Fix

Replace the AppleScript probe with `_ax_api_works()` — a **real in-process AX read** (`AXUIElementCreateSystemWide` → `AXFocusedApplication`), the same machinery the window watcher uses:
- Grant **absent** → macOS returns `kAXErrorAPIDisabled` (-25211) → `False`.
- Grant **present** → request is serviced (`kAXErrorSuccess`, or `kAXErrorNoValue` when nothing is focused) → `True`.

This **preserves** the reason the old fallback existed — the `AXIsProcessTrusted()` false-negative for unsigned x86_64 binaries under Rosetta (a real AX read succeeds even when `AXIsProcessTrusted()` lies) — while **removing** the Automation false-positive. No safety guard removed; the inaccurate probe is replaced with an accurate, use-case-matching one.

## Tests

New `tests/test_permissions.py` (deterministic on all CI platforms via a fake `ApplicationServices` module):
- `AXIsProcessTrusted` fast-path → granted
- Rosetta false-negative (`AXIsProcessTrusted` False, AX read serviced) → still granted
- **the regression:** `AXIsProcessTrusted` False **and** AX API disabled → now correctly reports missing (old code masked this)
- no focused app (`kAXErrorNoValue`) → granted
- guard: `check_accessibility()` never shells out to AppleScript/`subprocess`
- `_ax_api_works` error-code mapping + fail-safe when the binding is unavailable

Full suite: **688 passed**.

## Scope / follow-up
- Independent of the #4/#5a decouple PR (#73); branched off `main`.
- Not addressed here (separate, lower-priority): `grant_tcc_permissions()`'s `.tcc_grant_done` marker still suppresses a re-prompt after a *later* loss once a grant has ever succeeded. With detection now honest, the startup gate at least fires correctly on the no-marker path; the marker-suppression case can be a follow-up (notify rather than silently skip).

🤖 Generated with [Claude Code](https://claude.com/claude-code)