### PR TITLE
fix(sync): coalesce same-window flickers so per-app attribution survives the filter

### DIFF
--- a/src/__init__.py
+++ b/src/__init__.py
@@ -1,4 +1,4 @@
 """BetterFlow - ActivityWatch to BetterFlow sync companion app."""
 
-__version__ = "1.5.89"
+__version__ = "1.5.90"
 __author__ = "BetterQA"

--- a/src/sync/sync_engine.py
+++ b/src/sync/sync_engine.py
@@ -1220,9 +1220,20 @@ class SyncEngine:
         new bucket-processing path can't silently classify against an empty
         context (this is the window-classification entry point).
         """
-        # Feed window events to activity analyzer for window change detection
+        # Feed window events to activity analyzer for window change detection.
+        # Uses the RAW events (pre-coalesce) so genuine window switches are
+        # still visible to change detection.
         if bucket_type in (BUCKET_TYPE_WINDOW, BUCKET_TYPE_WINDOW_ALT):
             self._activity_analyzer.add_window_events(events)
+
+        # Coalesce runs of sub-threshold same-window fragments so an AW
+        # heartbeat-merge failure doesn't cost the whole span's per-app
+        # attribution to the flicker filter (see _coalesce_window_flickers).
+        # The checkpoint below is computed from the ORIGINAL events, so
+        # coalescing cannot skip, re-fetch, or double-send anything.
+        checkpoint_events = events
+        if _is_window_like(bucket_type):
+            events = self._coalesce_window_flickers(events)
 
         transformed = []
         for event in events:
@@ -1307,8 +1318,8 @@ class SyncEngine:
                     ev["activity_metrics"].update(fraud.extra_metrics)
 
         pending_checkpoint = None
-        if events:
-            newest = max(events, key=lambda e: e.timestamp)
+        if checkpoint_events:
+            newest = max(checkpoint_events, key=lambda e: e.timestamp)
             pending_checkpoint = (bucket_id, newest.timestamp, newest.id)
 
         return transformed, pending_checkpoint
@@ -1445,6 +1456,63 @@ class SyncEngine:
                     continue
             collapsed.append(ev)
         return collapsed
+
+    # Two same-window fragments this far apart (or closer) are treated as one
+    # continuous focus. AW polls every ~1-2s, so a couple of seconds of slack
+    # bridges normal polling jitter without merging across a real gap (a real
+    # gap means a DIFFERENT window was focused, which breaks the run anyway).
+    _WINDOW_COALESCE_GAP_TOLERANCE_S = 2.0
+
+    @staticmethod
+    def _coalesce_window_flickers(events: list[AWEvent]) -> list[AWEvent]:
+        """Merge a run of consecutive, time-contiguous events that describe the
+        SAME window (app + title + url) into one event.
+
+        ActivityWatch is supposed to heartbeat-merge successive polls of an
+        unchanged window into a single growing event. When that merge fails it
+        emits the focus as dozens of sub-second/second fragments (observed:
+        bursts of ~100 window events all under the 5s flicker filter — Sachi
+        device 16, recurring). Each fragment then falls under
+        ``min_window_event_seconds`` in ``_transform_event`` and is dropped, so
+        the WHOLE span's per-app attribution is lost even though the watcher
+        was producing data the entire time.
+
+        Merging the run restores it as one event whose duration is the real
+        span, which clears the filter. This only ever combines fragments that
+        are provably the same window (identical app/title/url, back-to-back in
+        time) — exactly analogous to ``_collapse_afk_duplicates`` — so it can
+        only recover real attribution, never invent it. Billing is unaffected
+        either way (time comes from the AFK/input streams, not window events).
+
+        Source events are not mutated (new events via ``dataclasses.replace``);
+        the merged event keeps the FIRST fragment's id, so the ``_sent_cache``
+        dedup keys deterministically and the checkpoint (computed by the caller
+        from the ORIGINAL event list) is unaffected.
+        """
+        if len(events) <= 1:
+            return events
+        tolerance = timedelta(seconds=SyncEngine._WINDOW_COALESCE_GAP_TOLERANCE_S)
+        ordered = sorted(events, key=lambda e: e.timestamp)
+        merged: list[AWEvent] = []
+        for ev in ordered:
+            if merged:
+                last = merged[-1]
+                last_end = last.timestamp + timedelta(seconds=last.duration)
+                same_window = (
+                    last.app == ev.app
+                    and last.title == ev.title
+                    and last.url == ev.url
+                )
+                if same_window and last.timestamp <= ev.timestamp <= last_end + tolerance:
+                    ev_end = ev.timestamp + timedelta(seconds=ev.duration)
+                    if ev_end > last_end:
+                        merged[-1] = dataclasses.replace(
+                            last, duration=(ev_end - last.timestamp).total_seconds()
+                        )
+                    # else: ev is fully contained in last — drop the duplicate.
+                    continue
+            merged.append(ev)
+        return merged
 
     def _get_afk_events_for_range(
         self, start: datetime, end: datetime

--- a/tests/test_window_flicker_coalesce.py
+++ b/tests/test_window_flicker_coalesce.py
@@ -1,0 +1,132 @@
+"""Coalesce sub-threshold same-window fragments so an AW heartbeat-merge
+failure doesn't cost the whole span's per-app attribution to the flicker filter.
+
+Symptom (Sachi device 16, recurring 2026-06-26 .. 07-02): every session logs
+``the watcher IS producing window events but the filter is dropping them all
+(99 window event(s) under the 5s minimum (flicker filter))``. The window
+watcher emits a focus as many sub-5s fragments instead of one merged event;
+each fragment is individually dropped by ``min_window_event_seconds``, so the
+per-app category breakdown for that span disappears. Billing is unaffected
+(time comes from AFK/input), but the timeline loses attribution.
+
+Fix: merge runs of consecutive, time-contiguous, identical-window (app+title+
+url) fragments into one event before the filter runs — analogous to
+``_collapse_afk_duplicates``. The merged event clears the 5s filter and the
+attribution is recovered.
+"""
+
+from datetime import datetime, timedelta, timezone
+from unittest.mock import Mock
+
+from src.config import Config
+from src.sync.aw_client import BUCKET_TYPE_WINDOW, AWEvent
+from src.sync.sync_engine import SyncEngine, SyncStats, _SyncCycleContext
+
+BASE = datetime(2026, 7, 2, 9, 0, 0, tzinfo=timezone.utc)
+
+
+def _win(idx, offset_s, duration_s, app="Code.exe", title="main.py", url=None):
+    """A window AWEvent starting BASE+offset for duration_s seconds."""
+    data = {"app": app, "title": title}
+    if url is not None:
+        data["url"] = url
+    return AWEvent(
+        id=idx,
+        timestamp=BASE + timedelta(seconds=offset_s),
+        duration=duration_s,
+        data=data,
+    )
+
+
+class TestCoalesceWindowFlickers:
+    def test_merges_contiguous_identical_fragments(self):
+        # Three 2s fragments of the SAME window, back-to-back → one 6s event.
+        events = [_win(1, 0, 2), _win(2, 2, 2), _win(3, 4, 2)]
+        merged = SyncEngine._coalesce_window_flickers(events)
+        assert len(merged) == 1
+        assert merged[0].id == 1  # keeps the first fragment's id (stable dedup)
+        assert merged[0].duration == 6.0
+        assert merged[0].timestamp == BASE
+
+    def test_does_not_merge_different_apps(self):
+        events = [_win(1, 0, 2, app="Code.exe"), _win(2, 2, 2, app="Chrome.exe")]
+        merged = SyncEngine._coalesce_window_flickers(events)
+        assert len(merged) == 2
+
+    def test_does_not_merge_different_titles(self):
+        events = [_win(1, 0, 2, title="a.py"), _win(2, 2, 2, title="b.py")]
+        merged = SyncEngine._coalesce_window_flickers(events)
+        assert len(merged) == 2
+
+    def test_does_not_merge_across_a_real_gap(self):
+        # Same window but 30s apart — a different window was focused between
+        # them; these are two genuine visits, not one fragmented focus.
+        events = [_win(1, 0, 2), _win(2, 32, 2)]
+        merged = SyncEngine._coalesce_window_flickers(events)
+        assert len(merged) == 2
+
+    def test_fully_contained_duplicate_is_dropped_not_double_counted(self):
+        # A 6s event and a 2s event inside it (heartbeat-merge overlap) → one
+        # 6s event, never 8s.
+        events = [_win(1, 0, 6), _win(2, 2, 2)]
+        merged = SyncEngine._coalesce_window_flickers(events)
+        assert len(merged) == 1
+        assert merged[0].duration == 6.0
+
+    def test_empty_and_single_are_passthrough(self):
+        assert SyncEngine._coalesce_window_flickers([]) == []
+        one = [_win(1, 0, 2)]
+        assert SyncEngine._coalesce_window_flickers(one) == one
+
+
+class TestFlickerSurvivesFilterEndToEnd:
+    """Drive the real transform+filter path, asserting on emitted events."""
+
+    def _engine(self):
+        aw, bf, queue = Mock(), Mock(), Mock()
+        queue.get_checkpoint.return_value = None
+        config = Config()
+        assert config.sync.min_window_event_seconds == 5.0
+        analyzer = Mock()
+        analyzer.get_activity_state.return_value = "active"
+        analyzer.get_raw_metrics.return_value = Mock(
+            to_dict=lambda: {"presses": 0, "clicks": 0, "scrolls": 0, "window_changes": 0}
+        )
+        analyzer.get_fraud_assessment.return_value = Mock(
+            score=0, signals=[], extra_metrics={}
+        )
+        time_tracker = Mock()
+        return SyncEngine(
+            aw=aw, bf=bf, queue=queue, config=config,
+            activity_analyzer=analyzer, time_tracker=time_tracker,
+        )
+
+    def test_sub5s_fragments_are_recovered_as_one_attributed_event(self):
+        engine = self._engine()
+        # Three 2s fragments of the same window: each is BELOW the 5s filter,
+        # so pre-fix all three are dropped and attribution is lost.
+        events = [_win(1, 0, 2), _win(2, 2, 2), _win(3, 4, 2)]
+        stats = SyncStats()
+        transformed, checkpoint = engine._transform_and_checkpoint(
+            events, "aw-watcher-window_host", BUCKET_TYPE_WINDOW, stats, _SyncCycleContext()
+        )
+        # Post-fix: one window event survives, carrying the app attribution.
+        assert len(transformed) == 1
+        assert transformed[0]["data"]["app"] == "Code.exe"
+        assert transformed[0]["duration"] >= 5.0
+        # Checkpoint must still point at the NEWEST ORIGINAL event (id 3), not
+        # the coalesced event (id 1) — coalescing must not rewind progress.
+        assert checkpoint is not None
+        assert checkpoint[2] == 3
+
+    def test_genuine_short_distinct_windows_still_filtered(self):
+        # Two different sub-5s windows that are NOT the same focus must still be
+        # dropped — coalescing only rescues fragmented identical windows.
+        engine = self._engine()
+        events = [_win(1, 0, 2, app="A.exe", title="a"),
+                  _win(2, 2, 2, app="B.exe", title="b")]
+        stats = SyncStats()
+        transformed, _ = engine._transform_and_checkpoint(
+            events, "aw-watcher-window_host", BUCKET_TYPE_WINDOW, stats, _SyncCycleContext()
+        )
+        assert transformed == []


### PR DESCRIPTION
## Problem

Recurring on **Sachi's device (16)** every session since 2026-06-26 (confirmed again 07-02). Her log warns, once per session:

> `Window/app data has gone stale on the server across 3 cycles — the watcher IS producing window events but the filter is dropping them all (99 window event(s) under the 5s minimum (flicker filter)). Billing is unaffected (AFK/input still upload); only per-app attribution is lost for this span.`

ActivityWatch is supposed to heartbeat-merge successive polls of an unchanged window into one growing event. When that merge fails, it emits the focus as dozens of sub-5s fragments. Each fragment is then individually dropped by `min_window_event_seconds` in `_transform_event`, so the **whole span's per-app category attribution is lost** — even though the watcher produced data the entire time. Billing/tracked-time is unaffected (time comes from the AFK/input streams).

## Fix

`_coalesce_window_flickers` merges runs of consecutive, time-contiguous, **identical-window (app+title+url)** fragments into one event at the top of `_transform_and_checkpoint`, before the filter runs. Directly analogous to the existing `_collapse_afk_duplicates` — it only ever combines fragments that are provably the same window back-to-back in time, so it recovers real attribution and can never invent it. A fully-contained duplicate is dropped (no double count).

### Safety for the delicate transform/checkpoint path
- Merged event keeps the **first** fragment's id → `_sent_cache` dedup keys deterministically (re-fetched runs re-coalesce to the same id+duration and dedup-skip).
- Pending checkpoint is computed from the **original** (pre-coalesce) event list → coalescing cannot rewind progress, re-fetch, or double-send.
- `add_window_events()` still receives the **raw** events → genuine window-change detection unaffected.

### Scope note
This fully resolves the common case (one window fragmented into a burst). If a residual "stale" warning ever comes from *genuine* rapid switching across many distinct short-lived windows, that's a separate finer-grained design question — this PR deliberately does not synthesize attribution for windows that were never actually the same focus.

## Tests (proof-of-failure handshake)

New `tests/test_window_flicker_coalesce.py` (8 tests): pure-function merge rules + an end-to-end run through the real transform+filter. Run against a stash of `sync_engine.py` (pre-fix) the 7 meaningful assertions **failed** — the method didn't exist and the end-to-end test emitted **0** window events (all three 2s fragments dropped). Post-fix: **853 passed**, including the restart/double-count and checkpoint suites.

🤖 Generated with [Claude Code](https://claude.com/claude-code)