### PR TITLE
fix(sync): coalesce same-app window title-flicker instead of dropping it

### DIFF
--- a/src/__init__.py
+++ b/src/__init__.py
@@ -1,4 +1,4 @@
 """BetterFlow - ActivityWatch to BetterFlow sync companion app."""
 
-__version__ = "1.5.88"
+__version__ = "1.5.89"
 __author__ = "BetterQA"

--- a/src/sync/sync_engine.py
+++ b/src/sync/sync_engine.py
@@ -1220,12 +1220,24 @@ class SyncEngine:
         new bucket-processing path can't silently classify against an empty
         context (this is the window-classification entry point).
         """
-        # Feed window events to activity analyzer for window change detection
+        # Feed window events to activity analyzer for window change detection.
+        # The analyzer sees the RAW events (unchanged) — coalescing below only
+        # affects what we upload, not window-change/fraud detection.
         if bucket_type in (BUCKET_TYPE_WINDOW, BUCKET_TYPE_WINDOW_ALT):
             self._activity_analyzer.add_window_events(events)
 
+        # Coalesce same-app title flicker so a run of sub-minimum window events
+        # isn't dropped wholesale by the flicker filter (per-app attribution
+        # loss). The checkpoint below is still computed from the ORIGINAL events,
+        # so a merged span never rewinds or double-advances the checkpoint.
+        events_to_transform = (
+            self._coalesce_window_flicker(events)
+            if bucket_type in (BUCKET_TYPE_WINDOW, BUCKET_TYPE_WINDOW_ALT)
+            else events
+        )
+
         transformed = []
-        for event in events:
+        for event in events_to_transform:
             # Dedup: skip if already sent with same duration.
             # For gap-filled events, also accept the original AW duration
             # (gap-filling is deterministic, so the extended version was
@@ -1445,6 +1457,81 @@ class SyncEngine:
                     continue
             collapsed.append(ev)
         return collapsed
+
+    # AW emits back-to-back window events (no gap) on a focus/title change, so
+    # bridging only needs to absorb sub-second rounding between adjacent events.
+    _WINDOW_FLICKER_GAP_TOLERANCE = 2.0  # seconds
+
+    def _coalesce_window_flicker(self, events: list[AWEvent]) -> list[AWEvent]:
+        """Merge runs of consecutive SAME-APP window events when the run would
+        otherwise lose data to the flicker filter.
+
+        A window title that updates faster than ``min_window_event_seconds`` (a
+        browser tab with a live counter, a terminal, a media player) makes AW
+        emit a new window event on every title change — each shorter than the
+        minimum, so ``_transform_event`` drops them ALL and the app loses its
+        per-app timeline entirely (Sachi Navodi, 2026-07-01: chrome.exe, 99
+        sub-5s events dropped every cycle → "No activity tracked" while hours
+        still tracked). Continuous focus on ONE app must not be discarded just
+        because its title flickers.
+
+        We merge a maximal run of consecutive, contiguous, same-app events into a
+        single span (earliest start → latest end) so the run clears the minimum;
+        the representative title/url comes from the longest-lived event in the
+        run. A run is only merged when it actually rescues data — length >= 2 AND
+        at least one member is below the minimum — so a normal user's already-
+        passing events are left byte-identical (strictly additive change).
+        DIFFERENT apps are never merged, so genuine cross-app alt-tab noise is
+        still suppressed by the per-event minimum.
+
+        Safe by construction: window/web events are ATTRIBUTION-ONLY (billing
+        rides the AFK/input stream), and the server upserts by AW event id and
+        aggregates per app/day — so this only affects per-app attribution, never
+        billed hours. Source events are frozen and never mutated; merged spans
+        are new AWEvents anchored on the run's LAST id, matching the newest-event
+        heartbeat-extension semantics the dedup path already assumes.
+        """
+        if len(events) < 2:
+            return events
+        min_seconds = self.config.sync.min_window_event_seconds
+        tolerance = timedelta(seconds=self._WINDOW_FLICKER_GAP_TOLERANCE)
+        ordered = sorted(events, key=lambda e: e.timestamp)
+
+        merged: list[AWEvent] = []
+
+        def flush(run: list[AWEvent]) -> None:
+            # Merge only when the run would otherwise lose data: >=2 events and at
+            # least one below the minimum. Otherwise emit the run unchanged.
+            if len(run) >= 2 and any(e.duration < min_seconds for e in run):
+                first = run[0]
+                last = max(run, key=lambda e: e.timestamp + timedelta(seconds=e.duration))
+                end = last.timestamp + timedelta(seconds=last.duration)
+                span = round((end - first.timestamp).total_seconds(), 2)
+                rep = max(run, key=lambda e: e.duration)  # longest-lived title/url
+                merged.append(AWEvent(
+                    id=last.id,
+                    timestamp=first.timestamp,
+                    duration=span,
+                    data=rep.data,
+                ))
+            else:
+                merged.extend(run)
+
+        run: list[AWEvent] = []
+        for ev in ordered:
+            if run:
+                prev = run[-1]
+                prev_end = prev.timestamp + timedelta(seconds=prev.duration)
+                same_app = ev.app is not None and ev.app == prev.app
+                contiguous = ev.timestamp <= prev_end + tolerance
+                if same_app and contiguous:
+                    run.append(ev)
+                    continue
+                flush(run)
+                run = []
+            run.append(ev)
+        flush(run)
+        return merged
 
     def _get_afk_events_for_range(
         self, start: datetime, end: datetime

--- a/tests/test_window_flicker_coalesce.py
+++ b/tests/test_window_flicker_coalesce.py
@@ -1,0 +1,128 @@
+"""Window title-flicker coalescing.
+
+A window title that updates faster than min_window_event_seconds (a browser tab
+with a live counter, a terminal, a media player) makes ActivityWatch emit a new
+window event on every title change — each below the flicker filter's minimum, so
+_transform_event drops them ALL and the app loses its per-app timeline entirely
+(Sachi Navodi, 2026-07-01: chrome.exe, 99 sub-5s events dropped every cycle →
+"No activity tracked" while hours still tracked).
+
+_coalesce_window_flicker merges a run of consecutive SAME-APP events into one
+span so continuous focus survives the minimum, but ONLY when the run would
+otherwise lose data — so normal (already-passing) events are untouched.
+"""
+
+import tempfile
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+from unittest.mock import Mock
+
+from src.config import Config
+from src.sync.aw_client import AWEvent
+from src.sync.queue import OfflineQueue
+from src.sync.sync_engine import SyncEngine
+
+BASE = datetime(2026, 7, 1, 10, 0, 0, tzinfo=timezone.utc)
+
+
+def _engine() -> SyncEngine:
+    tmp = Path(tempfile.mkdtemp())
+    return SyncEngine(
+        aw=Mock(),
+        bf=Mock(),
+        queue=OfflineQueue(db_path=tmp / "q.db", max_size=10000),
+        config=Config(),  # min_window_event_seconds defaults to 5.0
+        time_tracker=Mock(),
+    )
+
+
+def _ev(offset_s: float, dur: float, app: str, title: str = "", eid: int = 0) -> AWEvent:
+    return AWEvent(
+        id=eid or int(offset_s * 1000),
+        timestamp=BASE + timedelta(seconds=offset_s),
+        duration=dur,
+        data={"app": app, "title": title},
+    )
+
+
+class TestCoalesceWindowFlicker:
+    def test_same_app_flicker_run_merges_into_one_passing_span(self):
+        eng = _engine()
+        # 6 back-to-back 1s chrome events (title flickering) — each < 5s min.
+        events = [_ev(i, 1.0, "chrome.exe", f"tab {i}", eid=100 + i) for i in range(6)]
+
+        merged = eng._coalesce_window_flicker(events)
+
+        assert len(merged) == 1, "the flicker run should collapse to a single span"
+        m = merged[0]
+        assert m.app == "chrome.exe"
+        assert abs(m.duration - 6.0) < 0.01, "span = first.start -> last.end"
+        assert m.timestamp == events[0].timestamp
+        assert m.id == events[-1].id, "anchored on the run's newest id"
+        # And it now clears the flicker filter (would have been dropped before).
+        assert m.duration >= eng.config.sync.min_window_event_seconds
+
+    def test_different_apps_are_not_merged(self):
+        eng = _engine()
+        # Alt-tab noise across apps: each 1s, different app — must NOT merge, so
+        # the per-event minimum still suppresses cross-app flicker.
+        events = [
+            _ev(0, 1.0, "chrome.exe", eid=1),
+            _ev(1, 1.0, "slack.exe", eid=2),
+            _ev(2, 1.0, "code.exe", eid=3),
+        ]
+        merged = eng._coalesce_window_flicker(events)
+        assert [m.app for m in merged] == ["chrome.exe", "slack.exe", "code.exe"]
+        assert all(m.duration == 1.0 for m in merged)
+
+    def test_all_long_events_are_left_byte_identical(self):
+        eng = _engine()
+        # Every event already clears the minimum → no data at risk → no merge.
+        events = [_ev(0, 30.0, "chrome.exe", eid=1), _ev(30, 30.0, "chrome.exe", eid=2)]
+        merged = eng._coalesce_window_flicker(events)
+        assert merged == events, "already-passing events must be untouched"
+
+    def test_flicks_are_absorbed_into_adjacent_same_app_event(self):
+        eng = _engine()
+        # A long chrome event followed by two 1s chrome title flicks → one span.
+        events = [
+            _ev(0, 10.0, "chrome.exe", "main", eid=1),
+            _ev(10, 1.0, "chrome.exe", "notif 1", eid=2),
+            _ev(11, 1.0, "chrome.exe", "notif 2", eid=3),
+        ]
+        merged = eng._coalesce_window_flicker(events)
+        assert len(merged) == 1
+        assert abs(merged[0].duration - 12.0) < 0.01
+        # Representative title comes from the longest-lived member.
+        assert merged[0].title == "main"
+
+    def test_gap_larger_than_tolerance_breaks_the_run(self):
+        eng = _engine()
+        # Same app but a 30s gap between the flicks → two separate runs, neither
+        # mergeable (each a lone 1s event), so both stay short (and would drop).
+        events = [_ev(0, 1.0, "chrome.exe", eid=1), _ev(31, 1.0, "chrome.exe", eid=2)]
+        merged = eng._coalesce_window_flicker(events)
+        assert len(merged) == 2, "a large gap must not be bridged"
+
+    def test_short_same_app_run_still_under_minimum_is_not_rescued(self):
+        eng = _engine()
+        # Two 1s flicks total 2s (< 5s) — merged, but still below the minimum, so
+        # this genuinely-brief same-app focus is still (correctly) suppressed.
+        events = [_ev(0, 1.0, "chrome.exe", eid=1), _ev(1, 1.0, "chrome.exe", eid=2)]
+        merged = eng._coalesce_window_flicker(events)
+        assert len(merged) == 1
+        assert merged[0].duration < eng.config.sync.min_window_event_seconds
+
+    def test_source_events_not_mutated(self):
+        eng = _engine()
+        events = [_ev(i, 1.0, "chrome.exe", f"t{i}", eid=i + 1) for i in range(4)]
+        before = [(e.id, e.timestamp, e.duration, dict(e.data)) for e in events]
+        eng._coalesce_window_flicker(events)
+        after = [(e.id, e.timestamp, e.duration, dict(e.data)) for e in events]
+        assert before == after, "frozen source events must never be mutated"
+
+    def test_fewer_than_two_events_returned_as_is(self):
+        eng = _engine()
+        assert eng._coalesce_window_flicker([]) == []
+        one = [_ev(0, 1.0, "chrome.exe", eid=1)]
+        assert eng._coalesce_window_flicker(one) == one


### PR DESCRIPTION
## Why

Diagnosed from Sachi Navodi's agent log (2026-07-01, Windows, 1.5.87). Her
dashboard showed **"No activity tracked"** while hours still accrued. The log
says it outright, every cycle:

> *Window/app data has gone stale on the server across 3 cycles — the watcher IS
> producing window events but the filter is dropping them all (99 window event(s)
> under the 5s minimum (flicker filter)). Billing is unaffected (AFK/input still
> upload); only per-app attribution is lost.*

Her window title updates faster than `min_window_event_seconds` (chrome.exe with
a live-updating title), so AW emits a new sub-5s window event on every title
change and `_transform_event` drops **all** of them — the per-app timeline goes
empty even though she's continuously in one app.

(Her other reported "no data" was a **separate**, already-resolved issue: an
06-30 backend HTTP 500 storm — 822 errors, all on 06-30 — not the agent, and not
the queue.)

## What

`_coalesce_window_flicker`: merge a run of consecutive, contiguous, **same-app**
window events into one span *before* the minimum is applied, so continuous focus
survives a flickering title. Mirrors the trusted `_collapse_afk_duplicates`
pattern.

- **Gated**: only merges runs that would otherwise lose data (≥2 events, at least
  one below the minimum). A normal user's already-passing events are
  byte-identical — strictly additive.
- **Different apps never merge**, so genuine cross-app alt-tab noise is still
  suppressed by the per-event minimum.
- Representative title/url = the longest-lived event in the run.

## Safety
- Window/web events are **attribution-only** (billing rides the AFK/input
  stream), and the server upserts by AW id + aggregates per app/day — this only
  affects per-app attribution, never billed hours.
- The checkpoint is still computed from the **original** events, so a merged span
  can't rewind or double-advance it.
- Frozen source events are never mutated; the activity/fraud analyzer still sees
  the raw events.

## Tests
- 8 unit tests (`tests/test_window_flicker_coalesce.py`): flicker run merges &
  clears the filter, different apps not merged, already-passing events untouched,
  flicks absorbed into an adjacent same-app event, gap breaks the run, still-brief
  runs stay suppressed, source not mutated.
- Full suite: **847 passed**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
