### PR TITLE
feat(private): auto-end Private Time after a safety cap + escalate the nudge

### DIFF
--- a/src/config.py
+++ b/src/config.py
@@ -376,6 +376,11 @@ class ReminderSettings:
     break_duration_minutes: int = 15  # Auto-break pause duration
     private_reminders_enabled: bool = True
     private_interval_minutes: int = 20  # 10, 20, or 30
+    # Hard safety cap: auto-end Private Time after this many continuous hours so a
+    # forgotten toggle can't silently zero a whole day's billable time (Raluca,
+    # 2026-06-25, ~11h private). 0 disables the cap. v1.5.79 already ends private
+    # on sleep; this covers the awake-but-forgotten case.
+    private_auto_end_hours: float = 4.0
 
 
 @dataclass

--- a/src/main.py
+++ b/src/main.py
@@ -210,6 +210,10 @@ class SyncCoordinator:
 
         # Optional callback wired by the app for auth-error re-login
         self._on_auth_error: Optional[Callable] = None
+        # Wired by BetterFlowApp to end Private Time when the auto-end safety cap
+        # is hit (the engine/tray/paused-flag teardown lives on the app). Called
+        # with the elapsed seconds. None until wired (e.g. in tests).
+        self.on_private_auto_end: Optional[Callable[[float], None]] = None
 
         # In-process input watcher reference, wired by the App after
         # construction. Used by `_check_idle_tracker_health` to cross-check
@@ -594,6 +598,25 @@ class SyncCoordinator:
     # short typing pause doesn't trip the warning.
     _IDLE_TRACKER_RECENT_INPUT_S = 180  # 3 min
 
+    def _check_private_auto_end(self) -> None:
+        """Hard safety cap: force-end Private Time after a configured number of
+        continuous hours so a forgotten toggle can't silently zero a whole day's
+        billable time (Raluca, 2026-06-25, ~11h private). v1.5.79 already ends
+        private on sleep; this covers the awake-but-forgotten case. 0 disables.
+        The actual teardown runs via the on_private_auto_end callback (wired by
+        BetterFlowApp, which owns the engine/tray/paused-flag state)."""
+        if self.reminder_manager is None or not self.sync_engine.is_private:
+            return
+        cap_hours = getattr(self.config.reminders, "private_auto_end_hours", 0) or 0
+        if cap_hours <= 0:
+            return
+        elapsed = self.reminder_manager.private_elapsed_seconds()
+        if elapsed is None or elapsed < cap_hours * 3600:
+            return
+        logger.warning("Private Time auto-ended after %.1fh (safety cap)", elapsed / 3600)
+        if self.on_private_auto_end is not None:
+            self.on_private_auto_end(elapsed)
+
     def _check_idle_tracker_health(self) -> None:
         """Detect when bf-idle-tracker is reporting AFK while the in-process
         input watcher is seeing keystrokes — Lucian's 2026-06-11 incident.
@@ -834,6 +857,7 @@ class SyncCoordinator:
             (self._check_permissions, "permissions"),
             (self._check_auth_warn, "auth_warn"),
             (self._check_idle_tracker_health, "idle_tracker_health"),
+            (self._check_private_auto_end, "private_auto_end"),
         ):
             self._run_tick_task(fn, label)
         if self.reminder_manager:
@@ -1409,6 +1433,7 @@ class BetterFlowApp:
             error_reporter=self.error_reporter,
         )
         self.coordinator._on_auth_error = self._on_session_expired
+        self.coordinator.on_private_auto_end = self._auto_end_private
         self.coordinator._input_watcher = self.input_watcher
         # The idle manager uses the same in-process watcher as an authoritative
         # override so a blind/stuck bf-idle-tracker can't paint live work as
@@ -2036,6 +2061,21 @@ class BetterFlowApp:
             self.reminder_manager.on_private_ended()
             self.reminder_manager.on_tracking_started()
             send_notification("Private Time Ended", "Tracking has resumed.", sound=False)
+
+    def _auto_end_private(self, elapsed_seconds: float) -> None:
+        """End Private Time the same way the user toggle does, with a message
+        making clear WE turned it off (so they re-enable if it was intended)."""
+        self._set_user_paused(False)
+        self.sync_engine.set_private_mode(False)
+        self.sync_engine.resume()
+        self.tray.set_paused(False)
+        self.reminder_manager.on_private_ended()
+        self.reminder_manager.on_tracking_started()
+        send_notification(
+            "Private Time auto-ended",
+            f"Private mode had been on for {elapsed_seconds / 3600:.1f}h, so tracking "
+            "was turned back on. Re-enable Private Time if you still need it.",
+        )
 
     def _on_idle_pause(self, paused: bool) -> None:
         """Handle idle pause/resume — also pause/resume input watcher and slow window polling."""

--- a/src/reminders.py
+++ b/src/reminders.py
@@ -80,6 +80,16 @@ class ReminderManager:
                 self._private_active = False
                 logger.debug("Private timer reset")
 
+    def private_elapsed_seconds(self) -> float | None:
+        """Seconds Private Time has been continuously active, or None when not
+        in private mode. Monotonic, so it excludes machine-sleep — paired with
+        the v1.5.79 end-private-on-sleep fix, this is the awake duration. The
+        coordinator uses it for the hard auto-end safety cap."""
+        with self._lock:
+            if not self._private_active or self._private_start is None:
+                return None
+            return time.monotonic() - self._private_start
+
     def on_break_started(self) -> None:
         """Call when auto-break begins (suppresses further break checks)."""
         with self._lock:
@@ -159,9 +169,18 @@ class ReminderManager:
             minutes = int(elapsed // 60)
             self._last_private_notification = now
 
-        # Send notification outside the lock
+        # Send notification outside the lock. Escalate past an hour: a multi-hour
+        # private session is almost always a forgotten toggle silently zeroing
+        # billable time, so the copy gets pointed rather than passive.
         logger.info(f"Private time reminder sent ({minutes}m elapsed)")
-        send_notification(
-            "Private Time Still Active",
-            f"Private mode has been on for {minutes}m - tracking is paused.",
-        )
+        if minutes >= 60:
+            send_notification(
+                "Private Time still on — is that intended?",
+                f"Private mode has been on for {minutes / 60:.1f}h and nothing is "
+                "being tracked. Turn it off if you've finished.",
+            )
+        else:
+            send_notification(
+                "Private Time Still Active",
+                f"Private mode has been on for {minutes}m - tracking is paused.",
+            )

--- a/tests/test_reminders.py
+++ b/tests/test_reminders.py
@@ -165,6 +165,35 @@ class TestPrivateReminders:
         self.mgr.check()
         mock_notify.assert_not_called()
 
+    @patch("src.reminders.time.monotonic")
+    def test_private_elapsed_seconds_tracks_active_session(self, mock_mono):
+        mock_mono.return_value = 100.0
+        assert self.mgr.private_elapsed_seconds() is None  # not in private
+
+        self.mgr.on_private_started()
+        mock_mono.return_value = 100.0 + 3600
+        assert self.mgr.private_elapsed_seconds() == 3600
+
+        self.mgr.on_private_ended()
+        assert self.mgr.private_elapsed_seconds() is None
+
+    @patch("src.reminders.send_notification")
+    @patch("src.reminders.time.monotonic")
+    def test_private_nudge_escalates_past_one_hour(self, mock_mono, mock_notify):
+        mock_mono.return_value = 0.0
+        self.mgr.on_private_started()
+
+        # 20m — passive copy.
+        mock_mono.return_value = 20 * 60
+        self.mgr.check()
+        assert "still active" in mock_notify.call_args[0][0].lower()
+
+        # 60m — escalated copy ("is that intended?").
+        mock_notify.reset_mock()
+        mock_mono.return_value = 60 * 60
+        self.mgr.check()
+        assert "intended" in mock_notify.call_args[0][0].lower()
+
 
 class TestBreakState:
     """Tests for break-state suppression and reset behavior."""

--- a/tests/test_sync_engine.py
+++ b/tests/test_sync_engine.py
@@ -1520,6 +1520,66 @@ class TestSyncCoordinatorBreak:
         self.coordinator.scheduler = Mock()
         self.coordinator.scheduler.running = True
 
+    def test_private_auto_end_fires_callback_past_cap(self):
+        self.config.reminders.private_auto_end_hours = 4.0
+        self.sync_engine.is_private = True
+        self.reminder.private_elapsed_seconds.return_value = 4 * 3600 + 1
+        cb = Mock()
+        self.coordinator.on_private_auto_end = cb
+
+        self.coordinator._check_private_auto_end()
+
+        cb.assert_called_once()
+        assert cb.call_args[0][0] >= 4 * 3600
+
+    def test_private_auto_end_below_cap_does_nothing(self):
+        self.config.reminders.private_auto_end_hours = 4.0
+        self.sync_engine.is_private = True
+        self.reminder.private_elapsed_seconds.return_value = 3 * 3600
+        cb = Mock()
+        self.coordinator.on_private_auto_end = cb
+
+        self.coordinator._check_private_auto_end()
+
+        cb.assert_not_called()
+
+    def test_private_auto_end_disabled_when_cap_zero(self):
+        self.config.reminders.private_auto_end_hours = 0
+        self.sync_engine.is_private = True
+        self.reminder.private_elapsed_seconds.return_value = 99 * 3600
+        cb = Mock()
+        self.coordinator.on_private_auto_end = cb
+
+        self.coordinator._check_private_auto_end()
+
+        cb.assert_not_called()
+
+    def test_private_auto_end_skipped_when_not_private(self):
+        self.config.reminders.private_auto_end_hours = 4.0
+        self.sync_engine.is_private = False
+        cb = Mock()
+        self.coordinator.on_private_auto_end = cb
+
+        self.coordinator._check_private_auto_end()
+
+        cb.assert_not_called()
+        self.reminder.private_elapsed_seconds.assert_not_called()
+
+    @patch("src.main.send_notification")
+    def test_auto_end_private_tears_down_and_notifies(self, mock_notify):
+        """The app-side teardown (wired as on_private_auto_end) ends private the
+        same way the user toggle does, with a 'we turned it off' notice."""
+        from src.main import BetterFlowApp
+        app = Mock()
+        BetterFlowApp._auto_end_private(app, 5 * 3600)
+        app._set_user_paused.assert_called_once_with(False)
+        app.sync_engine.set_private_mode.assert_called_once_with(False)
+        app.sync_engine.resume.assert_called_once()
+        app.reminder_manager.on_private_ended.assert_called_once()
+        app.reminder_manager.on_tracking_started.assert_called_once()
+        mock_notify.assert_called_once()
+        assert "auto-ended" in mock_notify.call_args[0][0].lower()
+
     def test_start_break_sets_flag(self):
         """start_break sets _on_break."""
         self.coordinator.start_break()


### PR DESCRIPTION
Phase 2 prevention for the forgotten-Private-Time trap (Raluca, ~11h private silently zeroing billable time). v1.5.79 ends private on sleep; this covers the **awake-but-forgotten** case.

**A — hard auto-end cap.** `SyncCoordinator._check_private_auto_end` (60s tick) ends Private Time once it's been continuously on for `ReminderSettings.private_auto_end_hours` (**default 4.0h**; 0 disables). Elapsed from the reminder's monotonic clock (excludes sleep). Teardown runs via an `on_private_auto_end` callback wired to `BetterFlowApp._auto_end_private` (owns engine/tray/paused-flag), with a clear *"turned it back on — re-enable if intended"* notice.

**B — escalating nudge.** `private_reminders_enabled` already defaults True; added escalation — past 1h the copy switches from passive ("still active") to pointed ("Private Time still on — is that intended? … nothing is being tracked").

**Tests** (suite 783): reminders (`private_elapsed_seconds` + >1h escalation), coordinator (cap fires the callback past threshold; no-op below cap / cap=0 / not-private), and the app-side `_auto_end_private` teardown.

🤖 Generated with [Claude Code](https://claude.com/claude-code)