### PR TITLE
fix(afk): salvage the observed active tail across a long pause/sleep

### DIFF
--- a/src/sync/afk_source.py
+++ b/src/sync/afk_source.py
@@ -29,6 +29,7 @@ class AfkSource:
         input_watcher=None,
         idle_clock: Callable[[], Optional[float]] = get_system_idle_seconds,
         retention_seconds: float = 7200.0,
+        max_samples: int = 20000,
     ) -> None:
         self._afk_timeout = float(afk_timeout_seconds)
         self._hostname = hostname
@@ -37,8 +38,14 @@ class AfkSource:
         self._retention_seconds = float(retention_seconds)
         self._retention = timedelta(seconds=retention_seconds)
         self._lock = threading.Lock()
-        # (sample_time, last_input_at)
-        self._samples: deque = deque()
+        # (sample_time, last_input_at). `maxlen` is an absolute memory backstop:
+        # `protect_since` can hold samples past the retention prune (so a long
+        # pause's pre-pause tail survives, and a held checkpoint can rebuild),
+        # but a pathological frozen checkpoint during a multi-day outage must
+        # not grow this without bound. ~20k samples ≈ 2 weeks at one per cycle;
+        # appends auto-evict the oldest beyond that (salvage past that horizon is
+        # moot anyway).
+        self._samples: deque = deque(maxlen=max_samples)
         # Sticky platform-capability latch: a transient idle-clock read failure
         # (e.g. a one-off `ioreg` timeout) must NOT revoke in-process mode for a
         # cycle — that would hand billing back to the external tracker and flap
@@ -183,6 +190,8 @@ class AfkSource:
                 spans.append((range_start, range_end, "afk"))
         else:
             first = activity[0]
+            # `first > range_start` also covers anchor == range_start (checkpoint
+            # set exactly to a last_input): no leading gap, so skip the span.
             if first > range_start and cover_unsampled:
                 spans.append((range_start, first, "afk"))  # leading unknown
             for a, b in zip(activity, activity[1:], strict=False):

--- a/src/sync/afk_source.py
+++ b/src/sync/afk_source.py
@@ -82,9 +82,16 @@ class AfkSource:
             self._available_latched = True
         return ok
 
-    def record_sample(self, now: datetime) -> None:
+    def record_sample(self, now: datetime, protect_since: Optional[datetime] = None) -> None:
         """Observe activity at ``now`` and append (now, last_input_at). No-op when
-        the OS idle clock is unavailable (Linux)."""
+        the OS idle clock is unavailable (Linux).
+
+        ``protect_since`` keeps samples at/after that instant from being pruned
+        even when they age past the retention window. The engine passes its
+        in-process AFK checkpoint so the active samples taken just before a
+        long pause survive the wake-cycle prune and can still be billed —
+        otherwise a sleep longer than retention drops the genuine pre-pause
+        work as an idle gap (Ecaterina/Matei Cocora, 2026-06-25)."""
         try:
             idle = self._idle_clock()
         except Exception as e:
@@ -111,6 +118,10 @@ class AfkSource:
             self._samples.append((now, last_input_at))
             cutoff = now - self._retention
             while self._samples and self._samples[0][0] < cutoff:
+                # Don't prune below a protected floor (the engine's checkpoint):
+                # those samples still cover an un-billed span before a pause.
+                if protect_since is not None and self._samples[0][0] >= protect_since:
+                    break
                 self._samples.popleft()
 
     def finalize_point(self, now: datetime) -> datetime:
@@ -133,13 +144,21 @@ class AfkSource:
     def build_afk_events(
         self, range_start: datetime, range_end: datetime,
         project_id: Optional[int] = None,
+        cover_unsampled: bool = True,
     ) -> list:
         """Reconstruct AFK spans over [range_start, range_end] from samples.
 
         Activity is known only at each sample's last_input_at. Between two
         activity instants the user is not-afk until last_input + afk_timeout,
         then afk (aw-watcher-afk parity). Any sub-range with no covering sample
-        is afk (never invent activity)."""
+        is afk (never invent activity).
+
+        With ``cover_unsampled=False`` the unsampled boundary regions (a leading
+        gap before the first observed instant, and a trailing gap past the last
+        one that already exceeds the timeout) are LEFT OUT instead of filled
+        with afk. Used by the long-pause re-seed path to salvage only the spans
+        the retained samples genuinely cover, leaving the unobserved sleep
+        window uncovered rather than reconstructing it."""
         if range_end <= range_start:
             return []
         timeout = timedelta(seconds=self._afk_timeout)
@@ -160,17 +179,18 @@ class AfkSource:
         # declaring afk, not how the billed span is classified.
         spans: list = []
         if not activity:
-            spans.append((range_start, range_end, "afk"))
+            if cover_unsampled:
+                spans.append((range_start, range_end, "afk"))
         else:
             first = activity[0]
-            if first > range_start:
+            if first > range_start and cover_unsampled:
                 spans.append((range_start, first, "afk"))  # leading unknown
             for a, b in zip(activity, activity[1:], strict=False):
                 spans.append((a, b, "not-afk" if (b - a) <= timeout else "afk"))
             last = activity[-1]
-            spans.append(
-                (last, range_end, "not-afk" if (range_end - last) <= timeout else "afk")
-            )
+            trailing = "not-afk" if (range_end - last) <= timeout else "afk"
+            if trailing == "not-afk" or cover_unsampled:
+                spans.append((last, range_end, trailing))
 
         events: list = []
         for start, end, status in sorted(spans, key=lambda s: s[0]):

--- a/src/sync/sync_engine.py
+++ b/src/sync/sync_engine.py
@@ -534,7 +534,13 @@ class SyncEngine:
         # cycle so the sample log stays dense regardless of bucket-fetch outcome.
         if self.afk_source is not None:
             try:
-                self.afk_source.record_sample(datetime.now(timezone.utc))
+                # Protect samples back to the in-process checkpoint so the active
+                # samples taken just before a long pause survive this prune and
+                # can still be billed by the re-seed salvage below.
+                self.afk_source.record_sample(
+                    datetime.now(timezone.utc),
+                    protect_since=self._afk_inproc_checkpoint,
+                )
             except Exception as e:
                 logger.debug("afk_source.record_sample failed: %s", e)
 
@@ -1973,14 +1979,43 @@ class SyncEngine:
         #    were pruned (2h). Reconstructing over an unsampled multi-hour window
         #    would mis-bill; the unobserved span is simply left uncovered (C).
         gap = (now - cp).total_seconds()
-        if now < cp or gap > self.afk_source.retention_seconds:
+        if now < cp:
+            # The wall clock stepped backward (NTP/manual). The window can't be
+            # trusted and the finalize guard below would stall the stream
+            # forever (D) — re-seed and move on.
             logger.info(
-                "in-process AFK: re-seeding checkpoint (gap %.0fs) — not billing "
-                "the unobserved window", gap,
+                "in-process AFK: re-seeding checkpoint (clock stepped back %.0fs)",
+                -gap,
             )
             self._afk_inproc_checkpoint = now
             self._afk_inproc_pending = None
             return []
+        if gap > self.afk_source.retention_seconds:
+            # A pause/sleep froze the checkpoint past the sample-retention
+            # window (2h). We can't reconstruct the whole multi-hour span, but
+            # discarding it outright dropped the genuine active work the agent
+            # had already observed in the final minutes before the machine
+            # slept — surfacing as a ~10-20 min idle/empty gap hugging every
+            # pause (Ecaterina/Matei Cocora, device 44, 2026-06-25). Salvage the
+            # spans the retained samples DO cover (cover_unsampled=False leaves
+            # the unobserved window uncovered, exactly as before) and re-seed
+            # past it. Emitted one-shot: the queue is the durability layer, and
+            # the checkpoint is reset to `now` so nothing is rebuilt.
+            with self._state_lock:
+                project = self._current_project
+            salvaged = self.afk_source.build_afk_events(
+                cp, self.afk_source.finalize_point(now),
+                project_id=project["id"] if project else None,
+                cover_unsampled=False,
+            )
+            logger.info(
+                "in-process AFK: re-seeding checkpoint (gap %.0fs) — salvaged %d "
+                "observed span(s), leaving the unobserved window uncovered",
+                gap, len(salvaged),
+            )
+            self._afk_inproc_checkpoint = now
+            self._afk_inproc_pending = None
+            return salvaged
 
         # Blind clock: the OS idle clock has failed for several consecutive
         # cycles, so there are no fresh samples. finalize_point would backdate

--- a/src/sync/sync_engine.py
+++ b/src/sync/sync_engine.py
@@ -536,7 +536,13 @@ class SyncEngine:
             try:
                 # Protect samples back to the in-process checkpoint so the active
                 # samples taken just before a long pause survive this prune and
-                # can still be billed by the re-seed salvage below.
+                # can still be billed by the re-seed salvage below (and so a
+                # held checkpoint can rebuild un-acked spans, finding B).
+                # The checkpoint read is lock-free: it's a GIL-atomic reference
+                # read, _advance_checkpoints_to_now only moves it FORWARD to now,
+                # and _build_inproc_afk re-reads it fresh — so a race only ever
+                # over-retains a few samples (bounded by the deque maxlen), never
+                # mis-bills.
                 self.afk_source.record_sample(
                     datetime.now(timezone.utc),
                     protect_since=self._afk_inproc_checkpoint,
@@ -2013,6 +2019,12 @@ class SyncEngine:
                 "observed span(s), leaving the unobserved window uncovered",
                 gap, len(salvaged),
             )
+            # INTENTIONAL deviation from finding B (checkpoint advances only after
+            # a confirmed send): the salvaged spans can't be rebuilt next cycle —
+            # the samples that produced them are about to age out. The offline
+            # queue is the durability layer instead: a queued salvage drains later
+            # and the server upserts idempotently on the stable (ms-precision) ids.
+            # Advancing to `now` prevents re-salvaging the same window every wake.
             self._afk_inproc_checkpoint = now
             self._afk_inproc_pending = None
             return salvaged

--- a/tests/test_inproc_afk_pause_salvage.py
+++ b/tests/test_inproc_afk_pause_salvage.py
@@ -69,7 +69,12 @@ def test_long_pause_reseed_salvages_observed_active_tail():
 
 def test_long_pause_with_no_observed_tail_emits_nothing():
     """If nothing was observed before the pause (only the wake sample), the
-    re-seed still emits nothing — we never invent activity over a blank window."""
+    re-seed still emits nothing — we never invent activity over a blank window.
+
+    NOTE: unlike the salvage test above, this one also passes on PRE-fix code
+    (the old re-seed also returned []). It is not a regression test — it guards
+    that the salvage path does not OVER-bill when there is no observed tail.
+    """
     eng = _engine(retention=7200.0)
     eng._afk_inproc_checkpoint = T0 - timedelta(hours=5)
     eng.afk_source.record_sample(T0, protect_since=eng._afk_inproc_checkpoint)
@@ -78,3 +83,14 @@ def test_long_pause_with_no_observed_tail_emits_nothing():
 
     assert events == [], "must not reconstruct an unobserved multi-hour window"
     assert eng._afk_inproc_checkpoint == T0
+
+
+def test_protect_since_respects_maxlen_backstop():
+    """`protect_since` keeps samples past retention, but the deque's maxlen is an
+    absolute memory cap — a frozen checkpoint can't grow it without bound."""
+    src = AfkSource(600, "host", idle_clock=lambda: 5.0,
+                    retention_seconds=7200.0, max_samples=100)
+    frozen_cp = T0  # checkpoint never advances (e.g. continuous send failure)
+    for i in range(500):
+        src.record_sample(T0 + timedelta(seconds=i), protect_since=frozen_cp)
+    assert len(src.samples) <= 100

--- a/tests/test_inproc_afk_pause_salvage.py
+++ b/tests/test_inproc_afk_pause_salvage.py
@@ -1,0 +1,80 @@
+"""In-process AFK: salvage the observed active tail across a long pause/sleep.
+
+Regression for the "~10-20 min idle/empty gap hugging every pause" report
+(Ecaterina Cocora / Matei Cocora device 44, 1.5.74, 2026-06-25).
+
+When the machine sleeps for longer than the sample-retention window the
+checkpoint freezes past retention and the cycle re-seeds. The old behaviour
+discarded the WHOLE window, including the genuine active work the agent had
+already observed in the final moments before the machine slept — so the
+server had no not-afk evidence there and rendered it as an idle/empty gap.
+
+These tests exercise the real AfkSource + SyncEngine (no phantom mocks):
+the pre-pause active samples must survive the wake-cycle prune and be emitted
+as not-afk spans, while the genuinely-unobserved sleep window stays uncovered.
+"""
+
+from datetime import datetime, timedelta, timezone
+from unittest.mock import Mock
+
+from src.config import Config
+from src.sync.activity_analyzer import ActivityAnalyzer
+from src.sync.afk_source import AfkSource
+from src.sync.daily_time_tracker import DailyTimeTracker
+from src.sync.sync_engine import SyncEngine
+
+T0 = datetime(2026, 6, 25, 9, 0, 0, tzinfo=timezone.utc)
+
+
+def _engine(retention=7200.0, idle=5.0):
+    cfg = Config()
+    cfg.sync.in_process_afk = True
+    eng = SyncEngine(aw=Mock(), bf=Mock(), queue=Mock(), config=cfg,
+                     activity_analyzer=Mock(spec=ActivityAnalyzer),
+                     time_tracker=Mock(spec=DailyTimeTracker))
+    eng.afk_source = AfkSource(600, "host", idle_clock=lambda: idle,
+                               retention_seconds=retention)
+    return eng
+
+
+def test_long_pause_reseed_salvages_observed_active_tail():
+    """A 5h sleep (> 2h retention) must NOT drop the active work observed in
+    the final minutes before the machine slept."""
+    eng = _engine(retention=7200.0)
+    pause_start = T0 - timedelta(hours=5)
+    # The last cycle finalized here, just before a final active burst + sleep.
+    eng._afk_inproc_checkpoint = pause_start - timedelta(seconds=5)
+
+    # Dense active samples in the last couple of minutes before the lid closed.
+    for off in (0, 60, 120):
+        eng.afk_source.record_sample(
+            pause_start + timedelta(seconds=off),
+            protect_since=eng._afk_inproc_checkpoint,
+        )
+    # 5h sleep; the machine wakes and the cycle records one fresh sample. The
+    # wake-cycle prune must keep the protected pre-pause samples.
+    eng.afk_source.record_sample(T0, protect_since=eng._afk_inproc_checkpoint)
+
+    events = eng._build_inproc_afk(T0)
+
+    notafk = [e for e in events if e["data"]["status"] == "not-afk"]
+    assert notafk, "observed pre-pause active tail was dropped (the idle-gap bug)"
+    # The checkpoint still re-seeds to now: the unobserved sleep window is left
+    # uncovered, never billed as active.
+    assert eng._afk_inproc_checkpoint == T0
+    # No span may extend into the unobserved sleep window as not-afk.
+    for e in notafk:
+        assert datetime.fromisoformat(e["timestamp"]) < pause_start + timedelta(minutes=10)
+
+
+def test_long_pause_with_no_observed_tail_emits_nothing():
+    """If nothing was observed before the pause (only the wake sample), the
+    re-seed still emits nothing — we never invent activity over a blank window."""
+    eng = _engine(retention=7200.0)
+    eng._afk_inproc_checkpoint = T0 - timedelta(hours=5)
+    eng.afk_source.record_sample(T0, protect_since=eng._afk_inproc_checkpoint)
+
+    events = eng._build_inproc_afk(T0)
+
+    assert events == [], "must not reconstruct an unobserved multi-hour window"
+    assert eng._afk_inproc_checkpoint == T0


### PR DESCRIPTION
## The bug

Reported in Slack by Ecaterina Cocora for **Matei Cocora's device (id 44, agent 1.5.74)** on 2026-06-25: *"some kind of 20-minute issue either before a pause or after one."* A ~10–20 min **idle/empty gap hugs each pause** in the Activity Timeline.

## Root cause (confirmed with real data)

`agent:debug-day --device=44 --date=2026-06-24` shows the "pauses" are **macOS sleep events** — two of them (2.1h and 4.1h) exceed the agent's in-process AFK **sample retention (2h / 7200s)**.

When a sleep is longer than retention, the checkpoint freezes past the retention window and `_build_inproc_afk` re-seeds. The old re-seed **discarded the entire `[checkpoint, now]` window** — including the genuine active work the agent had already observed in the final minutes before the lid closed. With no not-afk evidence there, the server renders those slots as an idle/empty gap (and that time isn't counted).

The committed/deployed **server** timeline can't itself open a mid-day gap (it fills from the window stream), so the missing evidence is upstream in the agent — this is the same family as the still-open AFK upload-stream-gap convergence work.

## The fix (agent-side, two parts)

- **`AfkSource.record_sample(protect_since=…)`** — keep samples at/after a protected floor (the engine's checkpoint) from being pruned, so the active samples taken just before a long pause survive the wake-cycle prune.
- **`_build_inproc_afk` re-seed branch** — split the `now < cp` (clock-backward) case from the `gap > retention` (pause) case. For a pause it now calls `build_afk_events(…, cover_unsampled=False)` to **salvage only the spans the retained samples genuinely cover**, leaving the unobserved sleep window uncovered (never billed active), then re-seeds to `now`. The clock-backward path is unchanged.

`cover_unsampled=False` is new on `build_afk_events`: it omits the unsampled boundary regions instead of filling them with afk, so we never invent activity over a genuinely unobserved window (the original finding-C concern stays honoured).

## Test (proof of failure pre-fix)

`tests/test_inproc_afk_pause_salvage.py`:
- `test_long_pause_reseed_salvages_observed_active_tail` — **fails pre-fix** (re-seed returned `[]`, the pre-pause not-afk span was lost); **passes post-fix** (the observed active tail is emitted as not-afk while the unobserved window stays uncovered).
- `test_long_pause_with_no_observed_tail_emits_nothing` — guards that a blank window still emits nothing.

Full suite: **769 passed**. Existing hardening tests (findings A–F, incl. `gap>retention` with no tail and clock-backward re-seed) pass unchanged.

## Scope / follow-up

- Needs a fleet bump (1.5.7x) to take effect.
- The server still renders the genuinely-unobserved sleep window as a gap; making that read as gray idle rather than white is a separate `internal-tool2` display change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)