### PR TITLE
feat: stop collecting outside enforced working hours (capture gate)

### DIFF
--- a/src/__init__.py
+++ b/src/__init__.py
@@ -1,4 +1,4 @@
 """BetterFlow - ActivityWatch to BetterFlow sync companion app."""
 
-__version__ = "1.5.85-beta.2"
+__version__ = "1.5.85-beta.3"
 __author__ = "BetterQA"

--- a/src/__init__.py
+++ b/src/__init__.py
@@ -1,4 +1,4 @@
 """BetterFlow - ActivityWatch to BetterFlow sync companion app."""
 
-__version__ = "1.5.85-beta.3"
+__version__ = "1.5.85-beta.4"
 __author__ = "BetterQA"

--- a/src/aw_manager.py
+++ b/src/aw_manager.py
@@ -473,6 +473,57 @@ class AWManager:
         with self._lifecycle_lock:
             self._disabled_components.add(name)
 
+    def suspend_watcher(self, name: str) -> None:
+        """Stop a managed watcher AND disable it so the watchdog won't revive it.
+
+        Used by the working-hours capture gate to stop the subprocess window
+        tracker (Windows/Linux) outside enforced hours, so no window titles are
+        recorded even locally. Disabling first means restart_if_needed and
+        _start_locked both skip it (they honour _disabled_components), so the
+        terminate below can't race a restart. No-op on macOS where the
+        subprocess tracker is already disabled in favour of the in-process
+        watcher. Mirrors _stop_idle_tracker_locked; reaps orphans so a killed
+        process can't keep posting to the bucket."""
+        with self._lifecycle_lock:
+            self._disabled_components.add(name)
+            proc = self._processes.pop(name, None)
+            if proc is not None and proc.poll() is None:
+                logger.info("Suspending %s (outside working hours)", name)
+                proc.terminate()
+                try:
+                    proc.wait(timeout=SHUTDOWN_TIMEOUT)
+                except subprocess.TimeoutExpired:
+                    proc.kill()
+            binaries_dir = self._get_binaries_dir()
+            if binaries_dir:
+                self._reap_orphan_processes(name, binaries_dir)
+
+    def resume_watcher(self, name: str) -> None:
+        """Re-enable a previously suspended watcher and (re)start it.
+
+        The inverse of suspend_watcher: clears the disabled flag so the watchdog
+        supervises it again, then starts a fresh process if the stack is up. A
+        no-op if the watcher wasn't suspended by us (e.g. macOS, where the
+        subprocess tracker stays disabled by design — clearing it here would be
+        wrong, so we only restart when it had actually been suspended)."""
+        with self._lifecycle_lock:
+            if name not in self._disabled_components:
+                return  # not suspended by us — nothing to resume
+            self._disabled_components.discard(name)
+            if not self._processes:
+                # Stack not started yet (pre-launch reconcile); start() will
+                # bring it up with the rest now that it's re-enabled.
+                return
+            existing = self._processes.get(name)
+            if existing is not None and existing.poll() is None:
+                return  # already running
+            binaries_dir = self._get_binaries_dir()
+            if not binaries_dir:
+                return
+            logger.info("Resuming %s (back inside working hours)", name)
+            self._reap_orphan_processes(name, binaries_dir)
+            self._start_component(name, binaries_dir)
+
     @property
     def is_managing(self) -> bool:
         """True when we own at least one tracker process to supervise.

--- a/src/config.py
+++ b/src/config.py
@@ -9,9 +9,11 @@ import sys
 import threading
 import uuid
 from dataclasses import dataclass, field, fields as dc_fields, asdict
+from datetime import datetime
 from logging.handlers import RotatingFileHandler
 from pathlib import Path
 from typing import Optional
+from zoneinfo import ZoneInfo
 
 from platformdirs import user_config_dir, user_data_dir, user_log_dir
 
@@ -413,6 +415,32 @@ class WorkingHoursConfig:
     working_days: list = field(default_factory=lambda: [1, 2, 3, 4, 5, 6, 7])
     timezone: str = ""
 
+    def enforces(self) -> bool:
+        """True only when the server restricts the time-of-day window. The single
+        gate for every out-of-hours decision (capture suspension AND the upload
+        filter) so they can never disagree about whether a user is restricted."""
+        return bool(self.enforced)
+
+    def is_within_window(self, dt: datetime) -> bool:
+        """True if the aware datetime ``dt`` falls inside the working-hours
+        window, evaluated in the schedule's timezone (falling back to the
+        machine's local timezone when none is set). Independent of ``enforced``
+        — callers must check :meth:`enforces` first. Naive datetimes are treated
+        as UTC. Overnight windows (work_end <= work_start) are not supported,
+        mirroring the server, which rejects them on save."""
+        try:
+            tz = ZoneInfo(self.timezone) if self.timezone else None
+        except Exception:
+            tz = None
+        if dt.tzinfo is None:
+            from datetime import timezone as _tz
+            dt = dt.replace(tzinfo=_tz.utc)
+        local = dt.astimezone(tz) if tz else dt.astimezone()
+        if self.working_days and local.isoweekday() not in self.working_days:
+            return False
+        hhmm = local.strftime("%H:%M")
+        return self.work_start <= hhmm <= self.work_end
+
 
 @dataclass
 class Config:
@@ -496,6 +524,12 @@ class Config:
         fraud_detection_data = data.pop("fraud_detection", {})
         call_detection_data = data.pop("call_detection", {})
         foreground_activity_data = data.pop("foreground_activity", {})
+        # Pop working_hours so it's reconstructed as a WorkingHoursConfig below.
+        # Without this it fell through the generic **data path as a raw dict, so
+        # getattr(wh, "enforced") read False on every restart — the persisted
+        # schedule was silently lost, defeating fail-closed launch (the agent
+        # forgot it was restricted until the first post-login server fetch).
+        working_hours_data = data.pop("working_hours", {})
         data.pop("screenshots", None)
 
         # Migrate legacy localhost:8000 URLs to production endpoint.
@@ -521,6 +555,7 @@ class Config:
             fraud_detection=_safe(FraudDetectionConfig, fraud_detection_data) if fraud_detection_data else FraudDetectionConfig(),
             call_detection=_safe(CallDetectionSettings, call_detection_data) if call_detection_data else CallDetectionSettings(),
             foreground_activity=_safe(ForegroundActivitySettings, foreground_activity_data) if foreground_activity_data else ForegroundActivitySettings(),
+            working_hours=_safe(WorkingHoursConfig, working_hours_data) if working_hours_data else WorkingHoursConfig(),
             **{k: v for k, v in data.items() if k in cls.__dataclass_fields__},
         )
 

--- a/src/main.py
+++ b/src/main.py
@@ -43,6 +43,7 @@ try:
     from .hours_tracker import HoursTracker
     from .update_handler import UpdateHandler
     from .system_event_handler import SystemEventHandler
+    from .work_schedule_gate import WorkScheduleGate
 except ImportError:
     from src import __version__
     from auth import KeychainManager, LoginManager
@@ -68,6 +69,7 @@ except ImportError:
     from hours_tracker import HoursTracker
     from update_handler import UpdateHandler
     from system_event_handler import SystemEventHandler
+    from work_schedule_gate import WorkScheduleGate
 
 # Import send_notification at module level so tests can patch src.main.send_notification
 try:
@@ -227,6 +229,11 @@ class SyncCoordinator:
         # is hit (the engine/tray/paused-flag teardown lives on the app). Called
         # with the elapsed seconds. None until wired (e.g. in tests).
         self.on_private_auto_end: Optional[Callable[[float], None]] = None
+        # Wired by BetterFlowApp: re-evaluate the working-hours capture gate every
+        # tick (suspend capture outside enforced hours, auto-resume on re-entry).
+        # The watcher/engine teardown lives on the app; the coordinator only
+        # triggers the check. None in tests / unrestricted setups.
+        self.on_schedule_gate: Optional[Callable[[], None]] = None
 
         # In-process input watcher reference, wired by the App after
         # construction. Used by `_check_idle_tracker_health` to cross-check
@@ -864,6 +871,11 @@ class SyncCoordinator:
         for fn, label in (
             (self._reconcile_inproc_afk_flag, "inproc_afk_reconcile"),
             (self.tray.tick_clock, "tick_clock"),
+            # Working-hours gate runs BEFORE the idle check: outside enforced
+            # hours it suspends capture outright, so the idle logic never needs
+            # to reason about a window it shouldn't be tracking in. On re-entry
+            # it resumes; idle then re-evaluates normally in the same tick.
+            (self._check_schedule_gate, "schedule_gate"),
             (self._check_idle_status, "idle_check"),
             (self._liveness_heartbeat, "liveness_heartbeat"),
             (self._refresh_hours_today, "hours_refresh"),
@@ -958,6 +970,14 @@ class SyncCoordinator:
         if eng.afk_source is None:
             return
         self.aw_manager.set_inproc_afk_active(eng.inproc_afk_active)
+
+    def _check_schedule_gate(self) -> None:
+        """Re-evaluate the working-hours capture gate (no-op until the app wires
+        on_schedule_gate). Only meaningful while logged in — a logged-out agent
+        isn't capturing anything to gate."""
+        if not self.logged_in or self.on_schedule_gate is None:
+            return
+        self.on_schedule_gate()
 
     def _check_idle_status(self) -> None:
         self.idle_mgr.check_idle_status(
@@ -1401,6 +1421,15 @@ class BetterFlowApp:
         self.config = Config.load()
         setup_logging(self.config.debug_mode)
 
+        # Working-hours capture gate. Built from the persisted schedule (restored
+        # by Config.load) so the launch decision below is correct BEFORE the
+        # first post-login server fetch — a returning restricted user who opens
+        # their laptop at night never starts capturing. Refreshed each 60s tick
+        # and right after every server-config fetch.
+        self.schedule_gate = WorkScheduleGate(self.config)
+        self._schedule_lock = threading.Lock()
+        self._schedule_suspended = False
+
         logger.info("BetterFlow starting...")
         logger.info(f"Using API URL: {self.config.api_url}")
 
@@ -1436,8 +1465,11 @@ class BetterFlowApp:
             self.display_tracker = None
 
         # Active browser-tab URL tracker (macOS). Off unless enabled; without it
-        # browser events carry no URL and collapse to generic "browsing".
-        if self.config.privacy.track_browser_urls:
+        # browser events carry no URL and collapse to generic "browsing". Also
+        # held back when launched outside enforced working hours — reading the
+        # active tab's URL is exactly the out-of-hours collection the gate must
+        # prevent. The gate starts it on re-entry (_start_capture_watchers).
+        if self.config.privacy.track_browser_urls and self.schedule_gate.collection_allowed():
             self.browser_tracker = start_browser_tracker()
         else:
             self.browser_tracker = None
@@ -1489,6 +1521,7 @@ class BetterFlowApp:
             on_check_update=lambda: self.update_handler._periodic_update_check(),
             on_tray_died=self._on_tray_died,
             on_show_hours=self._on_show_hours,
+            on_work_outside_hours=self._on_work_outside_hours,
         )
         self.tray.set_config(self.config)
 
@@ -1515,6 +1548,7 @@ class BetterFlowApp:
         )
         self.coordinator._on_auth_error = self._on_session_expired
         self.coordinator.on_private_auto_end = self._auto_end_private
+        self.coordinator.on_schedule_gate = self._apply_schedule_gate
         self.coordinator._input_watcher = self.input_watcher
         # The idle manager uses the same in-process watcher as an authoritative
         # override so a blind/stuck bf-idle-tracker can't paint live work as
@@ -1593,7 +1627,12 @@ class BetterFlowApp:
             if not check_accessibility() or not check_input_monitoring():
                 logger.info("Missing macOS permissions, attempting TCC grant")
                 grant_tcc_permissions()
-        if self.window_watcher:
+        # Window titles are personal content — don't start the window watcher
+        # when launched outside enforced hours (the gate resumes it on re-entry).
+        # The input watcher only records input-occurred timing (no content) and
+        # is left running: idle detection needs it, and restarting the macOS
+        # input watcher has proven unreliable.
+        if self.window_watcher and self.schedule_gate.collection_allowed():
             self.window_watcher.start()
         if self.input_watcher:
             self.input_watcher.start()
@@ -1647,6 +1686,13 @@ class BetterFlowApp:
         except Exception:
             logger.exception("Failed to fetch server configuration during startup")
 
+        # Reconcile capture against the freshly-fetched schedule: a launch
+        # decision made from the persisted (possibly stale) schedule is corrected
+        # here the moment the server's truth lands — e.g. a brand-new install
+        # whose disk config defaulted to unrestricted but is actually restricted
+        # + currently out-of-hours gets suspended now, not 60s later.
+        self._apply_schedule_gate()
+
         self.coordinator.fetch_projects()
         self._check_stale_session()
         self.coordinator.start()
@@ -1677,6 +1723,23 @@ class BetterFlowApp:
                 return
 
             self._set_startup_status("Starting trackers...")
+            # Fail-closed launch: if we're starting outside the enforced window,
+            # mark the gate suspended and pre-disable the subprocess window
+            # tracker (Windows/Linux) BEFORE the stack comes up, so it never
+            # records a single out-of-hours window title. macOS uses the
+            # in-process watcher, held back in _start_watchers below. The first
+            # post-login tick (and the reconcile after fetch_server_config)
+            # resumes everything the moment we're back inside hours.
+            if not self.schedule_gate.collection_allowed():
+                with self._schedule_lock:
+                    self._schedule_suspended = True
+                logger.info("Launched outside working hours — capture suspended until the work window")
+                if sys.platform != "darwin":
+                    self.aw_manager.suspend_watcher("bf-window-tracker")
+                try:
+                    self.sync_engine.pause()
+                except Exception:
+                    logger.exception("Launch suspend: engine pause failed")
             self.aw_manager.start()
             if self._shutdown_event.is_set():
                 return
@@ -2187,6 +2250,149 @@ class BetterFlowApp:
                 self.reminder_manager.on_tracking_started()
         if paused:
             self._try_auto_install()
+
+    # ── Working-hours capture gate ──────────────────────────────────────
+    def _is_user_paused(self) -> bool:
+        """Whether the user has an explicit pause/private active. Read under the
+        shared pause lock so a schedule-resume can't clobber a manual pause."""
+        with self._pause_state_lock:
+            return bool(getattr(self.sys_events, "_user_paused", False))
+
+    def _apply_schedule_gate(self) -> None:
+        """Edge-triggered: suspend capture when we leave the enforced window,
+        resume it when we re-enter (or the override is armed). Safe to call every
+        tick and after every config fetch — it only acts on a state change, so it
+        never fights the idle/manual/break pause sources, and it refreshes the
+        tray's "work outside hours" hint each call. Unrestricted users never trip
+        it (collection_allowed is always True for them)."""
+        try:
+            allowed = self.schedule_gate.collection_allowed()
+        except Exception:
+            logger.exception("Schedule-gate decision failed; leaving capture unchanged")
+            return
+
+        with self._schedule_lock:
+            was_suspended = self._schedule_suspended
+            transition = None
+            if not allowed and not was_suspended:
+                self._schedule_suspended = True
+                transition = "suspend"
+            elif allowed and was_suspended:
+                self._schedule_suspended = False
+                transition = "resume"
+
+        if transition == "suspend":
+            self._suspend_capture_for_schedule()
+        elif transition == "resume":
+            self._resume_capture_for_schedule()
+        elif not allowed:
+            # Steady out-of-hours with no edge — e.g. launched outside the window
+            # (suspended pre-login) and the user has now logged in. The capture
+            # was already held back at launch; just make sure the tray reflects
+            # it (no notification — that's only for the suspend edge).
+            self.tray.set_state(TrayState.PAUSED, "Outside working hours")
+
+        # The override item can appear/disappear without a suspend/resume edge
+        # (e.g. while steadily outside hours), so refresh the hint every call.
+        try:
+            self.tray.set_schedule_state(
+                suspended=not allowed,
+                offer_override=self.schedule_gate.should_offer_override(),
+            )
+        except Exception:
+            logger.debug("Tray schedule-state update failed", exc_info=True)
+
+    def _stop_capture_watchers(self) -> None:
+        """Stop the personal-content collectors: the window-title watcher (the
+        in-process one on macOS, the subprocess one elsewhere) and the browser
+        URL poller. The input watcher (input-occurred timing, no content) and the
+        AFK tracker are left running."""
+        if self.window_watcher is not None:
+            try:
+                self.window_watcher.stop()
+            except Exception:
+                logger.exception("Schedule suspend: window watcher stop failed")
+        if sys.platform != "darwin":
+            try:
+                self.aw_manager.suspend_watcher("bf-window-tracker")
+            except Exception:
+                logger.exception("Schedule suspend: window tracker suspend failed")
+        if getattr(self, "browser_tracker", None) is not None:
+            try:
+                self.browser_tracker.stop()
+            except Exception:
+                logger.exception("Schedule suspend: browser tracker stop failed")
+            self.browser_tracker = None
+            try:
+                self.sync_engine.set_browser_tracker(None)
+            except Exception:
+                logger.debug("Schedule suspend: clearing engine browser tracker failed", exc_info=True)
+
+    def _start_capture_watchers(self) -> None:
+        """Restart the collectors stopped by _stop_capture_watchers. The inverse
+        of suspension; mirrors the launch wiring so a resumed agent captures
+        exactly as a freshly-launched in-hours one does."""
+        if self.window_watcher is not None:
+            try:
+                self.window_watcher.start()
+            except Exception:
+                logger.exception("Schedule resume: window watcher start failed")
+        if sys.platform != "darwin":
+            try:
+                self.aw_manager.resume_watcher("bf-window-tracker")
+            except Exception:
+                logger.exception("Schedule resume: window tracker resume failed")
+        if self.config.privacy.track_browser_urls and getattr(self, "browser_tracker", None) is None:
+            try:
+                self.browser_tracker = start_browser_tracker()
+                self.sync_engine.set_browser_tracker(self.browser_tracker)
+            except Exception:
+                logger.exception("Schedule resume: browser tracker start failed")
+
+    def _suspend_capture_for_schedule(self) -> None:
+        """Enter the out-of-hours state: stop capture and pause upload."""
+        logger.info("Outside working hours — suspending activity capture")
+        self._stop_capture_watchers()
+        try:
+            self.sync_engine.pause()
+        except Exception:
+            logger.exception("Schedule suspend: engine pause failed")
+        self.tray.set_state(TrayState.PAUSED, "Outside working hours")
+        send_notification(
+            "Outside working hours",
+            "Tracking is paused. It resumes automatically at the start of your next work window.",
+            sound=False,
+        )
+
+    def _resume_capture_for_schedule(self) -> None:
+        """Leave the out-of-hours state: restart capture, and resume upload
+        unless the user has an independent manual pause / private time active —
+        in which case capture is restored to the normal baseline but their pause
+        is respected (the engine stays paused, exactly as during work hours)."""
+        logger.info("Back inside working hours — resuming activity capture")
+        self._start_capture_watchers()
+        if self._is_user_paused():
+            logger.info("Schedule resume: user pause/private active — leaving upload paused")
+            return
+        try:
+            self.sync_engine.resume()
+        except Exception:
+            logger.exception("Schedule resume: engine resume failed")
+        self.tray.set_state(TrayState.SYNCING)
+        self.coordinator.trigger_sync("schedule_resume_sync")
+
+    def _on_work_outside_hours(self) -> None:
+        """Tray action: the explicit 'strictly requested' escape. Arms the
+        override (collect until end of the local day), then re-evaluates the gate
+        so capture resumes immediately. Auto-expires at the next local midnight,
+        and a normal work-window start clears it implicitly."""
+        self.schedule_gate.request_work_outside_hours()
+        send_notification(
+            "Working outside hours",
+            "Tracking enabled until end of day. It returns to your schedule tomorrow.",
+            sound=False,
+        )
+        self._apply_schedule_gate()
 
     def _on_sync_now(self) -> None:
         """Handle sync now action from tray."""

--- a/src/sync/macos_window_watcher.py
+++ b/src/sync/macos_window_watcher.py
@@ -99,6 +99,11 @@ class MacOSWindowWatcher:
 
         Returns True if started successfully, False otherwise.
         """
+        # Clear any prior stop signal so the watcher is restartable — the
+        # working-hours capture gate stops it outside hours and starts it again
+        # on re-entry. Without this, a restarted thread would see the set event
+        # and exit on its first loop, leaving window capture silently dead.
+        self._stop_event.clear()
         # Verify PyObjC Accessibility APIs are available
         try:
             from AppKit import NSWorkspace  # noqa: F401

--- a/src/sync/sync_engine.py
+++ b/src/sync/sync_engine.py
@@ -12,7 +12,6 @@ from dataclasses import dataclass, field
 from datetime import datetime, timedelta, timezone
 from typing import Callable, Optional
 from urllib.parse import urlparse
-from zoneinfo import ZoneInfo
 
 try:
     from ..__init__ import __version__ as AGENT_VERSION
@@ -501,6 +500,17 @@ class SyncEngine:
         """Set the current project for event tagging."""
         with self._state_lock:
             self._current_project = project
+
+    def set_browser_tracker(self, tracker) -> None:
+        """Swap the active-tab URL tracker (or None to detach it).
+
+        Used by the working-hours capture gate, which stops the browser poller
+        outside enforced hours and starts a fresh one on re-entry. The engine
+        only dereferences this while enriching a window event, which is reached
+        only after the paused-guard early-return — and the gate pauses the engine
+        whenever it detaches the tracker — so a plain attribute swap (atomic under
+        the GIL) is sufficient; a transient None merely yields a URL-less event."""
+        self._browser_tracker = tracker
 
     def invalidate_category_cache(self) -> None:
         """Clear the in-memory category cache so next lookup re-reads from DB."""
@@ -1099,20 +1109,14 @@ class SyncEngine:
     def _within_working_hours(self, event: AWEvent) -> bool:
         """True if the event's start falls inside the server-enforced working-
         hours window. When the schedule is not enforced (B2B / unrestricted)
-        this is always True. Evaluated in the schedule's timezone, falling back
-        to the machine's local timezone when none is provided."""
+        this is always True. The upload-side backstop to the capture gate: even
+        if a stray out-of-hours event reached the local buckets, it is never
+        uploaded. Shares the single window check on WorkingHoursConfig so the
+        gate and this filter can never disagree about the window."""
         wh = self.config.working_hours
-        if not getattr(wh, "enforced", False):
+        if not wh.enforces():
             return True
-        try:
-            tz = ZoneInfo(wh.timezone) if wh.timezone else None
-        except Exception:
-            tz = None
-        local = event.timestamp.astimezone(tz) if tz else event.timestamp.astimezone()
-        if wh.working_days and local.isoweekday() not in wh.working_days:
-            return False
-        hhmm = local.strftime("%H:%M")
-        return wh.work_start <= hhmm <= wh.work_end
+        return wh.is_within_window(event.timestamp)
 
     def _fetch_bucket_events(
         self, bucket_id: str, stats: SyncStats

--- a/src/ui/tray.py
+++ b/src/ui/tray.py
@@ -179,6 +179,13 @@ class TrayModel:
         self.on_break: bool = False
         self.break_minutes_left: int = 0
 
+        # Working-hours capture gate. ``schedule_suspended`` is True while the
+        # agent is outside the enforced window (capture paused). ``offer_override``
+        # gates the "Work outside hours" menu item — shown only to a restricted
+        # user who is currently outside their window and hasn't armed the override.
+        self.schedule_suspended: bool = False
+        self.schedule_offer_override: bool = False
+
         # Permissions
         self.needs_permissions: bool = False
         # macOS Input Monitoring (keystroke/click capture). True until a check
@@ -448,6 +455,7 @@ class TrayIcon:
         on_check_update: Optional[Callable[[], None]] = None,
         on_tray_died: Optional[Callable[[], None]] = None,
         on_show_hours: Optional[Callable[[], Optional[str]]] = None,
+        on_work_outside_hours: Optional[Callable[[], None]] = None,
     ):
         """Initialize tray icon.
 
@@ -488,6 +496,7 @@ class TrayIcon:
         self._on_check_update = on_check_update
         self._on_tray_died = on_tray_died
         self._on_show_hours = on_show_hours
+        self._on_work_outside_hours = on_work_outside_hours
 
         self.model = TrayModel()
 
@@ -537,6 +546,8 @@ class TrayIcon:
                 "project_started_at": self.model.project_started_at,
                 "on_break": self.model.on_break,
                 "break_minutes_left": self.model.break_minutes_left,
+                "schedule_suspended": self.model.schedule_suspended,
+                "schedule_offer_override": self.model.schedule_offer_override,
                 "sync_interval": self.model.sync_interval,
                 "hash_titles": self.model.hash_titles,
                 "domain_only_urls": self.model.domain_only_urls,
@@ -635,6 +646,17 @@ class TrayIcon:
             items.append(Item("End Private Time", self._handle_private_toggle, enabled=logged_in))
         elif not s["on_break"]:
             items.append(Item("Private Time", self._handle_private_toggle, enabled=logged_in))
+
+        # ── Work-outside-hours override ─────────────────────────────────────
+        # Only for a restricted user currently outside their enforced window:
+        # the explicit, single-day opt-in to collect anyway ("unless strictly
+        # requested"). Hidden once armed (offer_override goes False).
+        if s["schedule_offer_override"]:
+            items.append(Item(
+                "Work outside hours (today)",
+                self._handle_work_outside_hours,
+                enabled=logged_in,
+            ))
 
         # ── Private Time Reminder submenu ───────────────────
         items.append(Item("Private Time Reminder", pystray.Menu(
@@ -873,6 +895,12 @@ class TrayIcon:
         """Handle pause menu click."""
         if self._on_pause:
             self._on_pause()
+
+    def _handle_work_outside_hours(self, icon, item) -> None:
+        """Handle the 'Work outside hours' menu click — the explicit opt-in to
+        collect outside the enforced window for the rest of the day."""
+        if self._on_work_outside_hours:
+            self._on_work_outside_hours()
 
     def _handle_resume(self, icon, item) -> None:
         """Handle resume menu click."""
@@ -1152,6 +1180,18 @@ class TrayIcon:
             self.set_state(TrayState.PRIVATE)
         else:
             self.set_state(TrayState.SYNCING)
+
+    def set_schedule_state(self, suspended: bool, offer_override: bool) -> None:
+        """Update the working-hours gate hint shown in the menu. Rebuilds the
+        menu only when something actually changed, so the every-60s gate check
+        doesn't churn the menu on the steady state."""
+        with self.model.lock:
+            if (self.model.schedule_suspended == suspended
+                    and self.model.schedule_offer_override == offer_override):
+                return
+            self.model.schedule_suspended = suspended
+            self.model.schedule_offer_override = offer_override
+        self._update_menu()
 
     def update_stats(
         self,

--- a/src/work_schedule_gate.py
+++ b/src/work_schedule_gate.py
@@ -1,0 +1,126 @@
+"""Schedule-aware capture gate.
+
+Decides whether the agent is allowed to *collect* activity right now, based on
+the server-enforced working-hours schedule. This is the privacy boundary the
+admin UI promises: for a restricted user (B2E / Trainee), the agent must not
+read the machine outside the working window at all — not merely decline to
+upload it. The caller (the app) acts on the decision by stopping/starting the
+window + browser capture and pausing/resuming the sync engine.
+
+Fail-closed by construction: an *enforced* schedule is a hard boundary. The only
+way to collect outside it is the explicit, user-initiated override
+(:meth:`request_work_outside_hours`) — the "unless strictly requested" escape —
+which the user re-arms each day and which auto-expires at the end of the local
+day so it can never silently persist into tomorrow.
+
+Unrestricted users (B2B / flexible / no schedule) are never gated: ``enforces``
+is False, so :meth:`collection_allowed` is always True and behaviour is
+unchanged for them.
+
+Pure decision logic with a small amount of override state — no I/O, no watcher
+control. Owns its own leaf lock (no nesting with other locks).
+"""
+
+import logging
+import threading
+from datetime import datetime, timedelta, timezone
+from typing import Optional
+from zoneinfo import ZoneInfo
+
+logger = logging.getLogger(__name__)
+
+
+class WorkScheduleGate:
+    """Answers "may the agent collect right now?" from the working-hours config.
+
+    Holds the transient "work outside hours" override. Thread-safe; the override
+    is read every 60s tick from the scheduler thread and written from the tray
+    callback thread.
+    """
+
+    def __init__(self, config) -> None:
+        self.config = config
+        self._lock = threading.Lock()
+        # Aware-UTC instant the override stops applying; None means no override.
+        self._override_until: Optional[datetime] = None
+
+    # ── window helpers ────────────────────────────────────────────────
+    def _schedule_tz(self):
+        tz_name = self.config.working_hours.timezone
+        if not tz_name:
+            return None
+        try:
+            return ZoneInfo(tz_name)
+        except Exception:
+            return None
+
+    def _end_of_local_day(self, now: datetime) -> datetime:
+        """The next local midnight (in the schedule's timezone, falling back to
+        the machine's local zone) as an aware-UTC instant. The override expires
+        here so "work outside hours" never leaks into the following day."""
+        tz = self._schedule_tz()
+        local = now.astimezone(tz) if tz else now.astimezone()
+        next_midnight = (local + timedelta(days=1)).replace(
+            hour=0, minute=0, second=0, microsecond=0
+        )
+        return next_midnight.astimezone(timezone.utc)
+
+    @staticmethod
+    def _now(now: Optional[datetime]) -> datetime:
+        return now if now is not None else datetime.now(timezone.utc)
+
+    # ── override ──────────────────────────────────────────────────────
+    def request_work_outside_hours(self, now: Optional[datetime] = None) -> None:
+        """Arm the explicit override: collect outside the window until the end of
+        the current local day. Idempotent within a day. No effect on the actual
+        suspend/resume — the caller re-evaluates :meth:`collection_allowed`."""
+        now = self._now(now)
+        until = self._end_of_local_day(now)
+        with self._lock:
+            self._override_until = until
+        logger.info("Work-outside-hours override armed until %s", until.isoformat())
+
+    def clear_override(self) -> None:
+        with self._lock:
+            had = self._override_until is not None
+            self._override_until = None
+        if had:
+            logger.info("Work-outside-hours override cleared")
+
+    def override_active(self, now: Optional[datetime] = None) -> bool:
+        now = self._now(now)
+        with self._lock:
+            until = self._override_until
+            if until is None:
+                return False
+            if now >= until:
+                # Expired — drop it so a stale instant can't be re-read.
+                self._override_until = None
+                return False
+            return True
+
+    # ── decision ──────────────────────────────────────────────────────
+    def collection_allowed(self, now: Optional[datetime] = None) -> bool:
+        """True if the agent may collect right now.
+
+        Unrestricted schedule → always True. Restricted → True only inside the
+        window OR while the user's override is active. Fail-closed otherwise."""
+        wh = self.config.working_hours
+        if not wh.enforces():
+            return True
+        now = self._now(now)
+        if wh.is_within_window(now):
+            return True
+        return self.override_active(now)
+
+    def should_offer_override(self, now: Optional[datetime] = None) -> bool:
+        """Whether the tray should show the "Work outside hours" item: only for a
+        restricted user who is currently outside the window and has not already
+        armed the override."""
+        wh = self.config.working_hours
+        if not wh.enforces():
+            return False
+        now = self._now(now)
+        if wh.is_within_window(now):
+            return False
+        return not self.override_active(now)

--- a/tests/test_tray_schedule_override.py
+++ b/tests/test_tray_schedule_override.py
@@ -13,6 +13,37 @@ from unittest.mock import MagicMock, patch
 from src.ui.tray import TrayIcon
 
 
+class _FakeItem:
+    """Stand-in for pystray.MenuItem exposing the .text the assertions read.
+
+    The real pystray (and thus ``src.ui.tray.Item``) is None on a headless box
+    where the backend can't bind — e.g. Linux CI — so calling the real
+    ``_create_menu`` there raises ``'NoneType' object is not callable``. Faking
+    Item/Menu keeps the test exercising the real menu-building logic without
+    depending on a usable tray backend.
+    """
+
+    def __init__(self, text=None, action=None, *args, **kwargs):
+        self.text = text
+        self.action = action
+
+
+class _FakeMenu:
+    """Stand-in for pystray.Menu exposing .items as the passed tuple."""
+
+    def __init__(self, *items):
+        self.items = items
+
+
+def _menu_labels(tray) -> list:
+    """Build the menu under faked pystray/Item and return top-level item texts."""
+    fake_pystray = MagicMock()
+    fake_pystray.Menu = _FakeMenu
+    with patch("src.ui.tray.pystray", fake_pystray), patch("src.ui.tray.Item", _FakeItem):
+        menu = tray._create_menu()
+    return [getattr(i, "text", None) for i in menu.items]
+
+
 def _make_tray(on_work_outside_hours=None) -> TrayIcon:
     with patch("src.ui.tray.pystray"):
         tray = TrayIcon(
@@ -51,11 +82,11 @@ def test_override_item_present_only_when_offered():
     tray.model.user_email = "x@y.co"  # logged-in so items render
 
     tray.set_schedule_state(suspended=True, offer_override=True)
-    labels = [getattr(i, "text", None) for i in tray._create_menu().items]
+    labels = _menu_labels(tray)
     assert any("Work outside hours" in (t or "") for t in labels)
 
     tray.set_schedule_state(suspended=False, offer_override=False)
-    labels = [getattr(i, "text", None) for i in tray._create_menu().items]
+    labels = _menu_labels(tray)
     assert not any("Work outside hours" in (t or "") for t in labels)
 
 

--- a/tests/test_tray_schedule_override.py
+++ b/tests/test_tray_schedule_override.py
@@ -1,0 +1,66 @@
+"""Tray wiring for the working-hours capture gate.
+
+The gate decision is tested in test_work_schedule_gate; here we pin the thin
+tray layer: set_schedule_state updates the model + rebuilds the menu only on a
+real change, the "Work outside hours" item appears only when offered, and
+clicking it delegates to the app callback.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock, patch
+
+from src.ui.tray import TrayIcon
+
+
+def _make_tray(on_work_outside_hours=None) -> TrayIcon:
+    with patch("src.ui.tray.pystray"):
+        tray = TrayIcon(
+            on_login=lambda: None,
+            on_logout=lambda: None,
+            on_quit=lambda: None,
+            on_work_outside_hours=on_work_outside_hours,
+        )
+    tray._icon = MagicMock()
+    tray._update_icon = MagicMock()
+    tray._update_menu = MagicMock()
+    return tray
+
+
+def test_set_schedule_state_updates_model_and_rebuilds():
+    tray = _make_tray()
+    with patch.object(tray, "_update_menu") as upd:
+        tray.set_schedule_state(suspended=True, offer_override=True)
+    assert tray.model.schedule_suspended is True
+    assert tray.model.schedule_offer_override is True
+    upd.assert_called_once()
+
+
+def test_set_schedule_state_noop_when_unchanged():
+    """The 60s gate check pushes the same state repeatedly; an unchanged push
+    must not churn the menu."""
+    tray = _make_tray()
+    tray.set_schedule_state(suspended=False, offer_override=False)  # already the default
+    with patch.object(tray, "_update_menu") as upd:
+        tray.set_schedule_state(suspended=False, offer_override=False)
+    upd.assert_not_called()
+
+
+def test_override_item_present_only_when_offered():
+    tray = _make_tray()
+    tray.model.user_email = "x@y.co"  # logged-in so items render
+
+    tray.set_schedule_state(suspended=True, offer_override=True)
+    labels = [getattr(i, "text", None) for i in tray._create_menu().items]
+    assert any("Work outside hours" in (t or "") for t in labels)
+
+    tray.set_schedule_state(suspended=False, offer_override=False)
+    labels = [getattr(i, "text", None) for i in tray._create_menu().items]
+    assert not any("Work outside hours" in (t or "") for t in labels)
+
+
+def test_clicking_override_delegates_to_callback():
+    called = MagicMock()
+    tray = _make_tray(on_work_outside_hours=called)
+    tray._handle_work_outside_hours(tray._icon, MagicMock())
+    called.assert_called_once()

--- a/tests/test_work_schedule_gate.py
+++ b/tests/test_work_schedule_gate.py
@@ -1,0 +1,138 @@
+"""Tests for the schedule-aware capture gate and its supporting config.
+
+Covers the privacy boundary the admin UI promises: a restricted user is not
+collected outside the enforced window unless they explicitly opt in for the day,
+and the persisted schedule survives a restart so the launch decision is correct
+before the first server fetch (fail-closed launch).
+"""
+
+from datetime import datetime, timedelta, timezone
+
+from src.config import Config, WorkingHoursConfig
+from src.work_schedule_gate import WorkScheduleGate
+
+
+# Wednesday 2026-06-17 and Saturday 2026-06-20 (UTC) — stable, no Date.now().
+def wed(h, m=0):
+    return datetime(2026, 6, 17, h, m, tzinfo=timezone.utc)
+
+
+def sat(h=10, m=0):
+    return datetime(2026, 6, 20, h, m, tzinfo=timezone.utc)
+
+
+def _restricted() -> WorkingHoursConfig:
+    return WorkingHoursConfig(
+        enforced=True,
+        work_start="08:00",
+        work_end="22:00",
+        working_days=[1, 2, 3, 4, 5],
+        timezone="UTC",
+    )
+
+
+class TestWorkingHoursWindow:
+    def test_enforces_reflects_flag(self):
+        assert _restricted().enforces() is True
+        assert WorkingHoursConfig().enforces() is False  # default unrestricted
+
+    def test_is_within_window_boundaries(self):
+        wh = _restricted()
+        assert wh.is_within_window(wed(7, 30)) is False  # before clock-in
+        assert wh.is_within_window(wed(8, 0)) is True     # exactly at start
+        assert wh.is_within_window(wed(13, 0)) is True    # mid-day
+        assert wh.is_within_window(wed(22, 0)) is True     # exactly at end
+        assert wh.is_within_window(wed(22, 1)) is False    # past end
+
+    def test_is_within_window_non_working_day(self):
+        assert _restricted().is_within_window(sat()) is False
+
+    def test_naive_datetime_treated_as_utc(self):
+        wh = _restricted()
+        naive = datetime(2026, 6, 17, 9, 0)  # no tzinfo
+        assert wh.is_within_window(naive) is True
+
+
+class TestConfigRoundTrip:
+    def test_working_hours_survive_save_load(self, tmp_path, monkeypatch):
+        """The fail-closed-launch fix: an enforced schedule must be restored as a
+        WorkingHoursConfig (not a raw dict) so enforces()/is_within_window work
+        before the first post-login server fetch."""
+        monkeypatch.setattr("src.config.user_config_dir", lambda *a, **k: str(tmp_path))
+
+        cfg = Config()
+        cfg.working_hours = _restricted()
+        cfg.save()
+
+        loaded = Config.load()
+        assert isinstance(loaded.working_hours, WorkingHoursConfig)
+        assert loaded.working_hours.enforces() is True
+        assert loaded.working_hours.work_start == "08:00"
+        assert loaded.working_hours.working_days == [1, 2, 3, 4, 5]
+        assert loaded.working_hours.is_within_window(wed(7, 0)) is False
+        assert loaded.working_hours.is_within_window(wed(9, 0)) is True
+
+
+class TestCollectionAllowed:
+    def test_unrestricted_always_allowed(self):
+        cfg = Config()  # default enforced=False
+        gate = WorkScheduleGate(cfg)
+        assert gate.collection_allowed(sat(3)) is True
+        assert gate.collection_allowed(wed(2)) is True
+
+    def test_restricted_blocks_outside_window(self):
+        cfg = Config()
+        cfg.working_hours = _restricted()
+        gate = WorkScheduleGate(cfg)
+        assert gate.collection_allowed(wed(7, 0)) is False   # before hours
+        assert gate.collection_allowed(wed(9, 0)) is True    # inside hours
+        assert gate.collection_allowed(wed(23, 0)) is False  # after hours
+        assert gate.collection_allowed(sat()) is False        # weekend
+
+    def test_override_allows_outside_window(self):
+        cfg = Config()
+        cfg.working_hours = _restricted()
+        gate = WorkScheduleGate(cfg)
+        outside = wed(23, 0)
+        assert gate.collection_allowed(outside) is False
+        gate.request_work_outside_hours(now=outside)
+        assert gate.collection_allowed(outside) is True
+
+    def test_override_expires_at_end_of_local_day(self):
+        cfg = Config()
+        cfg.working_hours = _restricted()
+        gate = WorkScheduleGate(cfg)
+        outside = wed(23, 0)
+        gate.request_work_outside_hours(now=outside)
+        assert gate.override_active(outside) is True
+        # Next day, same hour — past local midnight, so the override is gone.
+        next_day = outside + timedelta(days=1)
+        assert gate.override_active(next_day) is False
+        assert gate.collection_allowed(next_day) is False
+
+    def test_clear_override(self):
+        cfg = Config()
+        cfg.working_hours = _restricted()
+        gate = WorkScheduleGate(cfg)
+        outside = wed(23, 0)
+        gate.request_work_outside_hours(now=outside)
+        gate.clear_override()
+        assert gate.override_active(outside) is False
+
+
+class TestShouldOfferOverride:
+    def test_offered_only_when_restricted_outside_and_not_overridden(self):
+        cfg = Config()
+        cfg.working_hours = _restricted()
+        gate = WorkScheduleGate(cfg)
+        # Outside hours, no override yet → offer it.
+        assert gate.should_offer_override(wed(23, 0)) is True
+        # Inside hours → nothing to offer.
+        assert gate.should_offer_override(wed(9, 0)) is False
+        # Once armed, the item disappears.
+        gate.request_work_outside_hours(now=wed(23, 0))
+        assert gate.should_offer_override(wed(23, 0)) is False
+
+    def test_never_offered_for_unrestricted(self):
+        gate = WorkScheduleGate(Config())
+        assert gate.should_offer_override(sat(3)) is False


### PR DESCRIPTION
## Why

The desktop agent had no concept of working hours: it recorded window titles and browser URLs **24/7** whenever the machine was active, then relied on the server to *exclude* out-of-hours activity from billed totals ("recorded but not counted"). For a restricted user (B2E / Trainee), that meant their personal evening/weekend activity was still captured, transmitted, and stored where an admin could see it — only filtered after the fact.

This makes the agent **stop collecting** outside enforced hours, rather than merely declining to upload.

## What

- **Outside enforced hours, capture is fully suspended:** the window-title watcher (in-process on macOS, the `bf-window-tracker` subprocess elsewhere) and the browser-URL poller are stopped, and the sync engine is paused. Nothing personal is read, recorded, or sent.
- **Fail-closed at launch:** a returning restricted user who opens their laptop outside hours never starts the watchers — the decision is made from the persisted schedule *before* the first server call, then reconciled the moment the server config lands after login. (Fixes a latent bug where `working_hours` wasn't restored from disk at all.)
- **Auto-resumes at the work-window start:** the 60s tick re-evaluates the gate (before the idle check), so capture restarts within a tick when the clock crosses into the window — no user action.
- **"Unless strictly requested":** a **"Work outside hours (today)"** tray item arms a one-day override that auto-expires at local midnight; shown only to a restricted user currently outside their window.
- **Backstop kept:** the existing upload-side filter remains, refactored to share the single window-check function so the gate and the filter can never disagree.
- **Unrestricted (B2B / flexible) users are unaffected** — they still record 24/7. The gate only bites `enforced` schedules.

## Commits

1. `fix(config)` — restore `working_hours` on load + window-check helpers
2. `feat(schedule)` — `WorkScheduleGate` decision module + tests
3. `feat(aw)` — `suspend_watcher`/`resume_watcher`
4. `fix(window-watcher)` — clear stop-event on `start()` so it's restartable
5. `refactor(sync)` — share window check in upload filter + `set_browser_tracker`
6. `feat(tray)` — "Work outside hours" override item + schedule state
7. `feat(main)` — wire the gate into tick / launch / suspend-resume

## Testing

- **841 tests pass** (16 new: gate decision/boundaries/override expiry, config save→load round-trip, tray wiring). New code is `ruff`-clean.
- Thread-safe (gate override + `_schedule_suspended` are locked); every exception handler logs; window-check logic deduplicated into `WorkingHoursConfig.is_within_window`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
