### PR TITLE
fix(afk): collapse in-process-AFK flag to one source of truth + escalate dead ticks

### DIFF
--- a/src/main.py
+++ b/src/main.py
@@ -145,6 +145,21 @@ class SyncCoordinator:
         # So a failed logs_requested upload surfaces to the ops ingest (it can't
         # surface via the log itself — that's the file we couldn't fetch).
         self.sync_engine.error_reporter = self.error_reporter
+        # Single source of truth for the in-process-AFK flag: the engine publishes
+        # its per-cycle decision straight to aw_manager on the path where the
+        # decision is made. The 60s _reconcile_inproc_afk_flag below is now only a
+        # backstop for paused periods (when the sync cycle doesn't run). Before
+        # this the timer was the ONLY writer — and it silently died for a whole
+        # release in Bug A (#76/#78), leaving the flag stale.
+        self.sync_engine.inproc_afk_flag_sink = self.aw_manager.set_inproc_afk_active
+
+        # _tick_60s sub-tasks each run under a try/except so one failure can't kill
+        # the scheduler — but that also HID Bug A (a reconcile that threw every 60s
+        # for a whole release, found only by reading fleet logs). Track consecutive
+        # per-task failures and escalate ONCE past a threshold to the ops ingest so
+        # the same silent-breakage class surfaces in minutes, not on a log dive.
+        self._tick_failure_counts: dict[str, int] = {}
+        self._tick_failure_reported: set[str] = set()
 
         self.scheduler = BackgroundScheduler()
         self._last_tick: Optional[datetime] = None
@@ -793,15 +808,52 @@ class SyncCoordinator:
             (self._check_auth_warn, "auth_warn"),
             (self._check_idle_tracker_health, "idle_tracker_health"),
         ):
-            try:
-                fn()
-            except Exception as e:
-                logger.warning("_tick_60s/%s failed: %s", label, e)
+            self._run_tick_task(fn, label)
         if self.reminder_manager:
-            try:
-                self.reminder_manager.check()
-            except Exception as e:
-                logger.warning("_tick_60s/reminders failed: %s", e)
+            self._run_tick_task(self.reminder_manager.check, "reminders")
+
+    # A _tick_60s sub-task that fails this many cycles in a row is escalated to
+    # the ops ingest (a transient blip is below this; chronic breakage is not).
+    _TICK_FAILURE_ESCALATE_THRESHOLD = 3
+
+    def _run_tick_task(self, fn: Callable[[], None], label: str) -> None:
+        """Run one _tick_60s sub-task. A single failure is logged but never kills
+        the scheduler (one dead sub-task must not freeze idle detection, hours,
+        permissions, etc). A sub-task that fails repeatedly is escalated ONCE to
+        the ops ingest — the missing signal that let Bug A run silently for a
+        release. A later success clears the streak and re-arms escalation."""
+        try:
+            fn()
+        except Exception as e:
+            logger.warning("_tick_60s/%s failed: %s", label, e)
+            self._note_tick_failure(label, e)
+            return
+        self._clear_tick_failure(label)
+
+    def _note_tick_failure(self, label: str, exc: Exception) -> None:
+        n = self._tick_failure_counts.get(label, 0) + 1
+        self._tick_failure_counts[label] = n
+        if n < self._TICK_FAILURE_ESCALATE_THRESHOLD or label in self._tick_failure_reported:
+            return
+        self._tick_failure_reported.add(label)
+        reporter = getattr(self, "error_reporter", None)
+        if reporter is None:
+            return
+        try:
+            reporter.capture(
+                f"_tick_60s sub-task '{label}' failed {n} consecutive times — a "
+                f"background tick is silently broken",
+                level="error",
+                tags={"component": "tick-60s", "task": label},
+                context={"consecutive_failures": n, "last_error": str(exc)},
+                fingerprint=f"tick-60s-{label}",
+            )
+        except Exception:
+            logger.debug("tick-failure escalation report failed", exc_info=True)
+
+    def _clear_tick_failure(self, label: str) -> None:
+        if self._tick_failure_counts.pop(label, None):
+            self._tick_failure_reported.discard(label)
 
     def _reconcile_inproc_afk_flag(self) -> None:
         """Keep aw_manager's in-process-AFK flag in step with the sync engine's

--- a/src/main.py
+++ b/src/main.py
@@ -148,9 +148,10 @@ class SyncCoordinator:
         # Single source of truth for the in-process-AFK flag: the engine publishes
         # its per-cycle decision straight to aw_manager on the path where the
         # decision is made. The 60s _reconcile_inproc_afk_flag below is now only a
-        # backstop for paused periods (when the sync cycle doesn't run). Before
-        # this the timer was the ONLY writer — and it silently died for a whole
-        # release in Bug A (#76/#78), leaving the flag stale.
+        # backstop for cycles that don't reach that decision point (paused/private,
+        # AW down, bucket-fetch error). Before this the timer was the ONLY writer —
+        # and it silently died for a whole release in Bug A (#76/#78), leaving the
+        # flag stale.
         self.sync_engine.inproc_afk_flag_sink = self.aw_manager.set_inproc_afk_active
 
         # _tick_60s sub-tasks each run under a try/except so one failure can't kill

--- a/src/sync/sync_engine.py
+++ b/src/sync/sync_engine.py
@@ -224,6 +224,16 @@ class SyncEngine:
         # sample log only retains ~2h, so a day-start rewind would re-emit afk over
         # a morning already billed correctly).
         self.afk_source = None
+        # Optional callback (set by the SyncCoordinator to aw_manager's
+        # set_inproc_afk_active) invoked every cycle with the in-process-AFK
+        # decision. The flag it sets gates the idle-tracker watchdog + AFK health
+        # telemetry. Publishing it from HERE — the path where the decision is
+        # actually made — makes the engine the single source of truth: the flag
+        # tracks the engine every active cycle independent of the 60s reconcile
+        # timer, which used to be the only writer and silently died in Bug A
+        # (#76/#78), leaving the flag stale for a whole release. None / errors
+        # tolerated — telemetry wiring must never break a sync cycle.
+        self.inproc_afk_flag_sink: Optional[Callable[[bool], None]] = None
         # Mutated only on the sync thread (record_sample / _build_inproc_afk /
         # _commit_inproc_afk_checkpoint all run inside SyncEngine.sync()).
         self._afk_inproc_checkpoint: Optional[datetime] = None
@@ -570,6 +580,11 @@ class SyncEngine:
         # upload our own stream below instead, so its (possibly frozen/blind)
         # events never reach the server.
         skip_external_afk = self._should_skip_external_afk()
+        # Publish the decision to the flag sink on the path where it's made, so
+        # aw_manager's flag (idle-tracker watchdog + AFK telemetry) stays in step
+        # with the engine every active cycle — one source of truth, not a cache a
+        # separate timer keeps in sync (and silently failed to: Bug A, #76/#78).
+        self._publish_inproc_afk_flag(skip_external_afk)
         for bucket in web_buckets + afk_buckets + input_buckets:
             if skip_external_afk and _is_afk_like(bucket.type):
                 continue
@@ -1912,6 +1927,21 @@ class SyncEngine:
         """Whether to drop the external bf-idle-tracker bucket from this cycle's
         upload (because the agent uploads its own AFK stream instead)."""
         return self._inproc_afk_active()
+
+    def _publish_inproc_afk_flag(self, active: bool) -> None:
+        """Push the per-cycle in-process-AFK decision to the flag sink
+        (aw_manager.set_inproc_afk_active). Called from the cycle's decision point
+        so the flag — which gates the idle-tracker watchdog + AFK health
+        telemetry — is a direct consequence of what the engine actually did this
+        cycle, not a cache a separate 60s timer keeps in sync. None / errors are
+        tolerated: telemetry wiring must never break a sync cycle."""
+        sink = self.inproc_afk_flag_sink
+        if sink is None:
+            return
+        try:
+            sink(active)
+        except Exception as e:
+            logger.debug("inproc_afk_flag_sink failed: %s", e)
 
     def _build_inproc_afk(self, now: datetime) -> list[dict]:
         """Build in-process AFK events for [checkpoint, now]. First cycle seeds

--- a/tests/test_afk_convergence_hardening.py
+++ b/tests/test_afk_convergence_hardening.py
@@ -1,0 +1,200 @@
+"""Tracker-convergence hardening (stage 1).
+
+Two independent failure modes from the in-process-AFK rollout:
+
+1. The aw_manager "in-process AFK active" flag (which gates the idle-tracker
+   watchdog + AFK health telemetry) was a CACHE kept in step with the engine's
+   real per-cycle decision only by a separate 60s reconcile timer. When that
+   timer silently died (Bug A, #76/#78: an AttributeError swallowed by
+   _tick_60s's per-task try/except), the flag went stale for a whole release and
+   nothing complained. Fix: the sync cycle itself publishes the decision to the
+   flag sink on the path where the decision is made — so during active work the
+   flag tracks the engine regardless of the timer's health (one source of truth).
+
+2. _tick_60s swallows every sub-task exception with a local logger.warning, so a
+   sub-task (like the reconcile above) can fail every 60s for a release with no
+   ops signal. Fix: escalate a repeatedly-failing sub-task to the error_reporter
+   so the same class of silent breakage surfaces in minutes, not on manual
+   fleet-log reading.
+"""
+
+from datetime import timedelta
+from unittest.mock import Mock
+
+from src.config import Config
+from src.main import SyncCoordinator
+from src.sync.activity_analyzer import ActivityAnalyzer
+from src.sync.afk_source import AfkSource
+from src.sync.daily_time_tracker import DailyTimeTracker
+from src.sync.sync_engine import SyncEngine
+
+# --------------------------------------------------------------------------- #
+# 1. Single source of truth: the cycle publishes its decision to the flag sink #
+# --------------------------------------------------------------------------- #
+
+def _runnable_engine(in_process_afk: bool) -> SyncEngine:
+    """A SyncEngine wired so a full sync() cycle runs to the AFK-decision point
+    with no real buckets — exercises the real code path, not a stub of it."""
+    cfg = Config()
+    cfg.sync.in_process_afk = in_process_afk
+
+    aw = Mock()
+    aw.is_running.return_value = True
+    aw.get_window_buckets.return_value = []
+    aw.get_web_buckets.return_value = []
+    aw.get_afk_buckets.return_value = []
+    aw.get_input_buckets.return_value = []
+
+    bf = Mock()
+    bf.is_reachable.return_value = True
+
+    queue = Mock()
+    queue.get_checkpoint.return_value = None
+    queue.is_empty.return_value = True
+
+    analyzer = Mock(spec=ActivityAnalyzer)
+    analyzer.get_activity_state.return_value = "active"
+    analyzer.get_raw_metrics.return_value = Mock(
+        to_dict=lambda: {"presses": 0, "clicks": 0, "scrolls": 0, "window_changes": 0}
+    )
+    analyzer.get_fraud_assessment.return_value = Mock(
+        score=0, signals=[], extra_metrics={"unique_apps": 0, "keystroke_variance": None}
+    )
+
+    tracker = Mock(spec=DailyTimeTracker)
+    tracker.get_today_active_time.return_value = timedelta(hours=1)
+
+    eng = SyncEngine(aw=aw, bf=bf, queue=queue, config=cfg,
+                     activity_analyzer=analyzer, time_tracker=tracker)
+    eng._config_fetched = True      # skip the first-cycle server-config fetch
+    eng._backlog_reconciled = True  # skip the one-time start-of-day backlog reconcile
+    return eng
+
+
+def test_cycle_publishes_inproc_flag_true_when_active():
+    eng = _runnable_engine(True)
+    eng.afk_source = AfkSource(600, "host", idle_clock=lambda: 5.0)
+    published: list = []
+    eng.inproc_afk_flag_sink = published.append
+
+    eng.sync()
+
+    # The decision (skip the external bucket, use the in-process stream) was
+    # pushed to the sink on the real cycle path.
+    assert published and published[-1] is True
+
+
+def test_cycle_publishes_inproc_flag_false_when_off():
+    eng = _runnable_engine(False)
+    eng.afk_source = AfkSource(600, "host", idle_clock=lambda: 5.0)
+    published: list = []
+    eng.inproc_afk_flag_sink = published.append
+
+    eng.sync()
+
+    # Flag off → the external tracker is still the source, so the flag MUST be
+    # False (otherwise its watchdog/alerts stay wrongly suppressed).
+    assert published and published[-1] is False
+
+
+def test_cycle_publish_matches_should_skip_decision():
+    eng = _runnable_engine(True)
+    eng.afk_source = AfkSource(600, "host", idle_clock=lambda: None)  # Linux: unavailable
+    published: list = []
+    eng.inproc_afk_flag_sink = published.append
+
+    eng.sync()
+
+    # Unavailable clock → not active → publish False, matching the gate.
+    assert published[-1] is eng._should_skip_external_afk() is False
+
+
+def test_missing_sink_does_not_break_the_cycle():
+    eng = _runnable_engine(True)
+    eng.afk_source = AfkSource(600, "host", idle_clock=lambda: 5.0)
+    eng.inproc_afk_flag_sink = None  # not wired
+    # Must not raise.
+    eng.sync()
+
+
+# --------------------------------------------------------------------------- #
+# 2. Loud escalation of a repeatedly-failing _tick_60s sub-task                #
+# --------------------------------------------------------------------------- #
+
+def _coord() -> SyncCoordinator:
+    c = SyncCoordinator.__new__(SyncCoordinator)
+    c._tick_failure_counts = {}
+    c._tick_failure_reported = set()
+    c.error_reporter = Mock()
+    c.reminder_manager = None
+    return c
+
+
+def test_tick_task_escalates_after_threshold():
+    c = _coord()
+
+    def boom():
+        raise RuntimeError("AttributeError-style silent breakage")
+
+    threshold = SyncCoordinator._TICK_FAILURE_ESCALATE_THRESHOLD
+    for _ in range(threshold):
+        c._run_tick_task(boom, "inproc_afk_reconcile")
+
+    assert c.error_reporter.capture.call_count == 1
+    kwargs = c.error_reporter.capture.call_args.kwargs
+    assert kwargs.get("fingerprint") == "tick-60s-inproc_afk_reconcile"
+
+
+def test_tick_task_escalates_only_once_while_still_failing():
+    c = _coord()
+
+    def boom():
+        raise RuntimeError("still broken")
+
+    for _ in range(SyncCoordinator._TICK_FAILURE_ESCALATE_THRESHOLD + 5):
+        c._run_tick_task(boom, "task")
+
+    assert c.error_reporter.capture.call_count == 1  # latched, no spam
+
+
+def test_tick_task_success_resets_and_re_arms_escalation():
+    c = _coord()
+
+    def boom():
+        raise RuntimeError("broken")
+
+    def ok():
+        return None
+
+    for _ in range(SyncCoordinator._TICK_FAILURE_ESCALATE_THRESHOLD):
+        c._run_tick_task(boom, "task")
+    assert c.error_reporter.capture.call_count == 1
+
+    c._run_tick_task(ok, "task")  # recovered → counter clears, latch re-arms
+
+    for _ in range(SyncCoordinator._TICK_FAILURE_ESCALATE_THRESHOLD):
+        c._run_tick_task(boom, "task")
+    assert c.error_reporter.capture.call_count == 2  # a fresh outage escalates again
+
+
+def test_tick_task_below_threshold_does_not_escalate():
+    c = _coord()
+
+    def boom():
+        raise RuntimeError("transient")
+
+    for _ in range(SyncCoordinator._TICK_FAILURE_ESCALATE_THRESHOLD - 1):
+        c._run_tick_task(boom, "task")
+
+    c.error_reporter.capture.assert_not_called()
+
+
+def test_tick_task_no_error_reporter_is_tolerated():
+    c = _coord()
+    c.error_reporter = None
+
+    def boom():
+        raise RuntimeError("broken")
+
+    for _ in range(SyncCoordinator._TICK_FAILURE_ESCALATE_THRESHOLD + 1):
+        c._run_tick_task(boom, "task")  # must not raise


### PR DESCRIPTION
## Tracker-convergence hardening (stage 1)

Picks up the open "tracker-convergence root cause" item. Per the agreed staging: **hardening first (this PR), stop-external state machine as a follow-up** with its own parity validation.

The in-process AFK source is already the sole *uploaded* source on macOS/Windows (#70/#76), but the convergence between the engine's decision and the `aw_manager` flag that gates the idle-tracker watchdog + AFK telemetry was held together by a fragile timer — which is exactly what **Bug A** (#76/#78) broke silently for a whole release.

### What changed

**1. One source of truth for the in-process-AFK flag.**
The flag was a cache kept in sync only by the 60s `_reconcile_inproc_afk_flag` timer. When that timer threw every cycle (Bug A), the flag went stale and nothing complained. The sync cycle now publishes the decision to `SyncEngine.inproc_afk_flag_sink` (→ `aw_manager.set_inproc_afk_active`) **on the path where the decision is made**, so during active work the flag tracks the engine regardless of the timer. The 60s reconcile stays as a backstop for paused periods.

**2. A silently-dead `_tick_60s` sub-task now gets loud.**
`_tick_60s` swallowed every sub-task exception with a local `logger.warning` — how Bug A stayed invisible. `_run_tick_task` now counts consecutive per-task failures and escalates **once** past a threshold (3) to the `error_reporter`; a success clears the streak and re-arms.

**3. Actionable re-prompt — already done.**
`_reprompt_idle_tracker_permission` already opens System Settings → Input Monitoring (`Privacy_ListenEvent`). No change needed; noted for completeness.

No billing-source behavior change.

### Tests
`tests/test_afk_convergence_hardening.py` (9):
- flag-publish tests drive a **real `sync()` cycle** (not a stub) — failed pre-fix because the sink was never called;
- escalation tests drive `_run_tick_task` directly — failed pre-fix because the threshold didn't exist.

Full suite: **743 passed**. Lint clean on touched files.

### Follow-up (stage 2)
Stop `bf-idle-tracker` when in-process AFK is active; re-launch only as the fallback when in-process goes unavailable (blind clock / config off / Linux). Tracked separately; needs parity validation before fleet rollout.

🤖 Generated with [Claude Code](https://claude.com/claude-code)