### PR TITLE
feat(update): act on the heartbeat's minimum_agent_version (fleet update push)

### DIFF
--- a/src/main.py
+++ b/src/main.py
@@ -1343,6 +1343,9 @@ class BetterFlowApp:
 
         # Sub-handlers
         self.update_handler = UpdateHandler(self.tray, self.config, self.coordinator, _VERSION)
+        # Let a server-advertised minimum version (heartbeat) push an update:
+        # the sync engine sees the floor, the handler stages + applies on idle.
+        self.sync_engine.on_update_required = self.update_handler.trigger_remote_update
         self.sys_events = SystemEventHandler(
             sync_engine=self.sync_engine,
             tray=self.tray,

--- a/src/sync/sync_engine.py
+++ b/src/sync/sync_engine.py
@@ -209,6 +209,12 @@ class SyncEngine:
         # channel) breaks that circular blindness. This is exactly why Windows
         # wedges were undiagnosable. None / errors tolerated.
         self.error_reporter = None
+        # Optional callback (set by BetterFlowApp → UpdateHandler) invoked with
+        # the server's advertised minimum version when this agent is below it.
+        # It stages the latest build and applies on next idle, so an urgent fix
+        # reaches the fleet in minutes instead of waiting for the 6h periodic
+        # check. None / errors tolerated — never let it break the heartbeat.
+        self.on_update_required: Optional[Callable[[str], None]] = None
         # Optional in-process AFK source (set by the SyncCoordinator). When
         # present, enabled by config, and the OS idle clock is readable, the
         # agent uploads its own AFK stream and ignores the external bf-idle-tracker
@@ -2260,6 +2266,15 @@ class SyncEngine:
                 logger.warning(
                     f"Agent {AGENT_VERSION} is below minimum {min_version} — update required"
                 )
+                # Act on it, don't just log: stage the latest build now (applied
+                # on next idle) so a server-pushed urgent fix lands in minutes
+                # instead of waiting up to 6h for the periodic check. The handler
+                # throttles itself so the 5-min heartbeat won't re-download.
+                if self.on_update_required is not None:
+                    try:
+                        self.on_update_required(min_version)
+                    except Exception as e:  # noqa: BLE001
+                        logger.debug("on_update_required failed: %s", e)
 
             # Clock skew detection: compare server time with local time
             server_time_str = payload.get("server_time")

--- a/src/update_handler.py
+++ b/src/update_handler.py
@@ -47,8 +47,11 @@ class UpdateHandler:
         # Throttle for server-pushed update checks (heartbeat-driven). The
         # heartbeat fires every ~5 min and keeps reporting the floor until the
         # agent has updated, so without this we'd re-hit GitHub / re-stage every
-        # beat. monotonic so a clock change can't wedge it.
-        self._last_remote_update_check = 0.0
+        # beat. monotonic so a clock change can't wedge it. Seeded to -inf (NOT
+        # 0.0) so the FIRST push is never throttled: on a freshly-booted machine
+        # monotonic() is small and `now - 0.0 < THROTTLE` would wrongly suppress
+        # the first check (passes on a long-uptime box, fails on a fresh runner).
+        self._last_remote_update_check = float("-inf")
 
     # Min gap between heartbeat-driven update checks.
     _REMOTE_UPDATE_THROTTLE = 1800.0  # 30 min

--- a/src/update_handler.py
+++ b/src/update_handler.py
@@ -10,7 +10,13 @@ Applying a staged build is loop-safe (see src/self_updater.get_staged_update).
 
 import logging
 import threading
+import time
 from typing import Optional
+
+try:
+    from .update_checker import _version_tuple
+except ImportError:
+    from update_checker import _version_tuple
 
 try:
     from .notifications import send_notification
@@ -37,6 +43,15 @@ class UpdateHandler:
         self._staged_lock = threading.Lock()
         self._update_jobs_started = False
         self._update_jobs_lock = threading.Lock()
+
+        # Throttle for server-pushed update checks (heartbeat-driven). The
+        # heartbeat fires every ~5 min and keeps reporting the floor until the
+        # agent has updated, so without this we'd re-hit GitHub / re-stage every
+        # beat. monotonic so a clock change can't wedge it.
+        self._last_remote_update_check = 0.0
+
+    # Min gap between heartbeat-driven update checks.
+    _REMOTE_UPDATE_THROTTLE = 1800.0  # 30 min
 
     def _flush_before_update_exit(self) -> None:
         """Best-effort flush of pending state right before the process is
@@ -199,6 +214,44 @@ class UpdateHandler:
             )
         except Exception:
             logger.debug("Periodic update check failed", exc_info=True)
+
+    def trigger_remote_update(self, target_version: str) -> None:
+        """Server (via the heartbeat's minimum_agent_version) says the fleet
+        should be at least `target_version` and this agent is below it. Kick an
+        off-cycle update check so the latest build stages now and applies on the
+        next idle/restart — reaching the fleet in minutes instead of waiting up
+        to 6h for the periodic check. Non-disruptive (no mid-session restart).
+
+        Guards: respects check_updates; skips if a build >= target is already
+        staged (it'll apply on idle); and throttles to one check per
+        _REMOTE_UPDATE_THROTTLE so the recurring heartbeat can't re-download.
+        """
+        if not self.config.check_updates:
+            return
+
+        # Already have it (or newer) downloaded — nothing to fetch; it applies
+        # on the next idle/restart via the staged-update path.
+        with self._staged_lock:
+            staged = self._staged_version
+        if staged is not None:
+            try:
+                if _version_tuple(staged) >= _version_tuple(target_version):
+                    return
+            except (ValueError, TypeError):
+                pass
+
+        now = time.monotonic()
+        with self._update_jobs_lock:
+            if now - self._last_remote_update_check < self._REMOTE_UPDATE_THROTTLE:
+                return
+            self._last_remote_update_check = now
+
+        logger.info(
+            "Server pushed update floor %s (agent %s) — staging latest build",
+            target_version,
+            self._version,
+        )
+        self._periodic_update_check()
 
     def on_install_update(self, asset_url: str) -> None:
         """Manual 'Install & Restart': download + apply immediately.

--- a/tests/test_sync_engine.py
+++ b/tests/test_sync_engine.py
@@ -483,6 +483,26 @@ class TestSyncEngine:
         self.bf.upload_logs.assert_called_once()
         self.engine.error_reporter.capture.assert_not_called()
 
+    def test_heartbeat_below_min_version_triggers_update(self):
+        """When the server advertises a minimum_agent_version above ours, the
+        heartbeat fires on_update_required so the handler can stage the build —
+        the fleet-push lever (not just a log line)."""
+        self.bf.heartbeat.return_value = {
+            "success": True, "data": {"minimum_agent_version": "999.0.0"},
+        }
+        self.engine.on_update_required = MagicMock()
+        self.engine._send_heartbeat()
+        self.engine.on_update_required.assert_called_once_with("999.0.0")
+
+    def test_heartbeat_at_or_above_min_version_does_not_trigger(self):
+        """An up-to-date agent must not be told to update."""
+        self.bf.heartbeat.return_value = {
+            "success": True, "data": {"minimum_agent_version": "0.0.1"},
+        }
+        self.engine.on_update_required = MagicMock()
+        self.engine._send_heartbeat()
+        self.engine.on_update_required.assert_not_called()
+
     def test_dropped_queue_events_are_reported_to_ops(self):
         """Events that exhaust their retries and get dropped are permanent data
         loss (captured activity the server never accepted). With the server now

--- a/tests/test_update_handler.py
+++ b/tests/test_update_handler.py
@@ -6,7 +6,7 @@ it. The handler must stage the latest build (applied on next idle) WITHOUT
 re-downloading on every 5-min heartbeat.
 """
 
-from unittest.mock import MagicMock
+from unittest.mock import MagicMock, patch
 
 from src.update_handler import UpdateHandler
 
@@ -50,6 +50,17 @@ def test_trigger_stages_when_staged_is_older_than_target():
     h = _handler("1.5.68")
     h._staged_version = "1.5.70"
     h.trigger_remote_update("1.5.71")
+    h._periodic_update_check.assert_called_once()
+
+
+def test_first_push_not_throttled_on_fresh_boot():
+    """Regression: on a freshly-booted machine time.monotonic() is small. With
+    the throttle seeded to 0.0, `now - 0.0 < THROTTLE` wrongly suppressed the
+    FIRST push (green on a long-uptime dev box, red on a fresh CI runner). The
+    first check must always fire regardless of the monotonic clock's origin."""
+    h = _handler("1.5.68")
+    with patch("src.update_handler.time.monotonic", return_value=5.0):
+        h.trigger_remote_update("1.5.71")
     h._periodic_update_check.assert_called_once()
 
 

--- a/tests/test_update_handler.py
+++ b/tests/test_update_handler.py
@@ -1,0 +1,60 @@
+"""Tests for UpdateHandler.trigger_remote_update (heartbeat-driven update push).
+
+The server advertises a fleet update floor (minimum_agent_version) on the
+heartbeat; the sync engine calls trigger_remote_update when the agent is below
+it. The handler must stage the latest build (applied on next idle) WITHOUT
+re-downloading on every 5-min heartbeat.
+"""
+
+from unittest.mock import MagicMock
+
+from src.update_handler import UpdateHandler
+
+
+def _handler(version: str = "1.5.68") -> UpdateHandler:
+    tray = MagicMock()
+    tray.model.update_in_progress = False
+    config = MagicMock(check_updates=True, update_channel="stable")
+    coordinator = MagicMock()
+    h = UpdateHandler(tray, config, coordinator, version)
+    h._periodic_update_check = MagicMock()  # don't hit GitHub in tests
+    return h
+
+
+def test_trigger_stages_when_agent_is_behind():
+    h = _handler("1.5.68")
+    h.trigger_remote_update("1.5.71")
+    h._periodic_update_check.assert_called_once()
+
+
+def test_trigger_is_throttled_across_repeated_heartbeats():
+    """The heartbeat keeps reporting the floor every ~5 min until the agent
+    updates; the handler must not re-download each time."""
+    h = _handler("1.5.68")
+    h.trigger_remote_update("1.5.71")
+    h.trigger_remote_update("1.5.71")
+    h.trigger_remote_update("1.5.71")
+    assert h._periodic_update_check.call_count == 1
+
+
+def test_trigger_skips_when_target_already_staged():
+    """A build >= the target is already downloaded — it applies on idle; we
+    must not fetch again."""
+    h = _handler("1.5.68")
+    h._staged_version = "1.5.71"
+    h.trigger_remote_update("1.5.71")
+    h._periodic_update_check.assert_not_called()
+
+
+def test_trigger_stages_when_staged_is_older_than_target():
+    h = _handler("1.5.68")
+    h._staged_version = "1.5.70"
+    h.trigger_remote_update("1.5.71")
+    h._periodic_update_check.assert_called_once()
+
+
+def test_trigger_respects_check_updates_disabled():
+    h = _handler("1.5.68")
+    h.config.check_updates = False
+    h.trigger_remote_update("1.5.71")
+    h._periodic_update_check.assert_not_called()


### PR DESCRIPTION
## Why

Publishing an urgent agent fix took **up to 6h + an idle/restart** to reach the fleet, with no way to push it sooner. (Tudor's agent sat on 1.5.68 after 1.5.71 published until he manually checked.)

## What

The agent already read `minimum_agent_version` off the heartbeat but only **logged** it. Now, when the server advertises a floor above this agent (internal-tool2 companion PR), the heartbeat fires `SyncEngine.on_update_required` → `UpdateHandler.trigger_remote_update`, which **stages the latest build and applies it on the next idle/restart**. Non-disruptive (no mid-session restart); reaches the fleet in minutes.

Guards:
- honors `check_updates`
- skips if a build ≥ the floor is already staged (applies on idle)
- throttles to one check / 30 min so the recurring ~5-min heartbeat can't re-download

Wiring mirrors `health_provider`/`error_reporter` (BetterFlowApp sets the callback after the handler exists).

## Tests

- heartbeat below floor fires `on_update_required`; at/above does not
- `trigger_remote_update`: stages when behind, throttled across repeated heartbeats, skips when target already staged, stages when staged is older, honors `check_updates=False`

733 agent tests pass; no new lint.

🤖 Generated with [Claude Code](https://claude.com/claude-code)