### PR TITLE
fix(sync): bound in-cycle retry budget under the watchdog deadline

### DIFF
--- a/src/main.py
+++ b/src/main.py
@@ -1008,13 +1008,21 @@ class SyncCoordinator:
         if auth_err is not None:
             self._handle_auth_error(auth_err, source="liveness_heartbeat")
 
-    _DO_SYNC_DEADLINE = 120  # seconds — must exceed request_timeout * (max_retries + 1)
+    # Must exceed the worst-case wall-clock of one in-cycle network chain so a
+    # slow/hung server can't masquerade as a wedged sync. The batch-upload path
+    # runs on BaseApiClient.DEFAULT_RETRY_CONFIG (max_retries=2) at a 30s timeout:
+    # 3 attempts * 30s + backoff ≈ 94s, plus the heartbeat (~11s) and bookkeeping.
+    # 150s leaves margin above that ~105s realistic worst case; only a genuine
+    # multi-minute hang trips it. (The old 120s was < the then-129s chain, which
+    # false-fired "Sync hung" during the 2026-06-30 outage.) Guarded by
+    # tests/test_sync_watchdog_budget.py.
+    _DO_SYNC_DEADLINE = 150  # seconds
     # A _do_sync holding _sync_lock longer than this is treated as wedged
     # (deadlock, or a call hung past the watchdog). A new cycle then abandons the
     # stuck holder and re-arms a fresh lock so syncing resumes instead of skipping
     # forever. Must exceed _DO_SYNC_DEADLINE so the watchdog's session-reset gets
     # its chance first.
-    _SYNC_WEDGE_CEILING = 300  # seconds
+    _SYNC_WEDGE_CEILING = 420  # seconds
 
     def _acquire_sync_slot(self) -> Optional[threading.Lock]:
         """Take the sync slot, returning the lock to release later, or None to

--- a/src/sync/http_client.py
+++ b/src/sync/http_client.py
@@ -158,8 +158,17 @@ class BaseApiClient:
     Single Responsibility: HTTP communication only.
     """
 
+    # In-cycle network budget. A single retrying request runs at most
+    # (max_retries + 1) attempts * timeout + backoff. With max_retries=3 and a
+    # 30s timeout that is ~129s — past the 120s sync watchdog (SyncCoordinator
+    # ._DO_SYNC_DEADLINE), so a hung/slow server (e.g. the 2026-06-30 Redis/502
+    # outage) false-trips "Sync hung". max_retries=2 bounds the worst-case chain
+    # to ~94s, comfortably inside the watchdog; the OfflineQueue is the durable
+    # cross-cycle retry, so a failed batch is re-sent next cycle regardless — the
+    # 4th in-cycle attempt only amplified the stall. Guarded by
+    # tests/test_sync_watchdog_budget.py.
     DEFAULT_RETRY_CONFIG = RetryConfig(
-        max_retries=3,
+        max_retries=2,
         base_delay=1.0,
         max_delay=30.0,
         exponential_base=2.0,

--- a/tests/test_sync_watchdog_budget.py
+++ b/tests/test_sync_watchdog_budget.py
@@ -1,0 +1,148 @@
+"""Watchdog vs. in-cycle retry budget invariant.
+
+Origin: 2026-06-30 server outage (Redis getaddrinfo / 502 storm on
+app.betterflow.eu). Agents whose connections *timed out* (rather than fast-502'd)
+fired the "Sync hung — exceeded 120s watchdog deadline" alert, fingerprint
+707a9ecc, seen across the darwin/1.5.84 fleet. It looked like a deadlock but was
+not: the batch-upload path (``events/batch``) retries on the default config —
+``max_retries=3`` (4 attempts) at a 30s request timeout plus exponential backoff
+— so a *single* request chain against a hanging server takes
+
+    4 * 30s  +  (1.25 + 2.5 + 5.0)  ≈  128.75s
+
+which EXCEEDS the 120s ``_DO_SYNC_DEADLINE``. The cycle breaks after the first
+failed batch (sync_engine ``_process_queue``), so one chain dominates the cycle.
+The watchdog therefore fires on a transient server outage, and can trip the 300s
+wedge re-arm — even though nothing is wedged.
+
+The fix bounds the in-cycle chain comfortably under the watchdog (fewer in-cycle
+retries — the OfflineQueue is the durable cross-cycle retry) AND restores real
+margin on the deadline. These tests pin the invariant so it can't silently
+regress again.
+
+Pre-fix: ``test_in_cycle_upload_chain_fits_under_watchdog`` FAILS (128.75 ≥ 120).
+Post-fix: it PASSES with margin.
+"""
+
+import http.server
+import inspect
+import threading
+import time
+
+import pytest
+
+from src.main import SyncCoordinator
+from src.sync.bf_client import BetterFlowClient
+from src.sync.http_client import BaseApiClient, BetterFlowClientError
+from src.sync.retry import RetryConfig, calculate_delay
+
+
+def _client_default_timeout() -> float:
+    """The request timeout the in-cycle BetterFlowClient runs with (no override)."""
+    return float(inspect.signature(BetterFlowClient.__init__).parameters["timeout"].default)
+
+
+def _worst_case_chain_seconds(cfg: RetryConfig, timeout: float) -> float:
+    """Upper bound on the wall-clock of ONE retrying request whose every attempt
+    consumes the full request timeout (server accepts the connection then hangs).
+
+    Mirrors ``retry_with_backoff``: ``max_retries + 1`` attempts, with a backoff
+    sleep before each of the ``max_retries`` retries. Jitter only ever *adds*
+    (0–25%), so the worst case is the no-jitter delay scaled by 1.25.
+    """
+    attempts = cfg.max_retries + 1
+    backoff = sum(
+        calculate_delay(
+            attempt,
+            cfg.base_delay,
+            cfg.max_delay,
+            cfg.exponential_base,
+            jitter=False,
+        )
+        * 1.25
+        for attempt in range(cfg.max_retries)
+    )
+    return attempts * timeout + backoff
+
+
+def test_in_cycle_upload_chain_fits_under_watchdog():
+    """A single batch-upload retry chain must finish well inside the watchdog
+    deadline, so a hung/slow server can't masquerade as a wedged sync.
+
+    Asserts the worst-case chain leaves headroom for the rest of the cycle
+    (heartbeat etc.) before ``_DO_SYNC_DEADLINE``."""
+    cfg = BaseApiClient.DEFAULT_RETRY_CONFIG
+    worst = _worst_case_chain_seconds(cfg, _client_default_timeout())
+    deadline = SyncCoordinator._DO_SYNC_DEADLINE
+
+    # Require the dominant in-cycle network cost to fit with >=25% headroom for
+    # the remainder of the cycle (heartbeat, bookkeeping). Pre-fix worst≈128.75s
+    # vs deadline 120s fails this outright.
+    assert worst < deadline * 0.75, (
+        f"worst-case batch-upload chain {worst:.1f}s does not fit under "
+        f"{deadline * 0.75:.1f}s (75% of the {deadline}s watchdog). A slow/hung "
+        f"server will false-trip the 'Sync hung' watchdog."
+    )
+
+
+def test_wedge_ceiling_above_watchdog():
+    """The wedge re-arm must sit above the watchdog so the watchdog's session
+    reset always gets its chance first (and a real wedge still self-recovers)."""
+    assert SyncCoordinator._SYNC_WEDGE_CEILING > SyncCoordinator._DO_SYNC_DEADLINE
+
+
+class _RetryableHandler(http.server.BaseHTTPRequestHandler):
+    """Always returns 503 (a retryable transient) and counts attempts."""
+
+    attempts = 0
+
+    def do_POST(self):  # noqa: N802
+        type(self).attempts += 1
+        self.send_response(503)
+        self.end_headers()
+        self.wfile.write(b'{"message":"unavailable"}')
+
+    def log_message(self, *args):  # silence test server noise
+        pass
+
+
+def test_real_request_chain_attempt_count_matches_budget_formula():
+    """Ground the budget formula in real behaviour: a real request chain against
+    a transient-failing server makes exactly ``max_retries + 1`` attempts, so the
+    ``attempts`` factor in ``_worst_case_chain_seconds`` is observed, not assumed.
+
+    Uses a scaled-down (near-zero) backoff config so the test is fast; the point
+    is the attempt COUNT, which is what the fix changes."""
+    _RetryableHandler.attempts = 0
+    server = http.server.HTTPServer(("127.0.0.1", 0), _RetryableHandler)
+    threading.Thread(target=server.serve_forever, daemon=True).start()
+    try:
+        host, port = server.server_address
+        fast_cfg = RetryConfig(
+            max_retries=BaseApiClient.DEFAULT_RETRY_CONFIG.max_retries,
+            base_delay=0.001,
+            max_delay=0.005,
+            exponential_base=2.0,
+            jitter=False,
+        )
+        client = BaseApiClient(
+            api_url=f"http://{host}:{port}",
+            timeout=2,
+            retry_config=fast_cfg,
+        )
+        start = time.monotonic()
+        with pytest.raises(BetterFlowClientError):
+            client._request("POST", "events/batch", data={"events": []})
+        elapsed = time.monotonic() - start
+    finally:
+        server.shutdown()
+
+    expected_attempts = BaseApiClient.DEFAULT_RETRY_CONFIG.max_retries + 1
+    assert _RetryableHandler.attempts == expected_attempts, (
+        f"expected {expected_attempts} attempts (max_retries+1), got "
+        f"{_RetryableHandler.attempts}"
+    )
+    # The chain must not exceed the formula's bound for this scaled config (503 is
+    # instant, so this is essentially the backoff sum) — proves the formula is an
+    # upper bound on real wall-clock.
+    assert elapsed <= _worst_case_chain_seconds(fast_cfg, timeout=2) + 1.0


### PR DESCRIPTION
## What

The **"Sync hung — exceeded 120s watchdog deadline"** alert (fingerprint `707a9ecc`, seen across the darwin/1.5.84 fleet on 2026-06-30) is **not a deadlock** — it's the in-cycle retry budget overrunning the watchdog during a server outage.

## Root cause

The batch-upload path (`events/batch`) runs on `BaseApiClient.DEFAULT_RETRY_CONFIG` — `max_retries=3` (4 attempts) at a 30s request timeout plus exponential backoff. A single chain against a server that accepts the connection then hangs takes:

```
4 * 30s + (1.25 + 2.5 + 5.0) ≈ 128.75s   >   120s _DO_SYNC_DEADLINE
```

The cycle breaks after the first failed batch, so one chain dominates. During the 06-30 `RedisException: getaddrinfo redis-xgph.railway.internal` / 502 storm on `app.betterflow.eu`, devices whose connections **timed out** (rather than fast-502'd) tripped the watchdog — and could trip the 300s wedge re-arm — with nothing actually wedged. Devices that got *fast* 502s only hit the 30s apscheduler `max-instances` skip, which is why the watchdog fired on only a few.

Evidence: pulled the log tails of 4 darwin/1.5.84 devices (Liviu, Alexandru, Marian, Cristian). All show the outage (`502`, `Cannot connect`, `Connection dropped mid-response`, `Request timed out`) plus `_do_sync ... skipped: maximum running instances` during the window. The watchdog comment even *claimed* the invariant `deadline > request_timeout * (max_retries + 1)` = 120s — but 120 does not exceed 120, and backoff pushes the real chain to ~129s.

## Fix

- `DEFAULT_RETRY_CONFIG`: **max_retries 3 → 2** — bounds the worst-case in-cycle chain to ~94s. The `OfflineQueue` is the durable cross-cycle retry, so a failed batch is re-sent next cycle regardless; the 4th in-cycle attempt only amplified the stall during an outage.
- **`_DO_SYNC_DEADLINE` 120 → 150**, **`_SYNC_WEDGE_CEILING` 300 → 420** — restore real margin above the realistic worst-case cycle (~94s upload + ~11s heartbeat ≈ 105s), so only a genuine multi-minute hang trips the watchdog/wedge.

## Test (proof-of-failure handshake)

`tests/test_sync_watchdog_budget.py` **failed on pre-fix code**: `test_in_cycle_upload_chain_fits_under_watchdog` asserts the worst-case batch chain fits under 75% of the watchdog and failed `128.75 >= 90` (max_retries=3 at 30s > 120s). A companion **real local-server test** confirms a real chain makes exactly `max_retries+1` attempts, grounding the budget formula in observed behaviour (not a phantom). Post-fix: worst case 93.75s < 112.5s; **828 tests green**, ruff clean on changed files.

## Not auto-merged

Held for human review: there's an active incident and `main` may be receiving concurrent direct fixes — per `cross-repo-safety`, auto-merge is suspended under multi-session risk.

🤖 Generated with [Claude Code](https://claude.com/claude-code)