### PR TITLE
fix(queue): only shed UNSTORABLE stuck heads; guard + observability (round 4)

### DIFF
--- a/src/config.py
+++ b/src/config.py
@@ -506,8 +506,14 @@ class Config:
         # and default-OFF. A device that ran a default-ON beta build already has
         # enabled=true on disk; honouring it would override the safe default on
         # update. Drop it on load so the code default wins; the server re-enables
-        # per-session via update_from_server. (save() also stops writing it.)
-        foreground_activity_data.pop("enabled", None)
+        # per-session via update_from_server. (save() also stops writing it.) Log
+        # when we drop a persisted True so a beta user's "dev-session credit
+        # stopped after update" has a trail rather than a silent flip-off.
+        if foreground_activity_data.pop("enabled", None) is True:
+            logger.info(
+                "Ignoring persisted foreground_activity.enabled=true on load; it "
+                "is server-driven and default-OFF (server re-enables per-session)"
+            )
         data.pop("screenshots", None)
 
         # Migrate legacy localhost:8000 URLs to production endpoint.

--- a/src/sync/sync_engine.py
+++ b/src/sync/sync_engine.py
@@ -741,12 +741,20 @@ class SyncEngine:
         # already burned most of the watchdog budget on a slow/hung regular send
         # (else two ~94s chains stack past _DO_SYNC_DEADLINE; the queue drains
         # next cycle).
-        if (
-            self.bf.is_reachable()
-            and not self.queue.is_empty()
-            and (time.monotonic() - cycle_start) < self._QUEUE_SKIP_IF_CYCLE_ELAPSED
-        ):
-            self._process_queue(stats)
+        if self.bf.is_reachable() and not self.queue.is_empty():
+            elapsed = time.monotonic() - cycle_start
+            if elapsed < self._QUEUE_SKIP_IF_CYCLE_ELAPSED:
+                self._process_queue(stats)
+            else:
+                # The regular send already burned most of the watchdog budget
+                # (slow/hung server). Skip the drain this cycle so two ~94s chains
+                # don't stack past the deadline; it drains next cycle. Log it so a
+                # climbing queue_size traces to drain-skips, not ingest failure.
+                logger.debug(
+                    "Skipping queue drain this cycle: %.0fs already elapsed "
+                    "(budget %ds, queue_size=%d)",
+                    elapsed, self._QUEUE_SKIP_IF_CYCLE_ELAPSED, self.queue.size(),
+                )
 
         # Check heartbeat counter — actual HTTP call is deferred to
         # after sync() returns so _sync_lock is not held during the
@@ -2370,9 +2378,12 @@ class SyncEngine:
     # head forever, freezing every newer event up to the 30-day expiry, silently
     # (the heartbeat stays green). After this many consecutive failed queue cycles
     # (with the backoff schedule, ~3h of sustained failure) we count the stuck
-    # head toward the drop so it ages out and the queue unblocks. The counter
-    # (_queue_consecutive_failures) resets on ANY success, so an outage that
-    # recovers never reaches this — only a genuinely stuck head does.
+    # head toward the drop so it ages out and the queue unblocks — BUT only if the
+    # head batch is unstorable (stale/bucketless); a stuck head that still holds
+    # recent bucketed activity is held, never dropped, so a long events-route
+    # degradation (server reachable, batches 5xx, nothing draining) can't lose real
+    # billable time. The counter (_queue_consecutive_failures) counts every
+    # transient queue failure and resets on any success.
     _STUCK_HEAD_CEILING = 20
     # The regular event upload AND the offline-queue drain both run inside one
     # sync() — i.e. inside the _do_sync watchdog. Each is a single retrying
@@ -2426,15 +2437,16 @@ class SyncEngine:
                     stats.events_sent += result.events_synced
                     processed += len(events)
                     self._queue_consecutive_failures = 0
-                elif result.accepted_ids:
+                elif result.accepted_ids and not result.transient:
                     # A per-event verdict and a transient (no-verdict) failure are
-                    # mutually exclusive in send_events — guard it, because this
-                    # branch increments retry unconditionally, and if a future
-                    # path returned accepted_ids alongside transient=True it would
-                    # drop the unconfirmed events during an outage (#99's bug).
-                    assert not result.transient, (
-                        "accepted_ids and transient are mutually exclusive"
-                    )
+                    # mutually exclusive in send_events today. The `and not
+                    # result.transient` is a fail-safe (NOT an assert: an assert is
+                    # stripped under python -O, and an AssertionError would crash
+                    # the whole sync cycle): if a future path ever returns both,
+                    # fall through to the transient `else` and HOLD the batch
+                    # rather than increment-and-drop the unconfirmed events during
+                    # an outage (#99's bug).
+                    #
                     # Partial success: remove accepted, increment retry on rest.
                     # An event without an "id" cannot be matched against
                     # accepted_ids — treat it as failed so it gets retried
@@ -2465,18 +2477,25 @@ class SyncEngine:
                     # still increments so it can't head-of-line-block the queue.
                     if not result.transient:
                         self.queue.increment_retry(event_ids)
-                    elif self._queue_consecutive_failures >= self._STUCK_HEAD_CEILING:
-                        # Transient, but this oldest batch has failed transiently
-                        # for so many consecutive cycles that it's almost certainly
-                        # a poison batch (a content-specific 5xx / a no-confirmation
-                        # loop) — or an outage far past any realistic duration. It
-                        # blocks every newer event at the dequeue head. Count it
-                        # toward the drop so it ages out and the queue unblocks.
+                    elif (
+                        self._queue_consecutive_failures >= self._STUCK_HEAD_CEILING
+                        and not self._batch_has_storable_activity(events)
+                    ):
+                        # Transient and stuck for many cycles AND the head batch is
+                        # entirely UNSTORABLE (stale past retention or bucketless —
+                        # the server would reject it anyway). Count it toward the
+                        # drop so it ages out and stops blocking the queue head.
+                        #
+                        # We deliberately do NOT shed a stuck head that still holds
+                        # recent, bucketed activity: a long events-route degradation
+                        # (server reachable, batches 5xx) where nothing drains would
+                        # otherwise lose real billable time after ~3h. Those events
+                        # are held for recovery / the 30-day expire_old backstop.
+                        # (A truly poison recent batch blocks only until it ages out
+                        # of the retention window — rare, and never a wrong drop.)
                         logger.warning(
-                            "Queue head batch (%d events) failed transiently for "
-                            "%d consecutive cycles — counting it toward the drop to "
-                            "unblock the queue (likely a poison batch or an outage "
-                            "past the ceiling).",
+                            "Unstorable queue head batch (%d events) stuck %d cycles "
+                            "— counting it toward the drop to unblock the queue.",
                             len(event_ids), self._queue_consecutive_failures,
                         )
                         self.queue.increment_retry(event_ids)
@@ -2494,6 +2513,34 @@ class SyncEngine:
                 logger.warning("Unexpected BetterFlowClientError escaped send_events: %s", e)
                 self._apply_queue_backoff()
                 break
+
+    def _batch_has_storable_activity(
+        self, events: list, *, now: Optional[datetime] = None
+    ) -> bool:
+        """True if any event in the batch is STORABLE — has a bucket to route to
+        AND a timestamp within the server's retention window. A batch with no
+        storable event (all stale past retention or bucketless) is one the server
+        would reject anyway, so it's safe to shed when it blocks the queue head.
+        Mirrors OfflineQueue.failed_event_summary's real-loss classification, so a
+        stuck head holding genuine recent activity is held, never dropped."""
+        now = now or datetime.now(timezone.utc)
+        cutoff = now - timedelta(days=7)  # matches the queue's stale_after_days
+        for ev in events:
+            if not isinstance(ev, dict):
+                continue
+            bid = ev.get("bucket_id")
+            ts = ev.get("timestamp")
+            if not bid or not ts:
+                continue
+            try:
+                parsed = datetime.fromisoformat(str(ts).replace("Z", "+00:00"))
+            except (ValueError, TypeError):
+                continue
+            if parsed.tzinfo is None:
+                parsed = parsed.replace(tzinfo=timezone.utc)
+            if parsed >= cutoff:
+                return True
+        return False
 
     def _apply_queue_backoff(self) -> None:
         """Apply exponential backoff for queue processing failures."""

--- a/tests/test_queue_no_drop_on_outage.py
+++ b/tests/test_queue_no_drop_on_outage.py
@@ -107,31 +107,47 @@ def test_definitive_rejection_still_drops_to_avoid_head_of_line_block():
     )
 
 
-def test_stuck_transient_head_eventually_drops_to_unblock_queue():
-    """A batch that fails transiently DETERMINISTICALLY (a content-specific 5xx,
-    or a server stuck returning no-confirmation) must not block the oldest-first
-    queue head forever. After _STUCK_HEAD_CEILING consecutive transient failures
-    it is counted toward the drop so newer events can flow again — otherwise it
-    would freeze the whole upload stream up to the 30-day expiry, silently.
+def _unstorable_events(n: int) -> list[dict]:
+    """n events the server would reject anyway: bucketless (nowhere to route)."""
+    now = datetime.now(timezone.utc).isoformat()
+    return [
+        {"id": f"u-{i}", "timestamp": now, "duration": 60.0, "data": {}}
+        for i in range(n)
+    ]
 
-    Guards against the regression #99 introduced (transient never increments)."""
+
+def test_storable_stuck_head_is_held_not_dropped():
+    """A stuck head that still holds RECENT, BUCKETED activity must be HELD, never
+    dropped — a long events-route degradation (server reachable, batches 5xx,
+    nothing draining) past the ceiling must not lose real billable time (audit
+    round 4: the round-1 ceiling-drop could shed good events here)."""
     from src.sync.sync_engine import SyncEngine
 
     tmp = Path(tempfile.mkdtemp())
     engine = _engine(tmp)
-    engine.queue.enqueue(_events(3))
-
-    # Permanent transient failure (server is "up" but this batch always fails).
+    engine.queue.enqueue(_events(3))  # storable: recent ts + bucket_id
     engine.bf.send_events = Mock(
         return_value=SyncResult(success=False, events_queued=3, transient=True)
     )
-    # Ceiling consecutive failures + max_retries(5) + margin.
+    _run_cycles(engine, SyncEngine._STUCK_HEAD_CEILING + 10)  # well past the ceiling
+
+    assert engine.queue.size() == 3, "storable activity must never be shed at the ceiling"
+
+
+def test_unstorable_stuck_head_is_dropped_to_unblock():
+    """A stuck head the server would reject anyway (bucketless / stale) IS shed at
+    the ceiling so it stops blocking the queue head."""
+    from src.sync.sync_engine import SyncEngine
+
+    tmp = Path(tempfile.mkdtemp())
+    engine = _engine(tmp)
+    engine.queue.enqueue(_unstorable_events(3))
+    engine.bf.send_events = Mock(
+        return_value=SyncResult(success=False, events_queued=3, transient=True)
+    )
     _run_cycles(engine, SyncEngine._STUCK_HEAD_CEILING + 8)
 
-    assert engine.queue.size() == 0, (
-        "a permanently-stuck transient head must eventually drop so newer events "
-        "are not blocked forever"
-    )
+    assert engine.queue.size() == 0, "an unstorable stuck head must be shed to unblock"
 
 
 def test_transient_outage_within_ceiling_still_holds_events():


### PR DESCRIPTION
Round-3 review found round-1's stuck-head ceiling could shed GOOD recent events during a long events-route degradation. Refine: only shed a stuck head that's entirely UNSTORABLE (stale/bucketless); HOLD recent bucketed activity (no data loss, benign failure mode). Plus assert→fail-safe guard, and two observability logs. 838 green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)