### PR TITLE
fix(queue): drain around a stuck head instead of freezing the queue

### DIFF
--- a/src/sync/queue.py
+++ b/src/sync/queue.py
@@ -294,14 +294,28 @@ class OfflineQueue:
             )
             return count
 
-    def dequeue(self, batch_size: int = 100, max_retries: int = 5) -> list[QueuedEvent]:
+    def dequeue(
+        self,
+        batch_size: int = 100,
+        max_retries: int = 5,
+        *,
+        offset: int = 0,
+    ) -> list[QueuedEvent]:
         """Get a batch of events from the queue (oldest first).
 
         Skips events that have exceeded max_retries (N7).
 
+        ``offset`` skips the oldest N eligible events. _process_queue uses it to
+        step past a batch that just failed this cycle (which stays at the head
+        because it isn't removed), so the events BEHIND a stuck head still get
+        served instead of being head-of-line-blocked. Ordering is a stable total
+        order (created_at, then id) so a fixed offset is deterministic even when
+        several events share a created_at.
+
         Args:
             batch_size: Maximum number of events to return
             max_retries: Skip events with retry_count >= this value
+            offset: Number of oldest eligible events to skip
 
         Returns:
             List of QueuedEvent objects
@@ -316,10 +330,10 @@ class OfflineQueue:
                 SELECT id, event_data, created_at, retry_count
                 FROM queued_events
                 WHERE retry_count < ?
-                ORDER BY created_at ASC
-                LIMIT ?
+                ORDER BY created_at ASC, id ASC
+                LIMIT ? OFFSET ?
                 """,
-                (max_retries, batch_size),
+                (max_retries, batch_size, offset),
             )
             rows = cursor.fetchall()
             result: list[QueuedEvent] = []

--- a/src/sync/queue.py
+++ b/src/sync/queue.py
@@ -20,6 +20,15 @@ __all__ = ["OfflineQueue", "QueuedEvent"]
 
 logger = logging.getLogger(__name__)
 
+# Client-side retention window for queued events, in days. This MUST stay in
+# lockstep with the server's ingest cutoff: internal-tool2
+# AgentEventProcessor::isValidEventTimestamp rejects any event older than 7 days
+# (and more than 5 min in the future). We use it to classify a queue drop as
+# benign — "unstorable": the server would reject it anyway — versus real activity
+# loss. Single source of truth so the two ends can't silently drift; if the
+# server window ever changes, change this too (ideally the server advertises it).
+STALE_AFTER_DAYS = 7
+
 
 @dataclass
 class QueuedEvent:
@@ -387,7 +396,7 @@ class OfflineQueue:
         max_retries: int = 5,
         *,
         now: Optional[datetime] = None,
-        stale_after_days: int = 7,
+        stale_after_days: int = STALE_AFTER_DAYS,
     ) -> dict:
         """Summarize events at/over the retry ceiling that remove_failed() is
         about to drop. Read-only — does NOT delete.

--- a/src/sync/sync_engine.py
+++ b/src/sync/sync_engine.py
@@ -2371,20 +2371,28 @@ class SyncEngine:
                 raise
 
     _QUEUE_PROCESS_TIMEOUT = 30.0  # Max wall-clock seconds for queue drain
-    # A transient whole-batch failure normally does NOT count toward the drop, so
-    # a server outage can't drop good activity (#99). But a batch that fails
-    # transiently DETERMINISTICALLY — a content-specific 5xx, or a server stuck
-    # returning no-confirmation — would otherwise sit at the oldest-first dequeue
-    # head forever, freezing every newer event up to the 30-day expiry, silently
-    # (the heartbeat stays green). After this many consecutive failed queue cycles
-    # (with the backoff schedule, ~3h of sustained failure) we count the stuck
-    # head toward the drop so it ages out and the queue unblocks — BUT only if the
-    # head batch is unstorable (stale/bucketless); a stuck head that still holds
-    # recent bucketed activity is held, never dropped, so a long events-route
-    # degradation (server reachable, batches 5xx, nothing draining) can't lose real
-    # billable time. The counter (_queue_consecutive_failures) counts every
-    # transient queue failure and resets on any success.
-    _STUCK_HEAD_CEILING = 20
+    # A transient whole-batch failure does NOT count toward the drop, so a server
+    # outage can't drop good activity (#99). The old risk was that a batch which
+    # fails transiently but DETERMINISTICALLY (a content-specific 5xx, or a server
+    # stuck returning no-confirmation) would sit at the oldest-first dequeue head
+    # forever, freezing every newer event up to the 30-day expiry — silently, with
+    # the heartbeat green. We now fix that at the source: on a failure the drain
+    # CONTINUES with a growing dequeue OFFSET that steps past the stuck head, so
+    # the events BEHIND it still get served. The queue drains AROUND a stuck head
+    # instead of blocking on it; nothing good is ever dropped to "unblock" it. The
+    # skip is in-memory and per-cycle: the next cycle starts at offset 0 and
+    # re-attempts the head, so a recovered server drains immediately (no persisted
+    # backoff to wait out). A definitively-rejected (4xx) batch still increments
+    # retry_count and drops after max_retries; a transiently-failing batch is held
+    # (retry_count untouched) and retried next cycle. This replaced the old
+    # stuck-head-ceiling shed heuristic.
+    #
+    # Bail out of a drain once this many batches fail transiently back-to-back
+    # with no success in between: the server is likely down, so stop hammering it
+    # this cycle and let the queue backoff throttle the retry cadence. A success
+    # resets the counter, so a lone poison head amid healthy traffic never trips
+    # it — the queue keeps draining around it.
+    _MAX_CONSECUTIVE_TRANSIENT_SKIPS = 3
     # The regular event upload AND the offline-queue drain both run inside one
     # sync() — i.e. inside the _do_sync watchdog. Each is a single retrying
     # request chain that can take ~94s against a hung server, so back-to-back they
@@ -2419,23 +2427,33 @@ class SyncEngine:
         # Process queue in batches
         deadline = time.monotonic() + self._QUEUE_PROCESS_TIMEOUT
         batch_size = self.config.sync.batch_size
-        processed = 0
+        attempted = 0
         max_per_cycle = batch_size * 10  # Max 10 batches per cycle
+        made_progress = False    # any event accepted this cycle
+        had_transient = False    # at least one transient (no-verdict) failure
+        # Events that FAIL this cycle stay at the queue head (not removed; a
+        # transient failure also leaves retry_count untouched). We step past them
+        # with a growing OFFSET so the events BEHIND a stuck head still get served
+        # — draining AROUND the stuck head instead of head-of-line-blocking on it.
+        skip_offset = 0
+        consecutive_transient = 0  # back-to-back transient failures (reset on success)
 
-        while processed < max_per_cycle and time.monotonic() < deadline:
-            queued = self.queue.dequeue(batch_size)
+        while attempted < max_per_cycle and time.monotonic() < deadline:
+            queued = self.queue.dequeue(batch_size, offset=skip_offset)
             if not queued:
                 break
 
             events = [q.event_data for q in queued]
             event_ids = [q.id for q in queued]
+            attempted += len(events)
 
             try:
                 result = self.bf.send_events(events)
                 if result.success:
                     self.queue.remove(event_ids)
                     stats.events_sent += result.events_synced
-                    processed += len(events)
+                    made_progress = True
+                    consecutive_transient = 0
                     self._queue_consecutive_failures = 0
                 elif result.accepted_ids and not result.transient:
                     # A per-event verdict and a transient (no-verdict) failure are
@@ -2443,16 +2461,15 @@ class SyncEngine:
                     # result.transient` is a fail-safe (NOT an assert: an assert is
                     # stripped under python -O, and an AssertionError would crash
                     # the whole sync cycle): if a future path ever returns both,
-                    # fall through to the transient `else` and HOLD the batch
-                    # rather than increment-and-drop the unconfirmed events during
-                    # an outage (#99's bug).
+                    # fall through to the transient branch and HOLD the batch
+                    # rather than increment-and-drop unconfirmed events during an
+                    # outage (#99's bug).
                     #
-                    # Partial success: remove accepted, increment retry on rest.
-                    # An event without an "id" cannot be matched against
-                    # accepted_ids — treat it as failed so it gets retried
-                    # rather than silently dropped. All event producers
-                    # (regular events, status spans, call events) now include
-                    # a stable id; this is defensive against future regressions.
+                    # Partial success: remove accepted, increment retry on the
+                    # server-rejected rest, and step past them (offset) so they
+                    # aren't re-served this cycle. An event without an "id" cannot
+                    # be matched against accepted_ids — treat it as failed so it
+                    # gets retried rather than silently dropped.
                     accepted_set = set(result.accepted_ids)
                     succeeded_ids = [eid for eid, ev in zip(event_ids, events)
                                      if ev.get("id") in accepted_set]
@@ -2460,47 +2477,35 @@ class SyncEngine:
                     if succeeded_ids:
                         self.queue.remove(succeeded_ids)
                         stats.events_sent += len(succeeded_ids)
+                        made_progress = True
                         self._queue_consecutive_failures = 0
                     if failed_ids:
                         self.queue.increment_retry(failed_ids)
-                    processed += len(succeeded_ids)
+                        skip_offset += len(failed_ids)
+                    consecutive_transient = 0
+                elif not result.transient:
+                    # Whole-batch DEFINITIVE rejection (4xx). Count it toward the
+                    # drop so a genuinely poison batch ages out after max_retries,
+                    # and step past it so it isn't re-served (burning all its
+                    # retries) within this same cycle — retries spread across
+                    # cycles, and dequeue serves newer events meanwhile.
+                    self.queue.increment_retry(event_ids)
+                    skip_offset += len(event_ids)
+                    consecutive_transient = 0
                 else:
-                    # Whole-batch failure with no per-event verdict. Only count
-                    # it toward the drop threshold when the server DEFINITIVELY
-                    # rejected the batch (a 4xx). A transient failure — server
-                    # down / 5xx / timeout / DNS / no delivery confirmation — is
-                    # not these events' fault; incrementing here drops good
-                    # activity after 5 down-cycles (the 2026-06-30 outage lost
-                    # real spans this way). Hold the events at their current
-                    # retry_count and retry next cycle; expire_old is the backstop
-                    # against unbounded growth, and a genuinely poison 4xx batch
-                    # still increments so it can't head-of-line-block the queue.
-                    if not result.transient:
-                        self.queue.increment_retry(event_ids)
-                    elif (
-                        self._queue_consecutive_failures >= self._STUCK_HEAD_CEILING
-                        and not self._batch_has_storable_activity(events)
-                    ):
-                        # Transient and stuck for many cycles AND the head batch is
-                        # entirely UNSTORABLE (stale past retention or bucketless —
-                        # the server would reject it anyway). Count it toward the
-                        # drop so it ages out and stops blocking the queue head.
-                        #
-                        # We deliberately do NOT shed a stuck head that still holds
-                        # recent, bucketed activity: a long events-route degradation
-                        # (server reachable, batches 5xx) where nothing drains would
-                        # otherwise lose real billable time after ~3h. Those events
-                        # are held for recovery / the 30-day expire_old backstop.
-                        # (A truly poison recent batch blocks only until it ages out
-                        # of the retention window — rare, and never a wrong drop.)
-                        logger.warning(
-                            "Unstorable queue head batch (%d events) stuck %d cycles "
-                            "— counting it toward the drop to unblock the queue.",
-                            len(event_ids), self._queue_consecutive_failures,
-                        )
-                        self.queue.increment_retry(event_ids)
-                    self._apply_queue_backoff()
-                    break
+                    # Whole-batch TRANSIENT failure (server down / 5xx / timeout /
+                    # DNS / no delivery confirmation). NOT these events' fault, so
+                    # retry_count is untouched — nothing good is ever dropped for a
+                    # server outage (#99). Step past this stuck head so the events
+                    # behind it still drain (fixes the silent head-of-line freeze);
+                    # it's retried from offset 0 next cycle. Bail if several
+                    # batches fail transiently back-to-back — the server is likely
+                    # down, so stop hammering and let the queue backoff throttle.
+                    skip_offset += len(event_ids)
+                    had_transient = True
+                    consecutive_transient += 1
+                    if consecutive_transient >= self._MAX_CONSECUTIVE_TRANSIENT_SKIPS:
+                        break
             except BetterFlowAuthError:
                 # Auth errors won't self-heal with retries; re-raise so
                 # the caller's auth handler can trigger re-login.
@@ -2508,39 +2513,17 @@ class SyncEngine:
             except BetterFlowClientError as e:
                 # send_events normally returns a SyncResult; reaching here means an
                 # unexpected client error escaped it (should never fire). Surface
-                # it, then treat as transient (server-side): back off without
-                # counting a retry.
+                # it and stop this cycle (treated as transient — no retry counted).
                 logger.warning("Unexpected BetterFlowClientError escaped send_events: %s", e)
-                self._apply_queue_backoff()
+                had_transient = True
                 break
 
-    def _batch_has_storable_activity(
-        self, events: list, *, now: Optional[datetime] = None
-    ) -> bool:
-        """True if any event in the batch is STORABLE — has a bucket to route to
-        AND a timestamp within the server's retention window. A batch with no
-        storable event (all stale past retention or bucketless) is one the server
-        would reject anyway, so it's safe to shed when it blocks the queue head.
-        Mirrors OfflineQueue.failed_event_summary's real-loss classification, so a
-        stuck head holding genuine recent activity is held, never dropped."""
-        now = now or datetime.now(timezone.utc)
-        cutoff = now - timedelta(days=7)  # matches the queue's stale_after_days
-        for ev in events:
-            if not isinstance(ev, dict):
-                continue
-            bid = ev.get("bucket_id")
-            ts = ev.get("timestamp")
-            if not bid or not ts:
-                continue
-            try:
-                parsed = datetime.fromisoformat(str(ts).replace("Z", "+00:00"))
-            except (ValueError, TypeError):
-                continue
-            if parsed.tzinfo is None:
-                parsed = parsed.replace(tzinfo=timezone.utc)
-            if parsed >= cutoff:
-                return True
-        return False
+        # Throttle a genuine outage: if the whole cycle made no progress but hit
+        # transient failures, back off before the next drain. When we DID make
+        # progress (queue is flowing, even around a stuck poison head), stay on
+        # the normal cadence so the head is retried promptly next cycle.
+        if had_transient and not made_progress:
+            self._apply_queue_backoff()
 
     def _apply_queue_backoff(self) -> None:
         """Apply exponential backoff for queue processing failures."""

--- a/tests/test_queue.py
+++ b/tests/test_queue.py
@@ -408,3 +408,29 @@ class TestOfflineQueue:
         assert removed == 2
         assert self.queue.get_counted_times("2026-06-15") == {("b", "3"): 3.0}
         assert self.queue.get_counted_times("2026-06-14") == {}
+
+    # ---- dequeue offset (drain-around-a-stuck-head) ----
+
+    def test_dequeue_offset_skips_oldest_events(self):
+        """dequeue(offset=N) steps past the oldest N eligible events, in a stable
+        total order — this is how _process_queue serves the events BEHIND a stuck
+        head instead of head-of-line-blocking on it."""
+        self.queue.enqueue([
+            {"id": "a", "timestamp": "2026-02-18T10:00:00Z", "duration": 60, "data": {}},
+            {"id": "b", "timestamp": "2026-02-18T10:00:00Z", "duration": 60, "data": {}},
+            {"id": "c", "timestamp": "2026-02-18T10:00:00Z", "duration": 60, "data": {}},
+        ])
+
+        # offset 0 = oldest first (stable by id when created_at ties).
+        assert [e.event_data["id"] for e in self.queue.dequeue()] == ["a", "b", "c"]
+        # offset 1 skips the stuck head "a"; "b","c" still get served.
+        assert [e.event_data["id"] for e in self.queue.dequeue(offset=1)] == ["b", "c"]
+        # offset 2 skips two.
+        assert [e.event_data["id"] for e in self.queue.dequeue(offset=2)] == ["c"]
+
+    def test_dequeue_offset_beyond_size_returns_empty(self):
+        """An offset past the end returns [] (the loop terminates cleanly once
+        every remaining event has been stepped past this cycle)."""
+        self.queue.enqueue([{"id": "a", "timestamp": "2026-02-18T10:00:00Z", "duration": 60, "data": {}}])
+        assert self.queue.dequeue(offset=1) == []
+        assert self.queue.size() == 1  # still held, not removed

--- a/tests/test_queue_no_drop_on_outage.py
+++ b/tests/test_queue_no_drop_on_outage.py
@@ -25,6 +25,7 @@ queue forever.
 import tempfile
 from datetime import datetime, timedelta, timezone
 from pathlib import Path
+from typing import Optional
 from unittest.mock import Mock
 
 from src.config import Config
@@ -33,12 +34,15 @@ from src.sync.queue import OfflineQueue
 from src.sync.sync_engine import SyncEngine, SyncStats
 
 
-def _engine(tmp: Path) -> SyncEngine:
+def _engine(tmp: Path, batch_size: Optional[int] = None) -> SyncEngine:
+    config = Config()
+    if batch_size is not None:
+        config.sync.batch_size = batch_size
     return SyncEngine(
         aw=Mock(),
         bf=Mock(),
         queue=OfflineQueue(db_path=tmp / "q.db", max_size=10000),
-        config=Config(),
+        config=config,
         time_tracker=Mock(),
     )
 
@@ -107,61 +111,82 @@ def test_definitive_rejection_still_drops_to_avoid_head_of_line_block():
     )
 
 
-def _unstorable_events(n: int) -> list[dict]:
-    """n events the server would reject anyway: bucketless (nowhere to route)."""
-    now = datetime.now(timezone.utc).isoformat()
-    return [
-        {"id": f"u-{i}", "timestamp": now, "duration": 60.0, "data": {}}
-        for i in range(n)
-    ]
-
-
 def test_storable_stuck_head_is_held_not_dropped():
-    """A stuck head that still holds RECENT, BUCKETED activity must be HELD, never
-    dropped — a long events-route degradation (server reachable, batches 5xx,
-    nothing draining) past the ceiling must not lose real billable time (audit
-    round 4: the round-1 ceiling-drop could shed good events here)."""
-    from src.sync.sync_engine import SyncEngine
-
+    """A stuck head that keeps failing transiently is HELD, never dropped — a long
+    events-route degradation (server reachable, batches 5xx) must not lose real
+    billable time, no matter how many cycles it lasts."""
     tmp = Path(tempfile.mkdtemp())
     engine = _engine(tmp)
     engine.queue.enqueue(_events(3))  # storable: recent ts + bucket_id
     engine.bf.send_events = Mock(
         return_value=SyncResult(success=False, events_queued=3, transient=True)
     )
-    _run_cycles(engine, SyncEngine._STUCK_HEAD_CEILING + 10)  # well past the ceiling
+    _run_cycles(engine, 40)  # sustained outage, well past any historical ceiling
 
-    assert engine.queue.size() == 3, "storable activity must never be shed at the ceiling"
+    assert engine.queue.size() == 3, "transiently-failing activity must never be dropped"
+    assert engine.queue.failed_event_summary(max_retries=5)["count"] == 0
 
 
-def test_unstorable_stuck_head_is_dropped_to_unblock():
-    """A stuck head the server would reject anyway (bucketless / stale) IS shed at
-    the ceiling so it stops blocking the queue head."""
-    from src.sync.sync_engine import SyncEngine
-
+def test_recent_poison_head_does_not_freeze_newer_events():
+    """GAP #1: a persistent recent 5xx head must NOT freeze the events behind it.
+    The queue drains AROUND the stuck head (dequeue offset); the poison is held
+    (never lost), the good events flow. Pre-fix this failed — only the poison head
+    was ever attempted and every newer event stayed frozen, heartbeat green."""
     tmp = Path(tempfile.mkdtemp())
-    engine = _engine(tmp)
-    engine.queue.enqueue(_unstorable_events(3))
-    engine.bf.send_events = Mock(
-        return_value=SyncResult(success=False, events_queued=3, transient=True)
+    engine = _engine(tmp, batch_size=1)  # one event per batch/head
+
+    # Separate enqueue calls => strictly increasing created_at, so the poison is
+    # unambiguously the oldest (dequeue head).
+    engine.queue.enqueue([_evt("POISON")])
+    engine.queue.enqueue([_evt("good-1")])
+    engine.queue.enqueue([_evt("good-2")])
+
+    attempted: list[str] = []
+
+    def fake_send(events):
+        eid = events[0]["id"]
+        attempted.append(eid)
+        if eid == "POISON":
+            return SyncResult(success=False, events_queued=1, transient=True)
+        return SyncResult(success=True, events_queued=0, events_synced=1)
+
+    engine.bf.send_events = Mock(side_effect=fake_send)
+    _run_cycles(engine, 3)
+
+    # Good events were sent and removed; the poison is held (skipped), not lost.
+    assert "good-1" in attempted and "good-2" in attempted, (
+        f"newer events must drain around a stuck head; only {set(attempted)} tried"
     )
-    _run_cycles(engine, SyncEngine._STUCK_HEAD_CEILING + 8)
+    remaining_ids = {
+        ev.event_data["id"] for ev in engine.queue.dequeue(batch_size=100)
+    }
+    # The poison event is still queued (held for a future retry); the good events
+    # have drained.
+    assert engine.queue.size() == 1, "exactly the poison event should remain queued"
+    assert "good-1" not in remaining_ids and "good-2" not in remaining_ids
 
-    assert engine.queue.size() == 0, "an unstorable stuck head must be shed to unblock"
+
+def _evt(eid: str) -> dict:
+    """A single storable event with a stable id (recent ts + bucket_id)."""
+    return {
+        "id": eid,
+        "timestamp": datetime.now(timezone.utc).isoformat(),
+        "duration": 60.0,
+        "bucket_id": "aw-watcher-window_host",
+        "data": {"app": "Terminal"},
+    }
 
 
-def test_transient_outage_within_ceiling_still_holds_events():
-    """The unblock escape must NOT fire for an outage shorter than the ceiling —
-    those events are held, not dropped (the #99 guarantee still holds)."""
-    from src.sync.sync_engine import SyncEngine
-
+def test_full_transient_outage_holds_all_events():
+    """A full outage (every batch fails transiently) holds ALL activity — never
+    dropped — however long it lasts (the #99 guarantee)."""
     tmp = Path(tempfile.mkdtemp())
     engine = _engine(tmp)
     engine.queue.enqueue(_events(5))
     engine.bf.send_events = Mock(
         return_value=SyncResult(success=False, events_queued=5, transient=True)
     )
-    _run_cycles(engine, SyncEngine._STUCK_HEAD_CEILING - 1)  # below the ceiling
+    _run_cycles(engine, 30)
 
-    assert engine.queue.size() == 5, "a sub-ceiling outage must not drop activity"
+    assert engine.queue.size() == 5, "a transient outage must not drop activity"
     assert engine.queue.failed_event_summary(max_retries=5)["count"] == 0


### PR DESCRIPTION
## Why

Follow-up to the 06-30 queue-durability train (#98–#104). Those fixes stopped a
transient outage from **dropping** good activity, but left a silent **liveness**
hole: a batch that fails transiently but *deterministically* (a content-specific
5xx, or a server stuck returning no-confirmation) sat at the oldest-first dequeue
head forever, **freezing every newer event** up to the 30-day expiry — with the
heartbeat green the whole time.

Confirmed with a red-first test: only the poison head was ever attempted; all
newer activity stayed frozen.

## What

Three small, individually-green commits:

1. **refactor(queue): single source of truth for the 7-day retention window** —
   extract the duplicated `7` into `STALE_AFTER_DAYS`, documented as lockstep
   with the server cutoff (`AgentEventProcessor::isValidEventTimestamp`, which
   rejects events >7d old). No behaviour change.
2. **feat(queue): add `dequeue(offset=…)`** — skip the oldest N eligible events
   under a stable total order (`created_at, id`). Additive primitive, unit-tested.
3. **fix(queue): drain around a stuck head instead of freezing the queue** — the
   drain no longer `break`s on failure; it steps past the stuck head with a
   growing offset so the events **behind** it still get served. In-memory,
   per-cycle, so a recovered server drains immediately (no persisted backoff to
   wait out). Bails after N consecutive transient failures so a real outage backs
   off instead of hammering.

### Guarantees preserved
- A transient outage still drops **nothing** (#99).
- A definitive 4xx still increments `retry_count` and drops after `max_retries`.
- `remove_failed` and `expire_old` remain the only delete paths.

### Removed
- The stuck-head-ceiling shed heuristic (`_STUCK_HEAD_CEILING` /
  `_batch_has_storable_activity`). The offset drain makes shedding-to-unblock
  unnecessary, so we no longer need a ~3h timer that could drop good recent
  activity.

## Tests
- Red-first `test_recent_poison_head_does_not_freeze_newer_events` (fails on
  main, passes here).
- `dequeue(offset=…)` unit tests; full-outage-holds-all; storable-head-held;
  definitive-drop retained.
- Full suite: **840 passed** locally.

## Note for review
This reworks logic @tuuude just landed across #98–#104 (4 audit rounds), so an
extra set of eyes from that context would be ideal. Draft until reviewed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
