### PR TITLE
fix: close audit round-2 residuals (watchdog dual-chain, beta config, guards)

### DIFF
--- a/src/aw_manager.py
+++ b/src/aw_manager.py
@@ -834,7 +834,11 @@ class AWManager:
                 # one probe-restart per retry interval instead of kill+relaunching
                 # every tick. Tracking continues via the activity stream meanwhile.
                 now_mono = time.monotonic()
-                blind = self._window_consecutive_stale >= WINDOW_BLIND_RESTART_THRESHOLD
+                # Read the authoritative flag (set once consecutive crossed the
+                # threshold and cleared on recovery together with the counter) so
+                # the backoff gate and the heartbeat's window_tracker_blind never
+                # diverge as this method grows.
+                blind = self._window_tracker_blind
                 if blind and (now_mono - self._window_last_restart_mono) < WINDOW_BLIND_RETRY_INTERVAL:
                     logger.debug(
                         "%s still stale but blind (%d restarts didn't take) — "

--- a/src/config.py
+++ b/src/config.py
@@ -502,6 +502,12 @@ class Config:
         fraud_detection_data = data.pop("fraud_detection", {})
         call_detection_data = data.pop("call_detection", {})
         foreground_activity_data = data.pop("foreground_activity", {})
+        # Ignore any persisted foreground_activity.enabled — it's server-driven
+        # and default-OFF. A device that ran a default-ON beta build already has
+        # enabled=true on disk; honouring it would override the safe default on
+        # update. Drop it on load so the code default wins; the server re-enables
+        # per-session via update_from_server. (save() also stops writing it.)
+        foreground_activity_data.pop("enabled", None)
         data.pop("screenshots", None)
 
         # Migrate legacy localhost:8000 URLs to production endpoint.
@@ -540,6 +546,14 @@ class Config:
         # accumulate in the app_categories DB table. Don't persist to avoid
         # unbounded growth and inability for the server to retract entries.
         data.get("privacy", {}).pop("default_categories", None)
+        # Never persist foreground_activity.enabled. It is a SERVER-driven,
+        # billing-affecting flag (default OFF) and update_from_server toggles it
+        # per-session. Persisting it would let a build that shipped it default-ON
+        # (v1.5.85-beta.*) pin enabled=true in config.json and override the safe
+        # default on a later update — so the "ship inert" guarantee held only for
+        # devices that never saved it. Drop it so the code default always wins on
+        # load and only the server can switch it on.
+        data.get("foreground_activity", {}).pop("enabled", None)
         tmp_file = config_file.with_suffix(".tmp")
         try:
             with open(tmp_file, "w") as f:

--- a/src/sync/sync_engine.py
+++ b/src/sync/sync_engine.py
@@ -552,6 +552,7 @@ class SyncEngine:
         6. Send heartbeat periodically
         """
         stats = SyncStats()
+        cycle_start = time.monotonic()  # to keep the queue drain inside the watchdog budget
 
         # Daily housekeeping before anything else, so it still runs while paused:
         # a long-running agent that never restarts across midnight would
@@ -736,8 +737,15 @@ class SyncEngine:
         # (the send was confirmed) — otherwise rebuild it next cycle (finding B).
         self._commit_inproc_afk_checkpoint(stats)
 
-        # Process offline queue if we're online
-        if self.bf.is_reachable() and not self.queue.is_empty():
+        # Process offline queue if we're online — but only if this cycle hasn't
+        # already burned most of the watchdog budget on a slow/hung regular send
+        # (else two ~94s chains stack past _DO_SYNC_DEADLINE; the queue drains
+        # next cycle).
+        if (
+            self.bf.is_reachable()
+            and not self.queue.is_empty()
+            and (time.monotonic() - cycle_start) < self._QUEUE_SKIP_IF_CYCLE_ELAPSED
+        ):
             self._process_queue(stats)
 
         # Check heartbeat counter — actual HTTP call is deferred to
@@ -2366,6 +2374,15 @@ class SyncEngine:
     # (_queue_consecutive_failures) resets on ANY success, so an outage that
     # recovers never reaches this — only a genuinely stuck head does.
     _STUCK_HEAD_CEILING = 20
+    # The regular event upload AND the offline-queue drain both run inside one
+    # sync() — i.e. inside the _do_sync watchdog. Each is a single retrying
+    # request chain that can take ~94s against a hung server, so back-to-back they
+    # can exceed _DO_SYNC_DEADLINE (150s) and false-trip "Sync hung" even though
+    # neither is wedged (the regular send hangs, then is_reachable()'s /health
+    # answers fast, then the queue drain hangs too). If the cycle has ALREADY
+    # spent this long before the queue drain, skip it this cycle (it drains next
+    # cycle); 50s + one ~94s chain stays under the 150s deadline with margin.
+    _QUEUE_SKIP_IF_CYCLE_ELAPSED = 50  # seconds
 
     def _process_queue(self, stats: SyncStats) -> None:
         """Process offline queue with exponential backoff.
@@ -2410,6 +2427,14 @@ class SyncEngine:
                     processed += len(events)
                     self._queue_consecutive_failures = 0
                 elif result.accepted_ids:
+                    # A per-event verdict and a transient (no-verdict) failure are
+                    # mutually exclusive in send_events — guard it, because this
+                    # branch increments retry unconditionally, and if a future
+                    # path returned accepted_ids alongside transient=True it would
+                    # drop the unconfirmed events during an outage (#99's bug).
+                    assert not result.transient, (
+                        "accepted_ids and transient are mutually exclusive"
+                    )
                     # Partial success: remove accepted, increment retry on rest.
                     # An event without an "id" cannot be matched against
                     # accepted_ids — treat it as failed so it gets retried

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -192,3 +192,32 @@ class TestUuidRegex:
 def test_in_process_afk_defaults_on():
     from src.config import Config
     assert Config().sync.in_process_afk is True
+
+
+def test_foreground_enabled_is_not_persisted(tmp_path, monkeypatch):
+    """foreground_activity.enabled must never be written to config.json — it's a
+    server-driven, default-OFF billing flag. Persisting it let a default-ON beta
+    build pin enabled=true and override the safe default on update (audit
+    round 2). On load, the code default (False) must win regardless of the saved
+    file."""
+    import json
+
+    from src.config import Config
+
+    cfg_file = tmp_path / "config.json"
+    monkeypatch.setattr(Config, "get_config_file", lambda self: cfg_file)
+
+    cfg = Config()
+    cfg.foreground_activity.enabled = True  # as a beta build would have it
+    cfg.save()
+
+    written = json.loads(cfg_file.read_text())
+    assert "enabled" not in written.get("foreground_activity", {}), (
+        "foreground_activity.enabled must not be persisted"
+    )
+
+    # Even a hand-edited config with enabled=true must not re-activate it.
+    written.setdefault("foreground_activity", {})["enabled"] = True
+    cfg_file.write_text(json.dumps(written))
+    reloaded = Config._from_dict(json.loads(cfg_file.read_text()))
+    assert reloaded.foreground_activity.enabled is False

--- a/tests/test_sync_watchdog_budget.py
+++ b/tests/test_sync_watchdog_budget.py
@@ -146,3 +146,22 @@ def test_real_request_chain_attempt_count_matches_budget_formula():
     # instant, so this is essentially the backoff sum) — proves the formula is an
     # upper bound on real wall-clock.
     assert elapsed <= _worst_case_chain_seconds(fast_cfg, timeout=2) + 1.0
+
+
+def test_queue_drain_skip_keeps_dual_chain_under_watchdog():
+    """The regular send AND the queue drain both run inside one watchdog cycle.
+    The queue is skipped once the cycle has spent _QUEUE_SKIP_IF_CYCLE_ELAPSED, so
+    the worst case is that elapsed budget + ONE more request chain. That must stay
+    under the watchdog deadline, or a slow server + non-empty queue false-trips
+    "Sync hung" (audit round 2)."""
+    from src.sync.sync_engine import SyncEngine
+
+    cfg = BaseApiClient.DEFAULT_RETRY_CONFIG
+    worst_chain = _worst_case_chain_seconds(cfg, _client_default_timeout())
+    deadline = SyncCoordinator._DO_SYNC_DEADLINE
+    budget = SyncEngine._QUEUE_SKIP_IF_CYCLE_ELAPSED
+
+    assert budget + worst_chain < deadline, (
+        f"queue-skip budget {budget}s + one chain {worst_chain:.1f}s = "
+        f"{budget + worst_chain:.1f}s must stay under the {deadline}s watchdog"
+    )


### PR DESCRIPTION
Second senior-review round on the 06-30 hotfix train. MEDIUM: the watchdog could still false-trip from the regular-send + queue-drain dual chain (~188s > 150s) — now skips the queue drain when the cycle is already over budget. MINOR: foreground detector default-OFF now actually holds for beta testers (enabled no longer persisted/restored). Plus a partial-success invariant assert and a blind-flag consistency fix. 837 tests green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)