### PR TITLE
fix(private): end Private Time at sleep instead of restoring it on wake

### DIFF
--- a/src/system_event_handler.py
+++ b/src/system_event_handler.py
@@ -73,6 +73,20 @@ class SystemEventHandler:
                     "on_system_sleep fired while a prior _sleep_start is still pending "
                     "(no wake yet) — keeping the earlier timestamp"
                 )
+        # End Private Time at the sleep boundary. Private has no auto-timeout,
+        # so a user who enables it and forgets — or whose machine sleeps mid-
+        # private — would otherwise stay private across the sleep AND into the
+        # next awake session, silently marking real post-wake work as private
+        # and uncounted (Raluca, 2026-06-24: a ~20-min private toggle stayed on
+        # ~11h overnight and swallowed her evening). Leaving it here records the
+        # true enable→sleep span via the normal leave path (private_time event +
+        # checkpoint advance); on wake we resume NORMAL tracking, never auto-
+        # restoring private.
+        if self._pre_sleep_private:
+            try:
+                self.sync_engine.set_private_mode(False)
+            except Exception as e:
+                logger.warning("ending private mode on sleep failed: %s", e)
         self.coordinator.paused_by_network = False
         self.coordinator.clear_idle_pause(send_event=True)
         self.sync_engine.pause()
@@ -89,11 +103,6 @@ class SystemEventHandler:
         except ImportError:
             from ui.tray import TrayState
 
-        try:
-            from .main import _day_greeting
-        except ImportError:
-            from main import _day_greeting
-
         self.bf.reset_session()
         self.aw.reset_session()
         # Emit the sleep_time event before any early-return paths so even
@@ -101,7 +110,6 @@ class SystemEventHandler:
         # span. Captured under the lock to avoid racing a second sleep.
         with self._pause_state_lock:
             user_paused = self._user_paused
-            pre_sleep_private = self._pre_sleep_private
             sleep_start = self._sleep_start
             self._sleep_start = None
         if sleep_start is not None:
@@ -115,12 +123,10 @@ class SystemEventHandler:
         if self.coordinator.is_on_break:
             logger.info("System wake - staying on break")
             return
-        if pre_sleep_private:
-            logger.info("System wake - restoring private time")
-            self.sync_engine.resume()
-            self.sync_engine.set_private_mode(True)
-            self.tray.set_state(TrayState.PRIVATE)
-            return
+        # Private Time is intentionally NOT auto-restored: it was ended at the
+        # sleep boundary (on_system_sleep), so a sleep cleanly ends a private
+        # session. The user re-enables it if they still want privacy — a
+        # forgotten toggle can no longer silently swallow post-wake work.
         self.sync_engine.resume()
         self.tray.set_state(TrayState.SYNCING)
         self.reminder_manager.on_tracking_started()

--- a/tests/test_sync_engine.py
+++ b/tests/test_sync_engine.py
@@ -1448,6 +1448,43 @@ class TestSystemSleepWakeEmitsSleepSpan:
         handler.on_system_wake()
         sync_engine.resume.assert_called_once()
 
+    def test_private_active_at_sleep_is_ended_and_not_restored_on_wake(self):
+        """A forgotten Private Time toggle must not survive a sleep.
+
+        Private has no auto-timeout, so a user who enables it and whose machine
+        then sleeps would otherwise stay private across the sleep AND into the
+        next awake session — silently marking real post-wake work as private and
+        uncounted (Raluca, 2026-06-24: a ~20-min private toggle stayed on ~11h
+        overnight and swallowed her evening). End it at the sleep boundary (the
+        normal leave path records the true enable→sleep span) and resume NORMAL
+        tracking on wake, never re-entering private.
+        """
+        handler, sync_engine = self._make_handler()
+        sync_engine.is_private = True
+
+        handler.on_system_sleep()
+        sync_engine.set_private_mode.assert_called_once_with(False)
+
+        sync_engine.set_private_mode.reset_mock()
+        handler.on_system_wake()
+
+        assert not any(
+            call.args == (True,)
+            for call in sync_engine.set_private_mode.call_args_list
+        ), "wake must NOT restore private mode"
+        sync_engine.resume.assert_called()
+
+    def test_non_private_sleep_does_not_touch_private_mode(self):
+        """When the user was NOT private at sleep, the flow never calls
+        set_private_mode (no spurious enter/leave)."""
+        handler, sync_engine = self._make_handler()
+        sync_engine.is_private = False
+
+        handler.on_system_sleep()
+        handler.on_system_wake()
+
+        sync_engine.set_private_mode.assert_not_called()
+
 
 class TestSyncCoordinatorBreak:
     """Tests for SyncCoordinator break state management."""


### PR DESCRIPTION
## Problem
Private Time has no auto-timeout. `on_system_wake` explicitly **restored** private mode, so a forgotten toggle (or a private session interrupted by a sleep) persisted across the sleep and into the next awake session — silently marking real post-wake work as private and uncounted.

Reported by Lenghel Raluca Oana (2026-06-24): an evening Private Time toggle ran across an overnight sleep, recording an ~11h private block.

## Fix
- `on_system_sleep`: end Private Time at the sleep boundary (the normal leave path records the true enable→sleep span via the private_time event + checkpoint advance).
- `on_system_wake`: stop auto-restoring private — a sleep cleanly ends a private session; the user re-enables it if they still want privacy.
- The periodic in-app private reminder (reminders.py, 15/35/45 min) is unchanged.
- Drops a now-unused `_day_greeting` import.

## Tests
`test_private_active_at_sleep_is_ended_and_not_restored_on_wake` (fails pre-fix — wake re-entered private) + a non-private guard. Full suite 773, lint clean.

## Scope note
This hardens the private-across-sleep trap (the overnight extension). The in-evening "private hid my work" behavior is by design (private excludes + hides app detail); see the thread for the local-time reconstruction.

🤖 Generated with [Claude Code](https://claude.com/claude-code)