### PR TITLE
feat(sync): in-process input watcher (dormant, opt-in) — fixes Windows zero-clicks

### DIFF
--- a/src/config.py
+++ b/src/config.py
@@ -319,6 +319,14 @@ class SyncSettings:
     # AND the probe is usable, the external window bucket is skipped so the two
     # sources never double-count.
     in_process_window: bool = False
+    # Count keystrokes/clicks/scrolls in-process (Windows ctypes low-level hooks
+    # / macOS CGEventTap) instead of relying on the external aw-watcher-input
+    # tracker. Same convergence move as in_process_window, for machines where
+    # aw-watcher-input's low-level hook is blocked (UIPI / AV) and reports ZERO
+    # keystrokes/clicks for hours (Fraud Risk 75). Default OFF — ships
+    # dormant/opt-in; when on AND an in-process backend is usable, the external
+    # input bucket is skipped so the two sources never double-count.
+    in_process_input: bool = False
 
 
 @dataclass
@@ -690,6 +698,15 @@ class Config:
                 self.sync.in_process_window = self._to_bool(sync["in_process_window"])
                 logger.info(
                     "Server config: in_process_window=%s", self.sync.in_process_window
+                )
+            if "in_process_input" in sync:
+                # Opt-in remote enable of the in-process input source (ships
+                # dormant). Use _to_bool (not bool()) like every sibling flag: a
+                # server payload of the STRING "false"/"0" must stay off —
+                # bool("false") is True and would silently enable it fleet-wide.
+                self.sync.in_process_input = self._to_bool(sync["in_process_input"])
+                logger.info(
+                    "Server config: in_process_input=%s", self.sync.in_process_input
                 )
 
         if "engagement" in server_config:

--- a/src/main.py
+++ b/src/main.py
@@ -1611,6 +1611,29 @@ class BetterFlowApp:
             else "inactive",
         )
 
+        # In-process INPUT source: the keystroke/click/scroll-count analogue of
+        # window_source. Counts input inside the agent process (Windows ctypes
+        # low-level hooks / macOS CGEventTap) and uploads it as the sole input
+        # source, so a device where the external aw-watcher-input hook is blocked
+        # (UIPI / AV) and reports ZERO input (Fraud Risk 75) still gets real
+        # counts. Ships dormant: inert unless config enables it AND a backend is
+        # usable (macOS/Windows; off on Linux). The backend listener thread is
+        # started with the other in-process watchers in _start_watchers().
+        try:
+            from .sync.input_source import InputSource
+        except ImportError:
+            from sync.input_source import InputSource
+        input_source = InputSource(
+            hostname=self.coordinator.sync_engine._hostname,
+        )
+        self.coordinator.sync_engine.input_source = input_source
+        self.input_source = input_source
+        logger.info(
+            "In-process input source: %s",
+            "active" if (self.config.sync.in_process_input and input_source.available())
+            else "inactive",
+        )
+
         # Reminder manager (created after coordinator for clean callback injection)
         self.reminder_manager = ReminderManager(self.config.reminders)
         self.coordinator.reminder_manager = self.reminder_manager
@@ -1659,6 +1682,14 @@ class BetterFlowApp:
             self.window_watcher.start()
         if self.input_watcher:
             self.input_watcher.start()
+        # Start the in-process input-count backend only when the (dormant, opt-in)
+        # feature is enabled — otherwise ~100% of the fleet would install an OS
+        # input hook for a source nothing drains. Gated + no-op when off.
+        if self.input_source is not None and self.config.sync.in_process_input:
+            try:
+                self.input_source.start()
+            except Exception as e:
+                logger.warning("In-process input source start failed: %s", e)
 
     def _ensure_system_event_listener(self) -> None:
         """Start system event listeners once without blocking tray startup."""
@@ -2650,6 +2681,11 @@ class BetterFlowApp:
             self.window_watcher.stop()
         if self.input_watcher:
             self.input_watcher.stop()
+        if getattr(self, "input_source", None) is not None:
+            try:
+                self.input_source.stop()
+            except Exception:
+                logger.debug("In-process input source stop failed", exc_info=True)
         if self.display_tracker is not None:
             self.display_tracker.stop()
         if getattr(self, "browser_tracker", None) is not None:

--- a/src/sync/input_source.py
+++ b/src/sync/input_source.py
@@ -1,0 +1,556 @@
+"""In-process input source: counts keystrokes, mouse clicks, and scroll events
+inside the agent process and uploads them as the input bucket, replacing the
+external ``aw-watcher-input`` tracker on machines where its low-level hook is
+blocked (Windows UIPI / AV) and produces ZERO input events for hours.
+
+Mirrors ``WindowSource`` / ``AfkSource``: thread-safe state under a lock, a
+sticky ``available()`` latch, a single-source-of-truth ``bucket_id``, and a
+drain-and-build reconstructor (``drain_input_event``). Ships dormant
+(``SyncSettings.in_process_input`` defaults False) — opt-in per the AFK/window
+convergence playbook.
+
+Counting backend: unlike WindowSource (which polls a frontmost probe each
+cycle), input COUNTS must be captured continuously — a keystroke between two
+60s cycles cannot be recovered by a later poll. So a backend runs a listener
+thread that increments this source's counters as events arrive:
+
+  * Windows: low-level ctypes hooks (``WH_KEYBOARD_LL`` / ``WH_MOUSE_LL``)
+    installed IN the agent process. This is the whole point of the feature —
+    the external tracker's hook is the one being blocked, so we run our own in
+    the (already-permitted) main process.
+  * macOS: reuses the existing ``MacOSInputWatcher``'s Quartz ``CGEventTap``
+    counters (it already counts in-process under the app's Input Monitoring
+    grant) — we do NOT reimplement an OS hook there.
+  * Linux / no backend: unavailable (a gap, never invented counts) — exactly
+    like WindowSource on a platform with no frontmost probe.
+
+Privacy: only COUNTS are captured, never key values / content — same as the
+external watcher and ``MacOSInputWatcher``.
+"""
+
+import logging
+import platform
+import threading
+from datetime import datetime
+from typing import Callable, Optional
+
+try:
+    from .aw_client import BUCKET_TYPE_INPUT
+except ImportError:  # PyInstaller bundle (src/ is import root)
+    from sync.aw_client import BUCKET_TYPE_INPUT
+
+logger = logging.getLogger(__name__)
+
+# Sentinel: distinguishes "caller didn't pass a backend" (build the platform
+# default) from "caller passed None" (explicitly no backend — e.g. a test
+# feeding counts directly, or a platform with no in-process hook).
+_UNSET = object()
+
+
+class InputSource:
+    """Counts input events via a listener backend and drains them to input
+    events for upload.
+
+    Divergence from ``WindowSource``: there is no per-cycle sampling. A backend
+    thread increments the counters live (``_on_press`` / ``_on_click`` /
+    ``_on_scroll``); the sync cycle only DRAINS the accumulated counts into an
+    event for [checkpoint, now] and resets them. A period with no backend
+    available produces no event (gap), exactly like a blind WindowSource probe —
+    we never invent counts.
+    """
+
+    def __init__(
+        self,
+        hostname: str,
+        *,
+        backend=_UNSET,
+        frontmost_app_getter=_UNSET,
+    ) -> None:
+        self._hostname = hostname
+        # Thread-safe counters, incremented by the backend listener thread and
+        # snapshot-and-reset by drain_input_event on the sync thread. Guarded by
+        # the same lock so a drain reads a coherent (presses, clicks, scrolls)
+        # triple.
+        self._presses = 0
+        self._clicks = 0
+        self._scrolls = 0
+        self._lock = threading.Lock()
+
+        # Sticky platform-capability latch: once the backend has started (the
+        # in-process hook installed), the platform HAS the capability, so a
+        # transient nothing-happened cycle must not flap in-process input off.
+        # Mirrors WindowSource / AfkSource audit finding A.
+        self._available_latched = False
+
+        # Not passed -> platform default backend. Passed as None -> no backend
+        # (unsupported platform, or a test that injects counts directly): the
+        # source stays permanently unavailable unless something injects counts.
+        self._backend = (
+            _default_input_backend(self) if backend is _UNSET else backend
+        )
+        # Not passed -> platform default frontmost-app getter (tag the batch so
+        # the server attributes counts to a real app row rather than "Unknown").
+        # Passed as None -> no app tagging (headless / unsupported).
+        self._frontmost_app_getter: Optional[Callable[[], Optional[str]]] = (
+            _default_frontmost_app_getter()
+            if frontmost_app_getter is _UNSET else frontmost_app_getter
+        )
+
+    # -- backend callbacks (called from the listener thread) ------------------
+
+    def _on_press(self, n: int = 1) -> None:
+        with self._lock:
+            self._presses += n
+
+    def _on_click(self, n: int = 1) -> None:
+        with self._lock:
+            self._clicks += n
+
+    def _on_scroll(self, n: int = 1) -> None:
+        with self._lock:
+            self._scrolls += n
+
+    # -- lifecycle -----------------------------------------------------------
+
+    def start(self) -> bool:
+        """Start the backend listener thread. No-op (returns False) when there
+        is no backend. Latches ``available()`` on once the backend reports it
+        started, so a quiet first cycle doesn't hand input back to the external
+        tracker."""
+        if self._backend is None:
+            return False
+        try:
+            ok = bool(self._backend.start())
+        except Exception as e:
+            logger.warning("InputSource backend start failed: %s", e)
+            return False
+        if ok:
+            self._available_latched = True
+        return ok
+
+    def stop(self) -> None:
+        """Stop the backend listener thread (no-op when there is no backend)."""
+        if self._backend is None:
+            return
+        try:
+            self._backend.stop()
+        except Exception as e:
+            logger.debug("InputSource backend stop failed: %s", e)
+
+    @property
+    def bucket_id(self) -> str:
+        """The synthetic input bucket id this source uploads under. Single
+        source of truth so the upload (_event) and the checkpoint-commit gate
+        agree."""
+        return f"bf-input-inproc_{self._hostname}"
+
+    @property
+    def counts(self) -> tuple[int, int, int]:
+        """Current (presses, clicks, scrolls) accumulated since the last drain.
+        For diagnostics/tests; the live values, read under the lock."""
+        with self._lock:
+            return (self._presses, self._clicks, self._scrolls)
+
+    def available(self) -> bool:
+        """True when an in-process input backend is (or has ever been) usable on
+        this platform. Sticky: once the backend has started it stays True, so a
+        cycle with no keystrokes cannot flap in-process input off. False forever
+        on a platform with no backend."""
+        if self._available_latched:
+            return True
+        if self._backend is None:
+            return False
+        try:
+            ok = bool(self._backend.available())
+        except Exception:
+            ok = False
+        if ok:
+            self._available_latched = True
+        return ok
+
+    def _frontmost_app(self) -> Optional[str]:
+        """Best-effort frontmost app name to attribute this batch to. None when
+        unavailable — never blocks or fails the drain."""
+        getter = self._frontmost_app_getter
+        if getter is None:
+            return None
+        try:
+            app = getter()
+        except Exception as e:
+            logger.debug("InputSource frontmost-app lookup failed: %s", e)
+            return None
+        app = str(app or "").strip()
+        return app or None
+
+    def drain_input_event(
+        self, range_start: datetime, range_end: datetime
+    ) -> Optional[dict]:
+        """Snapshot-and-reset the counters and build ONE input event spanning
+        [range_start, range_end] carrying the accumulated counts.
+
+        Returns None (and leaves the counters untouched) when the source isn't
+        available, when the range is empty/inverted, or when nothing was counted
+        — a zero-count period is a gap, never an emitted zero event (mirrors
+        ``MacOSInputWatcher``'s skip-zero and WindowSource's blind handling; it
+        also avoids ~1,440 empty events/day).
+
+        The counters are reset ONLY after we've captured the snapshot to build
+        the event, so the accumulation for the next range starts clean. On a
+        send failure the caller holds the checkpoint and the counts are already
+        folded into this (idempotent, stable-id) event, which the offline queue
+        redelivers — the same durability model as the AFK/window streams."""
+        if not self.available():
+            return None
+        if range_end <= range_start:
+            return None
+        with self._lock:
+            presses = self._presses
+            clicks = self._clicks
+            scrolls = self._scrolls
+            # Reset now that we've snapshotted — the next range accrues fresh.
+            self._presses = 0
+            self._clicks = 0
+            self._scrolls = 0
+        if presses == 0 and clicks == 0 and scrolls == 0:
+            return None
+        return self._event(range_start, range_end, presses, clicks, scrolls)
+
+    def _event(
+        self, start: datetime, end: datetime,
+        presses: int, clicks: int, scrolls: int,
+    ) -> dict:
+        duration = (end - start).total_seconds()
+        data = {"presses": presses, "clicks": clicks, "scrolls": scrolls}
+        app = self._frontmost_app()
+        if app:
+            data["app"] = app
+        return {
+            # Millisecond precision to match the AFK/window synthetic streams:
+            # two drains can legitimately start within the same whole second on a
+            # fast manual sync + cycle overlap; a second-truncated id would
+            # collide and the server upsert would drop one, under-counting.
+            "id": f"input-inproc_{self._hostname}_{int(start.timestamp() * 1000)}",
+            "timestamp": start.isoformat(),
+            "duration": round(duration, 2),
+            "bucket_id": self.bucket_id,
+            "bucket_type": BUCKET_TYPE_INPUT,
+            "data": data,
+        }
+
+
+def _default_frontmost_app_getter() -> Optional[Callable[[], Optional[str]]]:
+    """Return a getter yielding the frontmost app's name, or None when the
+    platform has no cheap frontmost probe. Reuses the same probes the other
+    in-process sources use so counts attribute to the same app rows."""
+    if platform.system() == "Darwin":
+        def getter() -> Optional[str]:
+            try:
+                from AppKit import NSWorkspace
+                app = NSWorkspace.sharedWorkspace().frontmostApplication()
+                if app is None:
+                    return None
+                name = app.localizedName()
+                return str(name) if name else None
+            except Exception as e:
+                logger.debug("frontmostApplication lookup failed: %s", e)
+                return None
+        return getter
+    # Windows/Linux: resolve the foreground window's process name via the same
+    # pid probe the foreground-activity detector uses (psutil for the app name).
+    try:
+        from .foreground_activity import _default_pid_getter
+    except ImportError:
+        from sync.foreground_activity import _default_pid_getter
+    pid_getter = _default_pid_getter()
+    if pid_getter is None:
+        return None
+
+    def getter() -> Optional[str]:
+        pid, _label = pid_getter()
+        if pid is None:
+            return None
+        try:
+            import psutil
+            return psutil.Process(pid).name()
+        except Exception as e:
+            logger.debug("InputSource process-name lookup failed: %s", e)
+            return None
+
+    return getter
+
+
+def _default_input_backend(source: "InputSource"):
+    """Build the platform's in-process input-counting backend, or None when the
+    platform has no in-process hook.
+
+    Windows -> ctypes low-level hooks (the machines the feature exists for).
+    macOS   -> reuse the existing MacOSInputWatcher's CGEventTap counters.
+    Linux   -> None (no in-process backend; the external tracker keeps its job).
+    """
+    system = platform.system()
+    if system == "Windows":
+        return _WindowsHookBackend(source)
+    if system == "Darwin":
+        return _MacOSTapBackend(source)
+    return None
+
+
+class _WindowsHookBackend:
+    """Low-level Windows input hooks (``WH_KEYBOARD_LL`` / ``WH_MOUSE_LL``)
+    installed in the agent process, incrementing the InputSource counters.
+
+    Runs its own thread with a Windows message loop (``GetMessage``) — the OS
+    only delivers low-level hook callbacks to a thread that pumps messages. The
+    callback reads ONLY the event type (WM_KEYDOWN / WM_*BUTTONDOWN / WM_*WHEEL),
+    never key values, then chains to the next hook.
+    """
+
+    # Windows message / hook constants (defined here to avoid importing win32 at
+    # module load — this module is imported on every platform).
+    _WH_KEYBOARD_LL = 13
+    _WH_MOUSE_LL = 14
+    _WM_KEYDOWN = 0x0100
+    _WM_SYSKEYDOWN = 0x0104
+    _WM_LBUTTONDOWN = 0x0201
+    _WM_RBUTTONDOWN = 0x0204
+    _WM_MBUTTONDOWN = 0x0207
+    _WM_XBUTTONDOWN = 0x020B
+    _WM_MOUSEWHEEL = 0x020A
+    _WM_MOUSEHWHEEL = 0x020E
+
+    def __init__(self, source: "InputSource") -> None:
+        self._source = source
+        self._thread: Optional[threading.Thread] = None
+        self._thread_id: Optional[int] = None
+        self._kbd_hook = None
+        self._mouse_hook = None
+        # Keep the ctypes callback objects alive for the hook's lifetime —
+        # letting them be GC'd while Windows holds the pointer crashes the app.
+        self._kbd_cb = None
+        self._mouse_cb = None
+        self._started = threading.Event()
+        self._start_ok = False
+
+    def available(self) -> bool:
+        """ctypes + user32 are always present on Windows; the hook install is
+        what can fail, and start() latches that. Report capability here."""
+        try:
+            import ctypes  # noqa: F401
+            return platform.system() == "Windows"
+        except Exception:
+            return False
+
+    def start(self) -> bool:
+        if self._thread is not None and self._thread.is_alive():
+            return self._start_ok
+        self._started.clear()
+        self._start_ok = False
+        self._thread = threading.Thread(
+            target=self._run, daemon=True, name="win-input-hook",
+        )
+        self._thread.start()
+        # Wait briefly for the hooks to install so available() reflects reality.
+        self._started.wait(timeout=2.0)
+        return self._start_ok
+
+    def stop(self) -> None:
+        tid = self._thread_id
+        if tid is None:
+            return
+        try:
+            import ctypes
+            # WM_QUIT == 0x0012 — breaks the message loop so the thread exits.
+            ctypes.windll.user32.PostThreadMessageW(tid, 0x0012, 0, 0)
+        except Exception as e:
+            logger.debug("Windows input hook stop failed: %s", e)
+
+    def _run(self) -> None:
+        try:
+            import ctypes
+            from ctypes import wintypes
+        except Exception as e:
+            logger.warning("ctypes unavailable — Windows input hook disabled: %s", e)
+            self._started.set()
+            return
+
+        user32 = ctypes.windll.user32
+        kernel32 = ctypes.windll.kernel32
+
+        # LowLevelKeyboardProc / LowLevelMouseProc signature.
+        HOOKPROC = ctypes.CFUNCTYPE(
+            ctypes.c_long, ctypes.c_int, wintypes.WPARAM, wintypes.LPARAM
+        )
+
+        src = self._source
+
+        def _kbd_proc(nCode, wParam, lParam):
+            if nCode == 0:  # HC_ACTION — a real event to process
+                if wParam in (self._WM_KEYDOWN, self._WM_SYSKEYDOWN):
+                    src._on_press()
+            return user32.CallNextHookEx(None, nCode, wParam, lParam)
+
+        def _mouse_proc(nCode, wParam, lParam):
+            if nCode == 0:
+                if wParam in (
+                    self._WM_LBUTTONDOWN,
+                    self._WM_RBUTTONDOWN,
+                    self._WM_MBUTTONDOWN,
+                    self._WM_XBUTTONDOWN,
+                ):
+                    src._on_click()
+                elif wParam in (self._WM_MOUSEWHEEL, self._WM_MOUSEHWHEEL):
+                    src._on_scroll()
+            return user32.CallNextHookEx(None, nCode, wParam, lParam)
+
+        self._kbd_cb = HOOKPROC(_kbd_proc)
+        self._mouse_cb = HOOKPROC(_mouse_proc)
+
+        # A NULL hMod with dwThreadId 0 requires the callback to live in this
+        # module (it does). Pass the module handle for robustness.
+        h_mod = kernel32.GetModuleHandleW(None)
+        self._kbd_hook = user32.SetWindowsHookExW(
+            self._WH_KEYBOARD_LL, self._kbd_cb, h_mod, 0
+        )
+        self._mouse_hook = user32.SetWindowsHookExW(
+            self._WH_MOUSE_LL, self._mouse_cb, h_mod, 0
+        )
+        if not self._kbd_hook or not self._mouse_hook:
+            logger.warning(
+                "SetWindowsHookEx failed (kbd=%s mouse=%s) — in-process input "
+                "counting disabled", self._kbd_hook, self._mouse_hook,
+            )
+            self._unhook(user32)
+            self._started.set()
+            return
+
+        self._thread_id = kernel32.GetCurrentThreadId()
+        self._start_ok = True
+        self._started.set()
+        logger.info("Windows in-process input hooks installed")
+
+        # Pump the message loop so the OS delivers hook callbacks. GetMessage
+        # blocks until WM_QUIT (posted by stop()), then returns 0.
+        msg = wintypes.MSG()
+        while user32.GetMessageW(ctypes.byref(msg), None, 0, 0) != 0:
+            user32.TranslateMessage(ctypes.byref(msg))
+            user32.DispatchMessageW(ctypes.byref(msg))
+
+        self._unhook(user32)
+        logger.info("Windows in-process input hooks removed")
+
+    def _unhook(self, user32) -> None:
+        for hook in (self._kbd_hook, self._mouse_hook):
+            if hook:
+                try:
+                    user32.UnhookWindowsHookEx(hook)
+                except Exception:
+                    logger.debug("UnhookWindowsHookEx failed", exc_info=True)
+        self._kbd_hook = None
+        self._mouse_hook = None
+
+
+class _MacOSTapBackend:
+    """macOS backend that reuses the existing ``MacOSInputWatcher``'s Quartz
+    ``CGEventTap`` counters instead of reimplementing an OS hook.
+
+    ``MacOSInputWatcher`` already counts presses/clicks/scrolls in-process under
+    the app's Input Monitoring grant. We wrap ONE watcher instance, poll the
+    delta of its cumulative counters on a light thread, and feed the delta into
+    the InputSource — so the drain/event/bucket machinery is identical across
+    platforms and the CGEventTap logic lives in exactly one place."""
+
+    _POLL_INTERVAL_S = 1.0
+
+    def __init__(self, source: "InputSource") -> None:
+        self._source = source
+        self._watcher = None
+        self._stop = threading.Event()
+        self._thread: Optional[threading.Thread] = None
+        # Last cumulative counts read from the watcher, to compute deltas.
+        self._last = (0, 0, 0)
+
+    def _build_watcher(self):
+        try:
+            from .macos_input_watcher import MacOSInputWatcher
+        except ImportError:
+            from sync.macos_input_watcher import MacOSInputWatcher
+        # A tiny AW stub: this backend only needs the watcher's COUNTERS, never
+        # its emitter (InputSource owns the drain/upload). A no-op client keeps
+        # the watcher self-contained and off the AW input bucket entirely.
+        return MacOSInputWatcher(_NullAwClient())
+
+    def available(self) -> bool:
+        """True when Quartz is importable (the CGEventTap capability). The
+        permission itself is handled by MacOSInputWatcher.start()."""
+        try:
+            import Quartz  # noqa: F401
+            return True
+        except Exception:
+            return False
+
+    def start(self) -> bool:
+        if self._thread is not None and self._thread.is_alive():
+            return True
+        self._watcher = self._build_watcher()
+        ok = False
+        try:
+            ok = bool(self._watcher.start())
+        except Exception as e:
+            logger.warning("MacOS input tap backend start failed: %s", e)
+            return False
+        if not ok:
+            return False
+        self._stop.clear()
+        self._last = self._read_watcher_counts()
+        self._thread = threading.Thread(
+            target=self._poll_loop, daemon=True, name="macos-input-poll",
+        )
+        self._thread.start()
+        return True
+
+    def stop(self) -> None:
+        self._stop.set()
+        if self._watcher is not None:
+            try:
+                self._watcher.stop()
+            except Exception:
+                logger.debug("MacOS input watcher stop failed", exc_info=True)
+        if self._thread and self._thread.is_alive():
+            self._thread.join(timeout=2.0)
+        self._thread = None
+
+    def _read_watcher_counts(self) -> tuple[int, int, int]:
+        w = self._watcher
+        if w is None:
+            return (0, 0, 0)
+        # Read under the watcher's own lock so the triple is coherent.
+        with w._lock:
+            return (w._presses, w._clicks, w._scrolls)
+
+    def _poll_loop(self) -> None:
+        while not self._stop.wait(self._POLL_INTERVAL_S):
+            cur = self._read_watcher_counts()
+            dp = cur[0] - self._last[0]
+            dc = cur[1] - self._last[1]
+            ds = cur[2] - self._last[2]
+            self._last = cur
+            # The watcher subtracts its counters after each emit, so a delta can
+            # go negative; clamp to 0 so a mid-emit read never under/over-counts.
+            if dp > 0:
+                self._source._on_press(dp)
+            if dc > 0:
+                self._source._on_click(dc)
+            if ds > 0:
+                self._source._on_scroll(ds)
+
+
+class _NullAwClient:
+    """No-op AW client for the macOS tap backend: MacOSInputWatcher calls
+    create_bucket/post_events, but this backend consumes counters directly and
+    must NOT also write the external aw-watcher-input bucket."""
+
+    def create_bucket(self, *args, **kwargs) -> None:
+        return None
+
+    def post_events(self, *args, **kwargs) -> None:
+        return None

--- a/src/sync/input_source.py
+++ b/src/sync/input_source.py
@@ -466,18 +466,18 @@ class _MacOSTapBackend:
         self._watcher = None
         self._stop = threading.Event()
         self._thread: Optional[threading.Thread] = None
-        # Last cumulative counts read from the watcher, to compute deltas.
-        self._last = (0, 0, 0)
 
     def _build_watcher(self):
         try:
             from .macos_input_watcher import MacOSInputWatcher
         except ImportError:
             from sync.macos_input_watcher import MacOSInputWatcher
-        # A tiny AW stub: this backend only needs the watcher's COUNTERS, never
-        # its emitter (InputSource owns the drain/upload). A no-op client keeps
-        # the watcher self-contained and off the AW input bucket entirely.
-        return MacOSInputWatcher(_NullAwClient())
+        # count_only=True: the watcher runs ONLY its CGEventTap counter — no
+        # emitter thread, no AW bucket. This backend drains the raw counters
+        # itself (below); if the watcher's own emitter also ran it would subtract
+        # counts out from under our poll and undercount. The no-op AW client is
+        # then never touched, but kept as a defensive stub.
+        return MacOSInputWatcher(_NullAwClient(), count_only=True)
 
     def available(self) -> bool:
         """True when Quartz is importable (the CGEventTap capability). The
@@ -501,7 +501,6 @@ class _MacOSTapBackend:
         if not ok:
             return False
         self._stop.clear()
-        self._last = self._read_watcher_counts()
         self._thread = threading.Thread(
             target=self._poll_loop, daemon=True, name="macos-input-poll",
         )
@@ -510,38 +509,48 @@ class _MacOSTapBackend:
 
     def stop(self) -> None:
         self._stop.set()
+        # Stop the poll thread first so it can't race the final drain below.
+        if self._thread and self._thread.is_alive():
+            self._thread.join(timeout=2.0)
+        self._thread = None
+        # Final drain: capture whatever accrued since the last poll (<= poll
+        # interval) before tearing down the tap, so a shutdown loses nothing.
+        presses, clicks, scrolls = self._drain_watcher_counts()
+        if presses > 0:
+            self._source._on_press(presses)
+        if clicks > 0:
+            self._source._on_click(clicks)
+        if scrolls > 0:
+            self._source._on_scroll(scrolls)
         if self._watcher is not None:
             try:
                 self._watcher.stop()
             except Exception:
                 logger.debug("MacOS input watcher stop failed", exc_info=True)
-        if self._thread and self._thread.is_alive():
-            self._thread.join(timeout=2.0)
-        self._thread = None
 
-    def _read_watcher_counts(self) -> tuple[int, int, int]:
+    def _drain_watcher_counts(self) -> tuple[int, int, int]:
+        """Atomically read AND zero the watcher's counters under its lock, so
+        this backend is the SOLE drainer. With count_only=True the watcher has no
+        emitter subtracting concurrently, so nothing is lost between polls."""
         w = self._watcher
         if w is None:
             return (0, 0, 0)
-        # Read under the watcher's own lock so the triple is coherent.
         with w._lock:
-            return (w._presses, w._clicks, w._scrolls)
+            counts = (w._presses, w._clicks, w._scrolls)
+            w._presses = 0
+            w._clicks = 0
+            w._scrolls = 0
+            return counts
 
     def _poll_loop(self) -> None:
         while not self._stop.wait(self._POLL_INTERVAL_S):
-            cur = self._read_watcher_counts()
-            dp = cur[0] - self._last[0]
-            dc = cur[1] - self._last[1]
-            ds = cur[2] - self._last[2]
-            self._last = cur
-            # The watcher subtracts its counters after each emit, so a delta can
-            # go negative; clamp to 0 so a mid-emit read never under/over-counts.
-            if dp > 0:
-                self._source._on_press(dp)
-            if dc > 0:
-                self._source._on_click(dc)
-            if ds > 0:
-                self._source._on_scroll(ds)
+            presses, clicks, scrolls = self._drain_watcher_counts()
+            if presses > 0:
+                self._source._on_press(presses)
+            if clicks > 0:
+                self._source._on_click(clicks)
+            if scrolls > 0:
+                self._source._on_scroll(scrolls)
 
 
 class _NullAwClient:

--- a/src/sync/macos_input_watcher.py
+++ b/src/sync/macos_input_watcher.py
@@ -46,9 +46,14 @@ class MacOSInputWatcher:
     # of toggling the switch in System Settings, without spamming logs.
     _PERMISSION_RETRY_INTERVAL_S = 30.0
 
-    def __init__(self, aw_client, emit_interval: float = 10.0):
+    def __init__(self, aw_client, emit_interval: float = 10.0, count_only: bool = False):
         self._aw = aw_client
         self._emit_interval = emit_interval
+        # count_only: run ONLY the CGEventTap counter — no emitter thread and no
+        # AW bucket. The in-process InputSource macOS backend uses this and
+        # drains the raw counters itself; running the emitter too would subtract
+        # the counts out from under the backend and undercount.
+        self._count_only = count_only
         self._stop_event = threading.Event()
         self._tap_thread: Optional[threading.Thread] = None
         self._emit_thread: Optional[threading.Thread] = None
@@ -139,10 +144,11 @@ class MacOSInputWatcher:
             )
             self._ensure_permission_retry()
             return False
-        try:
-            self._aw.create_bucket(self._bucket_id, "aw-watcher-input", self._hostname)
-        except Exception as e:
-            logger.warning(f"Failed to create input bucket: {e}")
+        if not self._count_only:
+            try:
+                self._aw.create_bucket(self._bucket_id, "aw-watcher-input", self._hostname)
+            except Exception as e:
+                logger.warning(f"Failed to create input bucket: {e}")
 
         # Reset stop signal so new threads don't exit immediately
         self._stop_event.clear()
@@ -157,14 +163,16 @@ class MacOSInputWatcher:
         self._tap_thread = threading.Thread(
             target=self._run_tap, daemon=True, name="macos-input-tap",
         )
-        self._emit_thread = threading.Thread(
-            target=self._run_emitter, daemon=True, name="macos-input-emitter",
-        )
         self._tap_thread.start()
-        self._emit_thread.start()
+        # count_only: no emitter — the backend drains the counters itself.
+        if not self._count_only:
+            self._emit_thread = threading.Thread(
+                target=self._run_emitter, daemon=True, name="macos-input-emitter",
+            )
+            self._emit_thread.start()
         logger.info(
             f"MacOSInputWatcher started (bucket={self._bucket_id}, "
-            f"interval={self._emit_interval}s)"
+            f"count_only={self._count_only}, interval={self._emit_interval}s)"
         )
         return True
 

--- a/src/sync/sync_engine.py
+++ b/src/sync/sync_engine.py
@@ -2684,21 +2684,21 @@ class SyncEngine:
     def _commit_inproc_input_checkpoint(
         self, stats: SyncStats, pending: Optional[datetime]
     ) -> None:
-        """Advance the in-process input checkpoint past the just-drained span, but
-        only if its bucket wasn't queued (the send succeeded). On a queued/failed
-        send we leave the checkpoint where it was; the counts were already drained
-        into this cycle's (stable-id) event which the offline queue redelivers, so
-        the server upserts it idempotently — we must NOT rebuild from counters (the
-        drain already reset them). Forward-only advance, mirroring
-        ``_commit_inproc_window_checkpoint``."""
+        """Advance the in-process input checkpoint past the just-drained span.
+
+        UNLIKE the window/AFK commits, this advances even on a QUEUED (failed)
+        send. drain_input_event already destructively reset the counters into
+        this cycle's stable-id event, so the counts now live ONLY in that event —
+        which the offline queue redelivers, upserted idempotently by id. Holding
+        the checkpoint (as window/AFK do, to rebuild from samples) would instead
+        make the next cycle re-drain an already-empty counter into a duplicate,
+        overlapping span; there is no counter left to rebuild from. `stats` is
+        unused here for exactly that reason — the queued/not-queued distinction
+        doesn't change the advance. Forward-only, mirroring
+        ``_commit_inproc_window_checkpoint``'s monotonic guard."""
+        del stats  # intentionally unused; see docstring (advance is unconditional)
         if pending is None:
             return
-        inproc_bucket = self.input_source.bucket_id
-        if inproc_bucket in stats.queued_bucket_ids:
-            # The drained counts live in the queued event; advance anyway so we
-            # don't re-drain an empty counter into a duplicate span. The queued
-            # event's stable id makes the eventual redelivery idempotent.
-            pass
         cp = self._input_inproc_checkpoint
         if cp is None or pending > cp:
             self._input_inproc_checkpoint = pending

--- a/src/sync/sync_engine.py
+++ b/src/sync/sync_engine.py
@@ -64,6 +64,13 @@ def _is_afk_like(bucket_type: str) -> bool:
     return bucket_type in (BUCKET_TYPE_AFK, BUCKET_TYPE_AFK_ALT)
 
 
+def _is_input_like(bucket_type: str) -> bool:
+    """Input buckets (keystroke/click/scroll counts, fraud detection). Single
+    source of truth so suppressing the external aw-watcher-input bucket when the
+    in-process source is active is a one-line membership check."""
+    return bucket_type == BUCKET_TYPE_INPUT
+
+
 # Seconds the latest AFK event may lag "now" before the tracker is presumed
 # frozen. A healthy bf-idle-tracker heartbeats its current event continuously,
 # so its end-time tracks now; a larger gap means it hung/went blind and its last
@@ -286,6 +293,19 @@ class SyncEngine:
         # NB: the per-cycle "pending" checkpoint is a LOCAL in sync() (threaded
         # build -> commit), not an instance field — see _build_inproc_window for
         # why (wedge re-arm can run two sync()s concurrently).
+
+        # Optional in-process INPUT source (set by the SyncCoordinator), the
+        # keystroke/click/scroll-count analogue of window_source. When present,
+        # enabled by config, and an in-process counting backend is usable
+        # (Windows ctypes hooks / macOS CGEventTap; off on Linux), the agent
+        # uploads its own input-count stream and the external aw-watcher-input
+        # bucket is skipped so the two never double-count. Ships dormant
+        # (in_process_input defaults False). Counts accrue continuously on the
+        # backend listener thread; the sync thread only DRAINS them into an event
+        # each cycle. Checkpoint committed only after a confirmed send, mirroring
+        # AFK/window. Mutated only on the sync thread.
+        self.input_source = None
+        self._input_inproc_checkpoint: Optional[datetime] = None
 
         # Monotonic timestamp of the current sync() cycle's start, stamped at the
         # top of sync(). Gates the per-bucket send loop's in-cycle network budget
@@ -747,8 +767,15 @@ class SyncEngine:
         # with the engine every active cycle — one source of truth, not a cache a
         # separate timer keeps in sync (and silently failed to: Bug A, #76/#78).
         self._publish_inproc_afk_flag(skip_external_afk)
+        # When the agent counts input in-process (the sole input source), drop the
+        # external aw-watcher-input bucket(s) so its (possibly hook-blocked, zero)
+        # events never reach the server and can't double-count. No-op when the
+        # flag is off (default): the external input bucket syncs exactly as today.
+        skip_external_input = self._should_skip_external_input()
         for bucket in web_buckets + afk_buckets + input_buckets:
             if skip_external_afk and _is_afk_like(bucket.type):
+                continue
+            if skip_external_input and _is_input_like(bucket.type):
                 continue
             try:
                 events, checkpoint = self._sync_bucket(bucket.id, bucket.type, stats, cycle)
@@ -784,6 +811,18 @@ class SyncEngine:
             )
             all_events.extend(window_events)
 
+        # Pending in-process input checkpoint for this cycle, kept as a LOCAL for
+        # the same wedge-recovery reason window_pending is (see _build_inproc_window).
+        input_pending: Optional[datetime] = None
+        if skip_external_input:
+            # Sole-source path: drain the accumulated keystroke/click/scroll
+            # counts into one event for the slice since the last covered instant.
+            input_event, input_pending = self._build_inproc_input(
+                datetime.now(timezone.utc)
+            )
+            if input_event is not None:
+                all_events.append(input_event)
+
         # Flush any ongoing call at sync boundary
         if self._call_detector:
             remaining = self._call_detector.flush()
@@ -801,6 +840,8 @@ class SyncEngine:
         # Same discipline for the in-process window stream: advance its checkpoint
         # only after a confirmed send. Pass this cycle's own pending value.
         self._commit_inproc_window_checkpoint(stats, window_pending)
+        # Same discipline for the in-process input stream.
+        self._commit_inproc_input_checkpoint(stats, input_pending)
 
         # Process offline queue if we're online — but only if this cycle hasn't
         # already burned most of the watchdog budget on a slow/hung regular send
@@ -2575,6 +2616,92 @@ class SyncEngine:
         cp = self._window_inproc_checkpoint
         if cp is None or pending > cp:
             self._window_inproc_checkpoint = pending
+
+    def _should_use_inproc_input(self) -> bool:
+        """True when the in-process input source should be the sole input source —
+        config flag on, a source is wired, and an in-process counting backend is
+        usable (Windows ctypes hooks / macOS CGEventTap; False on Linux). Gates
+        every in-process-input action, so the whole path is a no-op when the flag
+        is off (default). Mirrors ``_should_use_inproc_window``."""
+        return (
+            bool(self.config.sync.in_process_input)
+            and self.input_source is not None
+            and self.input_source.available()
+        )
+
+    def _should_skip_external_input(self) -> bool:
+        """Whether to drop the external aw-watcher-input bucket(s) from this
+        cycle's upload (because the agent uploads its own count stream instead).
+        Mirrors ``_should_skip_external_afk`` / ``_should_skip_external_window``.
+
+        Note: unlike the window source, the input backend has no per-sample
+        "blind" fallback — a period with no keystrokes is a legitimate gap, not a
+        blind probe. If the backend fails to install at all, ``available()`` never
+        latches on and this returns False, so the external tracker keeps its job.
+        """
+        return self._should_use_inproc_input()
+
+    def _build_inproc_input(
+        self, now: datetime
+    ) -> tuple[Optional[dict], Optional[datetime]]:
+        """Drain accumulated input counts into one event for [checkpoint, now].
+        First cycle seeds the checkpoint at `now` (account only while running).
+
+        Returns ``(event_or_None, pending)`` where `pending` is the checkpoint the
+        caller must commit via ``_commit_inproc_input_checkpoint`` AFTER a
+        confirmed send. The pending value is RETURNED, not stored on the instance,
+        for the same wedge-recovery concurrency reason as ``_build_inproc_window``.
+
+        Re-seed rather than build when the checkpoint can't be trusted (mirrors
+        _build_inproc_window):
+          - now <= cp: the wall clock stepped backward (NTP/manual), or nothing
+            new to cover. Re-seed to `now` so the stream doesn't stall. Any counts
+            accrued so far are intentionally dropped (we can't attribute them to a
+            trustworthy range) — unlike window/AFK, counts have no sample log to
+            rebuild from, but a clock step back is rare and bounded.
+        Unlike AFK/window there is no gap>retention branch: counts don't come from
+        a time-bounded sample deque, so a long sleep simply means whatever was
+        typed before it drains into the (long) span — harmless, since the counts
+        themselves are real. The drain returns None on a zero-count span, so an
+        idle span emits nothing."""
+        if not self._should_use_inproc_input():
+            return None, None
+        cp = self._input_inproc_checkpoint
+        if cp is None:
+            self._input_inproc_checkpoint = now
+            return None, None
+        if now <= cp:
+            self._input_inproc_checkpoint = now
+            return None, None
+        event = self.input_source.drain_input_event(cp, now)
+        if event is None:
+            # Nothing counted this span: advance the checkpoint so the next span
+            # starts at `now` (no event to send, so no confirmed-send gate needed).
+            self._input_inproc_checkpoint = now
+            return None, None
+        return event, now
+
+    def _commit_inproc_input_checkpoint(
+        self, stats: SyncStats, pending: Optional[datetime]
+    ) -> None:
+        """Advance the in-process input checkpoint past the just-drained span, but
+        only if its bucket wasn't queued (the send succeeded). On a queued/failed
+        send we leave the checkpoint where it was; the counts were already drained
+        into this cycle's (stable-id) event which the offline queue redelivers, so
+        the server upserts it idempotently — we must NOT rebuild from counters (the
+        drain already reset them). Forward-only advance, mirroring
+        ``_commit_inproc_window_checkpoint``."""
+        if pending is None:
+            return
+        inproc_bucket = self.input_source.bucket_id
+        if inproc_bucket in stats.queued_bucket_ids:
+            # The drained counts live in the queued event; advance anyway so we
+            # don't re-drain an empty counter into a duplicate span. The queued
+            # event's stable id makes the eventual redelivery idempotent.
+            pass
+        cp = self._input_inproc_checkpoint
+        if cp is None or pending > cp:
+            self._input_inproc_checkpoint = pending
 
     def _report_inproc_blind(self, failures: int) -> None:
         """Surface a blind in-process idle clock to the ops ingest. Logged-only

--- a/tests/test_input_source.py
+++ b/tests/test_input_source.py
@@ -1,7 +1,8 @@
+import threading
 from datetime import datetime, timedelta, timezone
 
 from src.sync.aw_client import BUCKET_TYPE_INPUT
-from src.sync.input_source import InputSource
+from src.sync.input_source import InputSource, _MacOSTapBackend
 
 T0 = datetime(2026, 6, 19, 12, 0, 0, tzinfo=timezone.utc)
 
@@ -169,3 +170,55 @@ def test_event_omits_app_when_getter_blank_or_fails():
 def test_bucket_id_is_single_source_of_truth():
     src = _src(_FakeBackend())
     assert src.bucket_id == "bf-input-inproc_host"
+
+
+# -- macOS backend: drain (not delta) so nothing is lost to the emitter --------
+
+
+class _StubWatcher:
+    def __init__(self, presses=0, clicks=0, scrolls=0):
+        self._lock = threading.Lock()
+        self._presses = presses
+        self._clicks = clicks
+        self._scrolls = scrolls
+
+
+def test_macos_backend_drains_and_zeroes_watcher_counters():
+    backend = _MacOSTapBackend(_src(backend=None))
+    backend._watcher = _StubWatcher(presses=5, clicks=2, scrolls=1)
+    assert backend._drain_watcher_counts() == (5, 2, 1)
+    # Zeroed, so this backend is the SOLE drainer and the next drain starts fresh.
+    assert backend._drain_watcher_counts() == (0, 0, 0)
+
+
+def test_macos_backend_drain_accumulates_without_loss():
+    # Two poll ticks with fresh counts arriving between them: draining owns the
+    # reset, so nothing is lost (the old delta+emitter-subtract path could lose
+    # counts the watcher subtracted before the next poll).
+    src = _src(backend=None)
+    backend = _MacOSTapBackend(src)
+    w = _StubWatcher()
+    backend._watcher = w
+
+    def poll_once():
+        p, c, s = backend._drain_watcher_counts()
+        if p:
+            src._on_press(p)
+        if c:
+            src._on_click(c)
+        if s:
+            src._on_scroll(s)
+
+    with w._lock:
+        w._presses = 10
+    poll_once()
+    with w._lock:
+        w._presses = 7  # more arrived after the first drain
+    poll_once()
+    assert src.counts == (17, 0, 0)
+
+
+def test_macos_watcher_count_only_skips_emitter_flag():
+    from src.sync.macos_input_watcher import MacOSInputWatcher
+    assert MacOSInputWatcher(aw_client=object(), count_only=True)._count_only is True
+    assert MacOSInputWatcher(aw_client=object())._count_only is False

--- a/tests/test_input_source.py
+++ b/tests/test_input_source.py
@@ -1,0 +1,171 @@
+from datetime import datetime, timedelta, timezone
+
+from src.sync.aw_client import BUCKET_TYPE_INPUT
+from src.sync.input_source import InputSource
+
+T0 = datetime(2026, 6, 19, 12, 0, 0, tzinfo=timezone.utc)
+
+
+class _FakeBackend:
+    """A backend whose start()/available() are scriptable and that lets a test
+    inject counts by calling the source's callbacks directly."""
+
+    def __init__(self, *, available=True, start_ok=True):
+        self._available = available
+        self._start_ok = start_ok
+        self.started = False
+        self.stopped = False
+
+    def available(self):
+        return self._available
+
+    def start(self):
+        self.started = True
+        return self._start_ok
+
+    def stop(self):
+        self.stopped = True
+
+
+def _src(backend=None, **kw):
+    return InputSource(hostname="host", backend=backend,
+                       frontmost_app_getter=None, **kw)
+
+
+# -- available() / sticky latch ----------------------------------------------
+
+
+def test_available_false_when_no_backend():
+    assert _src(backend=None).available() is False
+
+
+def test_available_true_when_backend_reports_usable():
+    assert _src(_FakeBackend(available=True)).available() is True
+
+
+def test_available_false_when_backend_unusable():
+    assert _src(_FakeBackend(available=False)).available() is False
+
+
+def test_available_latches_on_after_start():
+    b = _FakeBackend(available=False, start_ok=True)
+    src = _src(b)
+    assert src.available() is False  # backend reports not-yet-usable
+    assert src.start() is True
+    assert b.started is True
+    # Latched on: even though the backend still reports unusable, a started
+    # backend means the platform HAS the capability.
+    assert src.available() is True
+
+
+def test_start_returns_false_when_backend_fails():
+    src = _src(_FakeBackend(start_ok=False))
+    assert src.start() is False
+
+
+def test_start_noop_without_backend():
+    src = _src(backend=None)
+    assert src.start() is False
+
+
+def test_stop_delegates_to_backend():
+    b = _FakeBackend()
+    src = _src(b)
+    src.stop()
+    assert b.stopped is True
+
+
+# -- counters ----------------------------------------------------------------
+
+
+def test_callbacks_increment_counters():
+    src = _src(_FakeBackend())
+    src._on_press()
+    src._on_press(3)
+    src._on_click()
+    src._on_scroll(2)
+    assert src.counts == (4, 1, 2)
+
+
+# -- drain -------------------------------------------------------------------
+
+
+def test_drain_builds_event_with_counts_and_resets():
+    src = _src(_FakeBackend())
+    src._on_press(5)
+    src._on_click(2)
+    src._on_scroll(1)
+    ev = src.drain_input_event(T0, T0 + timedelta(seconds=60))
+    assert ev is not None
+    assert ev["data"] == {"presses": 5, "clicks": 2, "scrolls": 1}
+    assert ev["bucket_id"] == "bf-input-inproc_host"
+    assert ev["bucket_type"] == BUCKET_TYPE_INPUT
+    assert ev["timestamp"] == T0.isoformat()
+    assert ev["duration"] == 60.0
+    # Counters reset after the drain.
+    assert src.counts == (0, 0, 0)
+    # A second drain over a fresh (empty) span yields nothing.
+    assert src.drain_input_event(T0 + timedelta(seconds=60),
+                                 T0 + timedelta(seconds=120)) is None
+
+
+def test_drain_zero_counts_returns_none_and_holds_counters():
+    src = _src(_FakeBackend())
+    assert src.drain_input_event(T0, T0 + timedelta(seconds=60)) is None
+    # No counters to hold, but the counters stay at zero (not mutated below zero).
+    assert src.counts == (0, 0, 0)
+
+
+def test_drain_none_when_unavailable_and_preserves_counts():
+    # No backend -> never available -> a period produces no event (gap), and the
+    # counts injected are NOT drained/reset.
+    src = _src(backend=None)
+    src._on_press(3)
+    assert src.drain_input_event(T0, T0 + timedelta(seconds=60)) is None
+    assert src.counts == (3, 0, 0)  # preserved
+
+
+def test_drain_none_for_empty_or_inverted_range():
+    src = _src(_FakeBackend())
+    src._on_press(1)
+    assert src.drain_input_event(T0, T0) is None
+    assert src.drain_input_event(T0 + timedelta(seconds=1), T0) is None
+    # Counters untouched by a rejected range.
+    assert src.counts == (1, 0, 0)
+
+
+def test_event_id_is_ms_precision_and_stable():
+    src = _src(_FakeBackend())
+    src._on_press(1)
+    ev = src.drain_input_event(T0, T0 + timedelta(seconds=30))
+    assert ev["id"] == f"input-inproc_host_{int(T0.timestamp() * 1000)}"
+
+
+def test_event_includes_app_when_getter_available():
+    src = InputSource(hostname="host", backend=_FakeBackend(),
+                      frontmost_app_getter=lambda: "Code")
+    src._on_press(1)
+    ev = src.drain_input_event(T0, T0 + timedelta(seconds=30))
+    assert ev["data"]["app"] == "Code"
+
+
+def test_event_omits_app_when_getter_blank_or_fails():
+    src = InputSource(hostname="host", backend=_FakeBackend(),
+                      frontmost_app_getter=lambda: "")
+    src._on_press(1)
+    ev = src.drain_input_event(T0, T0 + timedelta(seconds=30))
+    assert "app" not in ev["data"]
+
+    def _boom():
+        raise RuntimeError("probe failed")
+
+    src2 = InputSource(hostname="host", backend=_FakeBackend(),
+                       frontmost_app_getter=_boom)
+    src2._on_click(1)
+    ev2 = src2.drain_input_event(T0, T0 + timedelta(seconds=30))
+    assert "app" not in ev2["data"]  # a failing probe must not fail the drain
+
+
+def test_bucket_id_is_single_source_of_truth():
+    src = _src(_FakeBackend())
+    assert src.bucket_id == "bf-input-inproc_host"

--- a/tests/test_sync_engine_inproc_input.py
+++ b/tests/test_sync_engine_inproc_input.py
@@ -1,0 +1,202 @@
+from datetime import datetime, timedelta, timezone
+from unittest.mock import Mock
+
+from src.config import Config
+from src.sync.activity_analyzer import ActivityAnalyzer
+from src.sync.aw_client import BUCKET_TYPE_INPUT
+from src.sync.daily_time_tracker import DailyTimeTracker
+from src.sync.input_source import InputSource
+from src.sync.sync_engine import SyncEngine, SyncStats, _is_input_like
+
+T0 = datetime(2026, 6, 19, 12, 0, 0, tzinfo=timezone.utc)
+
+
+def _engine(in_process_input: bool):
+    cfg = Config()
+    cfg.sync.in_process_input = in_process_input
+    return SyncEngine(aw=Mock(), bf=Mock(), queue=Mock(), config=cfg,
+                      activity_analyzer=Mock(spec=ActivityAnalyzer),
+                      time_tracker=Mock(spec=DailyTimeTracker))
+
+
+class _FakeBackend:
+    def available(self):
+        return True
+
+    def start(self):
+        return True
+
+    def stop(self):
+        pass
+
+
+def _source():
+    """An InputSource with a forced-usable backend and no app tagging."""
+    return InputSource(hostname="host", backend=_FakeBackend(),
+                       frontmost_app_getter=None)
+
+
+def _bucket(bucket_id, btype):
+    b = Mock()
+    b.id = bucket_id
+    b.type = btype
+    return b
+
+
+# -- gating ------------------------------------------------------------------
+
+
+def test_flag_off_is_no_op():
+    eng = _engine(False)
+    eng.input_source = _source()
+    eng.input_source._on_press(5)
+    assert eng._should_use_inproc_input() is False
+    assert eng._should_skip_external_input() is False
+    # Build is inert even with counts present, and the counters are untouched.
+    assert eng._build_inproc_input(T0 + timedelta(seconds=60)) == (None, None)
+    assert eng.input_source.counts == (5, 0, 0)
+
+
+def test_active_when_flag_on_and_available():
+    eng = _engine(True)
+    eng.input_source = _source()
+    assert eng._should_use_inproc_input() is True
+    assert eng._should_skip_external_input() is True
+
+
+def test_inactive_when_no_source_wired():
+    eng = _engine(True)
+    assert eng._should_skip_external_input() is False
+
+
+def test_inactive_when_backend_unavailable():
+    eng = _engine(True)
+    eng.input_source = InputSource(hostname="host", backend=None,
+                                   frontmost_app_getter=None)
+    assert eng._should_skip_external_input() is False
+
+
+# -- build / drain -----------------------------------------------------------
+
+
+def test_first_build_seeds_checkpoint_and_emits_nothing():
+    eng = _engine(True)
+    eng.input_source = _source()
+    eng.input_source._on_press(3)  # counts before first cycle
+    event, pending = eng._build_inproc_input(T0)
+    assert event is None and pending is None
+    assert eng._input_inproc_checkpoint == T0
+
+
+def test_build_drains_counts_into_event():
+    eng = _engine(True)
+    eng.input_source = _source()
+    eng._build_inproc_input(T0)  # seed
+    eng.input_source._on_press(7)
+    eng.input_source._on_click(2)
+    event, pending = eng._build_inproc_input(T0 + timedelta(seconds=60))
+    assert event is not None
+    assert event["data"]["presses"] == 7
+    assert event["data"]["clicks"] == 2
+    assert event["bucket_id"] == "bf-input-inproc_host"
+    assert event["bucket_type"] == BUCKET_TYPE_INPUT
+    assert pending == T0 + timedelta(seconds=60)
+    # Drained -> counters reset.
+    assert eng.input_source.counts == (0, 0, 0)
+
+
+def test_zero_count_span_advances_checkpoint_without_event():
+    eng = _engine(True)
+    eng.input_source = _source()
+    eng._build_inproc_input(T0)  # seed
+    event, pending = eng._build_inproc_input(T0 + timedelta(seconds=60))
+    assert event is None and pending is None
+    # Checkpoint advanced so the next span starts fresh (no stall).
+    assert eng._input_inproc_checkpoint == T0 + timedelta(seconds=60)
+
+
+def test_clock_step_back_reseeds():
+    eng = _engine(True)
+    eng.input_source = _source()
+    eng._build_inproc_input(T0)  # seed at T0
+    eng.input_source._on_press(1)
+    event, pending = eng._build_inproc_input(T0 - timedelta(seconds=30))
+    assert event is None and pending is None
+    assert eng._input_inproc_checkpoint == T0 - timedelta(seconds=30)
+
+
+# -- checkpoint commit -------------------------------------------------------
+
+
+def test_checkpoint_advances_on_confirmed_send():
+    eng = _engine(True)
+    eng.input_source = _source()
+    eng._build_inproc_input(T0)  # seed
+    eng.input_source._on_press(4)
+    _, pending = eng._build_inproc_input(T0 + timedelta(seconds=60))
+    stats = SyncStats()  # no queued buckets -> confirmed
+    eng._commit_inproc_input_checkpoint(stats, pending)
+    assert eng._input_inproc_checkpoint == T0 + timedelta(seconds=60)
+
+
+def test_checkpoint_advances_even_when_queued():
+    """Unlike window/AFK, the drain already RESET the counters, so the counts now
+    live only in the (stable-id) event the queue redelivers. Holding the
+    checkpoint would re-drain an empty counter into a duplicate span, so we
+    advance regardless — the queued event's stable id makes redelivery
+    idempotent."""
+    eng = _engine(True)
+    eng.input_source = _source()
+    eng._build_inproc_input(T0)  # seed
+    eng.input_source._on_press(4)
+    _, pending = eng._build_inproc_input(T0 + timedelta(seconds=60))
+    stats = SyncStats()
+    stats.queued_bucket_ids.add("bf-input-inproc_host")
+    eng._commit_inproc_input_checkpoint(stats, pending)
+    assert eng._input_inproc_checkpoint == T0 + timedelta(seconds=60)
+
+
+def test_commit_is_forward_only():
+    eng = _engine(True)
+    eng.input_source = _source()
+    eng._input_inproc_checkpoint = T0 + timedelta(seconds=100)
+    stats = SyncStats()
+    # A stale pending from an abandoned cycle must not rewind the checkpoint.
+    eng._commit_inproc_input_checkpoint(stats, T0 + timedelta(seconds=30))
+    assert eng._input_inproc_checkpoint == T0 + timedelta(seconds=100)
+
+
+def test_commit_noop_when_pending_none():
+    eng = _engine(True)
+    eng.input_source = _source()
+    eng._input_inproc_checkpoint = T0
+    eng._commit_inproc_input_checkpoint(SyncStats(), None)
+    assert eng._input_inproc_checkpoint == T0
+
+
+# -- coexistence with the external input path --------------------------------
+
+
+def test_external_input_buckets_skipped_when_active():
+    eng = _engine(True)
+    eng.input_source = _source()
+    input_buckets = [_bucket("aw-watcher-input_host", BUCKET_TYPE_INPUT)]
+    skip = eng._should_skip_external_input()
+    to_sync = [b for b in input_buckets if not _is_input_like(b.type)] if skip else input_buckets
+    assert to_sync == []  # external input bucket dropped, no double-count
+
+
+def test_external_input_buckets_kept_when_flag_off():
+    eng = _engine(False)
+    eng.input_source = _source()
+    input_buckets = [_bucket("aw-watcher-input_host", BUCKET_TYPE_INPUT)]
+    skip = eng._should_skip_external_input()
+    to_sync = [b for b in input_buckets if not _is_input_like(b.type)] if skip else input_buckets
+    assert to_sync == input_buckets  # unchanged when dormant
+
+
+def test_is_input_like_only_matches_input_type():
+    from src.sync.aw_client import BUCKET_TYPE_WINDOW, BUCKET_TYPE_AFK
+    assert _is_input_like(BUCKET_TYPE_INPUT) is True
+    assert _is_input_like(BUCKET_TYPE_WINDOW) is False
+    assert _is_input_like(BUCKET_TYPE_AFK) is False


### PR DESCRIPTION
## Why
Keystroke/click counts are **zero, ever** on affected Windows machines (Fraud
Risk 75, "zero keystrokes / zero clicks"). Those counts come only from the
external `aw-watcher-input`, whose low-level hook is blocked (privilege/UIPI or
AV) and never emits. AFK and window were already fixed by moving them
in-process; this does the same for input.

## What
`InputSource` counts keystrokes/clicks/scrolls **inside the agent process** and
uploads them under `bf-input-inproc_<host>`, mirroring `AfkSource`/`WindowSource`.
- **Windows backend:** `WH_KEYBOARD_LL` / `WH_MOUSE_LL` hooks via `ctypes` on a
  daemon message-pump thread. Reads **only the event type** (never key values —
  privacy-safe), always `CallNextHookEx` (never swallows input), keeps CFUNCTYPE
  refs alive, unhooks cleanly on `WM_QUIT`.
- **macOS backend:** reuses `MacOSInputWatcher`'s CGEventTap counters (no OS-hook
  reimplementation).
- **Linux / no backend:** `available()` never latches → external tracker keeps its job.

**Default OFF** (`in_process_input`, server-overridable). When on + a backend is
usable: skip the external `aw-watcher-input` bucket (no double-count) and
drain+upload the count stream each cycle. Off (default) = external path unchanged.

## Tests
`test_input_source.py` (16) + `test_sync_engine_inproc_input.py` (15). Full suite: **935 passed**.

## Rollout (pairs with the single-instance fix already in main, #122)
1. #122 (merged) should stop two agents fighting over the port/hook — likely clears much of the 0-events on its own.
2. If input is still zero after that, merge this, ship a Windows build, and enable `in_process_input = 1` for the affected device (per-device flag, same mechanism as window).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
