### PR TITLE
fix(privacy): trim PII from the cross-tenant ops ingest + correct the privacy doc

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -48,7 +48,7 @@ ActivityWatch (localhost:5600)
         |
         v
     SyncEngine (src/sync/sync_engine.py)
-        |-- Privacy filtering (hash titles, strip URLs to domain)
+        |-- Client-side privacy: drop excluded apps, strip URLs to domain
         |-- Transform events to BetterFlow format
         v
     BetterFlowClient (src/sync/bf_client.py)
@@ -69,11 +69,27 @@ ActivityWatch (localhost:5600)
 
 ### Privacy Model
 
-Privacy settings in `Config.privacy`:
-- `hash_titles` (default: True) - SHA-256 hash window titles, send first 16 hex chars
-- `title_allowlist` - Apps that send raw titles (IDEs, terminals)
-- `domain_only_urls` (default: True) - Strip URLs to domain only
-- `exclude_apps` - Apps never tracked (1Password, System Preferences)
+**Important:** window titles are sent **raw** to the backend, which applies
+privacy server-side (title handling + categorization). The agent does **not**
+hash titles before egress — there is no client-side title hashing today, and
+implementing it would disable server-side categorization (titles are the
+categorization signal). The settings in `Config.privacy`:
+
+- `hash_titles` (default: **False**) - a per-device preference *forwarded to the
+  server*, NOT a client-side transform. The agent never hashes; the server
+  honours this flag. (Despite the name, raw titles still leave the device.)
+- `domain_only_urls` (default: True) - **enforced client-side** — URLs are
+  reduced to their domain before egress. Full URLs require `collect_full_urls`
+  (default False, opt-in, sensitive).
+- `exclude_apps` (default: 1Password, Keychain, System Settings, ...) -
+  **enforced client-side** — these apps' events never leave the device. This is
+  the real "never send this app's titles" control.
+- `title_allowlist` - apps allowed to send raw titles even when `hash_titles` is
+  set (forwarded to the server alongside `hash_titles`).
+
+The OS keychain holds the auth token (never on disk / in config). If raw titles
+must never leave the device, that requires client-side hashing/redaction, which
+is **not implemented** — track it as a feature, not an assumed guarantee.
 
 ### Configuration Storage
 

--- a/src/auth/keychain.py
+++ b/src/auth/keychain.py
@@ -117,7 +117,9 @@ class KeychainManager:
         except KeyringError as e:
             logger.error("Keychain write failed — credentials NOT stored: %s", e)
             return False
-        logger.info("Credentials stored for %s", credentials.user_email)
+        # Log device_id, not the email — this log is uploaded on logs_requested,
+        # so keep PII (the email) out of the uploaded tail (privacy F5).
+        logger.info("Credentials stored for device %s", credentials.device_id)
         _purge_legacy_file()
         return True
 

--- a/src/auth/login.py
+++ b/src/auth/login.py
@@ -100,7 +100,9 @@ class LoginManager:
                     user_role=credentials.user_role,
                     device_id=credentials.device_id,
                 )
-                logger.info(f"Auto-login successful for {credentials.user_email}")
+                # device_id, not email — the log is uploaded on logs_requested;
+                # keep PII out of the uploaded tail (privacy F5).
+                logger.info(f"Auto-login successful for device {credentials.device_id}")
                 if self._on_login_callback:
                     self._on_login_callback(state)
                 return state

--- a/src/main.py
+++ b/src/main.py
@@ -2290,14 +2290,15 @@ class BetterFlowApp:
     def _error_context(self) -> dict:
         """Build the who/what context attached to every error report.
 
-        Reads the current user from the tray model under its lock so a report
-        names which user's agent failed.
+        Error reports go to the cross-tenant BetterQA ops ingest (betterqa-bot),
+        NOT the tenant's own server — so we deliberately do NOT attach the end
+        user's email or name. device_id maps back to a user server-side for an
+        admin who needs it, and user_role is enough to route/triage. This keeps
+        PII off a shared sink (privacy audit, 2026-06-24).
         """
         ctx: dict = {"app_version": _VERSION}
         try:
             with self.tray.model.lock:
-                ctx["user_email"] = self.tray.model.user_email
-                ctx["user_name"] = self.tray.model.user_name
                 ctx["user_role"] = self.tray.model.user_role
         except Exception as e:
             logger.debug("Could not read user context for error report: %s", e)

--- a/src/sync/sync_engine.py
+++ b/src/sync/sync_engine.py
@@ -2411,14 +2411,20 @@ class SyncEngine:
             # Default real=count keeps back-compat if a caller passes the old
             # shape (treat as loss rather than silently swallow).
             real = summary.get("real_loss_count", count)
-            buckets = ",".join(summary.get("bucket_ids") or []) or "unknown"
-            span = f"{summary.get('oldest')}..{summary.get('newest')}"
+            # bucket TYPES only — bucket ids embed the hostname (often a person's
+            # name); don't ship that to the cross-tenant ops ingest (privacy F4).
+            types = sorted({str(b).rsplit("_", 1)[0] for b in (summary.get("bucket_ids") or [])})
+            buckets = ",".join(types) or "unknown"
+            # Age, not wall-clock — a precise activity timestamp anchors a
+            # high-resolution timeline in the ops ingest, which the privacy model
+            # avoids (privacy F3; same discipline as the blind-tracker report).
+            window = self._dropped_window_age(summary.get("oldest"), summary.get("newest"))
             if real > 0:
                 other = count - real
                 extra = f"; {other} other unstorable" if other > 0 else ""
                 self.error_reporter.capture(
                     f"Dropped {real} queued event(s) after max retries — likely "
-                    f"real lost activity (buckets={buckets}, span={span}{extra})",
+                    f"real lost activity (buckets={buckets}, {window}{extra})",
                     level="warning",
                     tags={"component": "offline-queue"},
                     fingerprint="offline-queue-events-dropped",
@@ -2426,13 +2432,34 @@ class SyncEngine:
             else:
                 self.error_reporter.capture(
                     f"Flushed {count} unstorable queued event(s) — stale or no "
-                    f"bucket, never server-acceptable (buckets={buckets}, span={span})",
+                    f"bucket, never server-acceptable (buckets={buckets}, {window})",
                     level="info",
                     tags={"component": "offline-queue"},
                     fingerprint="offline-queue-events-flushed-unstorable",
                 )
         except Exception:
             logger.debug("dropped-events report failed", exc_info=True)
+
+    @staticmethod
+    def _dropped_window_age(oldest, newest, now: Optional[datetime] = None) -> str:
+        """Coarse age + duration of a dropped batch for the ops report — NEVER the
+        raw wall-clock event timestamps (those anchor a high-resolution activity
+        timeline in the cross-tenant ingest, which the privacy model avoids)."""
+        now = now or datetime.now(timezone.utc)
+
+        def _parse(s):
+            try:
+                d = datetime.fromisoformat(str(s).replace("Z", "+00:00"))
+                return d if d.tzinfo else d.replace(tzinfo=timezone.utc)
+            except (ValueError, TypeError):
+                return None
+
+        o, n = _parse(oldest), _parse(newest)
+        if o is None:
+            return "age unknown"
+        age_min = max(0.0, (now - o).total_seconds()) / 60
+        span_min = max(0.0, ((n or o) - o).total_seconds()) / 60
+        return f"oldest ~{age_min:.0f}m old, spans ~{span_min:.0f}m"
 
     def _report_upload_failure(self, reason: str) -> None:
         """Surface a logs_requested upload failure to the ops ingest. We can't

--- a/tests/test_sync_engine.py
+++ b/tests/test_sync_engine.py
@@ -983,15 +983,24 @@ class TestSyncEngine:
         self.time_tracker.close.assert_called_once()
 
     def test_report_dropped_events_warns_on_real_loss(self):
-        """A drop with real_loss_count > 0 escalates at warning level."""
+        """A drop with real_loss_count > 0 escalates at warning level, and the
+        message carries NO PII to the cross-tenant ops ingest: bucket TYPES only
+        (no hostname suffix) and NO wall-clock activity timestamps (age only)."""
         self.engine.error_reporter = MagicMock()
         self.engine._report_dropped_events({
             "count": 2, "real_loss_count": 1, "unstorable_count": 1,
-            "bucket_ids": ["aw-watcher-window_h"],
+            "bucket_ids": ["aw-watcher-window_Razvan-MacBook-Pro"],
             "oldest": "2026-06-24T07:30:00+00:00", "newest": "2026-06-24T07:31:00+00:00",
         })
         self.engine.error_reporter.capture.assert_called_once()
-        assert self.engine.error_reporter.capture.call_args.kwargs["level"] == "warning"
+        call = self.engine.error_reporter.capture.call_args
+        msg = call.args[0]
+        assert call.kwargs["level"] == "warning"
+        # F4: hostname (often a person's name) must be stripped to the bucket type.
+        assert "aw-watcher-window" in msg
+        assert "Razvan-MacBook-Pro" not in msg
+        # F3: no raw wall-clock activity timestamps in the ops report.
+        assert "2026-06-24T07:30:00" not in msg and "2026-06-24T07:31:00" not in msg
 
     def test_report_dropped_events_info_when_all_unstorable(self):
         """All-unstorable drops (stale / no-bucket) are a benign flush — reported
@@ -1619,3 +1628,24 @@ def test_bucket_failure_streak_resets_clear_no_restart():
     c._aw_buckets_failed_streak = 0
     c._handle_aw_bucket_failure()  # 1/2
     c.aw_manager.force_restart.assert_not_called()
+
+
+def test_error_context_omits_user_email_and_name():
+    """Error reports go to the cross-tenant BetterQA ops ingest, so they must NOT
+    carry the end user's email/name. device_id (maps back server-side) + role are
+    enough for routing."""
+    from src.main import BetterFlowApp
+    app = BetterFlowApp.__new__(BetterFlowApp)
+    app.tray = MagicMock()
+    app.tray.model.user_email = "someone@betterqa.co"
+    app.tray.model.user_name = "Some One"
+    app.tray.model.user_role = "B2E"
+    app.bf = MagicMock()
+    app.bf.device_id = 42
+
+    ctx = app._error_context()
+
+    assert "user_email" not in ctx
+    assert "user_name" not in ctx
+    assert ctx["user_role"] == "B2E"
+    assert ctx["device_id"] == 42


### PR DESCRIPTION
The runtime-egress half of the leak audit. Error reports and the uploaded log tail go to **BetterQA-operated sinks** (betterqa-bot `/notify/error`, the log-fetch endpoint) — *not* the tenant's own server — so PII on those paths is a cross-tenant leak.

## Fixes
- **F2 — error reports no longer carry `user_email` / `user_name`.** `_error_context` now sends only `device_id` (maps back to a user server-side for an admin) + `user_role`. Email/name no longer land in the ops Slack on every report.
- **F3 — no raw activity timestamps in the dropped-events report.** It now reports a coarse age + span (`_dropped_window_age`) instead of wall-clock event timestamps, which would anchor a high-resolution activity timeline in the ingest — the same discipline the blind-tracker report already uses.
- **F4 — bucket TYPES, not ids.** Bucket ids embed the hostname (often a person's name, e.g. `Razvan-MacBook-Pro`); the report now sends `aw-watcher-window` etc., host stripped.
- **F5 — auth no longer logs the user's email at INFO.** `keychain`/`login` log `device_id` instead (the log is uploaded on `logs_requested`, so the email was riding along into the tail).

## Doc correction (the important one)
`CLAUDE.md` claimed `hash_titles` defaults **True** and titles are **SHA-256 hashed before egress**. **That's false:** `hash_titles` defaults **False**, the agent **never hashes** (the flag is just forwarded to the server), and **raw window titles leave the device** for server-side categorization. `domain_only_urls` + `exclude_apps` are the real client-side controls. Doc rewritten to match the code, with an explicit note that client-side title hashing is **not implemented** (and would disable server-side categorization) — so it's tracked as a feature decision, not an assumed guarantee.

> Deliberately **not** included: turning on client-side title hashing. That changes what the backend receives and breaks categorization — a product/server call, not a unilateral agent change. Flagged for you to decide.

## Tests
`_error_context` omits email/name; dropped-events report strips the hostname and emits no wall-clock timestamps. **Full suite: 767.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)