### PR TITLE
fix(sync): name the cause when window events are produced but all filtered

### DIFF
--- a/src/sync/sync_engine.py
+++ b/src/sync/sync_engine.py
@@ -98,6 +98,16 @@ class SyncStats:
     buckets_synced: int = 0
     gaps_filled: int = 0
     calls_detected: int = 0
+    # Window-filter diagnostics: separate "the watcher produced nothing"
+    # (v1.5.83 logs that watcher-side) from "the watcher produced window events
+    # but the privacy filter dropped them all" (this side). window_seen = window
+    # events read from AW this cycle; window_sent = those that survived filtering;
+    # the drop sets/counter name WHY (which excluded app, or how many sub-minimum
+    # flickers) so the next stall classifies itself (Cristian Dragota, 2026-06-25).
+    window_seen: int = 0
+    window_sent: int = 0
+    window_drop_excluded_apps: set = field(default_factory=set)
+    window_drop_short: int = 0
     errors: list[str] = field(default_factory=list)
     queued_bucket_ids: set = field(default_factory=set)
     _should_heartbeat: bool = False
@@ -272,6 +282,14 @@ class SyncEngine:
         # Dedicated lock for all BoundedLRU caches (ops are multi-step and
         # touched from the sync thread plus heartbeat thread).
         self._cache_lock = threading.Lock()
+
+        # Window-filter streak: consecutive sync cycles where the watcher produced
+        # window events but the privacy filter dropped them ALL (window_seen>0,
+        # window_sent==0). Distinguishes "produced-but-filtered" from the
+        # watcher-quiet case (v1.5.83 logs that watcher-side). Single-threaded
+        # (only _do_sync touches it via sync()), so no lock needed.
+        self._window_filter_streak: int = 0
+        self._window_filter_warned: bool = False
 
         # App category cache — avoids SQLite lookups on every event.
         # Populated lazily; invalidated when categories are refreshed.
@@ -660,7 +678,57 @@ class SyncEngine:
                 self._heartbeat_count = 0
         stats._should_heartbeat = should_heartbeat
 
+        self._assess_window_filter(stats)
+
         return stats
+
+    # Warn after this many consecutive cycles where window events were produced
+    # but the filter dropped them all. At a 5-min sync interval this is ~15 min,
+    # matching the server's window-ingest-stall threshold; at 1-min, ~3 min.
+    _WINDOW_FILTER_WARN_CYCLES = 3
+
+    def _assess_window_filter(self, stats: SyncStats) -> None:
+        """Classify a 'no window data on the server' gap as filter-side.
+
+        When the watcher produced window events this cycle (window_seen>0) but
+        the privacy filter dropped them all (window_sent==0), the server sees
+        window/app data go stale even though the watcher is healthy — so the
+        watcher-side warning (v1.5.83) stays silent. After a sustained streak,
+        warn once and NAME the cause (which excluded app, or sub-minimum
+        flickers) so the next occurrence classifies itself instead of being a
+        third indistinguishable silence (Cristian Dragota, 2026-06-25).
+        """
+        produced_but_filtered = stats.window_seen > 0 and stats.window_sent == 0
+        if not produced_but_filtered:
+            if self._window_filter_warned:
+                logger.info(
+                    "Window/app events are reaching the server again "
+                    "(filter no longer dropping them all)"
+                )
+            self._window_filter_streak = 0
+            self._window_filter_warned = False
+            return
+
+        self._window_filter_streak += 1
+        if self._window_filter_warned or self._window_filter_streak < self._WINDOW_FILTER_WARN_CYCLES:
+            return
+        self._window_filter_warned = True
+        if stats.window_drop_excluded_apps:
+            cause = "excluded app(s) frontmost: " + ", ".join(sorted(stats.window_drop_excluded_apps))
+        elif stats.window_drop_short:
+            cause = (
+                f"{stats.window_drop_short} window event(s) under the "
+                f"{self.config.sync.min_window_event_seconds:.0f}s minimum (flicker filter)"
+            )
+        else:
+            cause = "all window events filtered (dedup / zero-duration)"
+        logger.warning(
+            "Window/app data has gone stale on the server across %d cycles — the "
+            "watcher IS producing window events but the filter is dropping them all "
+            "(%s). Billing is unaffected (AFK/input still upload); only per-app "
+            "attribution is lost for this span.",
+            self._window_filter_streak, cause,
+        )
 
     def _prepare_input_analysis(self, input_buckets: list) -> _SyncCycleContext:
         """Fetch recent input events, feed the activity analyzer, and return a
@@ -1090,7 +1158,9 @@ class SyncEngine:
                 stats.events_filtered += 1
                 continue
 
-            if _is_window_like(bucket_type):
+            is_window = _is_window_like(bucket_type)
+            if is_window:
+                stats.window_seen += 1
                 transformed_events = self._transform_window_event_with_timeout(
                     event, bucket_id, bucket_type, cycle
                 )
@@ -1104,8 +1174,19 @@ class SyncEngine:
                 transformed.extend(transformed_events)
                 with self._cache_lock:
                     self._sent_cache[cache_key] = event.duration
+                if is_window:
+                    stats.window_sent += 1
             else:
                 stats.events_filtered += 1
+                # Attribute a dropped WINDOW event so a "no window data" stall can
+                # be classified as filter-side (vs the watcher going quiet). The
+                # reasons mirror _transform_event's drop conditions.
+                if is_window:
+                    app = event.app
+                    if app and app in self.config.privacy.exclude_apps:
+                        stats.window_drop_excluded_apps.add(app)
+                    elif event.duration < self.config.sync.min_window_event_seconds:
+                        stats.window_drop_short += 1
 
         # Batch fraud assessment: one call per cycle instead of per-event.
         # The fraud detector's underlying data changes once per record_window_metrics()

--- a/tests/test_sync_engine.py
+++ b/tests/test_sync_engine.py
@@ -12,7 +12,7 @@ from src.reminders import ReminderManager
 from src.sync.activity_analyzer import ActivityAnalyzer
 from src.sync.aw_client import BUCKET_TYPE_AFK, BUCKET_TYPE_INPUT, BUCKET_TYPE_WINDOW, AWEvent
 from src.sync.daily_time_tracker import DailyTimeTracker
-from src.sync.sync_engine import SyncEngine, _SyncCycleContext
+from src.sync.sync_engine import SyncEngine, SyncStats, _SyncCycleContext
 from src.ui.tray import TrayState
 
 
@@ -189,7 +189,7 @@ class TestSyncEngine:
             duration=90.0,
             data={"app": "Terminal", "title": "Work"},
         )
-        stats = Mock(events_filtered=0)
+        stats = SyncStats()
 
         transformed, checkpoint = self.engine._transform_and_checkpoint(
             [event],
@@ -219,7 +219,7 @@ class TestSyncEngine:
             duration=60.0,
             data={"app": "Terminal", "title": "Work"},
         )
-        stats = Mock(events_filtered=0)
+        stats = SyncStats()
 
         transformed, _ = self.engine._transform_and_checkpoint(
             [event],
@@ -246,7 +246,7 @@ class TestSyncEngine:
             duration=20 * 60.0,
             data={"app": "Terminal", "title": "Work"},
         )
-        stats = Mock(events_filtered=0)
+        stats = SyncStats()
 
         transformed, _ = self.engine._transform_and_checkpoint(
             [event],
@@ -273,7 +273,7 @@ class TestSyncEngine:
             duration=120.0,
             data={"app": "Terminal", "title": "Work"},
         )
-        stats = Mock(events_filtered=0)
+        stats = SyncStats()
 
         transformed, _ = self.engine._transform_and_checkpoint(
             [event],
@@ -331,7 +331,7 @@ class TestSyncEngine:
             duration=300.0,
             data={"app": "Terminal", "title": "Work"},
         )
-        stats = Mock(events_filtered=0)
+        stats = SyncStats()
 
         transformed, _ = self.engine._transform_and_checkpoint(
             [event],

--- a/tests/test_window_filter_signal.py
+++ b/tests/test_window_filter_signal.py
@@ -1,0 +1,90 @@
+"""Tests for the per-reason window-filter signal (_assess_window_filter).
+
+Origin: Cristian Dragota / sync:67a77a43-787, 2026-06-25 — the server saw window/
+app data go stale while AFK/input uploaded normally. Two ways that happens:
+the watcher went quiet (v1.5.83 logs that watcher-side), OR the watcher produced
+window events but the privacy filter dropped them all (excluded app frontmost, or
+sub-minimum flickers). This signal names the latter so the next occurrence
+classifies itself instead of being an indistinguishable silence.
+
+These drive _assess_window_filter directly with crafted SyncStats — no AW/network
+needed. Each fails pre-fix (the method + counters don't exist).
+"""
+
+import logging
+from unittest.mock import Mock
+
+from src.config import Config
+from src.sync.sync_engine import SyncEngine, SyncStats
+
+
+def _engine():
+    return SyncEngine(aw=Mock(), bf=Mock(), queue=Mock(), config=Config())
+
+
+def _filtered_stats(*, excluded=None, short=0):
+    s = SyncStats()
+    s.window_seen = 1
+    s.window_sent = 0
+    if excluded:
+        s.window_drop_excluded_apps.update(excluded)
+    s.window_drop_short = short
+    return s
+
+
+def test_warns_after_streak_naming_the_excluded_app(caplog):
+    eng = _engine()
+    with caplog.at_level(logging.WARNING):
+        for _ in range(eng._WINDOW_FILTER_WARN_CYCLES - 1):
+            eng._assess_window_filter(_filtered_stats(excluded={"1Password"}))
+        assert not any("dropping them all" in r.getMessage() for r in caplog.records)
+
+        eng._assess_window_filter(_filtered_stats(excluded={"1Password"}))
+        warns = [r for r in caplog.records if "dropping them all" in r.getMessage()]
+        assert len(warns) == 1
+        assert "1Password" in warns[0].getMessage()
+        assert "Billing is unaffected" in warns[0].getMessage()
+
+        # One-shot: further filtered cycles don't re-warn.
+        eng._assess_window_filter(_filtered_stats(excluded={"1Password"}))
+        warns = [r for r in caplog.records if "dropping them all" in r.getMessage()]
+        assert len(warns) == 1
+
+
+def test_short_flicker_cause_is_named(caplog):
+    eng = _engine()
+    with caplog.at_level(logging.WARNING):
+        for _ in range(eng._WINDOW_FILTER_WARN_CYCLES):
+            eng._assess_window_filter(_filtered_stats(short=4))
+        warns = [r for r in caplog.records if "dropping them all" in r.getMessage()]
+        assert len(warns) == 1
+        assert "minimum" in warns[0].getMessage()  # "...under the 5s minimum (flicker filter)"
+
+
+def test_healthy_cycle_resets_streak_and_logs_recovery(caplog):
+    eng = _engine()
+    with caplog.at_level(logging.INFO):
+        for _ in range(eng._WINDOW_FILTER_WARN_CYCLES):
+            eng._assess_window_filter(_filtered_stats(excluded={"Keychain Access"}))
+        assert eng._window_filter_warned is True
+
+        healthy = SyncStats()
+        healthy.window_seen = 2
+        healthy.window_sent = 2
+        eng._assess_window_filter(healthy)
+
+        assert eng._window_filter_streak == 0
+        assert eng._window_filter_warned is False
+        assert any("reaching the server again" in r.getMessage() for r in caplog.records)
+
+
+def test_no_window_events_does_not_trip_filter_signal(caplog):
+    # window_seen == 0 is the watcher-quiet case (v1.5.83's signal), NOT a filter
+    # drop — it must not accumulate the filter streak.
+    eng = _engine()
+    with caplog.at_level(logging.WARNING):
+        empty = SyncStats()  # window_seen == 0, window_sent == 0
+        for _ in range(eng._WINDOW_FILTER_WARN_CYCLES + 2):
+            eng._assess_window_filter(empty)
+        assert eng._window_filter_streak == 0
+        assert not any("dropping them all" in r.getMessage() for r in caplog.records)


### PR DESCRIPTION
## Why
v1.5.83 made a **watcher-quiet** window stall loud on the watcher side. But the other half — the watcher **produces** window events and the privacy filter **drops them all** before upload — was still invisible: those drops only ticked the combined `events_filtered` counter with no per-reason / per-app detail. So a "no window/app data on the server" gap (**Cristian Dragota, 2026-06-25**) had three indistinguishable causes: watcher quiet, produced-but-filtered, or a real upload stall.

## Change
- `SyncStats` now tracks `window_seen` / `window_sent` per cycle, plus **why** window events were dropped: `window_drop_excluded_apps` (which app) and `window_drop_short` (sub-`min_window_event_seconds` flickers).
- `_assess_window_filter` runs once per cycle. When `window_seen>0 && window_sent==0` (produced but all filtered) for **3 consecutive cycles** (≈15 min at a 5-min interval — matches the server's window-ingest-stall threshold), it logs one `WARNING` **naming the cause**, with an `INFO` recovery line when window events flow again.
- `window_seen==0` is the **watcher-quiet** case (v1.5.83's signal), so it **resets** this streak instead of tripping it — the two signals stay cleanly separated. Next stall now classifies itself: watcher-quiet vs filtered-out(named app) vs upload stall.
- The warning states explicitly that **billing is unaffected** (AFK/input still upload); only per-app attribution is lost.

## Tests
`tests/test_window_filter_signal.py` drives `_assess_window_filter` with crafted `SyncStats`: streak warns once naming the app, short-flicker cause named, reset + recovery, and `window_seen==0` does **not** trip it. All fail pre-fix (method + counters absent). Migrated 5 `_transform_and_checkpoint` tests off a fragile `Mock(events_filtered=0)` to real `SyncStats()`. **Full suite 797 green**; ruff adds nothing (pre-existing N812/I001/B905 only).