### PR TITLE
feat(tray): show the real release version (incl. -beta.N) in menu/tooltip

### DIFF
--- a/build.spec
+++ b/build.spec
@@ -18,11 +18,29 @@ _version_file = Path(SPECPATH) / "src" / "__init__.py"
 _version_match = re.search(r'__version__\s*=\s*["\']([^"\']+)["\']', _version_file.read_text())
 APP_VERSION = _version_match.group(1) if _version_match else "0.0.0"
 
+# Resolve the human-facing release version (carries -beta.N/-rc.N from the tag,
+# so a prerelease build is distinguishable in the tray). APP_VERSION stays
+# numeric for CFBundleVersion; RELEASE_VERSION is display-only.
+import subprocess
+sys.path.insert(0, str(Path(SPECPATH) / "src"))
+from release_version import format_release_version
+try:
+    _git_tag = subprocess.run(
+        ["git", "describe", "--tags", "--exact-match"],
+        capture_output=True, text=True, cwd=str(SPECPATH),
+    ).stdout.strip()
+except Exception:
+    _git_tag = ""
+RELEASE_VERSION = format_release_version(
+    os.environ.get("GITHUB_REF_NAME", ""), _git_tag, APP_VERSION
+)
+
 # Stamp build metadata into _build_info.py
 _build_info = Path(SPECPATH) / "src" / "_build_info.py"
 _build_info.write_text(
     f'"""Build metadata - regenerated at build time."""\n\n'
     f'APP_VERSION = "{APP_VERSION}"\n'
+    f'RELEASE_VERSION = "{RELEASE_VERSION}"\n'
     f'BUILD_DATE = "{date.today().isoformat()}"\n'
 )
 

--- a/src/release_version.py
+++ b/src/release_version.py
@@ -1,0 +1,38 @@
+"""Resolve the human-facing release version (which may carry a prerelease suffix).
+
+``__version__`` / ``CFBundleVersion`` must stay a plain dotted number (macOS
+rejects a non-numeric ``CFBundleVersion``), so the ``-beta.N`` / ``-rc.N`` suffix
+that distinguishes a prerelease lives only on the git tag. This helper recovers
+that suffix for *display* (tray menu + tooltip) at build time, so a beta build
+shows ``v1.5.68-beta.1`` instead of a bare ``v1.5.68`` indistinguishable from
+stable.
+
+Kept as a tiny dependency-free pure function so build.spec can import it and it
+can be unit-tested without invoking PyInstaller.
+"""
+import re
+
+# A version-like tag: optional leading "v", then MAJOR.MINOR.PATCH, optionally
+# followed by a "-beta.N" / "-rc.N" / etc. prerelease suffix.
+_VERSION_TAG_RE = re.compile(r"^v?\d+\.\d+\.\d+")
+
+
+def format_release_version(ci_ref: str, git_tag: str, app_version: str) -> str:
+    """Pick the display version, preferring a real release tag over the number.
+
+    Args:
+        ci_ref: CI-provided ref name (e.g. GitHub ``GITHUB_REF_NAME``). On a tag
+            build this is the tag (``v1.5.68-beta.1``); on a branch/PR build it
+            is the branch name, which must be ignored.
+        git_tag: Output of ``git describe --tags --exact-match`` (the tag at
+            HEAD), or "" when HEAD is not tagged.
+        app_version: The numeric ``__version__`` fallback.
+
+    Returns:
+        The display version with any prerelease suffix, ``v`` stripped — or the
+        numeric ``app_version`` when neither input is a version tag.
+    """
+    for candidate in (ci_ref, git_tag):
+        if candidate and _VERSION_TAG_RE.match(candidate.strip()):
+            return candidate.strip().lstrip("v")
+    return app_version

--- a/src/ui/tray.py
+++ b/src/ui/tray.py
@@ -20,23 +20,31 @@ from pathlib import Path
 from typing import TYPE_CHECKING, Callable, Optional, TypedDict
 
 try:
-    from .._build_info import APP_VERSION as _APP_VERSION, BUILD_DATE  # module execution
+    from .. import _build_info as _bi  # module execution
+    _APP_VERSION = _bi.APP_VERSION
+    BUILD_DATE = _bi.BUILD_DATE
+    # RELEASE_VERSION carries any -beta.N/-rc.N suffix; getattr keeps us working
+    # against an older bundle stamped before the field existed.
+    _RELEASE_VERSION = getattr(_bi, "RELEASE_VERSION", _APP_VERSION)
 except ImportError:
     try:
         import _build_info as _bi  # PyInstaller bundle (src/ is root, no parent package)
         _APP_VERSION = _bi.APP_VERSION
         BUILD_DATE = _bi.BUILD_DATE
+        _RELEASE_VERSION = getattr(_bi, "RELEASE_VERSION", _APP_VERSION)
     except ImportError:
         try:
             from .. import __version__ as _APP_VERSION
         except ImportError:
             _APP_VERSION = "unknown"
         BUILD_DATE = "dev"
+        _RELEASE_VERSION = _APP_VERSION
 
 # Tray hover tooltip base. Surfaces the running version on hover even when the
 # icon sits in the Windows hidden-icons overflow, where the right-click menu
-# (and its Preferences > version item) isn't reachable.
-_BASE_TOOLTIP = f"BetterFlow v{_APP_VERSION}"
+# (and its Preferences > version item) isn't reachable. Uses the release version
+# so a beta hover reads "BetterFlow v1.5.68-beta.1".
+_BASE_TOOLTIP = f"BetterFlow v{_RELEASE_VERSION}"
 
 from PIL import Image, ImageDraw, ImageFont
 
@@ -730,7 +738,7 @@ class TrayIcon:
         else:
             pref_items.append(Item("Check for Update", self._handle_check_update))
 
-        pref_items.append(Item(f"v{_APP_VERSION} ({BUILD_DATE})", None, enabled=False))
+        pref_items.append(Item(f"v{_RELEASE_VERSION} ({BUILD_DATE})", None, enabled=False))
 
         items.append(Item("Preferences", pystray.Menu(*pref_items), enabled=logged_in))
 

--- a/tests/test_release_version.py
+++ b/tests/test_release_version.py
@@ -1,0 +1,52 @@
+"""Tests for release-version display resolution (src/release_version.py).
+
+A beta build must be distinguishable in the tray. __version__ stays numeric (for
+CFBundleVersion), so the -beta.N/-rc.N suffix is recovered from the release tag
+at build time and shown as RELEASE_VERSION.
+"""
+from src.release_version import format_release_version
+
+
+def test_ci_beta_tag_keeps_suffix():
+    assert format_release_version("v1.5.68-beta.1", "", "1.5.68") == "1.5.68-beta.1"
+
+
+def test_ci_rc_tag_keeps_suffix():
+    assert format_release_version("v2.0.0-rc.3", "", "2.0.0") == "2.0.0-rc.3"
+
+
+def test_ci_stable_tag_strips_v():
+    assert format_release_version("v1.5.69", "", "1.5.69") == "1.5.69"
+
+
+def test_branch_ref_ignored_falls_back_to_git_tag():
+    # On a branch/PR build GITHUB_REF_NAME is the branch — must be ignored in
+    # favour of an exact git tag at HEAD.
+    assert format_release_version("main", "v1.5.68-beta.2", "1.5.68") == "1.5.68-beta.2"
+
+
+def test_branch_ref_and_no_tag_falls_back_to_numeric():
+    assert format_release_version("feat/some-branch", "", "1.5.68") == "1.5.68"
+
+
+def test_no_inputs_returns_numeric():
+    assert format_release_version("", "", "1.5.68") == "1.5.68"
+
+
+def test_tag_without_leading_v():
+    assert format_release_version("1.5.68-beta.1", "", "1.5.68") == "1.5.68-beta.1"
+
+
+def test_whitespace_trimmed():
+    assert format_release_version(" v1.5.68-beta.1\n", "", "1.5.68") == "1.5.68-beta.1"
+
+
+def test_tray_uses_release_version_for_display():
+    """The tray surfaces a release version (not None) and wires it into the
+    hover tooltip. Doesn't import _build_info directly: that module is generated
+    at build time and is absent during CI's test step, where the tray falls back
+    to __version__ — the wiring must hold on every import path."""
+    from src.ui import tray
+
+    assert tray._RELEASE_VERSION  # set on every import path (build_info or fallback)
+    assert f"BetterFlow v{tray._RELEASE_VERSION}" == tray._BASE_TOOLTIP


### PR DESCRIPTION
## Problem

The tray version line and hover tooltip rendered `v{__version__}`. `__version__` is deliberately **numeric** (macOS rejects a non-numeric `CFBundleVersion`), so the `-beta.N` / `-rc.N` suffix that marks a prerelease lives only on the git tag. Result: a beta build showed a bare `v1.5.67` — **indistinguishable from stable 1.5.67**, so a beta tester couldn't tell from the UI they were on a prerelease.

## Fix

Stamp a **display-only** `RELEASE_VERSION` into `_build_info.py` at build time, resolved from the release tag:
1. CI `GITHUB_REF_NAME` (the tag on a tag build), else
2. `git describe --tags --exact-match` (local tagged build), else
3. the numeric `__version__`.

The tray menu item and hover tooltip now render `RELEASE_VERSION`, so a beta build shows **`v1.5.68-beta.1`**. `APP_VERSION` / `CFBundleVersion` are unchanged (still numeric).

Resolution lives in a tiny dependency-free helper (`src/release_version.py`) so `build.spec` can import it and it's unit-testable without invoking PyInstaller.

## Notes
- `src/_build_info.py` is gitignored (generated at build time), so it's absent during CI's test step — the tray import falls back to `__version__`, and the test was written to hold on every import path (verified by hiding the module locally).
- Tooltip + menu both updated for consistency.

## Tests
`tests/test_release_version.py`: `format_release_version` across beta/rc/stable tags, branch-ref-ignored, no-tag fallback, leading-`v` and whitespace handling; plus a tray-wiring check. Full suite **689 passed**, ruff clean on changed files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)