### PR TITLE
feat(sync): in-process Windows window watcher (dormant, opt-in)

### DIFF
--- a/src/config.py
+++ b/src/config.py
@@ -311,6 +311,14 @@ class SyncSettings:
     # independently reversible: with the tracker stopped, recovery can't fall back
     # to it without flipping a flag, so this ships dark until validated.
     stop_external_afk_tracker: bool = False
+    # Generate the per-app active-window stream in-process from the OS
+    # frontmost-window probe (+ psutil process name) instead of the external
+    # bf-window-tracker bucket. Same convergence move as in_process_afk, for
+    # machines where the bundled aw-watcher-window launches but its Win32 capture
+    # returns zero events for hours. Default OFF — ships dormant/opt-in; when on
+    # AND the probe is usable, the external window bucket is skipped so the two
+    # sources never double-count.
+    in_process_window: bool = False
 
 
 @dataclass
@@ -674,6 +682,13 @@ class Config:
                         self.sync.min_window_event_seconds = val
                 except (TypeError, ValueError):
                     logger.warning("Invalid min_window_event_seconds from server, ignoring")
+            if "in_process_window" in sync:
+                # Opt-in remote enable of the in-process window source (ships
+                # dormant). Bool-coerced and logged so a rollout is auditable.
+                self.sync.in_process_window = bool(sync["in_process_window"])
+                logger.info(
+                    "Server config: in_process_window=%s", self.sync.in_process_window
+                )
 
         if "engagement" in server_config:
             eng = server_config["engagement"]

--- a/src/main.py
+++ b/src/main.py
@@ -1559,6 +1559,27 @@ class BetterFlowApp:
             self.config.sync.in_process_afk and afk_source.available()
         )
 
+        # In-process WINDOW source: the per-app analogue of afk_source. The agent
+        # generates its own per-app active-window stream from the OS
+        # frontmost-window probe (+ psutil process name) and uploads it as the
+        # sole window source, so a bf-window-tracker that launches but captures
+        # zero events (the Windows blind-capture failure) can't lose per-app
+        # coverage. Ships dormant: inert unless config enables it AND the probe
+        # is usable (macOS/Windows; off on Linux without an X11 active-window pid).
+        try:
+            from .sync.window_source import WindowSource
+        except ImportError:
+            from sync.window_source import WindowSource
+        window_source = WindowSource(
+            hostname=self.coordinator.sync_engine._hostname,
+        )
+        self.coordinator.sync_engine.window_source = window_source
+        logger.info(
+            "In-process window source: %s",
+            "active" if (self.config.sync.in_process_window and window_source.available())
+            else "inactive",
+        )
+
         # Reminder manager (created after coordinator for clean callback injection)
         self.reminder_manager = ReminderManager(self.config.reminders)
         self.coordinator.reminder_manager = self.reminder_manager

--- a/src/main.py
+++ b/src/main.py
@@ -354,6 +354,17 @@ class SyncCoordinator:
                 id="trends_refresh_job",
                 replace_existing=True,
             )
+            # Frequent frontmost-window sampler for the in-process window source.
+            # Window focus changes far faster than the 60s sync cycle, so we
+            # sample every few seconds to give the reconstructed per-app spans
+            # real resolution. Gated + cheap: a no-op unless in_process_window is
+            # on and the probe is usable, so it adds nothing to the default path.
+            self.scheduler.add_job(
+                self._sample_window,
+                trigger=IntervalTrigger(seconds=self.WINDOW_SAMPLE_INTERVAL_SECONDS),
+                id="window_sample_job",
+                replace_existing=True,
+            )
             self.scheduler.start()
             logger.info(
                 f"Sync loop started (interval: {self.config.sync.interval_seconds}s)"
@@ -848,6 +859,22 @@ class SyncCoordinator:
                 "please enable BetterFlow and bf-idle-tracker under Input "
                 "Monitoring.",
             )
+
+    # Frontmost-window sampling cadence for the in-process window source. Window
+    # focus changes far faster than the 60s sync cycle; ~5s keeps the sample log
+    # dense enough for real per-app span resolution without meaningful cost
+    # (one GetForegroundWindow + psutil name lookup). Only fires work when
+    # in_process_window is enabled and the probe is usable.
+    WINDOW_SAMPLE_INTERVAL_SECONDS = 5
+
+    def _sample_window(self) -> None:
+        """Dedicated fast sampler for the in-process window source. Gated no-op
+        unless in_process_window is on and the frontmost-window probe is usable,
+        so it costs nothing on the default path."""
+        try:
+            self.sync_engine.record_window_sample_if_active(datetime.now(timezone.utc))
+        except Exception as e:
+            logger.debug("window sample tick failed: %s", e)
 
     def _tick_60s(self) -> None:
         """Unified 60-second tick - one wakeup instead of five.

--- a/src/sync/sync_engine.py
+++ b/src/sync/sync_engine.py
@@ -266,6 +266,21 @@ class SyncEngine:
         self._inproc_blind_reported = False
         self._INPROC_BLIND_THRESHOLD = 3
 
+        # Optional in-process WINDOW source (set by the SyncCoordinator), the
+        # per-app analogue of afk_source. When present, enabled by config, and
+        # the OS frontmost-window probe is usable, the agent uploads its own
+        # per-app active-window stream and the external bf-window-tracker bucket
+        # is skipped so the two never double-count. Ships dormant
+        # (in_process_window defaults False). Same checkpoint discipline as AFK:
+        # the checkpoint is the last instant covered by an upload, seeded to
+        # `now` on the first cycle, committed only after a confirmed send.
+        # Mutated only on the sync thread.
+        self.window_source = None
+        self._window_inproc_checkpoint: Optional[datetime] = None
+        # Proposed next checkpoint for the span built this cycle; committed by
+        # _commit_inproc_window_checkpoint only after a confirmed send.
+        self._window_inproc_pending: Optional[datetime] = None
+
         # Queue retry backoff
         self._queue_consecutive_failures = 0
         self._queue_backoff_until = datetime.min.replace(tzinfo=timezone.utc)
@@ -633,6 +648,15 @@ class SyncEngine:
             except Exception as e:
                 logger.debug("afk_source.record_sample failed: %s", e)
 
+        # Record a frontmost-window sample for the in-process window timeline
+        # (no-op when no source is wired, the flag is off, or the probe is
+        # unusable). Done every cycle so the sample log stays dense.
+        if self._should_use_inproc_window():
+            try:
+                self.window_source.record_sample(datetime.now(timezone.utc))
+            except Exception as e:
+                logger.debug("window_source.record_sample failed: %s", e)
+
         # Get buckets to sync
         try:
             window_buckets = self.aw.get_window_buckets()
@@ -670,9 +694,20 @@ class SyncEngine:
         # transform path — no per-cycle state lives on the instance.
         cycle = self._prepare_input_analysis(input_buckets)
 
+        # When the agent is the sole per-app window source (in-process), drop the
+        # external bf-window-tracker bucket(s) entirely — we upload our own stream
+        # below instead, so its (possibly blind) events never reach the server and
+        # can't double-count. No-op when the flag is off (default): the external
+        # window bucket syncs exactly as today.
+        skip_external_window = self._should_skip_external_window()
+        window_buckets_to_sync = (
+            [b for b in window_buckets if not _is_window_like(b.type)]
+            if skip_external_window else window_buckets
+        )
+
         # Sync window buckets with gap-filling
         all_events, call_events, pending_checkpoints = self._sync_window_buckets(
-            window_buckets, stats, cycle
+            window_buckets_to_sync, stats, cycle
         )
 
         # Foreground-CPU activity: sample the focused process and credit engaged
@@ -722,6 +757,11 @@ class SyncEngine:
             if synth_afk:
                 all_events.append(synth_afk)
 
+        if skip_external_window:
+            # Sole-source path: upload the in-process per-app window stream for
+            # the slice since the last covered instant.
+            all_events.extend(self._build_inproc_window(datetime.now(timezone.utc)))
+
         # Flush any ongoing call at sync boundary
         if self._call_detector:
             remaining = self._call_detector.flush()
@@ -736,6 +776,9 @@ class SyncEngine:
         # Commit the in-process AFK checkpoint only if its bucket wasn't queued
         # (the send was confirmed) — otherwise rebuild it next cycle (finding B).
         self._commit_inproc_afk_checkpoint(stats)
+        # Same discipline for the in-process window stream: advance its checkpoint
+        # only after a confirmed send.
+        self._commit_inproc_window_checkpoint(stats)
 
         # Process offline queue if we're online — but only if this cycle hasn't
         # already burned most of the watchdog budget on a slow/hung regular send
@@ -2254,6 +2297,77 @@ class SyncEngine:
             self._afk_inproc_checkpoint = pending
         self._afk_inproc_pending = None
 
+    def _should_use_inproc_window(self) -> bool:
+        """True when the in-process window source should be the sole per-app
+        window source — config flag on, a source is wired, and the OS
+        frontmost-window probe is usable (macOS/Windows; False on Linux without
+        an X11 active-window pid). Gates every in-process-window action, so the
+        whole path is a no-op when the flag is off (default)."""
+        return (
+            bool(self.config.sync.in_process_window)
+            and self.window_source is not None
+            and self.window_source.available()
+        )
+
+    def _should_skip_external_window(self) -> bool:
+        """Whether to drop the external bf-window-tracker bucket(s) from this
+        cycle's upload (because the agent uploads its own per-app window stream
+        instead). Mirrors ``_should_skip_external_afk``."""
+        return self._should_use_inproc_window()
+
+    def _build_inproc_window(self, now: datetime) -> list[dict]:
+        """Build in-process window events for [checkpoint, now]. First cycle seeds
+        the checkpoint at `now` (we only account for time while running). The
+        checkpoint is NOT advanced here — it is committed by
+        ``_commit_inproc_window_checkpoint`` only once the send succeeds, so a
+        terminal send failure can't lose a span. Returns [] when not active."""
+        if not self._should_use_inproc_window():
+            return []
+        cp = self._window_inproc_checkpoint
+        if cp is None:
+            self._window_inproc_checkpoint = now
+            return []
+        # Re-seed rather than reconstruct when the checkpoint can't be trusted
+        # (mirrors _build_inproc_afk):
+        #  - now <= cp: the wall clock stepped backward (NTP/manual), or nothing
+        #    new to cover. Re-seed to `now` so the stream doesn't stall.
+        #  - gap > retention: a pause/sleep froze the checkpoint while samples
+        #    were pruned (2h). Reconstructing over an unsampled multi-hour window
+        #    would mis-count; the unobserved span is simply left uncovered.
+        if now <= cp:
+            self._window_inproc_checkpoint = now
+            self._window_inproc_pending = None
+            return []
+        gap = (now - cp).total_seconds()
+        if gap > self.window_source.retention_seconds:
+            logger.info(
+                "in-process window: re-seeding checkpoint (gap %.0fs) — leaving "
+                "the unobserved window uncovered",
+                gap,
+            )
+            self._window_inproc_checkpoint = now
+            self._window_inproc_pending = None
+            return []
+        events = self.window_source.build_window_events(cp, now)
+        # Defer the checkpoint advance to _commit_inproc_window_checkpoint.
+        self._window_inproc_pending = now
+        return events
+
+    def _commit_inproc_window_checkpoint(self, stats: SyncStats) -> None:
+        """Advance the in-process window checkpoint past the just-built span, but
+        only if its bucket wasn't queued (the send succeeded). On a queued/failed
+        send we leave the checkpoint where it was so the next cycle rebuilds the
+        same span from samples — the synthetic ids are stable, so a later queue
+        drain + the rebuild upsert idempotently. Mirrors
+        ``_commit_inproc_afk_checkpoint``."""
+        pending = self._window_inproc_pending
+        if pending is None:
+            return
+        inproc_bucket = self.window_source.bucket_id
+        if inproc_bucket not in stats.queued_bucket_ids:
+            self._window_inproc_checkpoint = pending
+        self._window_inproc_pending = None
+
     def _report_inproc_blind(self, failures: int) -> None:
         """Surface a blind in-process idle clock to the ops ingest. Logged-only
         clock failures are invisible until billing is already wrong; the
@@ -2883,6 +2997,13 @@ class SyncEngine:
         if self._afk_inproc_checkpoint is not None:
             self._afk_inproc_checkpoint = now
         self._afk_inproc_pending = None
+
+        # Same for the in-process window stream (its own checkpoint, not an AW
+        # bucket) — otherwise the next _build_inproc_window reconstructs the
+        # paused/private window and uploads it. Forward-only.
+        if self._window_inproc_checkpoint is not None:
+            self._window_inproc_checkpoint = now
+        self._window_inproc_pending = None
 
         bucket_ids: set[str] = set()
 

--- a/src/sync/sync_engine.py
+++ b/src/sync/sync_engine.py
@@ -648,14 +648,10 @@ class SyncEngine:
             except Exception as e:
                 logger.debug("afk_source.record_sample failed: %s", e)
 
-        # Record a frontmost-window sample for the in-process window timeline
-        # (no-op when no source is wired, the flag is off, or the probe is
-        # unusable). Done every cycle so the sample log stays dense.
-        if self._should_use_inproc_window():
-            try:
-                self.window_source.record_sample(datetime.now(timezone.utc))
-            except Exception as e:
-                logger.debug("window_source.record_sample failed: %s", e)
+        # Record a frontmost-window sample for the in-process window timeline.
+        # Done every cycle too (in addition to the dedicated fast sampler) so a
+        # fresh sample always exists right before build_window_events runs.
+        self.record_window_sample_if_active(datetime.now(timezone.utc))
 
         # Get buckets to sync
         try:
@@ -2308,6 +2304,20 @@ class SyncEngine:
             and self.window_source is not None
             and self.window_source.available()
         )
+
+    def record_window_sample_if_active(self, now: datetime) -> None:
+        """Sample the frontmost window IFF the in-process window source is the
+        active per-app source. Called both per sync cycle and by the dedicated
+        fast sampler (~5s) — window focus changes far faster than the 60s cycle,
+        so dense samples are what give minute-vs-cycle resolution to the spans
+        build_window_events reconstructs. Cheap, gated, and a no-op when the
+        flag is off (default), so it adds no work to the default path."""
+        if not self._should_use_inproc_window():
+            return
+        try:
+            self.window_source.record_sample(now)
+        except Exception as e:
+            logger.debug("window_source.record_sample failed: %s", e)
 
     def _should_skip_external_window(self) -> bool:
         """Whether to drop the external bf-window-tracker bucket(s) from this

--- a/src/sync/window_source.py
+++ b/src/sync/window_source.py
@@ -1,0 +1,258 @@
+"""In-process window source: builds the per-app active-window stream from the
+OS frontmost-window probe (+ psutil process name), replacing the external
+bf-window-tracker bucket on machines where its Win32 capture goes blind.
+
+Mirrors ``AfkSource``: a retention-pruned deque of samples under a lock, a
+sticky ``available()`` latch, a single-source-of-truth ``bucket_id``, and a
+``build_window_events(range_start, range_end)`` reconstructor. Ships dormant
+(``SyncSettings.in_process_window`` defaults False) — opt-in per the AFK
+convergence playbook."""
+
+import logging
+import threading
+from collections import deque
+from datetime import datetime, timedelta
+from typing import Callable, Optional
+
+try:
+    from .aw_client import BUCKET_TYPE_WINDOW
+    from .foreground_activity import _default_pid_getter
+except ImportError:  # PyInstaller bundle (src/ is import root)
+    from sync.aw_client import BUCKET_TYPE_WINDOW
+    from sync.foreground_activity import _default_pid_getter
+
+logger = logging.getLogger(__name__)
+
+# Sentinel: distinguishes "caller didn't pass a getter" (use the platform
+# default) from "caller passed None" (explicitly unsupported — e.g. a test
+# simulating a platform with no frontmost probe).
+_UNSET = object()
+
+
+def _default_foreground_getter() -> Optional[Callable[[], Optional[tuple[str, str]]]]:
+    """Return a getter yielding (app_name, title) for the frontmost window, or
+    None when the platform has no frontmost-pid probe.
+
+    Reuses the same platform probes the foreground-CPU detector uses. On
+    macOS the probe's app label is already the localized application name; on
+    Windows/Linux the probe returns the window TITLE, so we resolve the real
+    process name via psutil (the app) and keep the probe string as the title.
+    A focus we can't read at all yields None (a gap — never an invented app)."""
+    pid_getter = _default_pid_getter()
+    if pid_getter is None:
+        return None
+
+    def getter() -> Optional[tuple[str, str]]:
+        pid, label = pid_getter()
+        if pid is None:
+            return None
+        # macOS: the probe already hands back the app's localized name; there is
+        # no separate window title from this probe, so reuse it for both.
+        import sys
+
+        if sys.platform == "darwin":
+            app = str(label or "").strip()
+            if not app:
+                return None
+            return app, app
+        # Windows/Linux: label is the window title; the app is the process name.
+        try:
+            import psutil
+
+            app = psutil.Process(pid).name()
+        except Exception as e:  # process gone / psutil error / import failure
+            logger.debug("WindowSource process-name lookup failed: %s", e)
+            return None
+        app = str(app or "").strip()
+        if not app:
+            return None
+        return app, str(label or "")
+
+    return getter
+
+
+class WindowSource:
+    """Records frontmost-window samples and reconstructs per-app focus spans."""
+
+    def __init__(
+        self,
+        hostname: str,
+        *,
+        foreground_getter=_UNSET,
+        retention_seconds: float = 7200.0,
+        max_samples: int = 20000,
+    ) -> None:
+        self._hostname = hostname
+        # Not passed -> platform default probe. Passed as None -> unsupported
+        # platform (no frontmost probe): the source stays permanently
+        # unavailable, exactly like AfkSource on Linux.
+        self._getter: Optional[Callable[[], Optional[tuple[str, str]]]] = (
+            _default_foreground_getter() if foreground_getter is _UNSET
+            else foreground_getter
+        )
+        self._retention_seconds = float(retention_seconds)
+        self._retention = timedelta(seconds=retention_seconds)
+        self._lock = threading.Lock()
+        # (sample_time, app, title). `maxlen` is an absolute memory backstop
+        # mirroring AfkSource: ~20k samples ≈ 2 weeks at one per cycle; appends
+        # auto-evict the oldest beyond that.
+        self._samples: deque = deque(maxlen=max_samples)
+        # Sticky platform-capability latch: a transient probe failure (a focus we
+        # momentarily can't read) must NOT revoke in-process mode for a cycle —
+        # that would hand per-app coverage back to the external tracker and flap.
+        # Once a read has ever succeeded the platform HAS the capability, so we
+        # stay latched on (mirrors AfkSource audit finding A).
+        self._available_latched = False
+        # Consecutive probe failures, for blind-probe visibility. Reset to 0 on
+        # any successful read.
+        self._consecutive_failures = 0
+
+    @property
+    def samples(self) -> list:
+        with self._lock:
+            return list(self._samples)
+
+    @property
+    def retention_seconds(self) -> float:
+        return self._retention_seconds
+
+    @property
+    def consecutive_failures(self) -> int:
+        return self._consecutive_failures
+
+    @property
+    def bucket_id(self) -> str:
+        """The synthetic window bucket id this source uploads under. Single
+        source of truth so the upload (_event) and the checkpoint-commit gate
+        agree."""
+        return f"bf-window-inproc_{self._hostname}"
+
+    def available(self) -> bool:
+        """True when the frontmost-window probe is (or has ever been) usable on
+        this platform. Sticky: once a read succeeds it stays True, so a transient
+        failure cannot flap in-process window capture off for a cycle. False
+        forever on a platform with no probe (getter is None)."""
+        if self._available_latched:
+            return True
+        if self._getter is None:
+            return False
+        try:
+            ok = self._getter() is not None
+        except Exception:
+            ok = False
+        if ok:
+            self._available_latched = True
+        return ok
+
+    def record_sample(self, now: datetime) -> None:
+        """Observe the frontmost window at ``now`` and append (now, app, title).
+
+        A focus we can't read (getter returns None or a blank app) is a GAP: we
+        append nothing rather than invent an app, so an unreadable moment cannot
+        fabricate window time. No-op when the probe is unsupported."""
+        if self._getter is None:
+            return
+        try:
+            result = self._getter()
+        except Exception as e:
+            logger.debug("WindowSource foreground getter failed: %s", e)
+            self._consecutive_failures += 1
+            return
+        if result is None:
+            self._consecutive_failures += 1
+            return
+        app, title = result
+        app = str(app or "").strip()
+        if not app:
+            # Readable focus but no resolvable app — treat as a gap, never invent.
+            self._consecutive_failures += 1
+            return
+        self._consecutive_failures = 0
+        title = str(title or "")
+        with self._lock:
+            self._samples.append((now, app, title))
+            cutoff = now - self._retention
+            while self._samples and self._samples[0][0] < cutoff:
+                self._samples.popleft()
+
+    def build_window_events(self, range_start: datetime, range_end: datetime) -> list:
+        """Reconstruct per-app focus spans over [range_start, range_end].
+
+        Each maximal run of CONTIGUOUS same-app samples becomes ONE window event
+        spanning [first_sample_time, next_different_sample_time_or_range_end].
+        The representative title is the one held longest within the run. A change
+        of app closes the current span and opens a new one. Spans are clamped to
+        [range_start, range_end]; zero/negative-duration events are dropped (we
+        never invent time for a focus we couldn't observe)."""
+        if range_end <= range_start:
+            return []
+        with self._lock:
+            samples = [
+                (t, app, title) for (t, app, title) in self._samples
+                if range_start <= t < range_end
+            ]
+        if not samples:
+            return []
+        samples.sort(key=lambda s: s[0])
+
+        events: list = []
+        run_start = samples[0][0]
+        run_app = samples[0][1]
+        # title -> total held seconds within the current run, to pick the
+        # longest-held representative title.
+        title_held: dict[str, float] = {}
+        prev_time = samples[0][0]
+        prev_title = samples[0][2]
+
+        def _close(end: datetime) -> None:
+            # Credit the final observed title's tail up to the span end.
+            title_held[prev_title] = (
+                title_held.get(prev_title, 0.0) + (end - prev_time).total_seconds()
+            )
+            title = max(title_held, key=lambda k: title_held[k]) if title_held else ""
+            self._append_event(events, run_start, end, run_app, title, range_start, range_end)
+
+        for t, app, title in samples[1:]:
+            if app != run_app:
+                # App changed: close the run at this instant, open a new one.
+                _close(t)
+                run_start = t
+                run_app = app
+                title_held = {}
+                prev_time = t
+                prev_title = title
+                continue
+            # Same app: accrue the just-elapsed interval to the previously-held
+            # title, then advance the cursor.
+            title_held[prev_title] = (
+                title_held.get(prev_title, 0.0) + (t - prev_time).total_seconds()
+            )
+            prev_time = t
+            prev_title = title
+        # Close the trailing run at range_end.
+        _close(range_end)
+        return events
+
+    def _append_event(
+        self, events: list, start: datetime, end: datetime, app: str, title: str,
+        range_start: datetime, range_end: datetime,
+    ) -> None:
+        s = max(start, range_start)
+        e = min(end, range_end)
+        if e <= s:
+            return
+        events.append(self._event(s, (e - s).total_seconds(), app, title))
+
+    def _event(self, start: datetime, duration: float, app: str, title: str) -> dict:
+        return {
+            # Millisecond precision: two spans can legitimately start within the
+            # same whole second (rapid app switches at a fine cadence); a
+            # second-truncated id would collide and the server upsert would drop
+            # one, under-counting (mirrors AfkSource audit finding F).
+            "id": f"win-inproc_{self._hostname}_{int(start.timestamp() * 1000)}",
+            "timestamp": start.isoformat(),
+            "duration": round(duration, 2),
+            "bucket_id": self.bucket_id,
+            "bucket_type": BUCKET_TYPE_WINDOW,
+            "data": {"app": app, "title": title},
+        }

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -194,6 +194,19 @@ def test_in_process_afk_defaults_on():
     assert Config().sync.in_process_afk is True
 
 
+def test_in_process_window_defaults_off():
+    # Ships dormant/opt-in — the in-process window source must be off by default.
+    from src.config import Config
+    assert Config().sync.in_process_window is False
+
+
+def test_in_process_window_enabled_from_server():
+    from src.config import Config
+    cfg = Config()
+    cfg.update_from_server({"sync": {"in_process_window": True}})
+    assert cfg.sync.in_process_window is True
+
+
 def test_foreground_enabled_is_not_persisted(tmp_path, monkeypatch):
     """foreground_activity.enabled must never be written to config.json — it's a
     server-driven, default-OFF billing flag. Persisting it let a default-ON beta

--- a/tests/test_sync_engine_inproc_window.py
+++ b/tests/test_sync_engine_inproc_window.py
@@ -126,3 +126,27 @@ def test_external_window_buckets_kept_when_flag_off():
     skip = eng._should_skip_external_window()
     to_sync = [b for b in window_buckets if not _is_window_like(b.type)] if skip else window_buckets
     assert to_sync == window_buckets  # unchanged when dormant
+
+
+def test_record_window_sample_if_active_gates_on_flag():
+    """The public sampler (used by both the per-cycle call and the ~5s tick)
+    records only when the in-process window source is active, and is a cheap
+    no-op otherwise — so the default (flag-off) path adds no window sampling."""
+    # Active: a fresh sample is appended.
+    eng = _engine(True)
+    src = _FakeSource([])
+    eng.window_source = src
+    before = len(src.samples)
+    eng.record_window_sample_if_active(T0)
+    assert len(src.samples) == before + 1
+
+    # Flag off: no-op (no sample recorded).
+    eng_off = _engine(False)
+    src_off = _FakeSource([])
+    eng_off.window_source = src_off
+    eng_off.record_window_sample_if_active(T0)
+    assert len(src_off.samples) == 0
+
+    # No source wired: no crash, no-op.
+    eng_none = _engine(True)
+    eng_none.record_window_sample_if_active(T0)  # must not raise

--- a/tests/test_sync_engine_inproc_window.py
+++ b/tests/test_sync_engine_inproc_window.py
@@ -1,0 +1,128 @@
+from datetime import datetime, timedelta, timezone
+from unittest.mock import Mock
+
+from src.config import Config
+from src.sync.activity_analyzer import ActivityAnalyzer
+from src.sync.daily_time_tracker import DailyTimeTracker
+from src.sync.sync_engine import SyncEngine, SyncStats, _is_window_like
+from src.sync.window_source import WindowSource
+
+T0 = datetime(2026, 6, 19, 12, 0, 0, tzinfo=timezone.utc)
+
+
+def _engine(in_process_window: bool):
+    cfg = Config()
+    cfg.sync.in_process_window = in_process_window
+    return SyncEngine(aw=Mock(), bf=Mock(), queue=Mock(), config=cfg,
+                      activity_analyzer=Mock(spec=ActivityAnalyzer),
+                      time_tracker=Mock(spec=DailyTimeTracker))
+
+
+class _FakeSource(WindowSource):
+    """A WindowSource with a scripted-usable probe (available() forced on)."""
+
+    def __init__(self, samples):
+        super().__init__(hostname="host", foreground_getter=lambda: ("Code", "a"))
+        with self._lock:
+            for st, app, title in samples:
+                self._samples.append((st, app, title))
+
+
+def test_flag_off_is_no_op():
+    eng = _engine(False)
+    eng.window_source = _FakeSource([(T0, "Code", "a")])
+    assert eng._should_use_inproc_window() is False
+    assert eng._should_skip_external_window() is False
+    # Build is inert even with samples present.
+    assert eng._build_inproc_window(T0 + timedelta(seconds=60)) == []
+
+
+def test_active_when_flag_on_and_available():
+    eng = _engine(True)
+    eng.window_source = _FakeSource([(T0, "Code", "a")])
+    assert eng._should_use_inproc_window() is True
+    assert eng._should_skip_external_window() is True
+
+
+def test_inactive_when_no_source_wired():
+    eng = _engine(True)
+    assert eng._should_skip_external_window() is False
+
+
+def test_inactive_when_probe_unavailable():
+    eng = _engine(True)
+    # No frontmost probe on this platform.
+    eng.window_source = WindowSource(hostname="host", foreground_getter=None)
+    assert eng._should_skip_external_window() is False
+
+
+def test_inproc_window_events_built_for_uploaded_range():
+    eng = _engine(True)
+    eng.window_source = _FakeSource([
+        (T0, "Code", "a"),
+        (T0 + timedelta(seconds=30), "Code", "a"),
+    ])
+    eng._build_inproc_window(T0)  # first call seeds the checkpoint at T0, returns []
+    events = eng._build_inproc_window(T0 + timedelta(seconds=30))
+    assert events
+    assert all(e["bucket_id"] == "bf-window-inproc_host" for e in events)
+    assert events[0]["data"]["app"] == "Code"
+
+
+def test_checkpoint_committed_only_after_successful_send():
+    eng = _engine(True)
+    eng.window_source = _FakeSource([
+        (T0, "Code", "a"),
+        (T0 + timedelta(seconds=30), "Code", "a"),
+    ])
+    eng._build_inproc_window(T0)  # seed
+    eng._build_inproc_window(T0 + timedelta(seconds=30))  # sets pending
+    pending = eng._window_inproc_pending
+    assert pending is not None
+
+    # Queued send -> checkpoint held, pending cleared so next cycle rebuilds.
+    stats = SyncStats()
+    stats.queued_bucket_ids.add("bf-window-inproc_host")
+    eng._commit_inproc_window_checkpoint(stats)
+    assert eng._window_inproc_checkpoint == T0  # unchanged
+    assert eng._window_inproc_pending is None
+
+
+def test_checkpoint_advances_on_confirmed_send():
+    eng = _engine(True)
+    eng.window_source = _FakeSource([
+        (T0, "Code", "a"),
+        (T0 + timedelta(seconds=30), "Code", "a"),
+    ])
+    eng._build_inproc_window(T0)
+    eng._build_inproc_window(T0 + timedelta(seconds=30))
+    stats = SyncStats()  # no queued buckets -> confirmed send
+    eng._commit_inproc_window_checkpoint(stats)
+    assert eng._window_inproc_checkpoint == T0 + timedelta(seconds=30)
+
+
+def _bucket(bucket_id, btype):
+    b = Mock()
+    b.id = bucket_id
+    b.type = btype
+    return b
+
+
+def test_external_window_buckets_skipped_when_active():
+    from src.sync.aw_client import BUCKET_TYPE_WINDOW as WIN
+    eng = _engine(True)
+    eng.window_source = _FakeSource([(T0, "Code", "a")])
+    window_buckets = [_bucket("aw-watcher-window_host", WIN)]
+    skip = eng._should_skip_external_window()
+    to_sync = [b for b in window_buckets if not _is_window_like(b.type)] if skip else window_buckets
+    assert to_sync == []  # external window bucket dropped, no double-count
+
+
+def test_external_window_buckets_kept_when_flag_off():
+    from src.sync.aw_client import BUCKET_TYPE_WINDOW as WIN
+    eng = _engine(False)
+    eng.window_source = _FakeSource([(T0, "Code", "a")])
+    window_buckets = [_bucket("aw-watcher-window_host", WIN)]
+    skip = eng._should_skip_external_window()
+    to_sync = [b for b in window_buckets if not _is_window_like(b.type)] if skip else window_buckets
+    assert to_sync == window_buckets  # unchanged when dormant

--- a/tests/test_window_source.py
+++ b/tests/test_window_source.py
@@ -1,0 +1,215 @@
+from datetime import datetime, timedelta, timezone
+
+from src.sync.aw_client import BUCKET_TYPE_WINDOW
+from src.sync.window_source import WindowSource
+
+T0 = datetime(2026, 6, 19, 12, 0, 0, tzinfo=timezone.utc)
+
+
+class _Getter:
+    """Fake foreground getter driven by a scripted list of (app, title) or None."""
+
+    def __init__(self, results):
+        self._results = list(results)
+        self._i = 0
+
+    def __call__(self):
+        if self._i >= len(self._results):
+            return self._results[-1] if self._results else None
+        r = self._results[self._i]
+        self._i += 1
+        return r
+
+
+def _src(getter, **kw):
+    return WindowSource(hostname="host", foreground_getter=getter, **kw)
+
+
+def _seed(src, *triples):
+    """triples: (sample_time, app, title)."""
+    for st, app, title in triples:
+        with src._lock:
+            src._samples.append((st, app, title))
+
+
+def _spans(events):
+    return [(e["data"]["app"], e["data"]["title"], e["timestamp"], round(e["duration"]))
+            for e in events]
+
+
+# -- available() / sticky latch ----------------------------------------------
+
+
+def test_available_true_when_getter_reads():
+    assert _src(_Getter([("Code", "main.py")])).available() is True
+
+
+def test_available_false_when_getter_returns_none():
+    assert _src(_Getter([None])).available() is False
+
+
+def test_available_false_when_unsupported_platform():
+    assert _src(None).available() is False
+
+
+def test_available_latch_survives_transient_failure():
+    src = _src(_Getter([("Code", "a"), None, None]))
+    assert src.available() is True  # first read succeeds -> latched
+    # A later blind read must NOT flap availability off.
+    src.record_sample(T0 + timedelta(seconds=30))  # returns None -> gap
+    assert src.available() is True
+
+
+# -- record_sample -----------------------------------------------------------
+
+
+def test_record_sample_appends_app_and_title():
+    src = _src(_Getter([("Code", "main.py")]))
+    src.record_sample(T0)
+    assert src.samples == [(T0, "Code", "main.py")]
+
+
+def test_record_sample_noop_when_unsupported():
+    src = _src(None)
+    src.record_sample(T0)
+    assert src.samples == []
+
+
+def test_blind_getter_invents_no_events():
+    # A focus we can't read (None) must append nothing — never an invented app.
+    src = _src(_Getter([None, None]))
+    src.record_sample(T0)
+    src.record_sample(T0 + timedelta(seconds=30))
+    assert src.samples == []
+    ev = src.build_window_events(T0, T0 + timedelta(seconds=60))
+    assert ev == []
+
+
+def test_blank_app_is_a_gap():
+    src = _src(_Getter([("", "some title")]))
+    src.record_sample(T0)
+    assert src.samples == []
+    assert src.consecutive_failures == 1
+
+
+def test_consecutive_failures_reset_on_success():
+    src = _src(_Getter([None, ("Code", "a")]))
+    src.record_sample(T0)
+    assert src.consecutive_failures == 1
+    src.record_sample(T0 + timedelta(seconds=30))
+    assert src.consecutive_failures == 0
+
+
+def test_retention_prunes_old_samples():
+    src = _src(_Getter([("Code", "a"), ("Code", "b")]), retention_seconds=100)
+    src.record_sample(T0)
+    src.record_sample(T0 + timedelta(seconds=200))  # T0 now older than retention
+    assert [s[0] for s in src.samples] == [T0 + timedelta(seconds=200)]
+
+
+# -- build_window_events -----------------------------------------------------
+
+
+def test_same_app_run_coalesces_into_one_span():
+    src = _src(_Getter([]))
+    _seed(src,
+          (T0, "Code", "a.py"),
+          (T0 + timedelta(seconds=30), "Code", "a.py"),
+          (T0 + timedelta(seconds=60), "Code", "a.py"))
+    ev = src.build_window_events(T0, T0 + timedelta(seconds=90))
+    assert _spans(ev) == [("Code", "a.py", T0.isoformat(), 90)]
+
+
+def test_app_change_opens_new_span():
+    src = _src(_Getter([]))
+    _seed(src,
+          (T0, "Code", "a.py"),
+          (T0 + timedelta(seconds=30), "Chrome", "docs"),
+          (T0 + timedelta(seconds=60), "Chrome", "docs"))
+    ev = src.build_window_events(T0, T0 + timedelta(seconds=90))
+    assert _spans(ev) == [
+        ("Code", "a.py", T0.isoformat(), 30),
+        ("Chrome", "docs", (T0 + timedelta(seconds=30)).isoformat(), 60),
+    ]
+
+
+def test_representative_title_is_longest_held():
+    # Same app the whole run, but the title changes. "b" is held from +10 to +60
+    # (50s) vs "a" from 0 to +10 (10s) -> "b" wins.
+    src = _src(_Getter([]))
+    _seed(src,
+          (T0, "Code", "a"),
+          (T0 + timedelta(seconds=10), "Code", "b"),
+          (T0 + timedelta(seconds=60), "Code", "b"))
+    ev = src.build_window_events(T0, T0 + timedelta(seconds=60))
+    assert len(ev) == 1
+    assert ev[0]["data"] == {"app": "Code", "title": "b"}
+    assert round(ev[0]["duration"]) == 60
+
+
+def test_no_samples_in_range_is_empty():
+    src = _src(_Getter([]))
+    assert src.build_window_events(T0, T0 + timedelta(seconds=300)) == []
+
+
+def test_single_sample_spans_to_range_end():
+    src = _src(_Getter([]))
+    _seed(src, (T0, "Code", "a"))
+    ev = src.build_window_events(T0, T0 + timedelta(seconds=60))
+    assert _spans(ev) == [("Code", "a", T0.isoformat(), 60)]
+
+
+def test_empty_range_returns_empty():
+    src = _src(_Getter([]))
+    _seed(src, (T0, "Code", "a"))
+    assert src.build_window_events(T0 + timedelta(seconds=60), T0) == []
+
+
+def test_events_clamped_to_range():
+    src = _src(_Getter([]))
+    _seed(src,
+          (T0, "Code", "a"),
+          (T0 + timedelta(seconds=120), "Code", "a"))
+    # Range ends before the last sample; span is clamped to range_end.
+    ev = src.build_window_events(T0, T0 + timedelta(seconds=60))
+    assert _spans(ev) == [("Code", "a", T0.isoformat(), 60)]
+
+
+def test_no_zero_duration_events():
+    src = _src(_Getter([]))
+    _seed(src, (T0, "Code", "a"), (T0, "Chrome", "b"))
+    ev = src.build_window_events(T0, T0 + timedelta(seconds=30))
+    # The Code run at exactly T0 has zero duration (closes at the Chrome sample,
+    # also T0) -> dropped. Only the Chrome span survives.
+    for e in ev:
+        assert e["duration"] > 0
+    assert [e["data"]["app"] for e in ev] == ["Chrome"]
+
+
+# -- event dict shape --------------------------------------------------------
+
+
+def test_event_shape_and_ids():
+    src = _src(_Getter([]))
+    _seed(src, (T0, "Code", "a"), (T0 + timedelta(seconds=30), "Code", "a"))
+    ev = src.build_window_events(T0, T0 + timedelta(seconds=30))[0]
+    assert ev["bucket_id"] == "bf-window-inproc_host"
+    assert ev["bucket_type"] == BUCKET_TYPE_WINDOW
+    assert ev["id"] == f"win-inproc_host_{int(T0.timestamp() * 1000)}"
+    assert ev["timestamp"] == T0.isoformat()
+    assert ev["data"] == {"app": "Code", "title": "a"}
+
+
+def test_bucket_id_single_source_of_truth():
+    assert _src(_Getter([])).bucket_id == "bf-window-inproc_host"
+
+
+# -- immutability ------------------------------------------------------------
+
+
+def test_source_not_mutated_by_build():
+    src = _src(_Getter([]))
+    _seed(src, (T0, "Code", "a"), (T0 + timedelta(seconds=30), "Chrome", "b"))
+    before = src.samples
+    src.build_window_events(T0, T0 + timedelta(seconds=60))
+    assert src.samples == before


### PR DESCRIPTION
## Why

Windows per-app coverage is **61%** vs **92%** on macOS this week. Root cause,
pinned from Sachi Navodi's logs + prod: the external `bf-window-tracker`
(bundled `aw-watcher-window`) **launches fine (fresh PID every restart) but its
Win32 capture returns zero window events for hours** — an environment/capture
failure (elevation/UIPI under her `Administrator` session, or AV blocking the
window API), not a missing/stale binary. Restarts can't fix a process that
launches-but-can't-see (the log says so at 09:50). On Jul 1 she was **blind
13:00→18:00 (5h, zero window events while AFK flowed)** — on 1.5.88, so the
agent update didn't help because it only changes restart *policy*, not capture.

AFK already solved the analogous external-tracker failure by moving **in-process**
(`AfkSource` → `bf-afk-inproc`). This does the same for window capture.

## What

New `WindowSource` (mirrors `AfkSource`): reads the frontmost window in the
agent's own process (`GetForegroundWindow → pid → title` + `psutil` process
name) and reconstructs contiguous same-app focus spans under
`bf-window-inproc_<host>`. When enabled, the sync loop skips the external window
bucket so the two never double-count, and commits the in-process checkpoint only
after a confirmed send (same discipline as in-process AFK).

- **Ships default-OFF** (`in_process_window=False`, server-overridable). Dormant:
  the external window path is byte-for-byte unchanged until enabled per-platform.
- Blind/unreadable focus = a gap (never invents an app); sticky `available()`;
  ms-precision ids; frozen inputs never mutated.

## Tests
- 21 unit (`test_window_source.py`) + 9 integration (`test_sync_engine_inproc_window.py`)
  + config assertions. Full suite: **871 passed**.

## ⚠️ Before enabling (follow-up, not in this PR)
- **Sampling cadence:** the source currently samples **once per sync cycle
  (~60s)**, so attribution is minute-granular. That's a massive improvement over
  *zero* (today's Windows outage), but coarser than the external tracker when it
  works. Add a faster window-sampling tick (~3–5s) before enabling broadly.
- **Rollout:** enable via server config for the affected Windows users first
  (Sachi), verify per-app timeline returns, then widen.
- The `tracking_degraded` blind-spot (never fires for this failure) is still worth
  fixing separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
