### PR TITLE
fix(window): keep a flapping win32 tracker backed off; sticky blind-clear

### DIFF
--- a/src/aw_manager.py
+++ b/src/aw_manager.py
@@ -87,6 +87,14 @@ IDLE_BLIND_RETRY_INTERVAL = 1800  # 30 minutes
 # and probe at most once per retry interval.
 WINDOW_BLIND_RESTART_THRESHOLD = 5
 WINDOW_BLIND_RETRY_INTERVAL = 1800  # 30 minutes
+# A FLAPPING (not permanently-wedged) window-capture source emits the odd event
+# between blind spells; clearing the blind flag on the first one reset the churn
+# counter and let it re-enter a full restart burst ~30s later, defeating the
+# retry-interval backoff (Sachi, win32, 2026-07-01: blind at 09:50, a lone event
+# ~09:55 cleared it, then a second 4-restart burst at 09:57). Require this many
+# CONSECUTIVE healthy health-checks (~30s each) before trusting recovery and
+# unlatching, so a flapping source stays backed off instead of churning per flap.
+WINDOW_BLIND_CLEAR_HEALTHY_CYCLES = 3
 
 
 def _get_platform_key() -> str:
@@ -395,6 +403,11 @@ class AWManager:
         self._window_consecutive_stale: int = 0
         self._window_tracker_blind: bool = False
         self._window_last_restart_mono: float = 0.0
+        # Consecutive healthy (fresh-event) health-checks observed WHILE blind.
+        # The blind flag only clears once this reaches
+        # WINDOW_BLIND_CLEAR_HEALTHY_CYCLES so a flapping source's stray events
+        # don't unlatch it prematurely (see WINDOW_BLIND_CLEAR_HEALTHY_CYCLES).
+        self._window_healthy_streak: int = 0
         # When the agent uploads its own in-process AFK stream, the external
         # bf-idle-tracker bucket is ignored — don't restart it or raise blind
         # alerts about a tracker we no longer consume.
@@ -820,13 +833,38 @@ class AWManager:
             running_for = self._component_running_seconds(watcher)
             reachable = self._port_in_use()
             if not self._is_window_tracker_stale(age, running_for, reachable):
-                # Emitting fresh window events again: clear blind state so a
-                # future genuine stall restarts promptly. (age None here is just
-                # launch lag or an AW outage, not recovery — don't reset on it.)
+                # Emitting fresh window events again. (age None here is just
+                # launch lag or an AW outage, not recovery — don't count it.)
                 if age is not None and age <= STALE_THRESHOLD:
-                    self._window_consecutive_stale = 0
-                    self._window_tracker_blind = False
+                    if self._window_tracker_blind:
+                        # A flapping source emits a stray event between blind
+                        # spells; unlatching on the FIRST one lets it re-enter a
+                        # full restart burst, defeating the retry-interval backoff
+                        # (see WINDOW_BLIND_CLEAR_HEALTHY_CYCLES). Require sustained
+                        # emission before we trust recovery and clear the flag.
+                        self._window_healthy_streak += 1
+                        if self._window_healthy_streak >= WINDOW_BLIND_CLEAR_HEALTHY_CYCLES:
+                            self._window_tracker_blind = False
+                            self._window_consecutive_stale = 0
+                            self._window_healthy_streak = 0
+                            logger.info(
+                                "%s emitting steadily again across %d checks — "
+                                "clearing blind flag; per-app attribution restored",
+                                watcher,
+                                WINDOW_BLIND_CLEAR_HEALTHY_CYCLES,
+                            )
+                    else:
+                        # Not blind: reset promptly so a future genuine stall
+                        # restarts on the next tick, not after a fresh burst.
+                        self._window_consecutive_stale = 0
+                else:
+                    # age None (launch lag / AW outage): not proof of recovery —
+                    # a flap through such a gap must not count toward the streak.
+                    self._window_healthy_streak = 0
             else:
+                # Staleness breaks any in-progress recovery streak — the healthy
+                # cycles must be CONSECUTIVE for the blind flag to clear.
+                self._window_healthy_streak = 0
                 # Stale. If it has stayed stale across several restarts it is
                 # blind — a wedged/blocked window-capture source a restart can't
                 # fix (Sachi, win32, 2026-06-30: restart #1→#5 every 30s while the

--- a/tests/test_aw_manager_window_blind.py
+++ b/tests/test_aw_manager_window_blind.py
@@ -121,10 +121,15 @@ def test_blind_window_tracker_stops_churning_and_flags_blind():
     )
 
 
-def test_window_blind_clears_when_tracker_recovers():
-    """Once the window tracker emits fresh events again, the blind flag and the
-    consecutive counter reset so a future genuine stall restarts promptly."""
-    from src.aw_manager import WINDOW_BLIND_RESTART_THRESHOLD
+def test_window_blind_clears_after_sustained_recovery():
+    """The blind flag clears only after the tracker emits fresh events across
+    WINDOW_BLIND_CLEAR_HEALTHY_CYCLES consecutive health-checks — sustained
+    recovery, not a single stray event (see flapping test below). Once cleared,
+    the consecutive counter resets so a future genuine stall restarts promptly."""
+    from src.aw_manager import (
+        WINDOW_BLIND_CLEAR_HEALTHY_CYCLES,
+        WINDOW_BLIND_RESTART_THRESHOLD,
+    )
 
     mgr, window = _mgr(window_age=STALE_THRESHOLD + 80, running_for=WINDOW_BLIND_GRACE + 120)
     for _ in range(WINDOW_BLIND_RESTART_THRESHOLD):
@@ -132,9 +137,50 @@ def test_window_blind_clears_when_tracker_recovers():
         mgr.restart_if_needed()
     assert mgr.window_tracker_blind is True
 
-    # Recovers: fresh window events.
+    # Recovers: fresh window events, sustained across the required cycles.
     mgr._get_latest_window_event_age = MagicMock(return_value=5)
-    mgr.restart_if_needed()
+    for i in range(WINDOW_BLIND_CLEAR_HEALTHY_CYCLES):
+        assert mgr.window_tracker_blind is True, (
+            f"must stay latched until {WINDOW_BLIND_CLEAR_HEALTHY_CYCLES} healthy "
+            f"cycles (cleared early at cycle {i})"
+        )
+        mgr.restart_if_needed()
 
     assert mgr.window_tracker_blind is False
     assert mgr._window_consecutive_stale == 0
+
+
+def test_flapping_window_tracker_stays_backed_off():
+    """A win32 capture source that FLAPS — a lone fresh event between blind
+    spells — must not re-enter a full restart burst. Clearing blind on the first
+    stray event (pre-fix) reset the counter and let a second 5-restart burst run
+    ~30s later, defeating the retry-interval backoff (Sachi, win32, 2026-07-01:
+    blind at 09:50, a lone event ~09:55 cleared it, then a 4-restart burst at
+    09:57). Once blind, a single healthy cycle followed by staleness again must
+    stay backed off (no new restart) until sustained recovery clears the flag."""
+    from src.aw_manager import WINDOW_BLIND_RESTART_THRESHOLD
+
+    mgr, window = _mgr(window_age=STALE_THRESHOLD + 80, running_for=WINDOW_BLIND_GRACE + 120)
+    for _ in range(WINDOW_BLIND_RESTART_THRESHOLD):
+        window.poll.return_value = None
+        mgr.restart_if_needed()
+    assert mgr.window_tracker_blind is True
+    restarts_at_blind = mgr._start_component.call_count
+    assert restarts_at_blind == WINDOW_BLIND_RESTART_THRESHOLD
+
+    # One stray fresh event (the flap) — NOT sustained recovery.
+    mgr._get_latest_window_event_age = MagicMock(return_value=5)
+    mgr.restart_if_needed()
+
+    # Source dies again immediately. Because it's still blind and within the
+    # retry interval, the watchdog must back off, not launch a fresh burst.
+    mgr._get_latest_window_event_age = MagicMock(return_value=STALE_THRESHOLD + 80)
+    for _ in range(WINDOW_BLIND_RESTART_THRESHOLD + 2):
+        window.poll.return_value = None
+        mgr.restart_if_needed()
+
+    assert mgr.window_tracker_blind is True, "a flap must not unlatch the blind flag"
+    assert mgr._start_component.call_count == restarts_at_blind, (
+        "a flapping source must stay backed off — no new restart burst "
+        f"(expected {restarts_at_blind} restarts, got {mgr._start_component.call_count})"
+    )


### PR DESCRIPTION
## Summary

Follow-up to #101. That PR bounded each window-tracker restart burst and flagged `window_tracker_blind`, but cleared the flag on the **first** fresh window event. A **flapping** (not permanently-wedged) win32 capture source emits the odd event between blind spells, so a lone event reset the churn counter and let the tracker re-enter a full 5-restart burst ~30s later — defeating the 30-min `WINDOW_BLIND_RETRY_INTERVAL` backoff.

## Observed live

Sachi, win32, v1.5.87, 2026-07-01 (device 16, from her uploaded agent log):
- `09:50:27` — blind flagged after restart #1→#5
- `~09:55` — a lone window event cleared the flag + reset the counter
- `09:57:56–09:59:26` — a **second** burst, restart #6→#9 (counter reset to `consecutive 1`)
- `~09:59:56` — recovered for real; healthy for the following 64+ min

Billing was unaffected the whole time (the activity stream is independent of the window tracker), but the tracker churned in repeated bursts rather than holding the backoff. This is the "#101 may not fully fix the win32 root capture failure" caveat, now characterized.

## Fix

Make the blind-clear **sticky**: require `WINDOW_BLIND_CLEAR_HEALTHY_CYCLES` (3) **consecutive** healthy health-checks before unlatching `window_tracker_blind`; any staleness or age-None gap resets the streak. A flapping source stays backed off (one probe-restart per retry interval) instead of re-bursting per flap; a genuinely recovered tracker clears after ~90s of steady emission. Non-blind behavior is unchanged.

## Test (proof-of-failure handshake)

- **New** `test_flapping_window_tracker_stays_backed_off`: 5 stale ticks (blind, 5 restarts) → one stray fresh event → staleness again. **Pre-fix it FAILED** — `_start_component` called 10× (a second full burst; the captured log reproduced Sachi's exact #1→#10 double-flag) vs expected 5. **Post-fix passes** (stays 5, flag latched).
- **Updated** `test_window_blind_clears_when_tracker_recovers` → `test_window_blind_clears_after_sustained_recovery`: asserts the flag holds until 3 consecutive healthy cycles.
- Full suite: **839 passed**. No new ruff findings in the changed files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)