### PR TITLE
chore(security): leak-prevention hardening for the public repo

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -8,6 +8,12 @@ on:
     branches: [main]
   workflow_dispatch:
 
+# Least-privilege by default: build/test jobs only read. The release job opts up
+# to contents: write below. Pins the token so it never inherits a read-write org
+# default (defense-in-depth, esp. against any future pull_request_target change).
+permissions:
+  contents: read
+
 jobs:
   build:
     strategy:
@@ -242,6 +248,8 @@ jobs:
     needs: build
     runs-on: ubuntu-latest
     if: startsWith(github.ref, 'refs/tags/v')
+    permissions:
+      contents: write  # create the GitHub release + upload assets
 
     steps:
       - name: Download macOS ARM artifact

--- a/.github/workflows/sync-downloads.yml
+++ b/.github/workflows/sync-downloads.yml
@@ -10,6 +10,11 @@ on:
         required: false
         type: string
 
+# Read-only token: this workflow only reads release metadata and POSTs to the
+# downloads backend with its own secret; it never needs to write to the repo.
+permissions:
+  contents: read
+
 jobs:
   sync:
     runs-on: ubuntu-latest

--- a/.gitignore
+++ b/.gitignore
@@ -72,6 +72,16 @@ src/_build_info.py
 # Generated at build time - bakes the error-reporting DSN into the bundle; never commit
 src/_build_secrets.py
 
+# Signing / key material — belt-and-suspenders so a locally-exported Developer ID
+# cert (the project's highest-value secret; lives only in GitHub Actions secrets)
+# can never be staged into this PUBLIC repo by a stray `git add .`.
+*.p12
+*.pem
+*.key
+*.crt
+*.cer
+*.keychain-db
+
 # Plans (local only)
 plans.md
 docs/plans/

--- a/tests/test_setup_wizard_consent.py
+++ b/tests/test_setup_wizard_consent.py
@@ -23,10 +23,10 @@ def _make_wizard() -> SetupWizard:
 class TestConsentRouting:
     def test_non_macos_login_routes_to_consent(self):
         w = _make_wizard()
-        state = MagicMock(logged_in=True, user_email="cati@betterqa.co")
+        state = MagicMock(logged_in=True, user_email="x@y.co")
         with patch("src.ui.setup_wizard.sys.platform", "win32"):
             w._on_login_complete(state)
-        w._show_consent.assert_called_once_with("cati@betterqa.co")
+        w._show_consent.assert_called_once_with("x@y.co")
         w._show_success.assert_not_called()
 
     def test_linux_login_routes_to_consent(self):
@@ -63,11 +63,11 @@ class TestConsentRender:
         w._draw_scene = MagicMock(return_value=300)
         w._make_button = MagicMock()
         # Use the real method (un-mock it for this render test).
-        SetupWizard._show_consent(w, "cati@betterqa.co")
+        SetupWizard._show_consent(w, "x@y.co")
         w._draw_scene.assert_called_once()
         w._make_button.assert_called_once()
         # The action button forwards to the success screen on acknowledgement.
         label, action = w._make_button.call_args.args[0], w._make_button.call_args.args[1]
         assert "Agree" in label
         action()
-        w._show_success.assert_called_once_with("cati@betterqa.co")
+        w._show_success.assert_called_once_with("x@y.co")


### PR DESCRIPTION
A 4-front read-only audit of this **public** repo — git history secrets, current-tree secrets, runtime egress (PII), and build/CI/gitignore.

## Audit verdict: no credential leak
- **Git history (all 562 commits, all objects): clean.** No DSN/key/token/cert/.env ever committed; `_build_secrets.py` never tracked.
- **Current tree:** no hardcoded secrets — all via GitHub Actions secrets + gitignored build-secrets module + OS keychain.
- **Public binaries:** only a **write-only telemetry DSN** is baked in (by design, like a Sentry DSN). Signing cert / notary creds are transient-only and never ship in the bundle. No `pull_request_target`, so fork PRs get null secrets.

The repo's public exposure is **source only, not credentials.**

## This PR — the safe, preventive fixes
- **`.gitignore`:** add `*.p12 *.pem *.key *.crt *.cer *.keychain-db`. The Developer ID signing cert is the highest-value secret in the project (lives only in GH Actions secrets); this stops a locally-exported copy being staged into the public repo by a stray `git add .`.
- **Workflows:** least-privilege `permissions:` — top-level `contents: read` on `build.yml` + `sync-downloads.yml`, with `contents: write` scoped to the **release job only**. Pins `GITHUB_TOKEN` off any read-write org default (defense-in-depth).
- **`tests/test_setup_wizard_consent.py`:** replace a real employee email (`cati@betterqa.co`) with the file's existing neutral placeholder (`x@y.co`).

Verified: touched test passes (5), both workflows parse as valid YAML, `git check-ignore` confirms `.p12` is now caught.

## Deferred (need a product/privacy decision — NOT in this PR)
1. **Privacy-doc mismatch:** `CLAUDE.md` says window titles are SHA-256 hashed before egress (`hash_titles` default True), but the agent **never hashes** and the default is **False** — raw titles go to the backend (privacy is server-side only). Implement client-side hashing, or correct the doc.
2. **Error reports** attach `user_email` + `user_name` to the cross-tenant BetterQA ops ingest on every report; minor: wall-clock activity timestamps in the dropped-events report, hostname (often a person's name) in bucket IDs, email logged at INFO into the uploaded log.

🤖 Generated with [Claude Code](https://claude.com/claude-code)