### PR TITLE
fix(queue): classify dropped events so benign flushes don't page ops at warning

### DIFF
--- a/src/sync/queue.py
+++ b/src/sync/queue.py
@@ -382,15 +382,32 @@ class OfflineQueue:
                 event_ids,
             )
 
-    def failed_event_summary(self, max_retries: int = 5) -> dict:
+    def failed_event_summary(
+        self,
+        max_retries: int = 5,
+        *,
+        now: Optional[datetime] = None,
+        stale_after_days: int = 7,
+    ) -> dict:
         """Summarize events at/over the retry ceiling that remove_failed() is
         about to drop. Read-only — does NOT delete.
 
-        Dropping queued events is permanent data loss (activity captured locally
-        that the server never accepted). It used to be a bare log line nobody
-        sees; this lets the caller surface it to the ops error channel instead.
-        Returns {count, bucket_ids, oldest, newest} — empty count 0 when clean.
+        Dropping queued events is normally permanent data loss, but not every
+        drop is real loss: the server legitimately rejects events that are
+        unstorable BY NATURE — older than its retention window (``stale_after_days``,
+        the >7d-stale rule) or carrying no ``bucket_id`` (nowhere to route them).
+        Those exhaust their retries and get flushed, which is benign. We classify
+        each so the caller can warn only on genuine loss (recent + bucketed) and
+        log the benign flushes quietly instead of paging ops.
+
+        Returns {count, bucket_ids, oldest, newest, real_loss_count,
+        unstorable_count} — all zero/empty when clean.
+
+        ``now`` is injectable for deterministic tests (defaults to UTC now).
         """
+        now = now or datetime.now(timezone.utc)
+        stale_cutoff = now - timedelta(days=stale_after_days)
+
         with self._cursor() as cursor:
             cursor.execute(
                 "SELECT event_data FROM queued_events WHERE retry_count >= ?",
@@ -400,10 +417,14 @@ class OfflineQueue:
 
         bucket_ids: set[str] = set()
         timestamps: list[str] = []
+        real_loss = 0
+        unstorable = 0
         for row in rows:
             try:
                 ev = json.loads(row[0])
             except (json.JSONDecodeError, TypeError):
+                # Can't even parse it → it could never be stored. Benign flush.
+                unstorable += 1
                 continue
             bid = ev.get("bucket_id")
             if bid:
@@ -411,13 +432,36 @@ class OfflineQueue:
             ts = ev.get("timestamp")
             if ts:
                 timestamps.append(str(ts))
+            # A drop is real loss only if it was actually storable: it has a
+            # bucket to route to AND its timestamp is within the retention window.
+            recent = bid and self._timestamp_within(ts, stale_cutoff)
+            if recent:
+                real_loss += 1
+            else:
+                unstorable += 1
         timestamps.sort()
         return {
             "count": len(rows),
             "bucket_ids": sorted(bucket_ids),
             "oldest": timestamps[0] if timestamps else None,
             "newest": timestamps[-1] if timestamps else None,
+            "real_loss_count": real_loss,
+            "unstorable_count": unstorable,
         }
+
+    @staticmethod
+    def _timestamp_within(ts: Optional[str], cutoff: datetime) -> bool:
+        """True when ``ts`` (ISO-8601) parses and is at/after ``cutoff``. A
+        missing or unparseable timestamp is treated as NOT within (unstorable)."""
+        if not ts:
+            return False
+        try:
+            parsed = datetime.fromisoformat(str(ts).replace("Z", "+00:00"))
+        except ValueError:
+            return False
+        if parsed.tzinfo is None:
+            parsed = parsed.replace(tzinfo=timezone.utc)
+        return parsed >= cutoff
 
     def remove_failed(self, max_retries: int = 5) -> int:
         """Remove events that have exceeded max retries.

--- a/src/sync/sync_engine.py
+++ b/src/sync/sync_engine.py
@@ -2383,23 +2383,45 @@ class SyncEngine:
             self._report_upload_failure(f"upload POST failed: {e}")
 
     def _report_dropped_events(self, summary: dict) -> None:
-        """Surface permanently-dropped queued events to the ops ingest. These
-        are events the server rejected on every retry until they hit the ceiling
-        — real captured activity that will never reach the dashboard. The
-        reporter's dedup window keeps repeated drops from flooding."""
+        """Surface permanently-dropped queued events to the ops ingest, split by
+        whether the drop is genuine loss or a benign flush.
+
+        Only RECENT, BUCKETED events are real lost activity worth a warning — the
+        server should have accepted them. Events that are stale (>retention) or
+        carry no bucket are unstorable by nature: the server always rejects them,
+        so flushing them after max retries loses nothing. Reporting those at
+        warning level (as it used to) cried wolf — a week-old queue aging out, or
+        a single bucketless event, paged ops the same as real loss. Now the
+        benign flush logs at info under a distinct fingerprint; warning is
+        reserved for actual loss. The reporter's dedup keeps repeats from
+        flooding."""
         if self.error_reporter is None:
             return
         try:
             count = summary.get("count", 0)
+            # Default real=count keeps back-compat if a caller passes the old
+            # shape (treat as loss rather than silently swallow).
+            real = summary.get("real_loss_count", count)
             buckets = ",".join(summary.get("bucket_ids") or []) or "unknown"
             span = f"{summary.get('oldest')}..{summary.get('newest')}"
-            self.error_reporter.capture(
-                f"Dropped {count} queued event(s) after max retries "
-                f"(buckets={buckets}, span={span})",
-                level="warning",
-                tags={"component": "offline-queue"},
-                fingerprint="offline-queue-events-dropped",
-            )
+            if real > 0:
+                other = count - real
+                extra = f"; {other} other unstorable" if other > 0 else ""
+                self.error_reporter.capture(
+                    f"Dropped {real} queued event(s) after max retries — likely "
+                    f"real lost activity (buckets={buckets}, span={span}{extra})",
+                    level="warning",
+                    tags={"component": "offline-queue"},
+                    fingerprint="offline-queue-events-dropped",
+                )
+            else:
+                self.error_reporter.capture(
+                    f"Flushed {count} unstorable queued event(s) — stale or no "
+                    f"bucket, never server-acceptable (buckets={buckets}, span={span})",
+                    level="info",
+                    tags={"component": "offline-queue"},
+                    fingerprint="offline-queue-events-flushed-unstorable",
+                )
         except Exception:
             logger.debug("dropped-events report failed", exc_info=True)
 

--- a/tests/test_queue.py
+++ b/tests/test_queue.py
@@ -133,7 +133,67 @@ class TestOfflineQueue:
         """No events past the ceiling → count 0, empty fields."""
         self.queue.enqueue([{"id": "fresh", "timestamp": "2026-06-23T05:00:00Z", "data": {}}])
         summary = self.queue.failed_event_summary(max_retries=5)
-        assert summary == {"count": 0, "bucket_ids": [], "oldest": None, "newest": None}
+        assert summary == {
+            "count": 0, "bucket_ids": [], "oldest": None, "newest": None,
+            "real_loss_count": 0, "unstorable_count": 0,
+        }
+
+    def _drop_n(self, events):
+        """Enqueue events and push them past the retry ceiling so they count as
+        about-to-drop in failed_event_summary."""
+        self.queue.enqueue(events)
+        queued = self.queue.dequeue(batch_size=len(events))
+        for _ in range(5):
+            self.queue.increment_retry([q.id for q in queued])
+
+    def test_failed_event_summary_classifies_stale_as_unstorable(self):
+        """Events older than the storable window (~7d) are unstorable — the
+        server legitimately rejects them, so dropping is a benign flush, not
+        real loss. (Diana's 06-16/06-17 batches.)"""
+        now = datetime(2026, 6, 24, 8, 0, tzinfo=timezone.utc)
+        self._drop_n([
+            {"id": "a", "bucket_id": "aw-watcher-window_h", "timestamp": "2026-06-16T15:56:00+00:00", "duration": 60, "data": {}},
+            {"id": "b", "bucket_id": "aw-watcher-input_h", "timestamp": "2026-06-17T06:04:00+00:00", "duration": 30, "data": {}},
+        ])
+        summary = self.queue.failed_event_summary(max_retries=5, now=now)
+        assert summary["count"] == 2
+        assert summary["real_loss_count"] == 0
+        assert summary["unstorable_count"] == 2
+
+    def test_failed_event_summary_classifies_no_bucket_as_unstorable(self):
+        """A recent event with no bucket_id can't be routed/stored → unstorable
+        (the 2026-06-19 buckets=unknown drop)."""
+        now = datetime(2026, 6, 19, 15, 0, tzinfo=timezone.utc)
+        self._drop_n([
+            {"id": "c", "timestamp": "2026-06-19T14:50:37+00:00", "duration": 60, "data": {}},
+        ])
+        summary = self.queue.failed_event_summary(max_retries=5, now=now)
+        assert summary["count"] == 1
+        assert summary["real_loss_count"] == 0
+        assert summary["unstorable_count"] == 1
+
+    def test_failed_event_summary_counts_recent_bucketed_as_real_loss(self):
+        """Recent + bucketed = genuine lost activity the server should have
+        accepted → real loss (warning-worthy)."""
+        now = datetime(2026, 6, 24, 8, 0, tzinfo=timezone.utc)
+        self._drop_n([
+            {"id": "d", "bucket_id": "aw-watcher-window_h", "timestamp": "2026-06-24T07:30:00+00:00", "duration": 60, "data": {}},
+        ])
+        summary = self.queue.failed_event_summary(max_retries=5, now=now)
+        assert summary["real_loss_count"] == 1
+        assert summary["unstorable_count"] == 0
+
+    def test_failed_event_summary_mixed_real_and_unstorable(self):
+        """A mix → counts split; the caller escalates because real loss > 0."""
+        now = datetime(2026, 6, 24, 8, 0, tzinfo=timezone.utc)
+        self._drop_n([
+            {"id": "e", "bucket_id": "aw-watcher-window_h", "timestamp": "2026-06-24T07:30:00+00:00", "duration": 60, "data": {}},
+            {"id": "f", "bucket_id": "aw-watcher-window_h", "timestamp": "2026-06-10T07:30:00+00:00", "duration": 60, "data": {}},
+            {"id": "g", "timestamp": "2026-06-24T07:31:00+00:00", "duration": 60, "data": {}},
+        ])
+        summary = self.queue.failed_event_summary(max_retries=5, now=now)
+        assert summary["real_loss_count"] == 1
+        assert summary["unstorable_count"] == 2
 
     def test_max_size_enforcement(self):
         """Test that queue enforces max size."""

--- a/tests/test_sync_engine.py
+++ b/tests/test_sync_engine.py
@@ -982,6 +982,31 @@ class TestSyncEngine:
         assert self.engine._session_active is False
         self.time_tracker.close.assert_called_once()
 
+    def test_report_dropped_events_warns_on_real_loss(self):
+        """A drop with real_loss_count > 0 escalates at warning level."""
+        self.engine.error_reporter = MagicMock()
+        self.engine._report_dropped_events({
+            "count": 2, "real_loss_count": 1, "unstorable_count": 1,
+            "bucket_ids": ["aw-watcher-window_h"],
+            "oldest": "2026-06-24T07:30:00+00:00", "newest": "2026-06-24T07:31:00+00:00",
+        })
+        self.engine.error_reporter.capture.assert_called_once()
+        assert self.engine.error_reporter.capture.call_args.kwargs["level"] == "warning"
+
+    def test_report_dropped_events_info_when_all_unstorable(self):
+        """All-unstorable drops (stale / no-bucket) are a benign flush — reported
+        at info with a distinct fingerprint so they don't page ops as warnings."""
+        self.engine.error_reporter = MagicMock()
+        self.engine._report_dropped_events({
+            "count": 20, "real_loss_count": 0, "unstorable_count": 20,
+            "bucket_ids": ["aw-watcher-input_h"],
+            "oldest": "2026-06-17T06:04:00+00:00", "newest": "2026-06-17T06:07:00+00:00",
+        })
+        self.engine.error_reporter.capture.assert_called_once()
+        kwargs = self.engine.error_reporter.capture.call_args.kwargs
+        assert kwargs["level"] == "info"
+        assert kwargs["fingerprint"] != "offline-queue-events-dropped"
+
     def test_transform_event_delta_time_tracking_on_refetch(self):
         """Test that re-fetched events with grown duration only add the delta."""
         cycle = _SyncCycleContext(has_input_data=True)


### PR DESCRIPTION
## Why
#79 (drop-report-to-ops) fired at **warning** for *every* permanently-dropped queued event. But not every drop is real loss, and today the ops channel got paged for two **benign** cases:
- a single **bucketless** event (`buckets=unknown`, 2026-06-19) — no bucket to route to, never storable;
- Diana's **15 + 20** events from 2026-06-16/17 — **>7 days stale**, which the server legitimately rejects per the batch-delivery contract.

Both are unstorable *by nature*: they exhaust retries and flush, losing nothing. Reporting them identically to genuine loss is crying wolf and risks burying a real loss report.

## What
- `failed_event_summary` now classifies each about-to-drop event: **real loss only if it has a `bucket_id` AND its timestamp is within the retention window** (`stale_after_days`, default 7). Returns `real_loss_count` / `unstorable_count` alongside the existing `count`/`bucket_ids`/`oldest`/`newest`. `now` is injectable so tests are deterministic (no hardcoded-date time bomb).
- `_report_dropped_events` uses the split:
  - `real_loss_count > 0` → **warning**, original fingerprint (`offline-queue-events-dropped`) — genuine lost activity to chase.
  - all unstorable → **info**, distinct fingerprint (`offline-queue-events-flushed-unstorable`) — benign flush, no page.

No change to what's actually dropped (`remove_failed` unchanged) — only how it's reported.

## Tests
- `test_queue.py`: classification for stale / no-bucket / recent-bucketed / mixed (all with injected `now`).
- `test_sync_engine.py`: `_report_dropped_events` level + fingerprint selection.
- Full suite **757 passed**.

Maps to the ops triage: this silences the P3 "drop-report noise" without losing the genuine-loss signal #79 was built for.

🤖 Generated with [Claude Code](https://claude.com/claude-code)