### PR TITLE
fix(sync): bound the per-bucket send loop to the in-cycle network budget

### DIFF
--- a/src/__init__.py
+++ b/src/__init__.py
@@ -1,4 +1,4 @@
 """BetterFlow - ActivityWatch to BetterFlow sync companion app."""
 
-__version__ = "1.5.91"
+__version__ = "1.5.92"
 __author__ = "BetterQA"

--- a/src/sync/sync_engine.py
+++ b/src/sync/sync_engine.py
@@ -281,6 +281,13 @@ class SyncEngine:
         # _commit_inproc_window_checkpoint only after a confirmed send.
         self._window_inproc_pending: Optional[datetime] = None
 
+        # Monotonic timestamp of the current sync() cycle's start, stamped at the
+        # top of sync(). Gates the per-bucket send loop's in-cycle network budget
+        # (_SEND_SKIP_IF_CYCLE_ELAPSED) so N buckets can't stack N retry chains
+        # past the _do_sync watchdog. None outside a sync() cycle (e.g. a direct
+        # _send_events call in a unit test) -> the budget guard is inert.
+        self._cycle_start_monotonic: Optional[float] = None
+
         # Queue retry backoff
         self._queue_consecutive_failures = 0
         self._queue_backoff_until = datetime.min.replace(tzinfo=timezone.utc)
@@ -568,6 +575,9 @@ class SyncEngine:
         """
         stats = SyncStats()
         cycle_start = time.monotonic()  # to keep the queue drain inside the watchdog budget
+        # Publish the cycle start so _send_events can bound the per-bucket send
+        # loop to the same in-cycle network budget as the queue drain.
+        self._cycle_start_monotonic = cycle_start
 
         # Daily housekeeping before anything else, so it still runs while paused:
         # a long-running agent that never restarts across midnight would
@@ -2487,7 +2497,34 @@ class SyncEngine:
             by_bucket.setdefault(event.get("bucket_id", ""), []).append(event)
 
         bucket_groups = list(by_bucket.values())
+        start = self._cycle_start_monotonic
+        budget = self._SEND_SKIP_IF_CYCLE_ELAPSED
         for idx, group in enumerate(bucket_groups):
+            # In-cycle network budget: each bucket group is its own retrying
+            # request chain (~94s against a hung server). Once this cycle has
+            # spent the budget on network, queue the remaining groups instead of
+            # starting another chain that would stack past the _do_sync watchdog
+            # ("Sync hung" / "Sync wedged"). The first group always attempts
+            # (idx == 0) so a cycle still makes forward progress. No-op when the
+            # cycle start is unset (direct _send_events call outside sync()).
+            if (
+                idx > 0
+                and start is not None
+                and (time.monotonic() - start) >= budget
+            ):
+                logger.warning(
+                    "Send budget spent (%.0fs elapsed >= %ds) — queuing %d "
+                    "remaining bucket group(s) for next cycle instead of stacking "
+                    "another upload chain past the watchdog",
+                    time.monotonic() - start, budget, len(bucket_groups) - idx,
+                )
+                for remaining in bucket_groups[idx:]:
+                    self.queue.enqueue(remaining)
+                    stats.events_queued += len(remaining)
+                    stats.queued_bucket_ids.update(
+                        e.get("bucket_id", "") for e in remaining
+                    )
+                return
             try:
                 self._send_bucket_events(group, stats)
             except BetterFlowAuthError:
@@ -2586,6 +2623,19 @@ class SyncEngine:
     # spent this long before the queue drain, skip it this cycle (it drains next
     # cycle); 50s + one ~94s chain stays under the 150s deadline with margin.
     _QUEUE_SKIP_IF_CYCLE_ELAPSED = 50  # seconds
+    # Same in-cycle network budget, applied to the REGULAR send. _send_events
+    # groups the cycle's events by bucket and sends each group in its own
+    # retrying request chain (~94s against a hung server). A device with N
+    # distinct buckets (window, afk, input, inproc-afk, inproc-window, call)
+    # would otherwise stack N chains inside one _do_sync watchdog: N~=3 overruns
+    # the 150s deadline ("Sync hung"), N~=6 overruns the 420s wedge ceiling
+    # ("Sync wedged") — the same root cause, differing only in bucket count
+    # (Azorel outage 2026-07-02, fps 707a9ecc/63a18e4f/d31bb248). Once the cycle
+    # has spent this budget, remaining buckets are queued (the durable
+    # OfflineQueue drains them next cycle) instead of starting another chain; the
+    # first bucket always attempts so a cycle still makes forward progress.
+    # 50s + one ~94s chain stays under the 150s deadline with margin.
+    _SEND_SKIP_IF_CYCLE_ELAPSED = 50  # seconds
 
     def _process_queue(self, stats: SyncStats) -> None:
         """Process offline queue with exponential backoff.

--- a/tests/test_sync_send_budget.py
+++ b/tests/test_sync_send_budget.py
@@ -1,0 +1,142 @@
+"""Regular-send in-cycle network budget: N buckets must not stack N retry chains.
+
+Origin: 2026-07-02 Azorel outage. betterflow-sync fired "Sync hung — exceeded
+120s/150s watchdog deadline" (86x + 24x, fingerprints 707a9ecc / 63a18e4f) plus
+one "Sync wedged — held sync lock >420s" (d31bb248), all on the same devices
+during a server outage.
+
+Root cause: ``SyncEngine._send_events`` groups the cycle's events BY BUCKET (the
+#4 blast-radius decoupling) and sends each group in its own retrying request
+chain. A hung server makes each chain take ~94s (max_retries=2 -> 3 attempts *
+30s + backoff). A device with N distinct buckets (window, afk, input,
+inproc-afk, inproc-window, call ~= 3-6) therefore stacks N * 94s SEQUENTIALLY
+inside a single ``sync()``, inside the ``_do_sync`` watchdog. The watchdog budget
+(150s deadline / 420s wedge) was sized for ONE regular chain plus the
+already-guarded queue drain, not N. N~=3 overruns 150s ("Sync hung"); N~=6
+overruns 420s ("Sync wedged") — the SAME root cause, differing only in bucket
+count.
+
+Fix: the same elapsed-budget guard that already gates the queue drain
+(``_QUEUE_SKIP_IF_CYCLE_ELAPSED``) now gates the per-bucket send loop. Once a
+cycle has spent ``_SEND_SKIP_IF_CYCLE_ELAPSED`` on network, the remaining
+buckets are queued (durable OfflineQueue drains them next cycle) instead of
+starting another chain. The first bucket always attempts, so a cycle still makes
+forward progress.
+
+Pre-fix: ``test_over_budget_stops_sending_remaining_buckets`` FAILS — all N
+buckets are sent (N send_events calls). Post-fix: only the first is sent, the
+rest are queued.
+"""
+
+import tempfile
+import time
+from datetime import datetime, timezone
+from pathlib import Path
+from unittest.mock import Mock
+
+from src.config import Config
+from src.main import SyncCoordinator
+from src.sync.aw_client import BUCKET_TYPE_AFK, BUCKET_TYPE_INPUT, BUCKET_TYPE_WINDOW
+from src.sync.bf_client import SyncResult
+from src.sync.daily_time_tracker import DailyTimeTracker
+from src.sync.http_client import BaseApiClient
+from src.sync.queue import OfflineQueue
+from src.sync.retry import calculate_delay
+from src.sync.sync_engine import SyncEngine
+
+
+def _worst_case_chain_seconds() -> float:
+    """Upper bound on ONE retrying request whose every attempt eats the full
+    timeout (mirrors tests/test_sync_watchdog_budget.py)."""
+    cfg = BaseApiClient.DEFAULT_RETRY_CONFIG
+    timeout = 30.0
+    attempts = cfg.max_retries + 1
+    backoff = sum(
+        calculate_delay(a, cfg.base_delay, cfg.max_delay, cfg.exponential_base, jitter=False) * 1.25
+        for a in range(cfg.max_retries)
+    )
+    return attempts * timeout + backoff
+
+
+def _events_across_buckets():
+    """One event in each of four distinct buckets, so _send_events forms four
+    by-bucket groups (four independent send chains)."""
+    now = datetime.now(timezone.utc).isoformat()
+    specs = [
+        ("aw-watcher-window_h", BUCKET_TYPE_WINDOW),
+        ("aw-watcher-afk_h", BUCKET_TYPE_AFK),
+        ("aw-watcher-input_h", BUCKET_TYPE_INPUT),
+        ("bf-window-inproc_h", BUCKET_TYPE_WINDOW),
+    ]
+    return [
+        {"id": f"e{i}", "timestamp": now, "duration": 1.0,
+         "bucket_id": bid, "bucket_type": btype, "data": {}}
+        for i, (bid, btype) in enumerate(specs)
+    ]
+
+
+def _engine():
+    tmp = Path(tempfile.mkdtemp())
+    q = OfflineQueue(db_path=tmp / "q.db", max_size=100000)
+    tt = DailyTimeTracker(db_path=tmp / "t.db")
+    bf = Mock()
+    bf.send_events = Mock(return_value=SyncResult(success=True, events_synced=1))
+    engine = SyncEngine(aw=Mock(), bf=bf, queue=q, config=Config(), time_tracker=tt)
+    return engine, bf, q, tt
+
+
+def test_over_budget_stops_sending_remaining_buckets():
+    """When the cycle has already spent the send budget, only the first bucket
+    group is sent over the network; the rest are queued for the next cycle."""
+    engine, bf, q, tt = _engine()
+    try:
+        # Simulate a cycle that has already burned past the budget (as it would
+        # after one ~94s chain against a hung server).
+        engine._cycle_start_monotonic = time.monotonic() - (
+            SyncEngine._SEND_SKIP_IF_CYCLE_ELAPSED + 5
+        )
+        from src.sync.sync_engine import SyncStats
+        stats = SyncStats()
+        engine._send_events(_events_across_buckets(), stats)
+
+        # Exactly ONE network chain (the first group, for forward progress); the
+        # other three buckets are queued without a send.
+        assert bf.send_events.call_count == 1, (
+            f"over-budget cycle must not start a chain per bucket; "
+            f"got {bf.send_events.call_count} send_events calls"
+        )
+        assert stats.events_queued == 3
+        assert q.size() == 3
+    finally:
+        q.close()
+        tt.close()
+
+
+def test_within_budget_sends_all_buckets():
+    """A healthy cycle (well under budget) still sends every bucket — no
+    regression to the decoupled-bucket delivery."""
+    engine, bf, q, tt = _engine()
+    try:
+        engine._cycle_start_monotonic = time.monotonic()  # elapsed ~= 0
+        from src.sync.sync_engine import SyncStats
+        stats = SyncStats()
+        engine._send_events(_events_across_buckets(), stats)
+
+        assert bf.send_events.call_count == 4, "healthy cycle must send all buckets"
+        assert stats.events_queued == 0
+        assert q.size() == 0
+    finally:
+        q.close()
+        tt.close()
+
+
+def test_send_budget_plus_one_chain_under_watchdog():
+    """Invariant: the send budget + one worst-case chain must fit under the
+    watchdog deadline, so at most one in-flight chain survives the budget cut."""
+    budget = SyncEngine._SEND_SKIP_IF_CYCLE_ELAPSED
+    worst = _worst_case_chain_seconds()
+    deadline = SyncCoordinator._DO_SYNC_DEADLINE
+    assert budget + worst < deadline, (
+        f"send budget {budget}s + one chain {worst:.1f}s = {budget + worst:.1f}s "
+        f"must stay under the {deadline}s watchdog"
+    )


### PR DESCRIPTION
## What

The Azorel fleet fired **"Sync hung — exceeded 120s/150s watchdog deadline" 86× + 24×** plus one **"Sync wedged — held sync lock >420s"** today (fps `707a9ecc` / `63a18e4f` / `d31bb248`) during a server outage.

## Root cause

`SyncEngine._send_events` groups a cycle's events **by bucket** (the #4 blast-radius decoupling) and sends each group in its own retrying request chain. A hung server makes each chain ~94s (`max_retries=2` → 3×30s + backoff). A device with N distinct buckets (window, afk, input, inproc-afk, inproc-window, call ≈ 3–6) stacked **N × 94s sequentially inside one `sync()`**, inside the `_do_sync` watchdog. The watchdog budget (150s deadline / 420s wedge) was sized for **one** regular chain + the already-guarded queue drain, not N.

- N≈3 → ~280s → **"Sync hung"** (the 86×/24×; two fps = "120s" on pre-1.5.85 vs "150s" on patched builds)
- N≈6 → ~560s → **"Sync wedged >420s"** (the 1×)

**The 420s wedge and the 150s hangs are the same root cause**, differing only in bucket count. Not a deadlock, not a DB lock (no DB in the agent loop), not a lock-release bug — the `finally` at `main.py:1291` releases cleanly on every path. The by-bucket refactor silently turned 1 regular chain into N.

## Fix

Apply the same elapsed-budget guard that already gates the queue drain (`_QUEUE_SKIP_IF_CYCLE_ELAPSED`) to the per-bucket send loop. `sync()` stamps `_cycle_start_monotonic`; once a cycle has spent `_SEND_SKIP_IF_CYCLE_ELAPSED` (50s) on network, `_send_events` queues the remaining bucket groups (durable `OfflineQueue` drains them next cycle) instead of starting another chain. The first bucket always attempts, so a cycle still makes forward progress. `50s + one ~94s chain < 150s` deadline.

**No data risk:** undelivered events were already queued durably either way — this only stops the wedge and the false "Sync hung" noise.

## Tests (`tests/test_sync_send_budget.py`)

- `test_over_budget_stops_sending_remaining_buckets` — **failed pre-fix** (4 `send_events` calls, one per bucket); post-fix makes 1 and queues the other 3 into a **real on-disk OfflineQueue** (`q.size()==3`).
- `test_within_budget_sends_all_buckets` — healthy cycle still sends all 4 (no regression to decoupled delivery).
- `test_send_budget_plus_one_chain_under_watchdog` — invariant: `budget + worst_chain < deadline`.

Full suite: **897 passed**. Version bumped 1.5.91 → 1.5.92.

## Related

- REPO_MAP for betterflow-sync already added in betterqa-bot #109 (autofix now fix-assesses these rows; prior rows self-heal via `skipped_retryable`).
- Extends `sync-hung-watchdog-is-retry-budget`; closes the "deadlock pair unconfirmed" question in `sync-wedge-self-recovery`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)