### PR TITLE
fix(sync): self-recover a wedged sync + emit sync-staleness on heartbeat

### DIFF
--- a/src/main.py
+++ b/src/main.py
@@ -202,6 +202,19 @@ class SyncCoordinator:
         self._paused_by_network = False
         self._state_lock = threading.Lock()
         self._sync_lock = threading.Lock()
+        # Wedge self-recovery (Cristian Dragota / sync:67a77a43-787, 2026-06-25):
+        # a _do_sync that hangs past the watchdog holds _sync_lock forever, so
+        # every later cycle skips and sync freezes while the heartbeat keeps
+        # last_seen fresh. _sync_takeover_lock guards the acquire/re-arm decision;
+        # a holder stamps _sync_started_at + _sync_holder so a later cycle can
+        # tell a healthy in-flight run from a wedged zombie.
+        self._sync_takeover_lock = threading.Lock()
+        self._sync_started_at: Optional[float] = None
+        self._sync_holder: Optional[threading.Lock] = None
+        # Monotonic clock of the last successful sync round-trip; surfaced on the
+        # heartbeat as sync_stale_seconds so the fleet can flag "alive but not
+        # syncing" directly instead of inferring it from upload gaps.
+        self._last_successful_sync: Optional[float] = None
 
         # Sub-managers (own their locks)
         self.break_mgr = BreakManager(sync_engine, tray, self.scheduler, config, reminder_manager)
@@ -996,10 +1009,64 @@ class SyncCoordinator:
             self._handle_auth_error(auth_err, source="liveness_heartbeat")
 
     _DO_SYNC_DEADLINE = 120  # seconds — must exceed request_timeout * (max_retries + 1)
+    # A _do_sync holding _sync_lock longer than this is treated as wedged
+    # (deadlock, or a call hung past the watchdog). A new cycle then abandons the
+    # stuck holder and re-arms a fresh lock so syncing resumes instead of skipping
+    # forever. Must exceed _DO_SYNC_DEADLINE so the watchdog's session-reset gets
+    # its chance first.
+    _SYNC_WEDGE_CEILING = 300  # seconds
+
+    def _acquire_sync_slot(self) -> Optional[threading.Lock]:
+        """Take the sync slot, returning the lock to release later, or None to
+        skip this cycle.
+
+        Normally a non-blocking acquire of _sync_lock. But a wedged cycle
+        (lock-ordering deadlock, or a call hung past the watchdog) holds the lock
+        forever — every later cycle would skip and sync would freeze while the
+        heartbeat keeps last_seen fresh (the device looks Active but uploads
+        nothing: Cristian Dragota / sync:67a77a43-787, 2026-06-25). The zombie
+        thread can't be killed, but it must stop blocking every future sync:
+        after _SYNC_WEDGE_CEILING we abandon it and re-arm a fresh lock.
+
+        All bookkeeping runs under _sync_takeover_lock (held briefly, never across
+        IO) so the acquire + re-arm decision is atomic. _sync_holder identifies
+        the current holder so a zombie's finally can't clear a successor's stamp.
+        """
+        with self._sync_takeover_lock:
+            lock = self._sync_lock
+            if lock.acquire(blocking=False):
+                self._sync_started_at = time.monotonic()
+                self._sync_holder = lock
+                return lock
+
+            started = self._sync_started_at
+            if started is None or time.monotonic() - started <= self._SYNC_WEDGE_CEILING:
+                return None  # a healthy in-flight cycle — just skip this tick
+
+            logger.error(
+                "Sync wedged >%ds — abandoning the stuck cycle and re-arming the "
+                "lock so syncing can resume",
+                self._SYNC_WEDGE_CEILING,
+            )
+            if self.error_reporter is not None:
+                self.error_reporter.capture(
+                    f"Sync wedged — held the sync lock >{self._SYNC_WEDGE_CEILING}s; "
+                    "re-armed to resume syncing",
+                    level="error",
+                    tags={"component": "sync-wedge"},
+                    fingerprint="sync-wedged",
+                )
+            fresh = threading.Lock()
+            fresh.acquire()
+            self._sync_lock = fresh
+            self._sync_started_at = time.monotonic()
+            self._sync_holder = fresh
+            return fresh
 
     def _do_sync(self) -> None:
         """Perform a sync cycle."""
-        if not self._sync_lock.acquire(blocking=False):
+        my_lock = self._acquire_sync_slot()
+        if my_lock is None:
             logger.debug("Sync already in progress, skipping")
             return
 
@@ -1120,6 +1187,8 @@ class SyncCoordinator:
             if stats.success or stats.events_sent > 0:
                 # A successful (or partial) sync clears the failure streak.
                 self._consecutive_sync_failures = 0
+                # Stamp the last good round-trip for the staleness telemetry.
+                self._last_successful_sync = time.monotonic()
                 # A successful authenticated round-trip means the token is fine,
                 # so any earlier 401/403 was transient — clear the auth streak.
                 self._consecutive_auth_failures = 0
@@ -1176,9 +1245,15 @@ class SyncCoordinator:
             self._set_sync_failure_state("Sync error")
             self._note_sync_failure("Sync error", exc=e)
         finally:
+            # Clear the wedge stamp only if we're still the current holder — a
+            # taken-over zombie reaching here must not wipe its successor's stamp.
+            with self._sync_takeover_lock:
+                if self._sync_holder is my_lock:
+                    self._sync_started_at = None
+                    self._sync_holder = None
             watchdog_cancelled.set()
             watchdog.cancel()
-            self._sync_lock.release()
+            my_lock.release()
 
         # Heartbeat runs AFTER _sync_lock is released — no need to hold
         # the lock during a blocking HTTP call that can take 30s on timeout.
@@ -1226,6 +1301,12 @@ class SyncCoordinator:
             "consecutive_sync_failures": self._consecutive_sync_failures,
             "idle_while_active_detections": blind_window,
         }
+        # Seconds since the last successful sync round-trip. Lets the server flag
+        # "alive but sync stale" (heartbeat fresh, uploads frozen) directly rather
+        # than inferring it from upload gaps. Omitted until the first good sync.
+        last_ok = self._last_successful_sync
+        if last_ok is not None:
+            telemetry["sync_stale_seconds"] = int(time.monotonic() - last_ok)
         try:
             telemetry.update(self.aw_manager.health_snapshot())
         except Exception as e:  # noqa: BLE001

--- a/src/sync/bf_client.py
+++ b/src/sync/bf_client.py
@@ -371,6 +371,7 @@ class BetterFlowClient(BaseApiClient):
                 "window_event_age_seconds",
                 "consecutive_sync_failures",
                 "idle_while_active_detections",
+                "sync_stale_seconds",
             ):
                 if key in health:
                     data[key] = health[key]

--- a/tests/test_sync_wedge_recovery.py
+++ b/tests/test_sync_wedge_recovery.py
@@ -1,0 +1,164 @@
+"""Tests for sync-wedge self-recovery (A) and sync-staleness telemetry (B).
+
+Origin: Cristian Dragota / sync:67a77a43-787, 2026-06-25 — the agent heartbeat
+stayed alive (last_seen fresh) while window/app uploads were frozen for ~40 min
+and only a restart cleared it. Root cause: a _do_sync that hangs past the
+watchdog holds the non-blocking _sync_lock forever, so every later cycle skips
+("Sync already in progress"). The watchdog only resets HTTP sessions — it can't
+release the lock or unblock the zombie thread, so the wedge never self-heals.
+
+A: after a hard ceiling, a new cycle abandons the stuck holder and re-arms a
+   fresh lock so syncing resumes.
+B: the heartbeat carries seconds-since-last-successful-sync so the fleet can flag
+   "alive but sync stale" directly instead of inferring it from upload gaps.
+
+Each test fails against pre-fix code (the new attrs/behaviour don't exist) and
+passes after the fix lands.
+"""
+
+import threading
+import time
+from types import SimpleNamespace
+from unittest.mock import Mock
+
+from src.config import Config
+from src.main import SyncCoordinator
+from src.reminders import ReminderManager
+from src.sync.bf_client import BetterFlowClient
+from src.sync.sync_engine import SyncEngine
+
+
+def _ok_stats():
+    """A SyncStats-shaped object that drives _do_sync down its success path."""
+    return SimpleNamespace(
+        success=True,
+        events_sent=0,
+        events_queued=0,
+        events_filtered=0,
+        gaps_filled=0,
+        errors=[],
+        aw_bucket_fetch_failed=False,
+    )
+
+
+class TestSyncWedgeRecovery:
+    """A — a wedged _do_sync no longer freezes sync forever."""
+
+    def setup_method(self):
+        self.config = Config()
+        self.aw = Mock()
+        self.aw.is_running.return_value = True
+        self.bf = Mock()
+        self.queue = Mock()
+        self.queue.get_checkpoint.return_value = None
+        self.queue.size.return_value = 0
+        self.queue.is_near_capacity.return_value = False
+        self.sync_engine = Mock(spec=SyncEngine)
+        self.sync_engine.is_paused = False
+        self.sync_engine.is_private = False
+        self.sync_engine.sync.return_value = _ok_stats()
+        self.tray = Mock()
+        self.tray.model = Mock()
+        self.tray.model.lock = threading.RLock()
+        self.aw_manager = Mock()
+        self.aw_manager.is_managing = False
+        self.reminder = Mock(spec=ReminderManager)
+        self.coord = SyncCoordinator(
+            config=self.config,
+            aw=self.aw,
+            bf=self.bf,
+            queue=self.queue,
+            sync_engine=self.sync_engine,
+            tray=self.tray,
+            aw_manager=self.aw_manager,
+            reminder_manager=self.reminder,
+        )
+        self.coord.scheduler = Mock()
+        self.coord.scheduler.running = True
+        self.coord.error_reporter = Mock()
+        # keep _do_sync's tail off the network
+        self.coord._fetch_hours_today = Mock(return_value="1:00")
+
+    def test_wedged_lock_is_taken_over_and_sync_resumes(self):
+        # Simulate a zombie cycle that grabbed the lock and never let go.
+        old = self.coord._sync_lock
+        old.acquire()
+        self.coord._sync_started_at = time.monotonic() - (
+            self.coord._SYNC_WEDGE_CEILING + 30
+        )
+        self.coord._sync_holder = old
+
+        self.coord._do_sync()
+
+        # The new cycle ran the real body despite the held lock.
+        self.sync_engine.sync.assert_called_once()
+        # The lock was re-armed (a different object) and the new cycle released it.
+        assert self.coord._sync_lock is not old
+        assert not self.coord._sync_lock.locked()
+        # The wedge was escalated for fleet visibility.
+        self.coord.error_reporter.capture.assert_called_once()
+        assert (
+            self.coord.error_reporter.capture.call_args.kwargs.get("fingerprint")
+            == "sync-wedged"
+        )
+
+        old.release()  # release the simulated zombie's (now-orphaned) lock
+
+    def test_healthy_in_progress_cycle_is_not_taken_over(self):
+        # A cycle that just started must NOT be abandoned — only a wedged one.
+        old = self.coord._sync_lock
+        old.acquire()
+        self.coord._sync_started_at = time.monotonic()
+        self.coord._sync_holder = old
+
+        self.coord._do_sync()
+
+        self.sync_engine.sync.assert_not_called()
+        assert self.coord._sync_lock is old  # not swapped
+        self.coord.error_reporter.capture.assert_not_called()
+
+        old.release()
+
+    def test_successful_sync_records_last_successful_timestamp(self):
+        assert self.coord._last_successful_sync is None
+        self.coord._do_sync()
+        assert self.coord._last_successful_sync is not None
+
+
+class TestSyncStalenessTelemetry:
+    """B — the heartbeat carries seconds-since-last-successful-sync."""
+
+    def setup_method(self):
+        self.config = Config()
+        self.sync_engine = Mock(spec=SyncEngine)
+        self.coord = SyncCoordinator(
+            config=self.config,
+            aw=Mock(),
+            bf=Mock(),
+            queue=Mock(),
+            sync_engine=self.sync_engine,
+            tray=Mock(),
+            aw_manager=Mock(),
+            reminder_manager=Mock(spec=ReminderManager),
+        )
+        self.coord.aw_manager.health_snapshot.return_value = {}
+
+    def test_health_telemetry_includes_sync_staleness(self):
+        self.coord._last_successful_sync = time.monotonic() - 42
+        tele = self.coord._build_health_telemetry()
+        assert 40 <= tele["sync_stale_seconds"] <= 70
+
+    def test_health_telemetry_omits_staleness_before_first_sync(self):
+        self.coord._last_successful_sync = None
+        tele = self.coord._build_health_telemetry()
+        assert "sync_stale_seconds" not in tele
+
+
+def test_heartbeat_forwards_sync_stale_seconds():
+    bf = BetterFlowClient(api_url="https://app.betterflow.eu/api/agent")
+    bf._request = Mock(return_value={})
+
+    bf.heartbeat(health={"sync_stale_seconds": 42})
+
+    sent = bf._request.call_args.kwargs["data"]
+    assert sent["sync_stale_seconds"] == 42


### PR DESCRIPTION
## Why

Azorel alerted on **Cristian Dragota / sync:67a77a43-787 (device 39, darwin v1.5.76)**: "upload stalled — agent active but no window/app data 15+ min, persisted across runs, tracked time frozen." He'd synced 8.32h earlier, so it was a **mid-session freeze**: heartbeat `last_seen` stayed fresh while window/app uploads were dead ~40 min, until he closed the laptop.

## Root cause (proven from code)

- One `BackgroundScheduler` runs `sync_job` and `tick_60s` as **separate jobs** — a hung `sync_job` can't stop `tick_60s`, and `_liveness_heartbeat` lives in `tick_60s`. → heartbeat alive while sync is dead.
- `_do_sync` guards with a **non-blocking** `_sync_lock.acquire(blocking=False)`, released only in `finally`. A body that blocks forever never releases it → every later cycle skips. **Permanent wedge until restart.**
- The 120s watchdog only `reset_session()`s — it can't release the lock, interrupt the hung call, or kill the zombie thread. Manual "Sync Now" can't break it either.

## Fix (trigger-independent, strictly safer)

- **A — self-recovering lock.** `_acquire_sync_slot()` (under a brief `_sync_takeover_lock`, never across IO): a holder stamps `_sync_started_at`/`_sync_holder`; a later cycle that finds the lock held past `_SYNC_WEDGE_CEILING=300s` (>2× watchdog) abandons the zombie and re-arms a fresh lock. `finally` clears the stamp only if `_sync_holder is my_lock`. Escalates via `error_reporter` (fingerprint `sync-wedged`).
- **B — staleness telemetry.** `_last_successful_sync` → `sync_stale_seconds` on the heartbeat (whitelisted in `bf_client.heartbeat`). Server consumer (internal-tool2) is a **separate follow-up**.

## Not in scope (deferred)

The exact trigger is most likely a **lock-ordering deadlock** among the fine-grained locks (all blocking, no timeout), but that's **unconfirmed pending the device's uploaded logs** (request armed). Lock-ordering hardening is deferred so we don't ship a phantom fix on the wrong pair.

## Tests

`tests/test_sync_wedge_recovery.py` holds a real lock, calls the real `_do_sync`, and asserts the lock got re-armed and the real sync body ran. Pre-fix: body skipped, `_last_successful_sync`/`sync_stale_seconds` absent → fails. Post-fix: 6/6 pass, **full suite 789 green**.