### PR TITLE
fix(sync): stop the checkpoint pinning at an idle gap (silent window/input loss)

### DIFF
--- a/scripts/reconcile_local_vs_prod.py
+++ b/scripts/reconcile_local_vs_prod.py
@@ -1,0 +1,104 @@
+#!/usr/bin/env python3
+"""Completeness check: is the agent uploading everything it should (no stall)?
+
+The stall this guards against (idle-gap checkpoint pin, fixed in v1.5.69) leaves a
+CONTIGUOUS span where the local AW store has activity but prod received nothing.
+That is the only "we'd need backfill" signal. It is NOT the same as a 1:1 event
+match: the agent legitimately drops window events shorter than
+min_window_event_seconds (default 5s), gap-fills, dedups and transforms — so a
+naive per-event diff always shows benign differences.
+
+So this compares COVERAGE per time bucket: for each bucket where the local store
+has *sendable* activity, prod must also have events. A bucket that is local-active
+but prod-empty is a hole (a stall). Run it any time — especially after an idle
+gap / "after an hour" — to confirm the live sync kept prod complete:
+
+    MYSQL_PWD=... DEVICE_ID=14 python3 scripts/reconcile_local_vs_prod.py [minutes]
+
+Exit 0 = complete (no holes), exit 1 = holes found.
+"""
+import os
+import sqlite3
+import subprocess
+import sys
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+
+LOOKBACK_MIN = int(sys.argv[1]) if len(sys.argv) > 1 else 120
+SETTLE_SECONDS = 180          # ignore the last 3 min (in-flight / next sync cycle)
+BUCKET_SECONDS = 300          # 5-min coverage buckets
+MIN_WINDOW_SECONDS = 5        # agent filters window events shorter than this
+DEVICE_ID = os.environ.get("DEVICE_ID", "14")
+# Connection comes entirely from the environment — no prod host/credentials are
+# committed. Set DB_HOST/DB_PORT/DB_NAME and MYSQL_PWD before running.
+DB_HOST = os.environ.get("DB_HOST", "127.0.0.1")
+DB_PORT = os.environ.get("DB_PORT", "3306")
+DB_NAME = os.environ.get("DB_NAME", "betterflow")
+AW_DB = Path.home() / "Library/Application Support/BetterFlow/data/aw-db.sqlite"
+
+# bucketrow -> (label, prod event_type, min_duration_to_send)
+STREAMS = {1: ("window", "window", MIN_WINDOW_SECONDS), 2: ("input", "input", 0)}
+
+now = datetime.now(timezone.utc)
+end = now - timedelta(seconds=SETTLE_SECONDS)
+start = end - timedelta(minutes=LOOKBACK_MIN)
+start_s, end_s = int(start.timestamp()), int(end.timestamp())
+
+
+def _local_buckets(bucketrow, min_dur):
+    con = sqlite3.connect(f"file:{AW_DB}?mode=ro", uri=True)
+    try:
+        rows = con.execute(
+            "SELECT (starttime/1000000000)/? , COUNT(*) "
+            "FROM events WHERE bucketrow=? AND (endtime-starttime)/1000000000 >= ? "
+            "AND starttime>=? AND starttime<? GROUP BY 1",
+            (BUCKET_SECONDS, bucketrow, min_dur, start_s * 1_000_000_000, end_s * 1_000_000_000),
+        ).fetchall()
+        return {int(b): c for b, c in rows}
+    finally:
+        con.close()
+
+
+def _prod_buckets(event_type):
+    sql = (
+        f"SELECT FLOOR(UNIX_TIMESTAMP(event_timestamp)/{BUCKET_SECONDS}), COUNT(*) "
+        f"FROM agent_events WHERE device_id={DEVICE_ID} AND event_type='{event_type}' "
+        f"AND event_timestamp>=FROM_UNIXTIME({start_s}) AND event_timestamp<FROM_UNIXTIME({end_s}) "
+        f"GROUP BY 1;"
+    )
+    out = subprocess.run(
+        ["mysql", "-h", DB_HOST, "-P", DB_PORT, "-u", "root", "-N",
+         "--connect-timeout=10", DB_NAME, "-e", sql],
+        capture_output=True, text=True,
+    )
+    if out.returncode != 0:
+        raise SystemExit(f"prod query failed: {out.stderr.strip()}")
+    res = {}
+    for ln in out.stdout.splitlines():
+        b, c = ln.split("\t")
+        res[int(b)] = int(c)
+    return res
+
+
+def _hhmm(bucket):
+    return datetime.fromtimestamp(bucket * BUCKET_SECONDS, timezone.utc).strftime("%H:%M")
+
+
+print(f"Coverage reconcile device {DEVICE_ID}: {start.strftime('%H:%M')}–{end.strftime('%H:%M')} UTC "
+      f"(last {LOOKBACK_MIN}m, {BUCKET_SECONDS // 60}-min buckets, settled to -{SETTLE_SECONDS}s)\n")
+
+ok = True
+for row, (label, prod_type, min_dur) in STREAMS.items():
+    loc = _local_buckets(row, min_dur)
+    pro = _prod_buckets(prod_type)
+    holes = sorted(b for b in loc if loc[b] > 0 and pro.get(b, 0) == 0)
+    status = "PASS" if not holes else "FAIL"
+    if holes:
+        ok = False
+    print(f"[{status}] {label:7s}  active buckets={len(loc):3d}  holes={len(holes)}")
+    for b in holes:
+        print(f"          - {_hhmm(b)} UTC: local={loc[b]} sendable, prod=0  <-- STALL")
+
+print("\nRESULT:", "COMPLETE — no local-active/prod-empty buckets; agent uploaded everything ✅"
+      if ok else "STALL — local activity missing from prod; backfill would be needed ❌")
+sys.exit(0 if ok else 1)

--- a/src/__init__.py
+++ b/src/__init__.py
@@ -1,4 +1,4 @@
 """BetterFlow - ActivityWatch to BetterFlow sync companion app."""
 
-__version__ = "1.5.69"
+__version__ = "1.5.70"
 __author__ = "BetterQA"

--- a/src/__init__.py
+++ b/src/__init__.py
@@ -1,4 +1,4 @@
 """BetterFlow - ActivityWatch to BetterFlow sync companion app."""
 
-__version__ = "1.5.68"
+__version__ = "1.5.69"
 __author__ = "BetterQA"

--- a/src/main.py
+++ b/src/main.py
@@ -808,10 +808,15 @@ class SyncCoordinator:
         actual per-cycle decision. The flag gates the idle-tracker watchdog and
         the AFK health telemetry; it was set once at startup, so without this it
         could diverge from what the engine actually does (audit finding A)."""
-        eng = self.coordinator.sync_engine
+        # This runs on SyncCoordinator (via _tick_60s), so the engine/manager are
+        # direct attributes — `self.coordinator` only exists on BetterFlowApp, so
+        # the old `self.coordinator.*` threw AttributeError every 60s and this
+        # reconcile never ran (the flag it maintains gates the idle-tracker
+        # watchdog + AFK telemetry).
+        eng = self.sync_engine
         if eng.afk_source is None:
             return
-        self.coordinator.aw_manager.set_inproc_afk_active(eng.inproc_afk_active)
+        self.aw_manager.set_inproc_afk_active(eng.inproc_afk_active)
 
     def _check_idle_status(self) -> None:
         self.idle_mgr.check_idle_status(

--- a/src/sync/sync_engine.py
+++ b/src/sync/sync_engine.py
@@ -969,7 +969,21 @@ class SyncEngine:
         # Empty leading window (e.g. an overnight quiet stretch right after the
         # checkpoint): advance past it so we don't re-poll the same empty span
         # forever while a backlog waits beyond it.
-        if not events and fetch_end < now:
+        #
+        # "Empty" must mean "no NEW events past the checkpoint" — NOT a literally
+        # empty slice. The 2-min lookback (above) always re-includes the pre-gap
+        # tail event, so an `if not events` test never fires after an idle gap
+        # longer than _BACKLOG_WINDOW: the checkpoint pins at the last pre-gap
+        # event, the fetch window stays parked ~2h behind it forever, and events
+        # captured after the gap are never read. (PiratesMac / device 14,
+        # 2026-06-23: window+input frozen at the prior evening's last event after
+        # an overnight gap; the morning's events sat captured-but-unsent until a
+        # checkpoint jump skipped them.) Gate the jump on events strictly AFTER
+        # the checkpoint so an idle gap can't pin the cursor. In steady state
+        # (fetch_end == now) the jump never fires, so the lookback's heartbeat-
+        # grown re-send is preserved.
+        new_events = [e for e in events if e.timestamp > checkpoint]
+        if not new_events and fetch_end < now:
             self.queue.set_checkpoint_forward(bucket_id, fetch_end)
             return [], lookback_start
 

--- a/tests/test_reconcile_inproc_afk_flag.py
+++ b/tests/test_reconcile_inproc_afk_flag.py
@@ -1,0 +1,37 @@
+"""Regression for Bug A (audit finding A, #76): _reconcile_inproc_afk_flag.
+
+The method lives on SyncCoordinator and runs every 60s via _tick_60s. It used
+`self.coordinator.sync_engine` / `self.coordinator.aw_manager`, but
+`self.coordinator` only exists on BetterFlowApp — so on SyncCoordinator it threw
+`AttributeError: 'SyncCoordinator' object has no attribute 'coordinator'` every
+60s and the reconcile never ran (it gates the idle-tracker watchdog + AFK
+telemetry). It must use self.sync_engine / self.aw_manager.
+"""
+from unittest.mock import Mock
+
+from src.main import SyncCoordinator
+
+
+def _coord(afk_source, inproc_active=True):
+    # Bypass the heavy __init__; the method only touches these two attributes.
+    c = SyncCoordinator.__new__(SyncCoordinator)
+    c.sync_engine = Mock()
+    c.sync_engine.afk_source = afk_source
+    c.sync_engine.inproc_afk_active = inproc_active
+    c.aw_manager = Mock()
+    return c
+
+
+def test_reconcile_propagates_flag_without_attributeerror():
+    """With a wired afk source, the flag is pushed to aw_manager — and crucially
+    the call does not raise (the old self.coordinator.* threw every 60s)."""
+    c = _coord(afk_source=object(), inproc_active=True)
+    SyncCoordinator._reconcile_inproc_afk_flag(c)  # must not raise
+    c.aw_manager.set_inproc_afk_active.assert_called_once_with(True)
+
+
+def test_reconcile_noop_when_no_afk_source():
+    """No in-process AFK source → early return, no flag write, no raise."""
+    c = _coord(afk_source=None)
+    SyncCoordinator._reconcile_inproc_afk_flag(c)
+    c.aw_manager.set_inproc_afk_active.assert_not_called()

--- a/tests/test_sync_engine_idle_gap_pin.py
+++ b/tests/test_sync_engine_idle_gap_pin.py
@@ -1,0 +1,113 @@
+"""Regression: an idle gap longer than _BACKLOG_WINDOW must not pin the cursor.
+
+Incident (PiratesMac / device 14, 2026-06-23): the user stopped work the prior
+evening, so the window/input forward checkpoint sat at that evening's last event.
+Overnight the gap exceeded _BACKLOG_WINDOW (2h). The next morning, every sync
+cycle fetched `[checkpoint-2min, checkpoint+2h]` — a slice entirely in the past
+that contained only the pre-gap tail event (re-surfaced by the 2-minute
+lookback). Because the slice wasn't *literally* empty, the "empty leading window"
+gap-jump never fired, the checkpoint never advanced, and that day's events were
+never read by the sync engine — captured locally, never uploaded.
+
+The fix gates the gap-jump on events strictly AFTER the checkpoint, so the
+lookback's re-surfaced tail can't keep the cursor pinned.
+"""
+import tempfile
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+from unittest.mock import Mock
+
+from src.config import Config
+from src.sync.activity_analyzer import ActivityAnalyzer
+from src.sync.aw_client import AWEvent
+from src.sync.daily_time_tracker import DailyTimeTracker
+from src.sync.queue import OfflineQueue
+from src.sync.sync_engine import SyncEngine, SyncStats
+
+BUCKET = "aw-watcher-window_test"
+
+
+def _engine(tmp, aw):
+    return SyncEngine(
+        aw=aw,
+        bf=Mock(),
+        queue=OfflineQueue(db_path=tmp / "q.db", max_size=100000),
+        config=Config(),
+        activity_analyzer=Mock(spec=ActivityAnalyzer),
+        time_tracker=Mock(spec=DailyTimeTracker),
+    )
+
+
+def _aw_serving(events):
+    """Mock AW whose get_events honours the [start, end) window like the real one."""
+    aw = Mock()
+
+    def get_events(bucket_id, start=None, end=None, limit=1000):
+        return [
+            e for e in events
+            if (start is None or e.timestamp >= start)
+            and (end is None or e.timestamp < end)
+        ]
+
+    aw.get_events.side_effect = get_events
+    return aw
+
+
+def test_gap_jump_fires_when_only_pregap_tail_in_window():
+    """Single cycle: checkpoint pinned at an idle-gap tail, the only in-window
+    event is that tail (≤ checkpoint). The cursor must advance, not pin."""
+    tmp = Path(tempfile.mkdtemp())
+    now = datetime.now(timezone.utc)
+    tail = now - timedelta(hours=13)  # last event before a long overnight gap
+
+    aw = _aw_serving([AWEvent(id=1, timestamp=tail, duration=10.0, data={"app": "Terminal"})])
+    engine = _engine(tmp, aw)
+    try:
+        engine.queue.set_checkpoint(BUCKET, tail)
+
+        engine._fetch_bucket_events(BUCKET, SyncStats())
+
+        cp = engine.queue.get_checkpoint(BUCKET)
+        # With the bug the slice isn't empty (tail re-surfaced) so the gap-jump
+        # is skipped and cp stays == tail. The fix advances past the gap.
+        assert cp > tail, f"checkpoint pinned at the idle-gap tail ({cp.isoformat()})"
+    finally:
+        engine.queue.close()
+
+
+def test_post_gap_events_are_eventually_fetched():
+    """End-to-end: after a >2h overnight gap, the morning's events must actually
+    get read. With the bug the cursor pins forever and they never are."""
+    tmp = Path(tempfile.mkdtemp())
+    now = datetime.now(timezone.utc)
+    tail = now - timedelta(hours=13)        # pre-gap tail
+    resume = now - timedelta(minutes=30)    # work resumes after the gap
+
+    events = [AWEvent(id=1, timestamp=tail, duration=10.0, data={"app": "Terminal"})]
+    events += [
+        AWEvent(id=100 + i, timestamp=resume + timedelta(seconds=30 * i),
+                duration=10.0, data={"app": "Terminal"})
+        for i in range(3)
+    ]
+    aw = _aw_serving(events)
+    engine = _engine(tmp, aw)
+    try:
+        engine.queue.set_checkpoint(BUCKET, tail)
+
+        fetched_post_gap = []
+        for _ in range(30):  # bounded; the walk-forward needs only ~7 cycles
+            batch, _lb = engine._fetch_bucket_events(BUCKET, SyncStats())
+            if batch:
+                # Simulate the downstream successful-send advance.
+                engine.queue.set_checkpoint_forward(BUCKET, max(e.timestamp for e in batch))
+                fetched_post_gap += [e for e in batch if e.timestamp >= resume]
+                if fetched_post_gap:
+                    break
+
+        assert fetched_post_gap, (
+            "post-gap events were never fetched — the cursor pinned at the "
+            "idle-gap tail and never reached the morning's events"
+        )
+        assert engine.queue.get_checkpoint(BUCKET) >= resume
+    finally:
+        engine.queue.close()


### PR DESCRIPTION
## The bug (live incident: PiratesMac / device 14, 2026-06-23)

The user stopped work the prior evening, so the window/input forward checkpoint sat at that evening's last event. Overnight the gap exceeded `_BACKLOG_WINDOW` (2h). The next morning, **window + input events were captured locally but never uploaded for ~44 min** (07:08–07:52) — never sent, never even queued. afk was unaffected (separate in-process cursor), so every backend health signal stayed green and **no alert fired**.

## Root cause — `_fetch_bucket_events` (`sync_engine.py`)

Each cycle fetches `[checkpoint − 2min, checkpoint + 2h]` and advances past a quiet stretch only if that slice is **literally empty**:

```python
lookback_start = checkpoint - timedelta(minutes=2)        # re-includes the pre-gap tail
fetch_end = min(now, lookback_start + self._BACKLOG_WINDOW)
events = self.aw.get_events(bucket_id, start=lookback_start, end=fetch_end, ...)
if not events and fetch_end < now:                        # ← never true after an idle gap
    self.queue.set_checkpoint_forward(bucket_id, fetch_end)
```

After an idle gap > 2h the slice is `[~T, T+2h]` (entirely in the past) and contains the pre-gap tail event re-surfaced by the 2-minute lookback. So `not events` is **never true** → the cursor pins at the last pre-gap event → the fetch window stays parked ~2h behind it forever → the morning's events are never read. The pending checkpoint computed from the tail equals the stored value, so `set_checkpoint_forward`'s monotonic guard also no-ops. The cursor only unsticks when something external jumps it (a restart's reconcile, or a pause/resume that jumps to `now` — which **skips** the stranded span).

**Affects any user idle > 2h (overnight, weekend, long meeting).**

## Fix

Gate the gap-jump on events **strictly after the checkpoint**, not a wholly-empty slice:

```python
new_events = [e for e in events if e.timestamp > checkpoint]
if not new_events and fetch_end < now:
    self.queue.set_checkpoint_forward(bucket_id, fetch_end)
    return [], lookback_start
```

In steady state (`fetch_end == now`) the jump still never fires, so the lookback's heartbeat-grown re-send is preserved — only the backlog/gap path changes.

## Test

`tests/test_sync_engine_idle_gap_pin.py` (real `OfflineQueue` + window-honouring mock AW):
- single-cycle: checkpoint pinned at an idle-gap tail → must advance, not pin
- end-to-end: after a >2h overnight gap, the morning's events are actually fetched
- **Mutation-verified:** reverting to `if not events` fails both.

Full suite **720 passed**, ruff clean on changed files.

## Not included (separate issues from the same incident)
- `_advance_checkpoints_to_now` skips undelivered events on a **network** pause/resume (the jump that abandoned the stranded span) — should preserve the backlog on a connectivity blip.
- `window_event_age_seconds` telemetry reflects local capture, not delivery → backend/bot can't detect this; no data-correctness monitor exists.
- afk `transient failure: unknown` = backend #1850 (`processed:0`) still undeployed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)