### PR TITLE
feat(afk): stop external bf-idle-tracker when in-process AFK is the source (stage 2, default-off)

### DIFF
--- a/src/aw_manager.py
+++ b/src/aw_manager.py
@@ -31,7 +31,8 @@ APP_AUTHOR = "BetterQA"
 # Binaries to manage (start order matters: server first, then watchers)
 # These are renamed from aw-* originals for white-labeling
 BF_SERVER = "bf-data-service"
-BF_WATCHERS = ["bf-window-tracker", "bf-idle-tracker"]
+IDLE_TRACKER = "bf-idle-tracker"
+BF_WATCHERS = ["bf-window-tracker", IDLE_TRACKER]
 ALL_COMPONENTS = [BF_SERVER] + BF_WATCHERS
 
 # Our Apple Developer Team. The build signs the bundled trackers with this
@@ -323,7 +324,8 @@ def _download_aw_binaries(install_dir: str) -> bool:
 class AWManager:
     """Manages lifecycle of bundled tracker processes."""
 
-    def __init__(self, aw_port: int = 5600, afk_timeout: int = 600):
+    def __init__(self, aw_port: int = 5600, afk_timeout: int = 600,
+                 stop_external_when_inproc: bool = False):
         # Clamp to reasonable ranges. These values are baked into argv for
         # the tracker binaries; bounding them prevents future config drift
         # from producing nonsense or huge argv strings.
@@ -333,6 +335,14 @@ class AWManager:
             raise ValueError(f"afk_timeout out of range: {afk_timeout!r}")
         self.aw_port = aw_port
         self.afk_timeout = afk_timeout  # seconds
+        # Stage 2 of tracker-convergence (default OFF, opt-in via
+        # config.sync.stop_external_afk_tracker): when True AND in-process AFK is
+        # the source, STOP the external bf-idle-tracker process entirely rather
+        # than just ignoring its bucket — killing the dual-source surface that
+        # produced Bug A. Default OFF because, with the tracker stopped, recovery
+        # can't fall back to it without flipping the (currently local-only)
+        # kill-switch — so it ships dark until validated/remotely-flippable.
+        self._stop_external_when_inproc = bool(stop_external_when_inproc)
         # Serializes every mutation of _processes, _using_external,
         # _disabled_components, and _stale_restart_count so scheduler
         # callbacks, tray callbacks, and shutdown never race.
@@ -374,9 +384,63 @@ class AWManager:
     def set_inproc_afk_active(self, active: bool) -> None:
         """Mark whether the agent is uploading its own in-process AFK stream. When
         active, the bf-idle-tracker stale/blind detection is suppressed (we no
-        longer consume its bucket, so it must not restart or raise alerts)."""
+        longer consume its bucket, so it must not restart or raise alerts).
+
+        Stage 2 (only when ``stop_external_when_inproc`` is enabled): on the
+        transition into/out of active, also STOP / re-launch the external
+        bf-idle-tracker process. Driven via ``_disabled_components`` so the single
+        membership flip gates every (re)start path (`_start_locked`, the watchdog,
+        `restart_idle_tracker`). Idempotent — only acts on an actual transition, as
+        the flag is now published every sync cycle."""
+        active = bool(active)
         with self._lifecycle_lock:
-            self._inproc_afk_active = bool(active)
+            was_active = self._inproc_afk_active
+            self._inproc_afk_active = active
+            if not self._stop_external_when_inproc or active == was_active:
+                return
+            if active:
+                # In-process is the sole source: disable + stop the external
+                # tracker so two AFK sources can't diverge and we don't run a dead
+                # process whose bucket we ignore anyway.
+                self._disabled_components.add(IDLE_TRACKER)
+                self._stop_idle_tracker_locked()
+            else:
+                # In-process unavailable (config off / no OS idle clock / Linux):
+                # fall back to the external tracker — re-enable and (re)start it.
+                self._disabled_components.discard(IDLE_TRACKER)
+                self._start_idle_tracker_locked()
+
+    def _stop_idle_tracker_locked(self) -> None:
+        """Terminate the bf-idle-tracker process if we're running it, and reap any
+        orphan so it can't keep posting to the AFK bucket. No-op if not running.
+        Caller holds _lifecycle_lock."""
+        proc = self._processes.pop(IDLE_TRACKER, None)
+        if proc is not None and proc.poll() is None:
+            logger.info("Stopping %s (in-process AFK is the sole source)", IDLE_TRACKER)
+            proc.terminate()
+            try:
+                proc.wait(timeout=SHUTDOWN_TIMEOUT)
+            except subprocess.TimeoutExpired:
+                proc.kill()
+        binaries_dir = self._get_binaries_dir()
+        if binaries_dir:
+            self._reap_orphan_processes(IDLE_TRACKER, binaries_dir)
+
+    def _start_idle_tracker_locked(self) -> None:
+        """(Re)start bf-idle-tracker as the fallback when in-process AFK is no
+        longer the source. No-op if already running or no binaries. Caller holds
+        _lifecycle_lock."""
+        if IDLE_TRACKER in self._disabled_components:
+            return  # left disabled by someone else — respect it
+        existing = self._processes.get(IDLE_TRACKER)
+        if existing is not None and existing.poll() is None:
+            return  # already running
+        binaries_dir = self._get_binaries_dir()
+        if not binaries_dir:
+            return
+        logger.info("(Re)starting %s (in-process AFK no longer the source)", IDLE_TRACKER)
+        self._reap_orphan_processes(IDLE_TRACKER, binaries_dir)
+        self._start_component(IDLE_TRACKER, binaries_dir)
 
     def disable_component(self, name: str) -> None:
         """Prevent a component from being started/restarted."""

--- a/src/aw_manager.py
+++ b/src/aw_manager.py
@@ -390,8 +390,15 @@ class AWManager:
         transition into/out of active, also STOP / re-launch the external
         bf-idle-tracker process. Driven via ``_disabled_components`` so the single
         membership flip gates every (re)start path (`_start_locked`, the watchdog,
-        `restart_idle_tracker`). Idempotent — only acts on an actual transition, as
-        the flag is now published every sync cycle."""
+        `restart_idle_tracker`). Idempotent — only acts on an actual TRANSITION, as
+        the flag is now published every sync cycle.
+
+        The transition does subprocess I/O (terminate/wait, orphan reap) under the
+        lock. That's bounded: `_inproc_afk_active()` is config + sticky
+        `available()`, neither of which changes at runtime, so a session flips at
+        most once (typically once at startup) — this is a one-time lock hold, the
+        same pattern `restart_idle_tracker`/`_stop_locked` already use, not a
+        per-cycle cost."""
         active = bool(active)
         with self._lifecycle_lock:
             was_active = self._inproc_afk_active
@@ -432,6 +439,13 @@ class AWManager:
         _lifecycle_lock."""
         if IDLE_TRACKER in self._disabled_components:
             return  # left disabled by someone else — respect it
+        if not self._processes:
+            # The stack hasn't been start()ed yet (this fired from a pre-start
+            # reconcile/cycle). Don't launch a lone tracker against a server that
+            # isn't up — start() will bring it up with the rest now that it's
+            # re-enabled. Without this guard an early False transition could leak
+            # a serverless tracker process.
+            return
         existing = self._processes.get(IDLE_TRACKER)
         if existing is not None and existing.poll() is None:
             return  # already running

--- a/src/config.py
+++ b/src/config.py
@@ -304,6 +304,12 @@ class SyncSettings:
     # watcher instead of the external bf-idle-tracker bucket. Kill-switch: set
     # False to fall back to the external bucket + stale-synthesis path.
     in_process_afk: bool = True
+    # Stage 2 of tracker-convergence: when in_process_afk is the source, STOP the
+    # external bf-idle-tracker process (not just ignore its bucket), eliminating
+    # the dual-source surface that produced Bug A. Default OFF — opt-in, and
+    # independently reversible: with the tracker stopped, recovery can't fall back
+    # to it without flipping a flag, so this ships dark until validated.
+    stop_external_afk_tracker: bool = False
 
 
 @dataclass

--- a/src/main.py
+++ b/src/main.py
@@ -1252,6 +1252,7 @@ class BetterFlowApp:
         self.aw_manager = AWManager(
             aw_port=self.config.aw.port,
             afk_timeout=self.config.aw.afk_timeout_minutes * 60,
+            stop_external_when_inproc=self.config.sync.stop_external_afk_tracker,
         )
 
         # Initialize components

--- a/tests/test_stop_external_afk_tracker.py
+++ b/tests/test_stop_external_afk_tracker.py
@@ -1,0 +1,128 @@
+"""Stage 2 of tracker-convergence: stop the external bf-idle-tracker process when
+the in-process AFK source is active, re-launch it as the fallback when in-process
+goes unavailable.
+
+Stage 1 (#81) made the in-process stream the sole *uploaded* AFK source, but the
+external tracker kept running and being ignored — the dual-source surface that
+produced Bug A. Stage 2 stops the redundant process entirely. It is gated behind
+`AWManager(stop_external_when_inproc=...)` (wired from
+`config.sync.stop_external_afk_tracker`, default OFF) so it ships without changing
+fleet behaviour until explicitly enabled, and so it is independently reversible —
+important because with the tracker STOPPED, recovery can't fall back to it the way
+stage 1 (tracker merely ignored) could.
+
+The mechanism reuses the existing `_disabled_components` set, which already makes
+`_start_locked`, the watchdog (`_restart_if_needed_locked`), and
+`restart_idle_tracker` all skip a component — so one membership flip gates every
+(re)start path.
+"""
+
+from unittest.mock import Mock
+
+from src.aw_manager import AWManager
+
+IDLE = "bf-idle-tracker"
+
+
+class FakeProc:
+    def __init__(self, alive=True):
+        self._alive = alive
+        self.terminated = False
+        self.killed = False
+
+    def poll(self):
+        return None if self._alive else 0
+
+    def terminate(self):
+        self.terminated = True
+        self._alive = False
+
+    def wait(self, timeout=None):
+        return 0
+
+    def kill(self):
+        self.killed = True
+
+
+def _mgr(stop_external: bool) -> AWManager:
+    m = AWManager(stop_external_when_inproc=stop_external)
+    m._get_binaries_dir = lambda: "/fake/bin"
+    m._start_component = Mock(return_value=True)
+    m._reap_orphan_processes = Mock()
+    return m
+
+
+def test_flag_defaults_off():
+    assert AWManager()._stop_external_when_inproc is False
+
+
+def test_off_mode_never_touches_the_tracker():
+    m = _mgr(stop_external=False)
+    proc = FakeProc()
+    m._processes[IDLE] = proc
+
+    m.set_inproc_afk_active(True)
+
+    # Stage-2 disabled → behave exactly as before: flag set, tracker untouched.
+    assert m._inproc_afk_active is True
+    assert IDLE not in m._disabled_components
+    assert proc.terminated is False
+    assert IDLE in m._processes
+
+
+def test_active_stops_and_disables_the_tracker():
+    m = _mgr(stop_external=True)
+    proc = FakeProc()
+    m._processes[IDLE] = proc
+
+    m.set_inproc_afk_active(True)
+
+    assert IDLE in m._disabled_components       # gates every (re)start path
+    assert proc.terminated is True              # process actually stopped
+    assert IDLE not in m._processes             # untracked so health checks ignore it
+    m._reap_orphan_processes.assert_called_once_with(IDLE, "/fake/bin")
+
+
+def test_inactive_reenables_and_restarts_the_tracker():
+    m = _mgr(stop_external=True)
+    m._processes[IDLE] = FakeProc()
+    m.set_inproc_afk_active(True)               # disable + stop
+    assert IDLE in m._disabled_components
+
+    m.set_inproc_afk_active(False)              # fallback: re-enable + start
+
+    assert IDLE not in m._disabled_components
+    m._start_component.assert_called_with(IDLE, "/fake/bin")
+
+
+def test_no_transition_is_idempotent():
+    m = _mgr(stop_external=True)
+    proc = FakeProc()
+    m._processes[IDLE] = proc
+
+    m.set_inproc_afk_active(True)
+    m.set_inproc_afk_active(True)               # same value — no second stop
+
+    assert m._reap_orphan_processes.call_count == 1
+    assert IDLE in m._disabled_components
+
+
+def test_active_when_tracker_not_running_is_a_noop_stop():
+    m = _mgr(stop_external=True)
+    # No process tracked yet (e.g. set before start()).
+    m.set_inproc_afk_active(True)
+
+    assert IDLE in m._disabled_components        # still disabled so start() skips it
+    m._start_component.assert_not_called()
+
+
+def test_restart_idle_tracker_skips_a_stage2_disabled_tracker():
+    # The existing disabled-gate must keep the blind-tracker health path from
+    # resurrecting a tracker stage 2 intentionally stopped.
+    m = _mgr(stop_external=True)
+    m.set_inproc_afk_active(True)
+    m._start_component.reset_mock()
+
+    m.restart_idle_tracker(reason="health check")
+
+    m._start_component.assert_not_called()

--- a/tests/test_stop_external_afk_tracker.py
+++ b/tests/test_stop_external_afk_tracker.py
@@ -85,14 +85,30 @@ def test_active_stops_and_disables_the_tracker():
 
 def test_inactive_reenables_and_restarts_the_tracker():
     m = _mgr(stop_external=True)
+    # A running stack: server + window tracker stay up; only the idle tracker is
+    # cycled. _processes is non-empty after the idle tracker is stopped, so the
+    # fallback restart is valid (server is up to receive its events).
+    m._processes["bf-data-service"] = FakeProc()
     m._processes[IDLE] = FakeProc()
-    m.set_inproc_afk_active(True)               # disable + stop
+    m.set_inproc_afk_active(True)               # disable + stop idle tracker
     assert IDLE in m._disabled_components
 
     m.set_inproc_afk_active(False)              # fallback: re-enable + start
 
     assert IDLE not in m._disabled_components
     m._start_component.assert_called_with(IDLE, "/fake/bin")
+
+
+def test_inactive_before_start_does_not_launch_a_serverless_tracker():
+    # Transition fired from a pre-start reconcile/cycle (nothing started yet):
+    # the fallback must NOT launch a lone tracker against a server that isn't up —
+    # start() will bring it up with the rest. (Review finding #2.)
+    m = _mgr(stop_external=True)
+    m.set_inproc_afk_active(True)               # _processes empty → disable only
+    m.set_inproc_afk_active(False)              # re-enable, but defer the start
+
+    assert IDLE not in m._disabled_components
+    m._start_component.assert_not_called()
 
 
 def test_no_transition_is_idempotent():


### PR DESCRIPTION
## Tracker-convergence stage 2 (follow-up to #81)

Stage 1 (#81) made the in-process stream the sole **uploaded** AFK source, but the external `bf-idle-tracker` kept **running** and being ignored — the dual-source surface that produced Bug A. Stage 2 stops the redundant process entirely, eliminating the root cause (two AFK sources kept in implicit sync).

### Behaviour
On the in-process-active **transition**, `AWManager`:
- **active:** disables + terminates `bf-idle-tracker` and reaps orphans (so it can't keep posting to the AFK bucket);
- **inactive** (config off / no OS idle clock / Linux): re-enables and re-launches it as the fallback.

Driven through the existing `_disabled_components` set — one membership flip gates **every** (re)start path (`_start_locked`, the watchdog `_restart_if_needed_locked`, `restart_idle_tracker`), so there's no new gating scattered around. Idempotent (acts only on a real transition; the flag is published every cycle since #81).

### Ships DARK — gated behind `config.sync.stop_external_afk_tracker` (default **FALSE**)
This is deliberate and addresses the rollback risk:
- The kill-switch is still **local-only**. With the tracker *stopped*, recovery can't fall back to it the way stage 1 (tracker merely *ignored*) could. So enabling fleet-wide should wait for **parity validation** and ideally a **remote kill-switch** first.
- Merging it default-off changes **zero** fleet behaviour while making the machinery available to enable cautiously and revert independently of stage 1's upload behaviour.

### Known limitation (documented in code)
A **permanently** blind in-process clock keeps the tracker stopped (`available()` is sticky). Billing outcome is identical to stage 1 (the external bucket is skipped on upload regardless), but there's no auto-fallback. A blind-triggered fallback is a possible **stage 2.1** if parity testing shows it's needed.

### Tests
`tests/test_stop_external_afk_tracker.py` (7): off-mode no-op, active stops+disables, inactive re-enables+restarts, idempotence, no-op stop when not running, flag default, and the disabled-gate keeping `restart_idle_tracker` from resurrecting a stopped tracker. **Full suite: 750 passed.**

### Rollout checklist (before flipping the flag on)
- [ ] #81 merged ✅ (it is)
- [ ] Parity check: active-seconds vs prior days on a canary device with the flag on
- [ ] Ideally: remote/server-controlled kill-switch so it can be reverted without a client update

🤖 Generated with [Claude Code](https://claude.com/claude-code)