### PR TITLE
chore(release): bump version to 1.5.94

### DIFF
--- a/src/__init__.py
+++ b/src/__init__.py
@@ -1,4 +1,4 @@
 """BetterFlow - ActivityWatch to BetterFlow sync companion app."""
 
-__version__ = "1.5.93"
+__version__ = "1.5.94"
 __author__ = "BetterQA"


### PR DESCRIPTION
Promotes the 1.5.94 line to a stable release off `main`:
- **#122** — Windows single-instance lock (the "two copies running at once" bug), previously only in `v1.5.94-beta`.
- **#123** — in-process input watcher (dormant / opt-in, default off; fixes Windows zero-clicks when the external hook is blocked).

Organic fleet auto-update; **no forced `AGENT_MINIMUM_VERSION`** — the single-instance fix is low-risk and the input watcher is off by default.

🤖 Generated with [Claude Code](https://claude.com/claude-code)