### PR TITLE
fix(sync): force_restart on a half-hung AW server (503 on buckets while /info OK)

### DIFF
--- a/src/main.py
+++ b/src/main.py
@@ -189,6 +189,14 @@ class SyncCoordinator:
         self._aw_unreachable_streak = 0
         self._AW_UNREACHABLE_ERROR_THRESHOLD = 2
 
+        # Consecutive cycles where AW answered is_running() (/info) but the bucket
+        # fetch (/buckets/) failed — a half-hung bf-data-service the is_running()
+        # watchdog can't see (Liviu's 2 AM 503 storm: 133 "Failed to get buckets"
+        # with zero recovery, cleared only by a manual restart). Separate from
+        # _aw_unreachable_streak, which is reset whenever is_running() passes —
+        # and is_running() DOES pass here, so reusing it would never escalate.
+        self._aw_buckets_failed_streak = 0
+
         # Flags set by the app layer - protected by _state_lock
         self._logged_in = False
         self._paused_by_network = False
@@ -856,6 +864,31 @@ class SyncCoordinator:
         if self._tick_failure_counts.pop(label, None):
             self._tick_failure_reported.discard(label)
 
+    def _handle_aw_bucket_failure(self) -> None:
+        """AW answers is_running() (/info) but the bucket fetch (/buckets/) keeps
+        failing — a half-hung bf-data-service. is_running() can't see this, so the
+        normal unreachable watchdog never fires; debounce, then force_restart to
+        reclaim the hung server (force_restart rebuilds the whole stack incl. a
+        port-held-but-HTTP-dead server). Without this the agent loops 'Failed to
+        get buckets' until the user manually restarts — Liviu's 2 AM 503 storm,
+        133 failures, ~75 min of tracking lost."""
+        self._aw_buckets_failed_streak += 1
+        if self._aw_buckets_failed_streak >= self._AW_UNREACHABLE_ERROR_THRESHOLD:
+            if self.aw_manager.is_managing:
+                logger.warning(
+                    "ActivityWatch responding but bucket fetch failing for %d "
+                    "cycles — forcing tracker+server restart (hung bf-data-service)",
+                    self._aw_buckets_failed_streak,
+                )
+                self.aw_manager.force_restart(reason="bucket fetch failing (server hung)")
+            self.tray.set_state(TrayState.ERROR, "ActivityWatch not responding")
+        else:
+            logger.info(
+                "ActivityWatch bucket fetch failing (%d/%d) — retrying next cycle "
+                "before forcing a restart",
+                self._aw_buckets_failed_streak, self._AW_UNREACHABLE_ERROR_THRESHOLD,
+            )
+
     def _reconcile_inproc_afk_flag(self) -> None:
         """Keep aw_manager's in-process-AFK flag in step with the sync engine's
         actual per-cycle decision. The flag gates the idle-tracker watchdog and
@@ -1034,6 +1067,13 @@ class SyncCoordinator:
             self._aw_unreachable_streak = 0
 
             stats = self.sync_engine.sync()
+
+            if stats.aw_bucket_fetch_failed:
+                # AW answers /info but 503s on /buckets/ — is_running() above
+                # passed, so only this path can recover the hung server.
+                self._handle_aw_bucket_failure()
+                return
+            self._aw_buckets_failed_streak = 0
 
             if stats.success or stats.events_sent > 0:
                 # A successful (or partial) sync clears the failure streak.

--- a/src/sync/sync_engine.py
+++ b/src/sync/sync_engine.py
@@ -101,6 +101,10 @@ class SyncStats:
     errors: list[str] = field(default_factory=list)
     queued_bucket_ids: set = field(default_factory=set)
     _should_heartbeat: bool = False
+    # True when AW answered is_running() (/info) but the bucket fetch (/buckets/)
+    # failed — a half-hung bf-data-service. The coordinator escalates this to a
+    # force_restart, which is_running() alone can't trigger.
+    aw_bucket_fetch_failed: bool = False
 
     @property
     def success(self) -> bool:
@@ -542,6 +546,11 @@ class SyncEngine:
             input_buckets = self.aw.get_input_buckets()
         except AWClientError as e:
             stats.errors.append(f"Failed to get buckets: {e}")
+            # is_running() (/info) can still pass while /buckets/ 503s on a
+            # half-hung bf-data-service. Flag it so the coordinator force_restarts
+            # the hung server instead of looping this error forever (the 2 AM 503
+            # storm that cost Liviu ~75 min, recovered only by a manual restart).
+            stats.aw_bucket_fetch_failed = True
             return stats
 
         # Track whether AFK watcher is running so _transform_event can

--- a/tests/test_sync_engine.py
+++ b/tests/test_sync_engine.py
@@ -1007,6 +1007,21 @@ class TestSyncEngine:
         assert kwargs["level"] == "info"
         assert kwargs["fingerprint"] != "offline-queue-events-dropped"
 
+    def test_sync_flags_bucket_fetch_failure(self):
+        """When AW answers /info (is_running True) but get_buckets fails (503 from
+        a half-hung bf-data-service), sync() flags aw_bucket_fetch_failed so the
+        coordinator can force_restart — is_running() alone can't see this."""
+        from src.sync.aw_client import AWClientError
+        self.aw.is_running.return_value = True
+        self.bf.is_reachable.return_value = True
+        self.engine._config_fetched = True
+        self.aw.get_window_buckets.side_effect = AWClientError("ActivityWatch API error: 503")
+
+        stats = self.engine.sync()
+
+        assert stats.aw_bucket_fetch_failed is True
+        assert stats.success is False
+
     def test_transform_event_delta_time_tracking_on_refetch(self):
         """Test that re-fetched events with grown duration only add the delta."""
         cycle = _SyncCycleContext(has_input_data=True)
@@ -1571,3 +1586,36 @@ class TestConfigDefaultCategories:
         config.save()
         loaded = Config.load()
         assert "Claude" in loaded.privacy.default_categories
+
+
+def _coord_for_bucket_watchdog():
+    """A SyncCoordinator with just the attrs _handle_aw_bucket_failure touches."""
+    c = SyncCoordinator.__new__(SyncCoordinator)
+    c._aw_buckets_failed_streak = 0
+    c._AW_UNREACHABLE_ERROR_THRESHOLD = 2
+    c.aw_manager = Mock()
+    c.aw_manager.is_managing = True
+    c.tray = Mock()
+    return c
+
+
+def test_bucket_failure_force_restarts_only_at_threshold():
+    """A single bucket-fetch failure is debounced; force_restart fires once the
+    streak crosses the threshold (the hung-server recovery is_running() missed)."""
+    c = _coord_for_bucket_watchdog()
+
+    c._handle_aw_bucket_failure()  # 1/2 — below threshold
+    c.aw_manager.force_restart.assert_not_called()
+
+    c._handle_aw_bucket_failure()  # 2/2 — escalate
+    c.aw_manager.force_restart.assert_called_once()
+    assert c.tray.set_state.call_args[0][0] == TrayState.ERROR
+
+
+def test_bucket_failure_streak_resets_clear_no_restart():
+    """A reset streak (e.g. after a healthy sync) needs the full threshold again
+    before another force_restart — no carry-over."""
+    c = _coord_for_bucket_watchdog()
+    c._aw_buckets_failed_streak = 0
+    c._handle_aw_bucket_failure()  # 1/2
+    c.aw_manager.force_restart.assert_not_called()


### PR DESCRIPTION
## The bug (P2, now evidenced by Liviu)
The unreachable watchdog only `force_restart`s when `is_running()` returns False. But **`is_running()` probes `/api/0/info`** while the sync fetches **`/api/0/buckets/`**. A hung `bf-data-service` can answer `/info` (200) while **503ing on `/buckets/`** — so `is_running()` stays True, the streak never trips, and the agent loops `Failed to get buckets: 503` forever with no recovery.

This is exactly **Liviu's 2 AM session** (he works after midnight): a 503 storm escalated **3× → 133×** consecutive failures and only cleared when he **manually restarted the app this afternoon** (the `self-update-relaunch.log` shows no relaunch across the whole window). In his words: *"logged off at 2 AM, recorded only 45 min"* — ~75 min of tracking lost.

## Fix
- `SyncStats.aw_bucket_fetch_failed` is set when `get_buckets` raises during the cycle (AW responding but buckets 503).
- The coordinator debounces it via a **separate** `_aw_buckets_failed_streak` (not `_aw_unreachable_streak`, which `is_running()` passing would reset every cycle — the reason this never escalated) and **`force_restart`s past the threshold**. `force_restart` rebuilds the whole stack, reclaiming a **port-held-but-HTTP-dead** server that `stop()+start()` can't.

## Tests
- `sync()` flags `aw_bucket_fetch_failed` on a `get_buckets` `AWClientError`.
- `_handle_aw_bucket_failure` debounces (no restart on the first failure) then `force_restart`s at threshold + sets the ERROR tray state.
- Full suite **760 passed**.

## Note (Liviu's lost time)
The ~75 min lost *during* the storm is likely unrecoverable by the agent (AW itself was down, so the watchers couldn't record it) — that needs a one-off **manual time adjustment** for Liviu. This PR prevents recurrence.

Closes the P2 item from the ops triage.

🤖 Generated with [Claude Code](https://claude.com/claude-code)