### PR TITLE
fix(window): bound AX calls + log a silent window-ingest stall

### DIFF
--- a/src/sync/macos_window_watcher.py
+++ b/src/sync/macos_window_watcher.py
@@ -12,6 +12,7 @@ import logging
 import platform
 import subprocess
 import threading
+import time
 from datetime import datetime, timezone
 from typing import Optional
 
@@ -52,6 +53,19 @@ class MacOSWindowWatcher:
     # the user having to restart the app.
     _ACCESSIBILITY_RECHECK_INTERVAL_S = 30.0
 
+    # Warn once when the watcher has posted no window heartbeat for this long
+    # while still running — surfaces a silent window-ingest stall, which was
+    # invisible in the logs during the Cristian Dragota incident (2026-06-25:
+    # window/app data went stale on the server for ~15 min while AFK/input kept
+    # flowing, with nothing in the agent log to say the window watcher had gone
+    # quiet or why).
+    _NO_EMIT_WARN_SECONDS = 90.0
+
+    # Bound each Accessibility messaging round-trip so a hung/unresponsive
+    # frontmost app can't block the poll thread inside AXUIElementCopyAttribute-
+    # Value (which would freeze window tracking with no exception and no log).
+    _AX_MESSAGING_TIMEOUT_S = 2.0
+
     def __init__(self, aw_client, poll_interval: float = 2.0):
         self._aw = aw_client
         self._poll_interval = poll_interval
@@ -73,6 +87,12 @@ class MacOSWindowWatcher:
         self._browser_cache_key: Optional[tuple[str, str]] = None
         self._browser_cache_url: Optional[str] = None
         self._browser_cache_incognito: Optional[bool] = None
+        # No-emit instrumentation: when post_heartbeat stops being called
+        # (frontmost is None, an AX error, or a blocked poll) window/app data
+        # silently goes stale on the server. Track the no-emit streak so a real
+        # gap leaves a one-shot fingerprint in the log instead of silence.
+        self._no_emit_since: Optional[float] = None
+        self._no_emit_warned: bool = False
 
     def start(self) -> bool:
         """Create the AW bucket and start the polling thread.
@@ -140,6 +160,16 @@ class MacOSWindowWatcher:
         # Get window title via Accessibility API
         title = ""
         app_ref = AXUIElementCreateApplication(pid)
+        # Bound the AX round-trips: an unresponsive frontmost app can otherwise
+        # block AXUIElementCopyAttributeValue and freeze this poll thread with no
+        # exception (silent window stall). The symbol is absent on some PyObjC
+        # builds, so guard it and fall back to the system default timeout.
+        try:
+            from ApplicationServices import AXUIElementSetMessagingTimeout
+
+            AXUIElementSetMessagingTimeout(app_ref, self._AX_MESSAGING_TIMEOUT_S)
+        except Exception:
+            pass
         err, focused_window = AXUIElementCopyAttributeValue(
             app_ref, "AXFocusedWindow", None,
         )
@@ -283,6 +313,10 @@ class MacOSWindowWatcher:
                     self._poll_once()
             except Exception as e:
                 logger.warning(f"Window watcher poll error: {e}")
+                # A raising poll also produces no heartbeat — count it toward the
+                # no-emit streak so a persistent failure escalates to the stall
+                # warning instead of just per-poll noise.
+                self._note_no_emit(f"poll error: {e}")
 
     def _maybe_log_accessibility_transition(self) -> None:
         """Re-check AXIsProcessTrusted() occasionally and log when the
@@ -311,10 +345,38 @@ class MacOSWindowWatcher:
             )
         self._last_accessibility = trusted
 
+    def _note_emit(self) -> None:
+        """A window heartbeat was posted — clear any no-emit streak (and log a
+        one-line recovery if we'd previously warned about a stall)."""
+        if self._no_emit_warned and self._no_emit_since is not None:
+            logger.info(
+                "Window watcher resumed posting after %.0fs of no window events",
+                time.monotonic() - self._no_emit_since,
+            )
+        self._no_emit_since = None
+        self._no_emit_warned = False
+
+    def _note_no_emit(self, reason: str) -> None:
+        """A poll produced no window heartbeat. Warn once when the gap crosses
+        the threshold so a silent window-ingest stall is diagnosable on the next
+        occurrence (Cristian Dragota, 2026-06-25)."""
+        now = time.monotonic()
+        if self._no_emit_since is None:
+            self._no_emit_since = now
+        gap = now - self._no_emit_since
+        if not self._no_emit_warned and gap >= self._NO_EMIT_WARN_SECONDS:
+            self._no_emit_warned = True
+            logger.warning(
+                "Window watcher has posted no window event for %.0fs (%s) — "
+                "window/app data is going stale on the server while the agent runs",
+                gap, reason,
+            )
+
     def _poll_once(self) -> None:
         """Single poll iteration: get active window, post heartbeat."""
         data = self._get_active_window()
         if not data or not data.get("app"):
+            self._note_no_emit("no frontmost app")
             return
 
         heartbeat_data = {
@@ -331,3 +393,4 @@ class MacOSWindowWatcher:
             self._bucket_id, timestamp, heartbeat_data,
             pulsetime=self._poll_interval + 1.0,
         )
+        self._note_emit()

--- a/tests/test_window_watcher_noemit.py
+++ b/tests/test_window_watcher_noemit.py
@@ -1,0 +1,93 @@
+"""Tests for MacOSWindowWatcher no-emit instrumentation + emit wiring.
+
+Origin: Cristian Dragota / sync:67a77a43-787, 2026-06-25 — window/app data went
+stale on the server for ~15 min while AFK/input kept flowing, and the agent log
+said NOTHING about the window watcher going quiet. These tests cover the new
+instrumentation that makes such a stall leave a one-shot fingerprint, and verify
+_poll_once records emit / no-emit on both paths.
+
+The module imports PyObjC only inside functions, so it imports fine off-macOS and
+the no-emit bookkeeping is unit-testable without a real window server.
+"""
+
+import logging
+from unittest.mock import Mock, patch
+
+from src.sync.macos_window_watcher import MacOSWindowWatcher
+
+
+def _watcher():
+    return MacOSWindowWatcher(Mock(), poll_interval=2.0)
+
+
+def test_no_emit_warns_once_after_threshold_then_recovers(caplog):
+    w = _watcher()
+    with patch("src.sync.macos_window_watcher.time.monotonic") as mono:
+        with caplog.at_level(logging.WARNING):
+            mono.return_value = 100.0
+            w._note_no_emit("no frontmost app")  # streak starts
+
+            mono.return_value = 100.0 + 89  # under the 90s threshold
+            w._note_no_emit("no frontmost app")
+            assert not any("no window event" in r.getMessage() for r in caplog.records)
+
+            mono.return_value = 100.0 + 95  # crosses the threshold
+            w._note_no_emit("no frontmost app")
+            warns = [r for r in caplog.records if "no window event" in r.getMessage()]
+            assert len(warns) == 1
+            assert "no frontmost app" in warns[0].getMessage()
+
+            # Further no-emits must NOT re-warn (one-shot per streak).
+            mono.return_value = 100.0 + 300
+            w._note_no_emit("no frontmost app")
+            warns = [r for r in caplog.records if "no window event" in r.getMessage()]
+            assert len(warns) == 1
+
+        with caplog.at_level(logging.INFO):
+            caplog.clear()
+            mono.return_value = 100.0 + 310
+            w._note_emit()  # a real heartbeat lands
+            assert any("resumed posting" in r.getMessage() for r in caplog.records)
+
+            # Streak reset: a fresh gap can warn again.
+            caplog.clear()
+            mono.return_value = 1000.0
+            w._note_no_emit("no frontmost app")
+            mono.return_value = 1000.0 + 95
+            w._note_no_emit("no frontmost app")
+            assert any("no window event" in r.getMessage() for r in caplog.records)
+
+
+def test_emit_without_prior_warning_is_silent(caplog):
+    w = _watcher()
+    with patch("src.sync.macos_window_watcher.time.monotonic", return_value=5.0), caplog.at_level(
+        logging.INFO
+    ):
+        w._note_emit()  # healthy steady state — no recovery line
+        assert not any("resumed posting" in r.getMessage() for r in caplog.records)
+
+
+def test_poll_once_records_no_emit_when_no_frontmost_app():
+    w = _watcher()
+    w._get_active_window = Mock(return_value=None)
+    w._note_no_emit = Mock()
+    w._note_emit = Mock()
+
+    w._poll_once()
+
+    w._note_no_emit.assert_called_once()
+    w._note_emit.assert_not_called()
+    w._aw.post_heartbeat.assert_not_called()
+
+
+def test_poll_once_records_emit_when_a_window_is_posted():
+    w = _watcher()
+    w._get_active_window = Mock(return_value={"app": "Google Chrome", "title": "x"})
+    w._note_no_emit = Mock()
+    w._note_emit = Mock()
+
+    w._poll_once()
+
+    w._aw.post_heartbeat.assert_called_once()
+    w._note_emit.assert_called_once()
+    w._note_no_emit.assert_not_called()


### PR DESCRIPTION
## Why
**Cristian Dragota (sync:67a77a43-787), 2026-06-25**: window/app data went stale on the server for ~15 min while AFK/input kept flowing (9.80h still collected — no billing lost, but the per-app breakdown for that span was missing). The agent log said **nothing** about the window watcher going quiet — so the root cause was unchaseable. This closes the two reasons it could go silent.

## Changes
1. **Bound the Accessibility call.** `_get_active_window()` called `AXUIElementCopyAttributeValue` with no messaging timeout, so an unresponsive frontmost app can block the poll thread indefinitely (no exception, no log). Now sets `AXUIElementSetMessagingTimeout(app_ref, 2s)`, guarded for PyObjC builds that lack the symbol.

2. **Make the silence loud.** `_poll_once` posts a (merge-extended) AW heartbeat only when there's a frontmost app; the no-post paths (frontmost `None`, AX error, raising poll) recorded nothing. Now a no-emit streak is tracked and, past **90s**, logs a one-shot `WARNING` naming the reason, with an `INFO` recovery line when posting resumes.

No change to what's tracked — a blocking-call guard + diagnostics.

## Scope
The window-source stall **root cause** (why frontmost/AX went quiet) stays open by design — it's only chaseable with this logging on a fresh occurrence, which is what this adds. (Heartbeat-merge semantics mean a *static* window stays fresh, so the stall required `post_heartbeat` to actually stop — exactly the paths now instrumented.)

## Tests
`tests/test_window_watcher_noemit.py`: threshold warns once → recovers → re-arms; `_poll_once` records emit/no-emit on both paths. **All 4 fail pre-fix** (helpers don't exist / aren't wired). Full suite **793 green**, ruff clean.