### PR TITLE
fix(queue): harden transient/drop classification (audit round 1)

### DIFF
--- a/src/sync/bf_client.py
+++ b/src/sync/bf_client.py
@@ -300,11 +300,19 @@ class BetterFlowClient(BaseApiClient):
             synced = payload.get("processed", payload.get("synced"))
             queued = payload.get("failed", payload.get("queued", 0))
 
-            if synced is None and not accepted_ids:
-                # No delivery confirmation — do not assume anything persisted.
-                # The server was reached but gave no per-event verdict, so this
-                # is transient (an idempotent replay, an unrecognised body): hold
-                # the batch, don't count it toward the drop threshold.
+            # No delivery confirmation — do not assume anything persisted. The
+            # server was reached but gave no per-event verdict, so this is
+            # transient (an idempotent replay, an unrecognised body), NOT a
+            # definitive rejection: hold the batch, don't count it toward the
+            # drop threshold. Covers both a confirmation-less body (synced None)
+            # AND an explicit zero-verdict (processed:0, failed:0) on a 2xx — the
+            # latter is just as ambiguous and must not silently drop good events.
+            no_confirmation = (
+                not accepted_ids
+                and (synced is None or synced == 0)
+                and not queued
+            )
+            if no_confirmation:
                 return SyncResult(
                     success=False,
                     events_synced=0,
@@ -334,13 +342,11 @@ class BetterFlowClient(BaseApiClient):
         except BetterFlowAuthError:
             raise  # Callers must handle token refresh / re-login
         except BetterFlowClientError as e:
-            # Transient unless the server gave a definitive 4xx rejection. A
-            # 5xx / timeout / connection / DNS failure (status_code None) is the
-            # server being unavailable, not a problem with these events — the
-            # queue must NOT count it toward the drop threshold.
-            status = getattr(e, "status_code", None)
-            transient = status is None or status >= 500
-            return SyncResult(success=False, error=str(e), transient=transient)
+            # Transient unless the server gave a definitive 4xx rejection. The
+            # error classifies itself (5xx / timeout / connection / DNS / 429 =>
+            # transient; a non-retryable 4xx => definitive) so the queue knows
+            # whether to count it toward the drop threshold.
+            return SyncResult(success=False, error=str(e), transient=e.is_transient)
 
     def start_session(self) -> dict:
         """Start a tracking session."""

--- a/src/sync/http_client.py
+++ b/src/sync/http_client.py
@@ -138,6 +138,17 @@ class BetterFlowClientError(Exception):
         super().__init__(message)
         self.status_code = status_code
 
+    @property
+    def is_transient(self) -> bool:
+        """True when this failure is transient (hold the events, don't count them
+        toward the drop): server unreachable, timeout/DNS, 5xx, or a retryable 4xx
+        (429/408/503/504 are raised WITHOUT a status_code). ``status_code`` is set
+        ONLY for a definitive client rejection (a non-retryable 4xx), so "no code"
+        means transient. NOTE: this is a rejection classifier, not a raw HTTP
+        status — do not set status_code on a retryable 4xx or it becomes
+        definitive and its events burn retries during e.g. a rate-limit window."""
+        return self.status_code is None or self.status_code >= 500
+
 
 class BetterFlowAuthError(BetterFlowClientError):
     """Authentication error."""

--- a/src/sync/sync_engine.py
+++ b/src/sync/sync_engine.py
@@ -2355,6 +2355,17 @@ class SyncEngine:
                 raise
 
     _QUEUE_PROCESS_TIMEOUT = 30.0  # Max wall-clock seconds for queue drain
+    # A transient whole-batch failure normally does NOT count toward the drop, so
+    # a server outage can't drop good activity (#99). But a batch that fails
+    # transiently DETERMINISTICALLY — a content-specific 5xx, or a server stuck
+    # returning no-confirmation — would otherwise sit at the oldest-first dequeue
+    # head forever, freezing every newer event up to the 30-day expiry, silently
+    # (the heartbeat stays green). After this many consecutive failed queue cycles
+    # (with the backoff schedule, ~3h of sustained failure) we count the stuck
+    # head toward the drop so it ages out and the queue unblocks. The counter
+    # (_queue_consecutive_failures) resets on ANY success, so an outage that
+    # recovers never reaches this — only a genuinely stuck head does.
+    _STUCK_HEAD_CEILING = 20
 
     def _process_queue(self, stats: SyncStats) -> None:
         """Process offline queue with exponential backoff.
@@ -2429,16 +2440,33 @@ class SyncEngine:
                     # still increments so it can't head-of-line-block the queue.
                     if not result.transient:
                         self.queue.increment_retry(event_ids)
+                    elif self._queue_consecutive_failures >= self._STUCK_HEAD_CEILING:
+                        # Transient, but this oldest batch has failed transiently
+                        # for so many consecutive cycles that it's almost certainly
+                        # a poison batch (a content-specific 5xx / a no-confirmation
+                        # loop) — or an outage far past any realistic duration. It
+                        # blocks every newer event at the dequeue head. Count it
+                        # toward the drop so it ages out and the queue unblocks.
+                        logger.warning(
+                            "Queue head batch (%d events) failed transiently for "
+                            "%d consecutive cycles — counting it toward the drop to "
+                            "unblock the queue (likely a poison batch or an outage "
+                            "past the ceiling).",
+                            len(event_ids), self._queue_consecutive_failures,
+                        )
+                        self.queue.increment_retry(event_ids)
                     self._apply_queue_backoff()
                     break
             except BetterFlowAuthError:
                 # Auth errors won't self-heal with retries; re-raise so
                 # the caller's auth handler can trigger re-login.
                 raise
-            except BetterFlowClientError:
-                # send_events normally returns a SyncResult; reaching here means
-                # an unexpected client error surfaced. Treat as transient
-                # (server-side): back off and retry without counting a retry.
+            except BetterFlowClientError as e:
+                # send_events normally returns a SyncResult; reaching here means an
+                # unexpected client error escaped it (should never fire). Surface
+                # it, then treat as transient (server-side): back off without
+                # counting a retry.
+                logger.warning("Unexpected BetterFlowClientError escaped send_events: %s", e)
                 self._apply_queue_backoff()
                 break
 

--- a/tests/test_bf_client.py
+++ b/tests/test_bf_client.py
@@ -385,7 +385,13 @@ class TestBetterFlowClient:
         result = self.client.send_events(events)
 
         assert result.success is False
-        assert result.events_queued == 0  # server reported 0 failed; caller re-queues whole batch
+        # processed:0/failed:0 is an ambiguous no-verdict, NOT a definitive
+        # rejection: re-queue the whole batch and HOLD it (transient), don't let
+        # it be counted toward the drop. Previously this fell through to the
+        # definitive default (transient False) and dropped good events after 5
+        # cycles (Finding 2).
+        assert result.events_queued == len(events)
+        assert result.transient is True
 
     @responses.activate
     def test_send_events_empty_list(self):

--- a/tests/test_queue_no_drop_on_outage.py
+++ b/tests/test_queue_no_drop_on_outage.py
@@ -105,3 +105,47 @@ def test_definitive_rejection_still_drops_to_avoid_head_of_line_block():
         "a definitively-rejected (4xx) batch must still drop after max retries "
         "so it can't head-of-line-block the queue"
     )
+
+
+def test_stuck_transient_head_eventually_drops_to_unblock_queue():
+    """A batch that fails transiently DETERMINISTICALLY (a content-specific 5xx,
+    or a server stuck returning no-confirmation) must not block the oldest-first
+    queue head forever. After _STUCK_HEAD_CEILING consecutive transient failures
+    it is counted toward the drop so newer events can flow again — otherwise it
+    would freeze the whole upload stream up to the 30-day expiry, silently.
+
+    Guards against the regression #99 introduced (transient never increments)."""
+    from src.sync.sync_engine import SyncEngine
+
+    tmp = Path(tempfile.mkdtemp())
+    engine = _engine(tmp)
+    engine.queue.enqueue(_events(3))
+
+    # Permanent transient failure (server is "up" but this batch always fails).
+    engine.bf.send_events = Mock(
+        return_value=SyncResult(success=False, events_queued=3, transient=True)
+    )
+    # Ceiling consecutive failures + max_retries(5) + margin.
+    _run_cycles(engine, SyncEngine._STUCK_HEAD_CEILING + 8)
+
+    assert engine.queue.size() == 0, (
+        "a permanently-stuck transient head must eventually drop so newer events "
+        "are not blocked forever"
+    )
+
+
+def test_transient_outage_within_ceiling_still_holds_events():
+    """The unblock escape must NOT fire for an outage shorter than the ceiling —
+    those events are held, not dropped (the #99 guarantee still holds)."""
+    from src.sync.sync_engine import SyncEngine
+
+    tmp = Path(tempfile.mkdtemp())
+    engine = _engine(tmp)
+    engine.queue.enqueue(_events(5))
+    engine.bf.send_events = Mock(
+        return_value=SyncResult(success=False, events_queued=5, transient=True)
+    )
+    _run_cycles(engine, SyncEngine._STUCK_HEAD_CEILING - 1)  # below the ceiling
+
+    assert engine.queue.size() == 5, "a sub-ceiling outage must not drop activity"
+    assert engine.queue.failed_event_summary(max_retries=5)["count"] == 0


### PR DESCRIPTION
Senior-review audit of the 06-30 hotfix train. Fixes a HIGH head-of-line-block regression (#99: a deterministically-transient batch froze the queue ~30 days silently), a MEDIUM `{processed:0}` misclassification (dropped good events), and moves transient classification onto `BetterFlowClientError.is_transient` (removes the getattr smell + 429/408 footgun). Verification rejected a 4th finding (408 already transient). 835 tests green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)