### PR TITLE
fix(afk): suppress blind external-tracker alarm when in-process AFK is the source

### DIFF
--- a/src/main.py
+++ b/src/main.py
@@ -618,6 +618,24 @@ class SyncCoordinator:
         if not self.logged_in:
             return
 
+        # When the in-process AFK source is active it is the SOLE billing source
+        # (#70): the agent uploads its own AFK stream and the external
+        # bf-idle-tracker bucket is ignored. A blind/stale external tracker then
+        # no longer affects recorded work time, so its disagreement with the
+        # input watcher is cosmetic. Skip the whole check — alarming the user
+        # ("your activity isn't being recorded as work time") would be FALSE, and
+        # paging ops produces the recurring blind-tracker error wave for nothing.
+        # The aw_manager watchdog already suppresses its own blind detection on
+        # the same condition; this closes the remaining un-gated path. When
+        # in-process AFK is unavailable (Linux, or the OS idle clock went blind)
+        # this flips False and the external tracker matters again — so the check
+        # correctly resumes.
+        try:
+            if self.sync_engine.inproc_afk_active:
+                return
+        except Exception as e:  # never let a telemetry guard break the tick
+            logger.debug("idle_tracker_health: inproc_afk_active check failed: %s", e)
+
         # Chronic-blind path: the watchdog gave up frequent restarts because
         # bf-idle-tracker stays stale across them — that's a missing Input
         # Monitoring grant (separate TCC subject), not a crash a restart fixes.

--- a/tests/test_idle_tracker_health.py
+++ b/tests/test_idle_tracker_health.py
@@ -30,6 +30,7 @@ def _make_coordinator(
     input_watcher=None,
     latest_afk_event=None,
     extra_buckets=None,
+    inproc_afk_active=False,
 ) -> SyncCoordinator:
     """Build a coordinator with mock deps and inject the input_watcher +
     a fake AWClient that returns canned AFK buckets/events.
@@ -72,12 +73,17 @@ def _make_coordinator(
 
     aw_manager = MagicMock()
     aw_manager.idle_tracker_blind = False  # default; a test flips it on
+    sync_engine = MagicMock()
+    # Default: external bf-idle-tracker IS the billing source, so its blindness
+    # is billing-relevant and the check should fire. The in-process-AFK case
+    # (where a blind external tracker is cosmetic) sets this True explicitly.
+    sync_engine.inproc_afk_active = inproc_afk_active
     coord = SyncCoordinator(
         config=MagicMock(),
         aw=aw,
         bf=MagicMock(),
         queue=MagicMock(),
-        sync_engine=MagicMock(),
+        sync_engine=sync_engine,
         tray=tray,
         aw_manager=aw_manager,
     )
@@ -136,6 +142,29 @@ def test_blind_capture_uses_coarse_input_age_not_timestamp(mock_send):
     ctx = coord.error_reporter.capture.call_args.kwargs["context"]
     assert "last_input" not in ctx, "must not leak the precise wall-clock timestamp"
     assert isinstance(ctx.get("last_input_age_seconds"), int)
+
+
+@patch("src.main.send_notification")
+def test_silent_when_inproc_afk_active(mock_send):
+    """When the in-process AFK source is the sole billing source (#70), a blind
+    external bf-idle-tracker no longer affects recorded work time — its 'afk'
+    disagreement is cosmetic, so the check must NOT alarm the user or page ops
+    (the "not being recorded as work time" message would be false). This is the
+    fix for the recurring [betterflow-sync] blind-tracker ops-error wave."""
+    input_watcher = MagicMock()
+    input_watcher.get_last_input_at.return_value = datetime.now(timezone.utc) - timedelta(seconds=30)
+
+    coord = _make_coordinator(
+        input_watcher=input_watcher,
+        latest_afk_event=_afk_event("afk", age_seconds=3600, duration=300),
+        inproc_afk_active=True,
+    )
+    coord.error_reporter = MagicMock()
+
+    coord._check_idle_tracker_health()
+
+    mock_send.assert_not_called()
+    coord.error_reporter.capture.assert_not_called()
 
 
 @patch("src.main.send_notification")


### PR DESCRIPTION
## The wave

`[betterflow-sync] 32× Idle tracker reporting AFK while input is active (blind tracker)` — top open error in the 2026-06-25 ops digest.

## Root cause

`SyncCoordinator._check_idle_tracker_health` (main.py) detects the external **bf-idle-tracker** reporting `afk` while the in-process input watcher sees fresh keystrokes — historically a missing Input Monitoring grant on the tracker's separate TCC subject (Lucian, 2026-06-11).

But since **#70 (1.5.64)** the in-process AFK source is the **sole billing source** by default: the agent uploads its own AFK stream and the external bucket is ignored. A blind external tracker then doesn't affect recorded work time — yet this path was never gated on it, so on the default macOS fleet it kept:
- telling the user *"your activity isn't being recorded as work time"* (**false** — in-process AFK records it), and
- paging ops with the blind-tracker capture → the recurring 32× wave.

The `aw_manager` watchdog already suppresses *its* blind detection when in-process AFK is active; this was the remaining un-gated path.

## Fix

Skip the check when `sync_engine.inproc_afk_active` is true. When in-process AFK is unavailable (Linux, or the OS idle clock went blind) the flag flips false and the external tracker is billing-relevant again, so the genuine detection resumes — no loss of the Lucian signal.

## Test

`test_silent_when_inproc_afk_active` — fails pre-fix (warn + ops capture both fired), passes after. The existing 15 idle-tracker-health tests now thread an explicit `inproc_afk_active=False` (they model the external-is-source case). Full suite **771 passed**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)