### PR TITLE
fix(updater): refuse self-update when running from a Downloads folder (win32)

### DIFF
--- a/src/__init__.py
+++ b/src/__init__.py
@@ -1,4 +1,4 @@
 """BetterFlow - ActivityWatch to BetterFlow sync companion app."""
 
-__version__ = "1.5.90"
+__version__ = "1.5.91"
 __author__ = "BetterQA"

--- a/src/self_updater.py
+++ b/src/self_updater.py
@@ -92,6 +92,68 @@ def _get_app_bundle_path() -> Optional[Path]:
     return None
 
 
+# Set once per process so the "install properly" nag isn't repeated on every
+# stage / staged-apply attempt within a single run.
+_downloads_warning_sent = False
+
+
+def _running_from_downloads(app_path: Optional[Path]) -> bool:
+    """True when the running app lives inside a Downloads folder.
+
+    Windows can't reliably replace a locked .exe in place, so a self-update
+    applied to an app that was unzipped-and-run from Downloads silently fails
+    to persist: the next cold start comes back on the bundled (often ancient)
+    version and re-applies the update, churning forever. Observed on Sachi's
+    device (16), 2026-07-02 — stuck bouncing back to 1.5.29 out of
+    ``C:\\Users\\Administrator\\Downloads\\BetterFlow-Windows (1)``.
+
+    Matches both the standard ``~/Downloads`` and any path with a ``Downloads``
+    component (a relocated-but-still-named Downloads folder).
+    """
+    if app_path is None:
+        return False
+    try:
+        if any(part.lower() == "downloads" for part in app_path.parts):
+            return True
+        downloads = (Path.home() / "Downloads").resolve()
+        resolved = app_path.resolve()
+        return resolved == downloads or downloads in resolved.parents
+    except Exception:
+        return False
+
+
+def _warn_downloads_install(
+    app_path: Path, on_progress: Optional[Callable[[str], None]]
+) -> None:
+    """Log, surface status, and (once per process) notify the user that a
+    Downloads install can't self-update and needs to be installed properly."""
+    global _downloads_warning_sent
+    logger.warning(
+        "self-update: app is running from a Downloads folder (%s); an in-place "
+        "update can't persist there and would revert on next launch. Skipping "
+        "the update and asking the user to install to a stable location.",
+        app_path,
+    )
+    if on_progress:
+        on_progress("Install BetterFlow outside Downloads to get updates")
+    if _downloads_warning_sent:
+        return
+    _downloads_warning_sent = True
+    try:
+        try:
+            from .notifications import send_notification
+        except ImportError:
+            from notifications import send_notification
+        send_notification(
+            "BetterFlow can't update itself",
+            "You're running BetterFlow from your Downloads folder, so updates "
+            "won't stick. Please install it to a permanent location and delete "
+            "the copies in Downloads.",
+        )
+    except Exception:
+        logger.debug("Downloads-install notification failed", exc_info=True)
+
+
 def _artifact_filename_from_url(download_url: str) -> str:
     """Derive a safe local filename (keeping the real extension) from the URL.
 
@@ -219,6 +281,16 @@ def _apply_local_artifact(
     logger.info("self-update: sys.executable=%s resolved app_path=%s", sys.executable, app_path)
     if app_path is None:
         _status("Cannot determine app location - update aborted")
+        return False
+
+    # Refuse to apply into a Downloads folder on Windows: the in-place replace
+    # can't persist a locked .exe there, so the update silently reverts on the
+    # next launch and the app churns re-applying it forever (Sachi, device 16).
+    # Sitting still on the current version + nagging to install properly beats
+    # an endless relaunch loop. macOS/Linux replace the whole bundle/AppImage
+    # atomically, so they aren't affected.
+    if sys.platform == "win32" and _running_from_downloads(app_path):
+        _warn_downloads_install(app_path, on_progress)
         return False
 
     is_dmg = artifact_path.name.lower().endswith(".dmg")
@@ -747,6 +819,15 @@ def stage_update(
         # Match apply_update: HTTPS + GitHub-host allowlist, not just HTTPS.
         logger.warning("Refusing to stage update from disallowed URL host")
         return False
+
+    # No point downloading ~60 MB every launch if the apply will be refused:
+    # a Windows Downloads-folder install can't persist an update (see
+    # _apply_local_artifact / _running_from_downloads).
+    if sys.platform == "win32":
+        app_path = _get_app_bundle_path()
+        if _running_from_downloads(app_path):
+            _warn_downloads_install(app_path, on_progress)
+            return False
 
     clear_staged_update()
     staging = _staging_dir()

--- a/tests/test_self_updater_downloads_guard.py
+++ b/tests/test_self_updater_downloads_guard.py
@@ -1,0 +1,107 @@
+"""A Windows app running from a Downloads folder must not churn self-updates.
+
+Sachi (device 16, 2026-07-02) ran BetterFlow straight out of
+``C:\\Users\\Administrator\\Downloads\\BetterFlow-Windows (1)``. Windows can't
+replace a locked .exe in place, so every self-update silently failed to
+persist: the app cold-started back on an ancient bundled 1.5.29, re-detected
+the update, re-applied, relaunched, and reverted again — forever. Her update
+banners showed ``1.5.29 -> v1.5.82/83/84/87/88`` across sessions.
+
+The updater now refuses to stage/apply when it's running from a Downloads
+folder (Windows only) and instead nags the user to install it properly.
+
+Windows paths are exercised via PureWindowsPath so the logic is testable on a
+POSIX CI host (a bare ``Path(r"C:\\...")`` there is a single POSIX component).
+"""
+
+from pathlib import Path, PureWindowsPath
+from unittest.mock import Mock
+
+import pytest
+
+import src.self_updater as su
+
+
+def _reset_warning():
+    su._downloads_warning_sent = False
+
+
+class TestRunningFromDownloads:
+    def test_standard_downloads_path_is_detected(self):
+        p = PureWindowsPath(r"C:\Users\Administrator\Downloads\BetterFlow-Windows (1)")
+        assert su._running_from_downloads(p) is True
+
+    def test_case_insensitive(self):
+        p = PureWindowsPath(r"C:\Users\admin\downloads\BetterFlow")
+        assert su._running_from_downloads(p) is True
+
+    def test_stable_install_location_is_not_flagged(self):
+        p = PureWindowsPath(r"C:\Program Files\BetterFlow")
+        assert su._running_from_downloads(p) is False
+
+    def test_none_is_not_flagged(self):
+        assert su._running_from_downloads(None) is False
+
+    def test_downloads_as_a_substring_is_not_a_false_positive(self):
+        # "Downloads2" is a different folder — only an exact path component counts.
+        p = PureWindowsPath(r"C:\Users\admin\Downloads2\BetterFlow")
+        assert su._running_from_downloads(p) is False
+
+
+class TestApplyRefusesFromDownloads:
+    def test_apply_returns_false_and_notifies_without_extracting(self, monkeypatch, tmp_path):
+        _reset_warning()
+        monkeypatch.setattr(su.sys, "platform", "win32", raising=False)
+        dl = PureWindowsPath(r"C:\Users\Administrator\Downloads\BetterFlow-Windows (1)")
+        monkeypatch.setattr(su, "_get_app_bundle_path", lambda: dl)
+        notify = Mock()
+        monkeypatch.setattr("src.notifications.send_notification", notify)
+        # If the guard fails to short-circuit, extraction would run — make it
+        # explode so the test can't pass by accident.
+        monkeypatch.setattr(su.tempfile, "mkdtemp",
+                            Mock(side_effect=AssertionError("should not extract")))
+
+        artifact = tmp_path / "BetterFlow-Windows-Update.zip"
+        artifact.write_bytes(b"not a real zip")
+
+        ok = su._apply_local_artifact(artifact)
+
+        assert ok is False
+        notify.assert_called_once()
+
+    def test_apply_not_blocked_on_macos_from_downloads(self, monkeypatch, tmp_path):
+        # macOS replaces the whole .app atomically — a Downloads run is fine and
+        # must NOT be refused. Prove the guard didn't short-circuit by letting
+        # execution reach extraction (mkdtemp), and confirm no nag fired.
+        _reset_warning()
+        monkeypatch.setattr(su.sys, "platform", "darwin", raising=False)
+        dl = Path("/Users/x/Downloads/BetterFlow.app")
+        monkeypatch.setattr(su, "_get_app_bundle_path", lambda: dl)
+        notify = Mock()
+        monkeypatch.setattr("src.notifications.send_notification", notify)
+        monkeypatch.setattr(su.tempfile, "mkdtemp",
+                            Mock(side_effect=RuntimeError("reached extraction")))
+
+        artifact = tmp_path / "BetterFlow-macOS-arm64.dmg"
+        artifact.write_bytes(b"x")
+
+        with pytest.raises(RuntimeError, match="reached extraction"):
+            su._apply_local_artifact(artifact)
+        notify.assert_not_called()  # the Downloads guard is win32-only
+
+
+class TestStageSkipsFromDownloads:
+    def test_stage_returns_false_without_downloading(self, monkeypatch):
+        _reset_warning()
+        monkeypatch.setattr(su.sys, "platform", "win32", raising=False)
+        dl = PureWindowsPath(r"C:\Users\Administrator\Downloads\BetterFlow-Windows (1)")
+        monkeypatch.setattr(su, "_get_app_bundle_path", lambda: dl)
+        monkeypatch.setattr("src.notifications.send_notification", Mock())
+        # Downloading must never be attempted when the guard trips.
+        monkeypatch.setattr(su, "_download_to_file",
+                            Mock(side_effect=AssertionError("should not download")))
+
+        url = ("https://github.com/Better-Quality-Assurance/betterflow-sync/"
+               "releases/download/v1.5.90/BetterFlow-Windows-Update.zip")
+        ok = su.stage_update(url, "1.5.90")
+        assert ok is False


### PR DESCRIPTION
## Problem

Sachi (device 16, 2026-07-02) ran BetterFlow straight out of `C:\Users\Administrator\Downloads\BetterFlow-Windows (1)`. On Windows the in-place update can't replace a locked `.exe` in a Downloads folder, so every self-update **silently failed to persist**: the app cold-started back on the bundled (ancient) **1.5.29**, re-detected the update, re-applied, relaunched, and reverted again — forever.

Evidence from her log: update banners across sessions repeatedly report `1.5.29 -> v1.5.82/83/84/87/88`. Fixes never "took" because half the time she was bounced back to 1.5.29, and each launch paid a relaunch-churn cost.

## Fix (Windows only)

- **`_running_from_downloads(app_path)`** — True when the app lives in a Downloads folder (exact path component, case-insensitive; plus a resolved `~/Downloads` fallback). A `Downloads2` sibling is not a false positive.
- **`_apply_local_artifact`** refuses the apply on win32 when running from Downloads and returns `False` (no extract, no relaunch). Sitting still on the current version beats an endless relaunch loop.
- **`stage_update`** short-circuits the same way, so we don't re-download ~60 MB every launch for an apply that will be refused.
- Both paths **notify the user once per process** to install to a stable location and delete the Downloads copies.

macOS (`.app`) and Linux (`.AppImage`) replace the whole bundle atomically, so they are unaffected and deliberately not gated.

## Tests (proof-of-failure handshake)

New `tests/test_self_updater_downloads_guard.py` (8 tests): the pure detector, win32 apply/stage refusal (+ notify, no extract, no download), and a macOS control proving the guard is win32-only. Run against a `git show HEAD:` copy of `self_updater.py` (pre-fix), the 6 meaningful assertions **failed** (the function didn't exist; apply reached extraction). Post-fix: **894 passed**. Windows paths use `PureWindowsPath` so the logic tests on the POSIX CI host.

## Note
This stops the churn and tells the user the real fix; it does not migrate the install for them. Sachi (and anyone else who unzip-and-runs from Downloads) will need to install to a permanent location once to start receiving updates again.

🤖 Generated with [Claude Code](https://claude.com/claude-code)