### PR TITLE
fix(auth): don't force re-auth on a transient startup outage

### DIFF
--- a/src/__init__.py
+++ b/src/__init__.py
@@ -1,4 +1,4 @@
 """BetterFlow - ActivityWatch to BetterFlow sync companion app."""
 
-__version__ = "1.5.88"
+__version__ = "1.5.89"
 __author__ = "BetterQA"

--- a/src/auth/login.py
+++ b/src/auth/login.py
@@ -39,6 +39,14 @@ class LoginState:
     user_role: Optional[str] = None
     device_id: Optional[str] = None
     error: Optional[str] = None
+    # True when login failed for a TRANSIENT reason (server unreachable —
+    # timeout / 5xx / connection drop) with the stored credentials left
+    # intact. The caller must NOT prompt re-auth in this case (the session is
+    # still valid; a re-auth flow can't even complete while the server is
+    # down) — it should retry auto-login in the background. False for a
+    # genuine logged-out state (no credentials, or credentials cleared after
+    # a definitive auth failure).
+    transient: bool = False
 
 
 class LoginManager:
@@ -119,8 +127,15 @@ class LoginManager:
                 return LoginState(logged_in=False, error="Stored credentials are invalid")
             except BetterFlowClientError as e:
                 logger.warning(f"Auto-login failed (network): {e}")
-                # Don't clear credentials on network error - might be temporary
-                return LoginState(logged_in=False, error="Network error - check your connection")
+                # Don't clear credentials on network error - might be temporary.
+                # transient=True tells the caller to retry in the background
+                # rather than kick the (still-authenticated) user to a re-auth
+                # prompt that can't complete while the server is unreachable.
+                return LoginState(
+                    logged_in=False,
+                    transient=True,
+                    error="Network error - check your connection",
+                )
 
     def login_via_browser(self) -> LoginState:
         """Log in via browser-based OAuth flow.

--- a/src/main.py
+++ b/src/main.py
@@ -1570,6 +1570,8 @@ class BetterFlowApp:
         self._shutdown_event = threading.Event()
         self._pause_state_lock = threading.RLock()
         self._login_lock = threading.Lock()
+        self._reconnect_lock = threading.Lock()
+        self._reconnect_thread: Optional[threading.Thread] = None
         self._startup_thread: Optional[threading.Thread] = None
         self._system_events_started = False
         self._system_events_lock = threading.Lock()
@@ -1692,17 +1694,89 @@ class BetterFlowApp:
             self._start_watchers()
             self._ensure_system_event_listener()
 
-            if state.logged_in:
-                self._finish_logged_in_startup(state, send_greeting=True)
-            else:
-                self.coordinator.logged_in = False
-                self.tray.set_state(TrayState.WAITING_AUTH, "Waiting for browser login...")
-                self.coordinator._maybe_warn_login_required(source="startup")
-                self._ensure_update_checks_started()
+            self._apply_startup_login_state(state)
 
             logger.info("Background startup complete")
         finally:
             self._login_lock.release()
+
+    # How often the background reconnect loop retries auto-login after a
+    # transient (server-unreachable) startup failure. The loop runs until the
+    # session comes back, the user logs in manually, or the app shuts down.
+    _RECONNECT_RETRY_INTERVAL_S = 30.0
+
+    def _apply_startup_login_state(self, state) -> None:
+        """Dispatch on the outcome of the startup auto-login.
+
+        Three outcomes, only two of which should ever prompt the user:
+
+        - logged in            → finish startup normally.
+        - transient failure    → the stored session is still valid but the
+          server was unreachable (e.g. the 2026-07-02 Railway outage). Do NOT
+          prompt re-auth — a re-auth flow can't complete while the server is
+          down, and the credentials are fine. Show an offline state and retry
+          auto-login in the background until connectivity returns.
+        - genuine logged-out   → no/invalid credentials: show WAITING_AUTH and
+          notify the user to sign back in.
+        """
+        if state.logged_in:
+            self._finish_logged_in_startup(state, send_greeting=True)
+            return
+
+        self.coordinator.logged_in = False
+        if getattr(state, "transient", False):
+            self.tray.set_state(TrayState.QUEUED, "Offline — reconnecting...")
+            self._start_reconnect_retry()
+        else:
+            self.tray.set_state(TrayState.WAITING_AUTH, "Waiting for browser login...")
+            self.coordinator._maybe_warn_login_required(source="startup")
+        self._ensure_update_checks_started()
+
+    def _start_reconnect_retry(self) -> None:
+        """Spawn the background auto-login retry loop (idempotent)."""
+        with self._reconnect_lock:
+            if self._reconnect_thread is not None and self._reconnect_thread.is_alive():
+                return
+            self._reconnect_thread = threading.Thread(
+                target=self._reconnect_loop, daemon=True, name="auth-reconnect"
+            )
+            self._reconnect_thread.start()
+
+    def _reconnect_loop(self) -> None:
+        """Retry auto-login until the transient outage clears.
+
+        On success, finish startup as if the session had been restored at
+        launch. If the credentials turn out to be genuinely invalid (e.g. the
+        token was revoked while we were offline), fall back to the real
+        re-auth prompt. Interruptible via the shutdown event.
+        """
+        while not self._shutdown_event.is_set():
+            # Interruptible sleep: returns True the moment shutdown is set.
+            if self._shutdown_event.wait(self._RECONNECT_RETRY_INTERVAL_S):
+                return
+            if self.coordinator.logged_in:
+                return  # a manual login (or another path) beat us to it
+            if not self._login_lock.acquire(timeout=5):
+                continue
+            try:
+                if self._shutdown_event.is_set() or self.coordinator.logged_in:
+                    return
+                state = self.login_manager.try_auto_login()
+                if state.logged_in:
+                    logger.info("Auto-login recovered after transient startup failure")
+                    self._finish_logged_in_startup(state, send_greeting=True)
+                    return
+                if not getattr(state, "transient", False):
+                    # Credentials are genuinely gone now — prompt re-auth.
+                    self.coordinator.logged_in = False
+                    self.tray.set_state(
+                        TrayState.WAITING_AUTH, "Waiting for browser login..."
+                    )
+                    self.coordinator._maybe_warn_login_required(source="reconnect")
+                    return
+                # Still transient — keep the offline state and try again.
+            finally:
+                self._login_lock.release()
 
     def run(self) -> None:
         """Run the application."""

--- a/tests/test_auth_tolerance.py
+++ b/tests/test_auth_tolerance.py
@@ -93,6 +93,7 @@ class TestTryAutoLoginRetries:
         with patch("src.auth.login.time.sleep"):
             state = mgr.try_auto_login()
         assert state.logged_in is False
+        assert state.transient is False  # definitive: caller should prompt re-auth
         bf.clear_credentials.assert_called_once()
 
     def test_network_error_never_clears(self):
@@ -100,4 +101,8 @@ class TestTryAutoLoginRetries:
         with patch("src.auth.login.time.sleep"):
             state = mgr.try_auto_login()
         assert state.logged_in is False
+        # A server outage is transient — credentials stay, caller must NOT
+        # prompt re-auth (Railway outage, 2026-07-02: valid sessions were
+        # wrongly kicked to a browser login that couldn't complete).
+        assert state.transient is True
         bf.clear_credentials.assert_not_called()

--- a/tests/test_startup_transient_login.py
+++ b/tests/test_startup_transient_login.py
@@ -1,0 +1,134 @@
+"""Startup auto-login must not kick a valid session to re-auth on an outage.
+
+2026-07-02 Railway (hosting) outage: app.betterflow.eu returned 502 / timed
+out. On launch, `try_auto_login` failed with a *network* error — but the
+startup path treated that identically to invalid credentials: it flipped the
+tray to WAITING_AUTH and fired a "your session ended, sign back in"
+notification. Users (Tiberiu, Lucian) were pushed into a browser OAuth flow
+that could not complete while the server was down, and experienced it as "the
+agent doesn't start / it crashed." Their tokens were valid the whole time.
+
+The fix: distinguish transient (server-unreachable) from definitive (bad
+credentials) at startup. On a transient failure keep the session, show an
+offline/reconnecting state, and retry auto-login in the background until the
+outage clears — never prompt re-auth.
+
+These tests drive the real dispatch + reconnect methods on a bare
+BetterFlowApp instance (built via __new__ so the heavy __init__ is skipped;
+only the handful of collaborators the methods touch are wired as mocks).
+"""
+
+import threading
+from unittest.mock import MagicMock
+
+from src.auth.login import LoginState
+from src.main import BetterFlowApp
+from src.ui.tray import TrayState
+
+
+def _make_app() -> BetterFlowApp:
+    """A BetterFlowApp with only the attributes the login-dispatch/reconnect
+    paths use. No scheduler, tray loop, or AW client is started."""
+    app = BetterFlowApp.__new__(BetterFlowApp)
+    app._shutdown_event = threading.Event()
+    app._login_lock = threading.Lock()
+    app._reconnect_lock = threading.Lock()
+    app._reconnect_thread = None
+    app.coordinator = MagicMock()
+    app.coordinator.logged_in = False
+    app.tray = MagicMock()
+    app.login_manager = MagicMock()
+    # Stub the heavy post-login work — we assert it's *called*, not its guts.
+    app._finish_logged_in_startup = MagicMock()
+    app._ensure_update_checks_started = MagicMock()
+    return app
+
+
+class TestStartupDispatch:
+    def test_transient_failure_does_not_prompt_reauth(self):
+        app = _make_app()
+        # Don't actually spawn the background thread in this unit.
+        app._start_reconnect_retry = MagicMock()
+
+        app._apply_startup_login_state(
+            LoginState(logged_in=False, transient=True, error="Network error")
+        )
+
+        # No "session ended" warning, no WAITING_AUTH — instead an offline
+        # state and a background reconnect.
+        app.coordinator._maybe_warn_login_required.assert_not_called()
+        app._start_reconnect_retry.assert_called_once()
+        state_arg = app.tray.set_state.call_args[0][0]
+        assert state_arg == TrayState.QUEUED
+        app._finish_logged_in_startup.assert_not_called()
+
+    def test_definitive_logout_prompts_reauth(self):
+        app = _make_app()
+        app._start_reconnect_retry = MagicMock()
+
+        app._apply_startup_login_state(
+            LoginState(logged_in=False, transient=False,
+                       error="Stored credentials are invalid")
+        )
+
+        app.coordinator._maybe_warn_login_required.assert_called_once_with(
+            source="startup"
+        )
+        app._start_reconnect_retry.assert_not_called()
+        state_arg = app.tray.set_state.call_args[0][0]
+        assert state_arg == TrayState.WAITING_AUTH
+
+    def test_logged_in_finishes_startup(self):
+        app = _make_app()
+        state = LoginState(logged_in=True, user_email="a@b.co")
+
+        app._apply_startup_login_state(state)
+
+        app._finish_logged_in_startup.assert_called_once()
+        app.coordinator._maybe_warn_login_required.assert_not_called()
+
+
+class TestReconnectLoop:
+    def test_recovers_when_server_returns(self):
+        app = _make_app()
+        # First retry still down (transient), second succeeds.
+        app.login_manager.try_auto_login.side_effect = [
+            LoginState(logged_in=False, transient=True),
+            LoginState(logged_in=True, user_email="a@b.co"),
+        ]
+        # Make the interruptible sleep instant and finite so the loop runs
+        # exactly its two iterations without a wall-clock wait.
+        app._RECONNECT_RETRY_INTERVAL_S = 0
+        app._shutdown_event.wait = MagicMock(return_value=False)
+
+        app._reconnect_loop()
+
+        assert app.login_manager.try_auto_login.call_count == 2
+        app._finish_logged_in_startup.assert_called_once()
+        # Recovery path must NOT nag the user to re-auth.
+        app.coordinator._maybe_warn_login_required.assert_not_called()
+
+    def test_falls_back_to_reauth_if_credentials_become_invalid(self):
+        app = _make_app()
+        app.login_manager.try_auto_login.return_value = LoginState(
+            logged_in=False, transient=False
+        )
+        app._RECONNECT_RETRY_INTERVAL_S = 0
+        app._shutdown_event.wait = MagicMock(return_value=False)
+
+        app._reconnect_loop()
+
+        app._finish_logged_in_startup.assert_not_called()
+        app.coordinator._maybe_warn_login_required.assert_called_once_with(
+            source="reconnect"
+        )
+        state_arg = app.tray.set_state.call_args[0][0]
+        assert state_arg == TrayState.WAITING_AUTH
+
+    def test_stops_on_shutdown(self):
+        app = _make_app()
+        app._shutdown_event.set()  # already shutting down
+
+        app._reconnect_loop()
+
+        app.login_manager.try_auto_login.assert_not_called()


### PR DESCRIPTION
## Problem

During the **2026-07-02 Railway (hosting) outage**, `app.betterflow.eu` returned 502 / timed out. On launch, `try_auto_login` failed with a *network* error — but the startup path treated that identically to *invalid credentials*: it flipped the tray to `WAITING_AUTH` and fired a "your session ended, sign back in" notification, pushing users into a browser OAuth flow **that could not complete while the server was down**.

Tiberiu and Lucian reported this as "the agent doesn't start / it crashed" (see Slack C0AJ10S39U4). Their tokens were valid the entire time. Tiberiu's log confirms the sequence:

```
12:03:43  Auto-login failed (network): Request timed out
12:03:44  Login required (startup) — tray sync paused until re-login
12:05 / 12:09 / 12:15  three browser re-auth attempts (fail while server down)
12:16:19  succeeds once Railway recovered
```

No data was lost — the offline queue held events (the #99 durability fix worked). This PR fixes the **auth** side: a transient outage should never log a valid session out.

## Fix

This is the auth-path analogue of the transient-vs-definitive handling already applied to the sync queue (#99) and heartbeat (#60).

- `LoginState` gains a `transient` flag. `try_auto_login` sets it `True` on a network/5xx/timeout failure (credentials **kept**), `False` on a definitive auth failure (credentials cleared) or no-credentials.
- Startup dispatch extracted to `_apply_startup_login_state`: on a transient failure it shows an offline/reconnecting state (`QUEUED`) and starts a background reconnect loop **instead of prompting re-auth**. Only a genuine logged-out state shows `WAITING_AUTH` + notifies.
- `_reconnect_loop` retries auto-login every 30s until the outage clears (then finishes startup as if the session restored at launch), the user logs in manually, or the app shuts down. It falls back to the real re-auth prompt only if credentials become genuinely invalid while offline.

## Tests (proof-of-failure handshake)

New `tests/test_startup_transient_login.py` (6 tests) + 2 extended assertions in `test_auth_tolerance.py`. All 8 were run against a `git stash` of `src/` (pre-fix) and **failed** — `LoginState` had no `transient` attr, `BetterFlowApp` had no `_reconnect_loop`, and the pre-fix branch fired `_maybe_warn_login_required` on a network failure. Post-fix: **845 passed**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)