### PR TITLE
fix(afk): harden in-process AFK path — six audit findings (A–F)

### DIFF
--- a/src/main.py
+++ b/src/main.py
@@ -784,6 +784,7 @@ class SyncCoordinator:
         Several callees already self-guard but tray.tick_clock() does not.
         """
         for fn, label in (
+            (self._reconcile_inproc_afk_flag, "inproc_afk_reconcile"),
             (self.tray.tick_clock, "tick_clock"),
             (self._check_idle_status, "idle_check"),
             (self._liveness_heartbeat, "liveness_heartbeat"),
@@ -801,6 +802,16 @@ class SyncCoordinator:
                 self.reminder_manager.check()
             except Exception as e:
                 logger.warning("_tick_60s/reminders failed: %s", e)
+
+    def _reconcile_inproc_afk_flag(self) -> None:
+        """Keep aw_manager's in-process-AFK flag in step with the sync engine's
+        actual per-cycle decision. The flag gates the idle-tracker watchdog and
+        the AFK health telemetry; it was set once at startup, so without this it
+        could diverge from what the engine actually does (audit finding A)."""
+        eng = self.coordinator.sync_engine
+        if eng.afk_source is None:
+            return
+        self.coordinator.aw_manager.set_inproc_afk_active(eng.inproc_afk_active)
 
     def _check_idle_status(self) -> None:
         self.idle_mgr.check_idle_status(

--- a/src/sync/afk_source.py
+++ b/src/sync/afk_source.py
@@ -34,22 +34,53 @@ class AfkSource:
         self._hostname = hostname
         self._input_watcher = input_watcher
         self._idle_clock = idle_clock
+        self._retention_seconds = float(retention_seconds)
         self._retention = timedelta(seconds=retention_seconds)
         self._lock = threading.Lock()
         # (sample_time, last_input_at)
         self._samples: deque = deque()
+        # Sticky platform-capability latch: a transient idle-clock read failure
+        # (e.g. a one-off `ioreg` timeout) must NOT revoke in-process mode for a
+        # cycle — that would hand billing back to the external tracker and flap
+        # the health telemetry. Once a read has ever succeeded the platform HAS
+        # the capability, so we stay latched on (audit finding A).
+        self._available_latched = False
+        # Consecutive idle-clock read failures, for blind-clock detection (audit
+        # finding E). Reset to 0 on any successful read.
+        self._consecutive_clock_failures = 0
 
     @property
     def samples(self) -> list:
         with self._lock:
             return list(self._samples)
 
+    @property
+    def retention_seconds(self) -> float:
+        return self._retention_seconds
+
+    @property
+    def consecutive_clock_failures(self) -> int:
+        return self._consecutive_clock_failures
+
+    @property
+    def bucket_id(self) -> str:
+        """The synthetic AFK bucket id this source uploads under. Single source
+        of truth so the upload (_event) and the checkpoint-commit gate agree."""
+        return f"bf-afk-inproc_{self._hostname}"
+
     def available(self) -> bool:
-        """True when the OS idle clock is readable on this platform."""
+        """True when the OS idle clock is (or has ever been) readable on this
+        platform. Sticky: once a read succeeds it stays True, so a transient
+        failure cannot flap in-process AFK off for a cycle (audit finding A)."""
+        if self._available_latched:
+            return True
         try:
-            return self._idle_clock() is not None
+            ok = self._idle_clock() is not None
         except Exception:
-            return False
+            ok = False
+        if ok:
+            self._available_latched = True
+        return ok
 
     def record_sample(self, now: datetime) -> None:
         """Observe activity at ``now`` and append (now, last_input_at). No-op when
@@ -58,9 +89,12 @@ class AfkSource:
             idle = self._idle_clock()
         except Exception as e:
             logger.debug("AfkSource idle clock failed: %s", e)
+            self._consecutive_clock_failures += 1
             return
         if idle is None:
+            self._consecutive_clock_failures += 1
             return
+        self._consecutive_clock_failures = 0
         last_input_at = now - timedelta(seconds=idle)
         # macOS in-process watcher holds the main app's grant — prefer it when
         # it reports a *more recent* input than the OS idle clock.
@@ -150,10 +184,14 @@ class AfkSource:
     def _event(self, start: datetime, duration: float, status: str,
                project_id: Optional[int]) -> dict:
         ev = {
-            "id": f"afk-inproc_{self._hostname}_{int(start.timestamp())}",
+            # Millisecond precision: two spans can legitimately start within the
+            # same whole second (an activity instant and a last_input+timeout
+            # boundary <1s apart); a second-truncated id would collide and the
+            # server upsert would drop one, under-billing (audit finding F).
+            "id": f"afk-inproc_{self._hostname}_{int(start.timestamp() * 1000)}",
             "timestamp": start.isoformat(),
             "duration": round(duration, 2),
-            "bucket_id": f"bf-afk-inproc_{self._hostname}",
+            "bucket_id": self.bucket_id,
             "bucket_type": BUCKET_TYPE_AFK,
             "data": {"status": status, "synthetic": True},
         }

--- a/src/sync/sync_engine.py
+++ b/src/sync/sync_engine.py
@@ -218,7 +218,15 @@ class SyncEngine:
         # sample log only retains ~2h, so a day-start rewind would re-emit afk over
         # a morning already billed correctly).
         self.afk_source = None
+        # Mutated only on the sync thread (record_sample / _build_inproc_afk /
+        # _commit_inproc_afk_checkpoint all run inside SyncEngine.sync()).
         self._afk_inproc_checkpoint: Optional[datetime] = None
+        # Proposed next checkpoint for the span built this cycle; committed by
+        # _commit_inproc_afk_checkpoint only after a confirmed send (finding B).
+        self._afk_inproc_pending: Optional[datetime] = None
+        # Blind-clock escalation latch + threshold (finding E).
+        self._inproc_blind_reported = False
+        self._INPROC_BLIND_THRESHOLD = 3
 
         # Queue retry backoff
         self._queue_consecutive_failures = 0
@@ -580,6 +588,9 @@ class SyncEngine:
 
         # Send events, then advance checkpoints per-bucket.
         self._send_and_advance_checkpoints(all_events, pending_checkpoints, stats)
+        # Commit the in-process AFK checkpoint only if its bucket wasn't queued
+        # (the send was confirmed) — otherwise rebuild it next cycle (finding B).
+        self._commit_inproc_afk_checkpoint(stats)
 
         # Process offline queue if we're online
         if self.bf.is_reachable() and not self.queue.is_empty():
@@ -1858,36 +1869,114 @@ class SyncEngine:
             and self.afk_source.available()
         )
 
+    @property
+    def inproc_afk_active(self) -> bool:
+        """Public view of the per-cycle in-process-AFK decision, so the app can
+        keep aw_manager's flag (which drives the idle-tracker watchdog + health
+        telemetry) reconciled with what the sync engine actually does (A)."""
+        return self._inproc_afk_active()
+
     def _should_skip_external_afk(self) -> bool:
         """Whether to drop the external bf-idle-tracker bucket from this cycle's
         upload (because the agent uploads its own AFK stream instead)."""
         return self._inproc_afk_active()
 
     def _build_inproc_afk(self, now: datetime) -> list[dict]:
-        """Build in-process AFK events for [checkpoint, now] and advance the
-        checkpoint. First cycle just seeds the checkpoint at `now` (we only
-        account for time while running). Returns [] when not active."""
+        """Build in-process AFK events for [checkpoint, now]. First cycle seeds
+        the checkpoint at `now` (we only account for time while running). The
+        checkpoint is NOT advanced here — it is committed by
+        ``_commit_inproc_afk_checkpoint`` only once the send succeeds, so a
+        terminal send failure can't lose a span (audit finding B). Returns []
+        when not active."""
         if not self._inproc_afk_active():
             return []
-        if self._afk_inproc_checkpoint is None:
+        cp = self._afk_inproc_checkpoint
+        if cp is None:
             self._afk_inproc_checkpoint = now
             return []
+
+        # Re-seed rather than reconstruct when the checkpoint can't be trusted:
+        #  - now < cp: the wall clock stepped backward (NTP/manual). Without this
+        #    the finalize guard below would stall the stream forever (D).
+        #  - gap > retention: a pause/sleep froze the checkpoint while samples
+        #    were pruned (2h). Reconstructing over an unsampled multi-hour window
+        #    would mis-bill; the unobserved span is simply left uncovered (C).
+        gap = (now - cp).total_seconds()
+        if now < cp or gap > self.afk_source.retention_seconds:
+            logger.info(
+                "in-process AFK: re-seeding checkpoint (gap %.0fs) — not billing "
+                "the unobserved window", gap,
+            )
+            self._afk_inproc_checkpoint = now
+            self._afk_inproc_pending = None
+            return []
+
+        # Blind clock: the OS idle clock has failed for several consecutive
+        # cycles, so there are no fresh samples. finalize_point would backdate
+        # the whole un-observed span as afk — billing real work as idle. Hold the
+        # checkpoint and surface it to ops instead (audit finding E). When the
+        # clock recovers, fresh samples resume and the held span bills correctly.
+        if self.afk_source.consecutive_clock_failures >= self._INPROC_BLIND_THRESHOLD:
+            if not self._inproc_blind_reported:
+                self._inproc_blind_reported = True
+                self._report_inproc_blind(self.afk_source.consecutive_clock_failures)
+            return []
+        self._inproc_blind_reported = False
+
         # Only finalize up to the point whose afk classification is settled. While
         # the user is within the timeout of their last input, the trailing region
         # is still pending (could go not-afk or afk), so it waits for a later cycle
         # — otherwise we'd commit it not-afk and be unable to flip it to afk if they
         # stay idle past the timeout.
         finalize_to = self.afk_source.finalize_point(now)
-        if finalize_to <= self._afk_inproc_checkpoint:
+        if finalize_to <= cp:
             return []
         with self._state_lock:
             project = self._current_project
         events = self.afk_source.build_afk_events(
-            self._afk_inproc_checkpoint, finalize_to,
+            cp, finalize_to,
             project_id=project["id"] if project else None,
         )
-        self._afk_inproc_checkpoint = finalize_to
+        # Defer the checkpoint advance to _commit_inproc_afk_checkpoint (finding B).
+        self._afk_inproc_pending = finalize_to
         return events
+
+    def _commit_inproc_afk_checkpoint(self, stats: SyncStats) -> None:
+        """Advance the in-process AFK checkpoint past the just-built span, but
+        only if its bucket wasn't queued (the send succeeded). On a queued/failed
+        send we leave the checkpoint where it was so the next cycle rebuilds the
+        same span from samples — the synthetic ids are stable, so a later queue
+        drain + the rebuild upsert idempotently. Unlike AW buckets, the
+        in-process stream has no source to re-fetch from, so advancing before a
+        confirmed send risks permanent loss on terminal queue failure (B)."""
+        pending = self._afk_inproc_pending
+        if pending is None:
+            return
+        inproc_bucket = self.afk_source.bucket_id
+        if inproc_bucket not in stats.queued_bucket_ids:
+            self._afk_inproc_checkpoint = pending
+        self._afk_inproc_pending = None
+
+    def _report_inproc_blind(self, failures: int) -> None:
+        """Surface a blind in-process idle clock to the ops ingest. Logged-only
+        clock failures are invisible until billing is already wrong; the
+        error_reporter is the channel an admin can see (audit finding E)."""
+        logger.warning(
+            "in-process AFK idle clock blind for %d consecutive cycles — holding "
+            "checkpoint; active time may be under-counted until it recovers",
+            failures,
+        )
+        if self.error_reporter is None:
+            return
+        try:
+            self.error_reporter.capture(
+                f"In-process AFK idle clock blind for {failures} consecutive cycles",
+                level="warning",
+                tags={"component": "inproc-afk"},
+                fingerprint="inproc-afk-blind",
+            )
+        except Exception:
+            logger.debug("inproc-afk-blind report failed", exc_info=True)
 
     def _send_events(self, events: list[dict], stats: SyncStats) -> None:
         """Send events to BetterFlow, grouped by bucket (#4 decouple buckets).

--- a/tests/test_inproc_afk_hardening.py
+++ b/tests/test_inproc_afk_hardening.py
@@ -1,0 +1,150 @@
+"""In-process AFK path hardening — the six audit findings (2026-06-22).
+
+Each test fails against the pre-fix implementation and passes after the fix,
+exercising real AfkSource / SyncEngine behaviour (no phantom mocks).
+
+A. available() flap → sticky latch + aw_manager reconciliation
+B. checkpoint advanced before send → permanent loss on terminal queue failure
+C. pause/sleep gap > retention → mis-billed span on resume (re-seed)
+D. wall-clock backward step → stalled/scrambled checkpoint (re-seed)
+E. blind OS idle clock → silent idle-billing (hold + report)
+F. synthetic id truncated to whole seconds → intra-batch collision
+"""
+
+from datetime import datetime, timedelta, timezone
+from unittest.mock import Mock
+
+from src.config import Config
+from src.sync.activity_analyzer import ActivityAnalyzer
+from src.sync.afk_source import AfkSource
+from src.sync.daily_time_tracker import DailyTimeTracker
+from src.sync.sync_engine import SyncEngine, SyncStats
+
+T0 = datetime(2026, 6, 19, 12, 0, 0, tzinfo=timezone.utc)
+
+
+def _engine(in_process_afk=True, idle=5.0, retention=7200.0):
+    cfg = Config()
+    cfg.sync.in_process_afk = in_process_afk
+    eng = SyncEngine(aw=Mock(), bf=Mock(), queue=Mock(), config=cfg,
+                     activity_analyzer=Mock(spec=ActivityAnalyzer),
+                     time_tracker=Mock(spec=DailyTimeTracker))
+    eng.afk_source = AfkSource(600, "host", idle_clock=lambda: idle,
+                               retention_seconds=retention)
+    return eng
+
+
+# ── F: synthetic id sub-second precision ──────────────────────────────────────
+
+def test_event_ids_distinct_within_same_second():
+    src = AfkSource(600, "host", idle_clock=lambda: 5.0)
+    a = src._event(T0, 0.3, "afk", None)
+    b = src._event(T0 + timedelta(milliseconds=400), 0.3, "not-afk", None)
+    assert a["id"] != b["id"], "two spans starting in the same second collide"
+
+
+# ── A: available() sticky latch ───────────────────────────────────────────────
+
+def test_available_latches_true_through_transient_failure():
+    seq = iter([5.0, None, None, 5.0])
+    src = AfkSource(600, "host", idle_clock=lambda: next(seq))
+    assert src.available() is True   # first read OK → capability confirmed
+    assert src.available() is True   # transient None must NOT revoke it
+    assert src.available() is True
+
+
+def test_available_false_until_first_success():
+    src = AfkSource(600, "host", idle_clock=lambda: None)  # Linux / never readable
+    assert src.available() is False
+    assert src.available() is False
+
+
+# ── E: blind-clock failure counter ────────────────────────────────────────────
+
+def test_consecutive_clock_failures_tracked_and_reset():
+    seq = iter([None, None, 5.0, None])
+    src = AfkSource(600, "host", idle_clock=lambda: next(seq))
+    src.record_sample(T0)
+    assert src.consecutive_clock_failures == 1
+    src.record_sample(T0)
+    assert src.consecutive_clock_failures == 2
+    src.record_sample(T0)
+    assert src.consecutive_clock_failures == 0  # success resets
+    src.record_sample(T0)
+    assert src.consecutive_clock_failures == 1
+
+
+def test_retention_seconds_exposed():
+    src = AfkSource(600, "host", retention_seconds=1234.0, idle_clock=lambda: 5.0)
+    assert src.retention_seconds == 1234.0
+
+
+# ── B: checkpoint held back until send confirmed ──────────────────────────────
+
+def test_inproc_checkpoint_held_until_send_confirmed():
+    eng = _engine()
+    eng.afk_source.record_sample(T0 - timedelta(seconds=30))
+    eng.afk_source.record_sample(T0)
+    eng._build_inproc_afk(T0)              # seed → checkpoint == T0
+    seed_cp = eng._afk_inproc_checkpoint
+    eng.afk_source.record_sample(T0 + timedelta(seconds=30))
+    events = eng._build_inproc_afk(T0 + timedelta(seconds=30))
+    assert events
+    # Not committed yet — the send hasn't been confirmed.
+    assert eng._afk_inproc_checkpoint == seed_cp
+
+    queued = SyncStats()
+    queued.queued_bucket_ids.add("bf-afk-inproc_host")
+    eng._commit_inproc_afk_checkpoint(queued)
+    assert eng._afk_inproc_checkpoint == seed_cp, "must stay held when queued"
+
+    # Next cycle rebuilds the same span (stable ids → idempotent) and the send
+    # succeeds this time, so the checkpoint finally advances.
+    events2 = eng._build_inproc_afk(T0 + timedelta(seconds=30))
+    assert events2, "held checkpoint means the span is rebuilt next cycle"
+    ok = SyncStats()
+    eng._commit_inproc_afk_checkpoint(ok)
+    assert eng._afk_inproc_checkpoint > seed_cp, "commit once the send succeeded"
+
+
+def test_inproc_afk_active_public_property():
+    # Public surface so main.py can reconcile aw_manager's flag each cycle (A).
+    assert _engine(in_process_afk=True).inproc_afk_active is True
+    assert _engine(in_process_afk=False).inproc_afk_active is False
+
+
+# ── C: pause/sleep gap beyond retention → re-seed, don't reconstruct ──────────
+
+def test_reseed_when_gap_exceeds_retention():
+    eng = _engine(retention=7200.0)
+    eng._afk_inproc_checkpoint = T0 - timedelta(hours=5)   # paused/asleep 5h
+    eng.afk_source.record_sample(T0)
+    events = eng._build_inproc_afk(T0)
+    assert events == [], "must not reconstruct an unobserved multi-hour window"
+    assert eng._afk_inproc_checkpoint == T0, "checkpoint re-seeded to now"
+
+
+# ── D: wall-clock backward step → re-seed, don't stall ────────────────────────
+
+def test_reseed_on_backward_clock_step():
+    eng = _engine()
+    eng._afk_inproc_checkpoint = T0 + timedelta(minutes=10)  # checkpoint ahead of now
+    eng.afk_source.record_sample(T0)
+    events = eng._build_inproc_afk(T0)
+    assert events == []
+    assert eng._afk_inproc_checkpoint == T0, "re-seeded to now, not stuck in the future"
+
+
+# ── E: blind clock → hold + report, don't backdate real work as idle ──────────
+
+def test_blind_clock_holds_and_reports():
+    eng = _engine()
+    eng.error_reporter = Mock()
+    eng.afk_source.record_sample(T0)
+    eng._build_inproc_afk(T0)              # seed
+    seed_cp = eng._afk_inproc_checkpoint
+    eng.afk_source._consecutive_clock_failures = 5   # clock blind for several cycles
+    events = eng._build_inproc_afk(T0 + timedelta(minutes=30))
+    assert events == [], "must not finalize-afk over an unobserved window"
+    assert eng._afk_inproc_checkpoint == seed_cp, "checkpoint held while blind"
+    assert eng.error_reporter.capture.called, "blind clock surfaced to ops"


### PR DESCRIPTION
Fixes the six findings from the 2026-06-22 focused audit of the in-process AFK billing path (the largest new code in 1.5.64/65/66 and the cross-PR #67↔#70↔#73 interaction surface). All TDD — `tests/test_inproc_afk_hardening.py` (10 tests) failed RED pre-fix, GREEN after.

| # | finding | fix |
|---|---|---|
| **A** | `available()` flapped on a transient OS-idle-clock failure → flipped in-process off for a cycle and left `aw_manager`'s flag diverged (watchdog + telemetry suppressed while external tracker was live) | sticky `available()` latch + per-cycle reconcile of `set_inproc_afk_active()` in `_tick_60s` |
| **B** | checkpoint advanced **before** the send → span lost forever on terminal queue-retry exhaustion (no source to re-fetch) | defer advance to `_commit_inproc_afk_checkpoint`, gated on the inproc bucket not being queued; held → rebuild next cycle (stable ids, idempotent) |
| **C** | pause/sleep froze the checkpoint while samples pruned (2h) → mis-bill on resume | re-seed to `now` when gap > retention |
| **D** | wall-clock backward step stalled the stream forever | re-seed when `now < checkpoint` |
| **E** | blind idle clock silently billed real work as idle | track consecutive read failures; past threshold, hold + report to ops (once per episode) |
| **F** | synthetic id truncated to whole seconds → same-second spans collided, server dropped one | ms-precision id; bucket id centralized on `AfkSource` |

**No regression:** 535 tests pass locally; the 14 collection errors + 1 failure are the pre-existing PIL x86_64/arm64 env issue (identical on HEAD). Lint clean on changed lines. **No version bump** — lands at 1.5.67 so Martin's next bump/tag includes it.