### PR TITLE
fix(queue): don't drop queued activity during a transient server outage

### DIFF
--- a/src/sync/bf_client.py
+++ b/src/sync/bf_client.py
@@ -93,6 +93,12 @@ class SyncResult:
     events_queued: int = 0
     error: Optional[str] = None
     accepted_ids: list[int] = field(default_factory=list)
+    # True when a failed sync was TRANSIENT (server down / 5xx / timeout / no
+    # delivery confirmation) rather than a definitive rejection of the batch (a
+    # 4xx). The queue uses this to decide whether to count a retry toward the
+    # drop threshold: a transient failure must NOT, or a long outage drops good
+    # activity (2026-06-30). Only meaningful when success is False.
+    transient: bool = False
 
 
 class BetterFlowClient(BaseApiClient):
@@ -296,11 +302,15 @@ class BetterFlowClient(BaseApiClient):
 
             if synced is None and not accepted_ids:
                 # No delivery confirmation — do not assume anything persisted.
+                # The server was reached but gave no per-event verdict, so this
+                # is transient (an idempotent replay, an unrecognised body): hold
+                # the batch, don't count it toward the drop threshold.
                 return SyncResult(
                     success=False,
                     events_synced=0,
                     events_queued=len(events),
                     error="server returned no delivery confirmation; re-queuing batch",
+                    transient=True,
                 )
 
             events_synced = synced if synced is not None else len(accepted_ids)
@@ -324,7 +334,13 @@ class BetterFlowClient(BaseApiClient):
         except BetterFlowAuthError:
             raise  # Callers must handle token refresh / re-login
         except BetterFlowClientError as e:
-            return SyncResult(success=False, error=str(e))
+            # Transient unless the server gave a definitive 4xx rejection. A
+            # 5xx / timeout / connection / DNS failure (status_code None) is the
+            # server being unavailable, not a problem with these events — the
+            # queue must NOT count it toward the drop threshold.
+            status = getattr(e, "status_code", None)
+            transient = status is None or status >= 500
+            return SyncResult(success=False, error=str(e), transient=transient)
 
     def start_session(self) -> dict:
         """Start a tracking session."""

--- a/src/sync/http_client.py
+++ b/src/sync/http_client.py
@@ -126,9 +126,17 @@ def _new_verified_session() -> requests.Session:
 
 
 class BetterFlowClientError(Exception):
-    """BetterFlow client error."""
+    """BetterFlow client error.
 
-    pass
+    ``status_code`` is set only when the failure is a definitive HTTP rejection
+    (a 4xx). Transient failures — 5xx, timeouts, connection/DNS errors, retries
+    exhausted — leave it None. The queue uses this to avoid counting a transient
+    server outage against an event's drop threshold (2026-06-30 data loss).
+    """
+
+    def __init__(self, message: str = "", status_code: Optional[int] = None):
+        super().__init__(message)
+        self.status_code = status_code
 
 
 class BetterFlowAuthError(BetterFlowClientError):
@@ -436,7 +444,8 @@ class BaseApiClient:
                 except (ValueError, AttributeError) as parse_err:
                     logger.debug("HTTPError body parse failed: %s", parse_err)
                 raise BetterFlowClientError(
-                    f"API error ({e.response.status_code}): {error_detail or str(e)}"
+                    f"API error ({e.response.status_code}): {error_detail or str(e)}",
+                    status_code=e.response.status_code,
                 ) from e
 
         effective_retry_config = retry_config_override or self.retry_config

--- a/src/sync/sync_engine.py
+++ b/src/sync/sync_engine.py
@@ -2417,7 +2417,18 @@ class SyncEngine:
                         self.queue.increment_retry(failed_ids)
                     processed += len(succeeded_ids)
                 else:
-                    self.queue.increment_retry(event_ids)
+                    # Whole-batch failure with no per-event verdict. Only count
+                    # it toward the drop threshold when the server DEFINITIVELY
+                    # rejected the batch (a 4xx). A transient failure — server
+                    # down / 5xx / timeout / DNS / no delivery confirmation — is
+                    # not these events' fault; incrementing here drops good
+                    # activity after 5 down-cycles (the 2026-06-30 outage lost
+                    # real spans this way). Hold the events at their current
+                    # retry_count and retry next cycle; expire_old is the backstop
+                    # against unbounded growth, and a genuinely poison 4xx batch
+                    # still increments so it can't head-of-line-block the queue.
+                    if not result.transient:
+                        self.queue.increment_retry(event_ids)
                     self._apply_queue_backoff()
                     break
             except BetterFlowAuthError:
@@ -2425,7 +2436,9 @@ class SyncEngine:
                 # the caller's auth handler can trigger re-login.
                 raise
             except BetterFlowClientError:
-                self.queue.increment_retry(event_ids)
+                # send_events normally returns a SyncResult; reaching here means
+                # an unexpected client error surfaced. Treat as transient
+                # (server-side): back off and retry without counting a retry.
                 self._apply_queue_backoff()
                 break
 

--- a/tests/test_queue_no_drop_on_outage.py
+++ b/tests/test_queue_no_drop_on_outage.py
@@ -1,0 +1,107 @@
+"""The offline queue must survive a server outage without dropping real activity.
+
+Origin: 2026-06-30 — internal-tool2 deploy `e2fd9a72` failed its healthcheck and
+betterflow.eu 500'd for ~1-2h. Agents on 1.5.84 dropped real tracked activity;
+Azorel reported a burst of "Dropped N queued event(s) after max retries — likely
+real lost activity" (12–100 events, spans up to ~18.5h; buckets
+aw-watcher-input / aw-watcher-window / bf-afk-inproc).
+
+Root cause: `_process_queue` incremented `retry_count` for the WHOLE batch on any
+whole-batch failure — server down / 5xx / timeout / no delivery confirmation. So
+`retry_count` counted "cycles the server was down", not "times the event was
+rejected". After 5 down-cycles the events crossed `max_retries=5` and
+`remove_failed` deleted them — permanent loss of good activity the server never
+actually refused.
+
+Fix: only count a retry when the server DEFINITIVELY rejected the batch (a 4xx,
+surfaced as `SyncResult.transient is False`). A transient failure holds the
+events at their current `retry_count` to retry when the server returns; a
+genuinely poison 4xx batch still increments so it can't head-of-line-block the
+queue forever.
+
+`test_outage_does_not_drop_events` fails pre-fix (events dropped after 5 cycles).
+"""
+
+import tempfile
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+from unittest.mock import Mock
+
+from src.config import Config
+from src.sync.bf_client import SyncResult
+from src.sync.queue import OfflineQueue
+from src.sync.sync_engine import SyncEngine, SyncStats
+
+
+def _engine(tmp: Path) -> SyncEngine:
+    return SyncEngine(
+        aw=Mock(),
+        bf=Mock(),
+        queue=OfflineQueue(db_path=tmp / "q.db", max_size=10000),
+        config=Config(),
+        time_tracker=Mock(),
+    )
+
+
+def _events(n: int) -> list[dict]:
+    """n storable events — recent timestamp + bucket_id, so a drop counts as
+    'real loss' (not a benign unstorable flush)."""
+    now = datetime.now(timezone.utc).isoformat()
+    return [
+        {
+            "id": f"evt-{i}",
+            "timestamp": now,
+            "duration": 60.0,
+            "bucket_id": "aw-watcher-window_host",
+            "data": {"app": "Terminal"},
+        }
+        for i in range(n)
+    ]
+
+
+def _run_cycles(engine: SyncEngine, n: int) -> None:
+    """Run n queue-processing cycles, clearing the backoff gate before each so
+    every cycle actually attempts a send (mirrors a sustained outage)."""
+    for _ in range(n):
+        engine._queue_backoff_until = datetime.now(timezone.utc) - timedelta(seconds=1)
+        engine._process_queue(SyncStats())
+
+
+def test_outage_does_not_drop_events():
+    tmp = Path(tempfile.mkdtemp())
+    engine = _engine(tmp)
+    engine.queue.enqueue(_events(10))
+    assert engine.queue.size() == 10
+
+    # Server is DOWN: every batch fails transiently (no per-event verdict).
+    engine.bf.send_events = Mock(
+        return_value=SyncResult(success=False, events_queued=10, transient=True)
+    )
+
+    # 8 outage cycles — well past the 5-retry drop ceiling.
+    _run_cycles(engine, 8)
+
+    assert engine.bf.send_events.called, "precondition: the queue was actually attempted"
+    assert engine.queue.size() == 10, (
+        "a transient server outage must NOT drop queued activity; the events "
+        "should still be queued, waiting for the server to return"
+    )
+    assert engine.queue.failed_event_summary(max_retries=5)["count"] == 0
+
+
+def test_definitive_rejection_still_drops_to_avoid_head_of_line_block():
+    """A genuinely unstorable batch (server 4xx) must still accrue retries and
+    become droppable — otherwise it blocks the queue head forever."""
+    tmp = Path(tempfile.mkdtemp())
+    engine = _engine(tmp)
+    engine.queue.enqueue(_events(3))
+
+    engine.bf.send_events = Mock(
+        return_value=SyncResult(success=False, events_queued=3, transient=False)
+    )
+    _run_cycles(engine, 6)  # > max_retries=5
+
+    assert engine.queue.size() == 0, (
+        "a definitively-rejected (4xx) batch must still drop after max retries "
+        "so it can't head-of-line-block the queue"
+    )


### PR DESCRIPTION
## What

During the **2026-06-30 outage** (internal-tool2 deploy `e2fd9a72` failed its healthcheck; `betterflow.eu` 500'd for ~1–2h), agents on 1.5.84 **dropped real tracked activity**. Azorel #azorel-logs showed a burst of `Dropped N queued event(s) after max retries — likely real lost activity` (12–100 events, spans up to **~18.5h**; buckets `aw-watcher-input / window / bf-afk-inproc`).

## Root cause

`_process_queue` incremented `retry_count` for the **whole batch** on any whole-batch failure — server down / 5xx / timeout / no delivery confirmation. So `retry_count` counted *"cycles the server was down"*, not *"times the event was rejected"*. After 5 down-cycles the events crossed `max_retries=5` and `remove_failed` deleted them — permanent loss of good activity the server never actually refused.

`send_events` collapses `BetterFlowClientError` to `SyncResult(success=False)`, so the drop happened on the `else` (no-`accepted_ids`) branch, **indistinguishable from a genuine per-event rejection**.

## Fix

Only count a retry when the server **definitively** rejected the batch (a 4xx):

- `BetterFlowClientError` now carries `status_code`, set **only** on the 4xx `HTTPError` path; 5xx / timeout / connection / DNS leave it `None`.
- `send_events` sets `SyncResult.transient` — `True` for server-down / 5xx / timeout, and for a *no-delivery-confirmation* response (server reached, no per-event verdict).
- `_process_queue` increments `retry_count` only when `result.transient is False`. A transient failure holds the events at their current `retry_count` to retry when the server returns. `expire_old` (30d) remains the backstop against unbounded growth, and a genuinely poison **4xx** batch still increments so it can't head-of-line-block the queue.

`retry_count` now means *"times the server saw this event and declined it"* — a server outage can no longer drop storable activity.

## Test (proof-of-failure handshake)

`tests/test_queue_no_drop_on_outage.py` drives a **real `OfflineQueue` + real `_process_queue`** with `send_events` returning transient failures for 8 cycles. **Pre-fix it dropped all 10 events** (`Removed 10 events that exceeded max retries`, `size 0 != 10`); **post-fix all 10 are retained**. A companion test confirms a definitive **4xx** batch still drops after max retries (no head-of-line block). **830 tests green**, ruff clean on changed files (no new issues).

## Relationship to #98

Independent. #98 stopped the false *"Sync hung"* watchdog trip; **this** stops the actual **data loss** during the same outage. Both are agent-side; the outage trigger itself (internal-tool2 deploy / Redis) is server-side and already recovered.

## Not auto-merged

Held for review — active incident + concurrent `main` work (per `cross-repo-safety`, auto-merge suspended under multi-session risk).

🤖 Generated with [Claude Code](https://claude.com/claude-code)