### PR TITLE
fix(aw): restart a blind window tracker (alive but emitting zero events)

### DIFF
--- a/src/aw_manager.py
+++ b/src/aw_manager.py
@@ -62,6 +62,14 @@ AW_TO_BF_NAMES = {
 STARTUP_TIMEOUT = 10  # seconds to wait for server to be ready
 SHUTDOWN_TIMEOUT = 5  # seconds before force-killing
 STALE_THRESHOLD = 120  # seconds with no new events before force-restarting watcher
+# A window tracker that has emitted ZERO events this long after launch (its bucket
+# is still empty) is blind, not just quiet — aw-watcher-window heartbeats even a
+# static window, so a healthy one emits within seconds. Past this grace, with AW
+# reachable, restart it (Sachi, win32, 2026-06-24: alive but never emitted, so the
+# age-based stale check — which needs an event to measure — never fired). The grace
+# also doubles as restart backoff: _start_component resets the launch clock, so a
+# persistently-blind tracker is re-probed at most once per grace, not every tick.
+WINDOW_BLIND_GRACE = 180  # seconds
 # After this many consecutive stale-restarts that DON'T take (the tracker emits
 # nothing again right after we restart it), bf-idle-tracker is blind — almost
 # always a missing Input Monitoring grant, which a restart can't fix (#46). Stop
@@ -348,6 +356,10 @@ class AWManager:
         # callbacks, tray callbacks, and shutdown never race.
         self._lifecycle_lock = threading.RLock()
         self._processes: dict[str, subprocess.Popen] = {}
+        # monotonic launch time per component, for the window-tracker blind-grace
+        # (a tracker emitting nothing only counts as blind once it's run past the
+        # grace; resetting this on (re)start also backs off blind re-probes).
+        self._component_started_at: dict[str, float] = {}
         self._using_external = False
         # Components intentionally disabled for this app session.
         self._disabled_components: set[str] = set()
@@ -762,7 +774,11 @@ class AWManager:
                 if name == BF_SERVER:
                     server_restarted = True
 
-        # Detect stalled window tracker (process alive but no new events)
+        # Detect stalled window tracker: either it froze (events exist but their
+        # end is old) OR it's blind — alive but emitting nothing at all, so the
+        # age helper has no event to measure and returns None. The blind case used
+        # to slip through (`age is not None` only), leaving window data frozen
+        # while AFK/input flowed (Sachi, win32).
         watcher = "bf-window-tracker"
         if (
             watcher not in self._disabled_components
@@ -770,11 +786,16 @@ class AWManager:
             and self._processes[watcher].poll() is None
         ):
             age = self._get_latest_window_event_age()
-            if age is not None and age > STALE_THRESHOLD:
+            running_for = self._component_running_seconds(watcher)
+            reachable = self._port_in_use()
+            if self._is_window_tracker_stale(age, running_for, reachable):
                 self._stale_restart_count += 1
+                detail = (
+                    f"no new events for {age:.0f}s" if age is not None
+                    else f"no events {running_for:.0f}s after launch (blind)"
+                )
                 logger.warning(
-                    f"{watcher} stale: no new events for {age:.0f}s "
-                    f"(threshold {STALE_THRESHOLD}s, "
+                    f"{watcher} stale: {detail} (threshold {STALE_THRESHOLD}s, "
                     f"restart #{self._stale_restart_count})"
                 )
                 proc = self._processes[watcher]
@@ -958,6 +979,7 @@ class AWManager:
 
             proc = subprocess.Popen(args, **kwargs)
             self._processes[name] = proc
+            self._component_started_at[name] = time.monotonic()
             logger.info(f"Started {name} (PID {proc.pid})")
             return True
 
@@ -1062,6 +1084,29 @@ class AWManager:
     def _get_latest_window_event_age(self) -> Optional[float]:
         """Return seconds since the most recent window event, or None on error."""
         return self._get_latest_event_age("aw-watcher-window")
+
+    def _component_running_seconds(self, name: str) -> Optional[float]:
+        """Seconds since we last (re)started ``name``, or None if we never did."""
+        started = self._component_started_at.get(name)
+        if started is None:
+            return None
+        return time.monotonic() - started
+
+    @staticmethod
+    def _is_window_tracker_stale(
+        age: Optional[float], running_for: Optional[float], reachable: bool
+    ) -> bool:
+        """Whether the window tracker should be restarted.
+
+        - ``age`` is not None: events exist; stale if their end is older than the
+          threshold (the original frozen-tracker case).
+        - ``age`` is None: no events at all. That's a blind tracker ONLY when it's
+          run well past the launch grace AND AW is reachable — otherwise None is
+          just startup lag or an AW outage (handled elsewhere), not a dead tracker.
+        """
+        if age is not None:
+            return age > STALE_THRESHOLD
+        return bool(reachable and running_for is not None and running_for > WINDOW_BLIND_GRACE)
 
     def _get_latest_afk_event_age(self) -> Optional[float]:
         """Return seconds since the most recent AFK event, or None on error.

--- a/tests/test_aw_manager_window_blind.py
+++ b/tests/test_aw_manager_window_blind.py
@@ -1,0 +1,100 @@
+"""Watchdog restarts a BLIND window tracker — one alive but emitting ZERO events.
+
+The window-stale check only restarted when _get_latest_window_event_age() returned
+a number greater than the threshold. But that helper returns None when the window
+bucket is empty — i.e. a tracker that's alive but has never emitted anything (blind
+from launch). So a totally-dead window tracker was never restarted: window data
+stayed frozen while AFK/input kept flowing (Sachi, win32, 2026-06-24 — the server
+flagged window_ingest_stalled with no window events at all).
+
+Fix: treat "no events, well past a launch grace, while AW is reachable" as stale
+too. Guards: the launch grace avoids restarting a just-launched tracker before it
+emits; the reachability check avoids mistaking an AW outage (also age None) for a
+blind tracker.
+"""
+
+import time
+from unittest.mock import MagicMock
+
+from src.aw_manager import STALE_THRESHOLD, WINDOW_BLIND_GRACE, AWManager
+
+
+def _mgr(window_age, running_for, reachable=True):
+    mgr = AWManager()
+    mgr._using_external = False
+    server = MagicMock()
+    server.poll.return_value = None
+    window = MagicMock()
+    window.poll.return_value = None
+    idle = MagicMock()
+    idle.poll.return_value = None
+    mgr._processes = {
+        "bf-data-service": server,
+        "bf-window-tracker": window,
+        "bf-idle-tracker": idle,
+    }
+    mgr._get_binaries_dir = MagicMock(return_value="/tmp/bin")
+    mgr._start_component = MagicMock()
+    mgr._get_latest_window_event_age = MagicMock(return_value=window_age)
+    mgr._get_latest_afk_event_age = MagicMock(return_value=5)  # afk fresh → idle block no-op
+    mgr._port_in_use = MagicMock(return_value=reachable)
+    mgr._component_started_at = (
+        {} if running_for is None
+        else {"bf-window-tracker": time.monotonic() - running_for}
+    )
+    return mgr, window
+
+
+def _restarted(mgr, window):
+    return window.terminate.called and (
+        ("bf-window-tracker",) in [c.args[:1] for c in mgr._start_component.call_args_list]
+    )
+
+
+# --- pure decision logic ---------------------------------------------------- #
+
+def test_is_window_tracker_stale_decision():
+    m = AWManager()
+    assert m._is_window_tracker_stale(age=5, running_for=600, reachable=True) is False
+    assert m._is_window_tracker_stale(age=STALE_THRESHOLD + 1, running_for=600, reachable=True) is True
+    # blind: no events, past grace, AW reachable
+    assert m._is_window_tracker_stale(age=None, running_for=WINDOW_BLIND_GRACE + 1, reachable=True) is True
+    # just launched: no events yet, within grace
+    assert m._is_window_tracker_stale(age=None, running_for=10, reachable=True) is False
+    # AW unreachable: None may be an outage, not a blind tracker
+    assert m._is_window_tracker_stale(age=None, running_for=600, reachable=False) is False
+    # unknown launch time → can't claim blind
+    assert m._is_window_tracker_stale(age=None, running_for=None, reachable=True) is False
+
+
+# --- watchdog integration --------------------------------------------------- #
+
+def test_blind_window_tracker_is_restarted():
+    mgr, window = _mgr(window_age=None, running_for=WINDOW_BLIND_GRACE + 120, reachable=True)
+    mgr.restart_if_needed()
+    assert _restarted(mgr, window), "a blind window tracker (zero events past grace) must be restarted"
+
+
+def test_blind_within_launch_grace_not_restarted():
+    mgr, window = _mgr(window_age=None, running_for=10, reachable=True)
+    mgr.restart_if_needed()
+    assert not window.terminate.called, "a just-launched tracker must get its grace before restart"
+
+
+def test_no_events_but_aw_unreachable_not_restarted():
+    mgr, window = _mgr(window_age=None, running_for=WINDOW_BLIND_GRACE + 120, reachable=False)
+    mgr.restart_if_needed()
+    assert not window.terminate.called, "age None during an AW outage is not a blind tracker"
+
+
+def test_frozen_window_tracker_still_restarted():
+    # Pre-existing behavior must be preserved: events exist but stale.
+    mgr, window = _mgr(window_age=STALE_THRESHOLD + 10, running_for=WINDOW_BLIND_GRACE + 120)
+    mgr.restart_if_needed()
+    assert _restarted(mgr, window)
+
+
+def test_fresh_window_tracker_not_restarted():
+    mgr, window = _mgr(window_age=5, running_for=WINDOW_BLIND_GRACE + 120)
+    mgr.restart_if_needed()
+    assert not window.terminate.called


### PR DESCRIPTION
## Why (task #7, Sachi)
The window-stale watchdog only restarted when `_get_latest_window_event_age()` returned a number past the threshold. But that helper returns **None when the window bucket is empty** — a tracker that's alive yet has emitted *nothing* (blind from launch). So a totally-dead window tracker was **never restarted**: window data froze while AFK/input kept flowing.

That's **Sachi (win32, 2026-06-24)**: the server flagged `window_ingest_stalled` with **no window events at all**, while her syncs otherwise succeeded (`1 sent, 0 queued` every 30s — the `100 filtered` is just benign lookback-dedup). Not the 503 case, not fixed by 1.5.74.

## Fix
The watchdog now also treats **"no events, well past a launch grace, while AW is reachable"** as stale (`_is_window_tracker_stale`). Two guards keep it safe:
- **Launch grace** (`WINDOW_BLIND_GRACE=180s`, tracked via `_component_started_at`): a just-launched tracker gets time to emit before any restart. The grace doubles as **backoff** — every (re)start resets the clock, so a persistently-blind tracker is re-probed at most once per grace, never every tick.
- **Reachability** (`_port_in_use`): `age None` during an AW outage is *not* a blind tracker, so we don't restart on a server outage (that's handled elsewhere).

### Blast radius
- **Healthy agents: no change** — a live tracker emits events → `age` is a number → the blind path never triggers.
- **macOS: unaffected** — `bf-window-tracker` is disabled there (in-process watcher). Scoped to win32/Linux external trackers.

## Tests
`test_aw_manager_window_blind.py`: pure decision logic + watchdog integration (blind→restart, within-grace→no, AW-unreachable→no, frozen→restart preserved, fresh→no). **Full suite 766.**

## Caveat
If Sachi's case turns out to be a Windows window-visibility limit (RDP/fullscreen app exposing no title) rather than a frozen tracker, a restart won't help — but the server flagged *zero* window events (not even "unknown"), which points to a dead tracker, so this should recover her. Worth confirming with her quit-reopen result before fleet rollout.

🤖 Generated with [Claude Code](https://claude.com/claude-code)