### PR TITLE
fix(update): verify the app actually started after a self-update relaunch

### DIFF
--- a/src/self_updater.py
+++ b/src/self_updater.py
@@ -318,26 +318,11 @@ def _apply_local_artifact(
             # logged a line). The helper therefore writes its own outcome (each
             # open attempt + exit code) to self-update-relaunch.log, which is the
             # ground truth a canary needs.
-            quoted_app = shlex.quote(str(app_path))
             try:
                 relaunch_log = str(Config.get_log_dir() / "self-update-relaunch.log")
             except Exception:
                 relaunch_log = "/tmp/betterflow-self-update-relaunch.log"
-            quoted_log = shlex.quote(relaunch_log)
-            # Capture rc into a var IMMEDIATELY after open — a $(date) in the same
-            # echo would otherwise reset $? and we'd log rc=0 for every failure.
-            script = (
-                f'L={quoted_log}; A={quoted_app}; '
-                f'echo "$(date -u +%FT%TZ) waiting for pid {os.getpid()}" >> "$L"; '
-                f'while kill -0 {os.getpid()} 2>/dev/null; do sleep 0.2; done; '
-                f'echo "$(date -u +%FT%TZ) pid gone; opening $A" >> "$L"; '
-                f'for i in 1 2 3 4 5; do '
-                f'open "$A" >> "$L" 2>&1; rc=$?; '
-                f'if [ "$rc" -eq 0 ]; then echo "$(date -u +%FT%TZ) open OK (try $i)" >> "$L"; exit 0; fi; '
-                f'echo "$(date -u +%FT%TZ) open FAILED rc=$rc (try $i)" >> "$L"; sleep 1; '
-                f'done; '
-                f'echo "$(date -u +%FT%TZ) RELAUNCH FAILED after 5 attempts" >> "$L"'
-            )
+            script = _build_macos_relaunch_script(str(app_path), os.getpid(), relaunch_log)
             subprocess.Popen(["/bin/sh", "-c", script], start_new_session=True)
             # os._exit works from any thread, unlike sys.exit which only raises
             # SystemExit in the calling thread.
@@ -603,6 +588,41 @@ def _codesign_verify(app_path: Path) -> bool:
     except subprocess.TimeoutExpired:
         logger.error("codesign verification timed out")
         return False
+
+
+def _build_macos_relaunch_script(app_path: str, pid: int, log_path: str) -> str:
+    """Shell helper run (detached) after os._exit to reopen the app post-update.
+
+    It waits for THIS process to die, opens the new bundle, and — crucially —
+    VERIFIES a real process actually came up before trusting it, retrying the
+    open if not. `open` returning 0 means LaunchServices ACCEPTED the request,
+    NOT that the app started: it can silently no-op (or the new instance can die
+    on startup) leaving NO running process while the helper logs "open OK" and
+    exits. That is the 6.5h black hole Botond hit (2026-06-25): a 09:18 relaunch
+    logged "open OK" but the agent never synced until the next relaunch at 15:35.
+    `open` is idempotent (it just reactivates an already-running app), so the
+    retry is always safe. The helper logs each outcome to its own file (the main
+    log can't capture anything after os._exit) — ground truth for a canary.
+    """
+    quoted_app = shlex.quote(str(app_path))
+    quoted_log = shlex.quote(str(log_path))
+    return (
+        f'L={quoted_log}; A={quoted_app}; '
+        f'echo "$(date -u +%FT%TZ) waiting for pid {pid}" >> "$L"; '
+        f'while kill -0 {pid} 2>/dev/null; do sleep 0.2; done; '
+        f'echo "$(date -u +%FT%TZ) pid gone; opening $A" >> "$L"; '
+        f'for i in 1 2 3 4 5; do '
+        # Capture rc IMMEDIATELY after open — a $(date) in the same echo would
+        # reset $? and we'd log rc=0 for every failure.
+        f'open "$A" >> "$L" 2>&1; rc=$?; '
+        f'if [ "$rc" -ne 0 ]; then echo "$(date -u +%FT%TZ) open FAILED rc=$rc (try $i)" >> "$L"; sleep 2; continue; fi; '
+        f'sleep 3; '
+        f'if pgrep -f "$A/Contents/MacOS/" >/dev/null 2>&1; then '
+        f'echo "$(date -u +%FT%TZ) open OK + process alive (try $i)" >> "$L"; exit 0; fi; '
+        f'echo "$(date -u +%FT%TZ) open returned 0 but NO running process (try $i) — retrying" >> "$L"; sleep 2; '
+        f'done; '
+        f'echo "$(date -u +%FT%TZ) RELAUNCH FAILED after 5 attempts (open accepted but no live process)" >> "$L"'
+    )
 
 
 def _verify_codesign(app_path: Path, current_app_path: Optional[Path] = None) -> bool:

--- a/tests/test_self_updater_relaunch_verify.py
+++ b/tests/test_self_updater_relaunch_verify.py
@@ -1,0 +1,44 @@
+"""The self-update relaunch helper must VERIFY the app actually started.
+
+Botond (2026-06-25): a 09:18 self-update relaunch logged "open OK" but the
+agent never synced for 6.5h (until the next relaunch at 15:35). `open` exiting 0
+only means LaunchServices accepted the request — the instance can silently fail
+to start, leaving no running process. The helper must confirm a live process
+(and retry the open otherwise) instead of trusting `open`'s exit code.
+"""
+
+import subprocess
+
+from src.self_updater import _build_macos_relaunch_script
+
+
+def test_relaunch_script_verifies_a_live_process_after_open():
+    script = _build_macos_relaunch_script("/Applications/BetterFlow 2.app", 4242, "/tmp/r.log")
+
+    # Verifies a real process is running (not just that `open` returned 0).
+    assert "pgrep -f" in script
+    assert "/Contents/MacOS/" in script
+    # The success path is gated on the pgrep, not on open's rc alone.
+    assert "process alive" in script
+    # On open-returns-0-but-no-process it retries rather than exiting.
+    assert "NO running process" in script
+    # Still waits for the old pid and opens the bundle (unchanged invariants).
+    assert "kill -0 4242" in script
+    assert "open \"$A\"" in script
+
+
+def test_relaunch_script_is_valid_sh():
+    script = _build_macos_relaunch_script("/Applications/BetterFlow 2.app", 4242, "/tmp/r.log")
+    # `sh -n` parses without executing — catches quoting/syntax regressions in
+    # the embedded shell (the bundle path contains a space).
+    result = subprocess.run(["/bin/sh", "-n", "-c", script], capture_output=True, text=True)
+    assert result.returncode == 0, f"generated relaunch script is not valid sh: {result.stderr}"
+
+
+def test_relaunch_script_no_longer_trusts_bare_open_ok():
+    """Regression guard: the pre-fix helper logged 'open OK' and exited on rc==0
+    alone. The success log line must now require the liveness check."""
+    script = _build_macos_relaunch_script("/Applications/BetterFlow.app", 1, "/tmp/r.log")
+    # There must be no success/exit that fires purely on `open` rc==0 without a
+    # subsequent pgrep gate. Assert the only "exit 0" follows the pgrep branch.
+    assert "if [ \"$rc\" -eq 0 ]; then echo \"$(date -u +%FT%TZ) open OK (try $i)\" >> \"$L\"; exit 0; fi" not in script


### PR DESCRIPTION
## The 6.5h black hole
Botond (2026-06-25): a **09:18 self-update relaunch logged "open OK"** but the agent recorded **nothing for 6.5h** until the next relaunch at 15:35 unstuck it — a whole workday silently lost while the device still looked "online."

Root cause: `open` exiting 0 means **LaunchServices accepted the request, not that the app started.** The relaunch helper trusted that exit code (logged "open OK" and quit), so a relaunch where the new instance silently failed to start left no running agent while reporting success.

## Fix
After each `open`, sleep briefly and `pgrep` the bundle's executable path to confirm a real process came up; **retry the open if not** (`open` is idempotent — it reactivates an already-running app, so retry is always safe). Success + exit only once a live process is confirmed; otherwise exhaust 5 tries and log `RELAUNCH FAILED` (diagnosable, not a false "open OK").

Extracted `_build_macos_relaunch_script(app_path, pid, log_path)` so it's unit-testable.

## Tests
Assert the pgrep liveness gate + retry, validate the embedded sh with `sh -n` (the bundle path has a space), and guard against regressing to bare-open-OK. Full suite **776**.

## Follow-up
`main.py::_spawn_deferred_open` (the permission-restart helper) has the same open-without-verify shape — worth the same treatment next.

🤖 Generated with [Claude Code](https://claude.com/claude-code)