### PR TITLE
fix(config): ship foreground-CPU detector default-OFF (billing safety)

### DIFF
--- a/src/config.py
+++ b/src/config.py
@@ -8,7 +8,8 @@ import re
 import sys
 import threading
 import uuid
-from dataclasses import dataclass, field, fields as dc_fields, asdict
+from dataclasses import asdict, dataclass, field
+from dataclasses import fields as dc_fields
 from logging.handlers import RotatingFileHandler
 from pathlib import Path
 from typing import Optional

--- a/src/config.py
+++ b/src/config.py
@@ -365,7 +365,12 @@ class ForegroundActivitySettings:
     last keyboard/mouse input), and only sessions of at least
     ``min_session_seconds`` are uploaded for server validation."""
 
-    enabled: bool = True
+    # Default OFF: this changes tracked/billed time (it injects AFK credit and
+    # dev-session spans) and its backend support (the dev-session bucket type) is
+    # still an unfinished follow-up. Ship inert so a fleet update can't flip
+    # billing for everyone; the server enables it via update_from_server once the
+    # backend lands and it's been validated.
+    enabled: bool = False
     cpu_threshold_percent: float = 15.0  # Frontmost-app CPU (single-core basis)
     max_credit_minutes: int = 20  # Max credit past the last real input
     min_session_seconds: int = 30  # Skip accidental blips

--- a/tests/test_foreground_activity.py
+++ b/tests/test_foreground_activity.py
@@ -401,3 +401,17 @@ def test_engine_is_active_dev_session_false_without_detector():
     eng, _ = _engine()
     eng._foreground_detector = None
     assert eng.is_active_dev_session() is False
+
+
+def test_foreground_activity_is_default_off_for_billing_safety():
+    """The foreground-CPU detector must default OFF. It changes tracked/billed
+    time (AFK credit + dev-session spans) and its backend support is an
+    unfinished follow-up, so a fleet update must NOT activate it for everyone;
+    the server enables it deliberately via update_from_server. Guards against a
+    silent flip back to on. See PR shipping v1.5.85."""
+    from src.config import ForegroundActivitySettings
+    from src.sync.foreground_activity import create_detector
+
+    assert ForegroundActivitySettings().enabled is False
+    # With the default (disabled) config, no detector is built — fully inert.
+    assert create_detector(ForegroundActivitySettings(), "test-host") is None


### PR DESCRIPTION
## Why

The foreground-CPU detector (#96) defaulted to **`enabled=True`** with psutil bundled, so tagging `main` as **v1.5.85** would **activate it across the whole fleet at once**. It changes tracked/**billed** time (injects AFK credit + dev-session spans), and its backend support (the dev-session bucket type) is an **unfinished follow-up per #96's own commit**. Flipping billing for everyone inside an emergency data-loss hotfix (#98/#99) is not acceptable.

## Fix

Default the detector **OFF** so it ships inert:
- The feature still ships and stays fully server-tunable — `update_from_server` already reads `foreground_activity.enabled`, so it can be switched on per-tenant once the backend lands and it's validated.
- Fleet devices updating from 1.5.84 have no `foreground_activity` block in their config, so they fall back to this code default → detector stays off. `create_detector` returns `None` before touching psutil.

This unblocks tagging `main` as-is for the v1.5.85 fleet release: #98 (watchdog) + #99 (data-loss) go live; the foreground detector ships dormant.

## Test

Guard test asserts `ForegroundActivitySettings().enabled is False` **and** `create_detector(default, host) is None`, so the default can't silently flip back on. 829 tests green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)