### PR TITLE
fix(private): show ongoing Private Time on the dashboard within one sync cycle

### DIFF
--- a/src/sync/sync_engine.py
+++ b/src/sync/sync_engine.py
@@ -624,8 +624,26 @@ class SyncEngine:
         self._maybe_rollover_counted_day()
 
         with self._state_lock:
-            if self._paused or self._private_mode:
-                return stats
+            paused = self._paused
+            private_mode = self._private_mode
+            private_start = self._private_start
+        if paused or private_mode:
+            # While Private Time is on, nothing is synced — so the backend
+            # cannot tell an ongoing private session from a network gap, and
+            # its tracked-hours trailing grace painted the window as counted
+            # "Tracked time" until the leave-time private_time event finally
+            # arrived (Ecaterina/Martin, 2026-07-07). Re-send the growing span
+            # every cycle: same deterministic id (private_<startts>_<engine>),
+            # so the server patches the duration in place and the timeline
+            # shows Private within one sync cycle instead of only after the
+            # session ends. Snapshots are NOT queued on failure — the next
+            # cycle's longer span supersedes this one; only the final
+            # leave-time send (set_private_mode) is queued for retry.
+            if private_mode and private_start is not None:
+                self._send_status_span(
+                    kind="private", start=private_start, queue_on_failure=False
+                )
+            return stats
 
         # Fetch server config on first successful sync
         if not self._config_fetched and self.bf.is_reachable():
@@ -2126,12 +2144,21 @@ class SyncEngine:
         kind: str,
         start: datetime,
         end: Optional[datetime] = None,
+        queue_on_failure: bool = True,
     ) -> None:
         """Send a duration event for a state-span (break/idle/private).
 
         Consolidates three formerly-identical send_*_event helpers. The only
         variation between them was the ``kind`` string used in the id prefix,
         bucket_type, and data.status field.
+
+        ``queue_on_failure=False`` is for periodic in-progress snapshots of a
+        still-growing span (the per-cycle private_time refresh): a failed
+        snapshot must not be queued because the next cycle re-sends the same
+        event id with a longer duration, which supersedes it — queueing every
+        snapshot would replay a stack of stale intermediate durations after
+        an outage. Final spans (sent when the state ends) keep the default
+        and are queued for offline retry.
         """
         if end is None:
             end = datetime.now(timezone.utc)
@@ -2174,9 +2201,15 @@ class SyncEngine:
             return
         if result.success:
             logger.info("Sent %s event (%.0fs)", bucket_type, duration)
-        else:
+        elif queue_on_failure:
             logger.warning("Failed to send %s event: %s — queueing", bucket_type, result.error or "unknown")
             self.queue.enqueue([event])
+        else:
+            # In-progress snapshot: superseded by the next cycle's re-send.
+            logger.debug(
+                "Failed to send %s snapshot: %s — not queued (next cycle re-sends)",
+                bucket_type, result.error or "unknown",
+            )
 
     def send_break_event(self, start: datetime, end: Optional[datetime] = None) -> None:
         """Send a break_time event covering the break duration."""

--- a/tests/test_sync_engine.py
+++ b/tests/test_sync_engine.py
@@ -1484,6 +1484,102 @@ class TestStatusSpanEvents:
         assert break_ev["data"]["status"] == "break"
 
 
+class TestPrivateOngoingSpanRefresh:
+    """While Private Time is ON, each sync cycle re-sends the growing span.
+
+    Without this the backend hears nothing until the user leaves private, so
+    an ongoing private session is indistinguishable from a network gap and the
+    dashboard's tracked-hours trailing grace painted it as counted "Tracked
+    time" (Ecaterina/Martin, 2026-07-07). The re-send uses the same
+    deterministic event id every cycle so the server patches the duration in
+    place instead of inserting duplicate rows.
+    """
+
+    def setup_method(self):
+        from src.sync.bf_client import SyncResult
+        self.aw = Mock()
+        self.bf = Mock()
+        self.bf.send_events.return_value = SyncResult(success=True, events_synced=1)
+        self.queue = Mock()
+        self.queue.get_checkpoint.return_value = None
+        self.config = Config()
+        self.engine = SyncEngine(
+            aw=self.aw, bf=self.bf, queue=self.queue, config=self.config,
+            activity_analyzer=Mock(spec=ActivityAnalyzer),
+            time_tracker=Mock(spec=DailyTimeTracker),
+        )
+
+    def _enter_private(self, seconds_ago=120):
+        self.engine._private_mode = True
+        self.engine._private_start = (
+            datetime.now(timezone.utc) - timedelta(seconds=seconds_ago)
+        )
+
+    def test_sync_while_private_sends_growing_span_with_stable_id(self):
+        self._enter_private(seconds_ago=120)
+
+        self.engine.sync()
+        assert self.bf.send_events.call_count == 1
+        first = self.bf.send_events.call_args[0][0][0]
+        assert first["bucket_type"] == "private_time"
+        assert first["data"]["status"] == "private"
+        assert first["duration"] == pytest.approx(120, abs=5)
+
+        self.engine.sync()
+        assert self.bf.send_events.call_count == 2
+        second = self.bf.send_events.call_args[0][0][0]
+        # Same deterministic id → the server patches the row in place.
+        assert second["id"] == first["id"]
+        assert second["duration"] >= first["duration"]
+
+    def test_private_snapshot_failure_is_not_queued(self):
+        """A failed in-progress snapshot must NOT be queued: the next cycle
+        re-sends the same id with a longer duration, superseding it. Queueing
+        every snapshot would replay a stack of stale durations after an
+        outage."""
+        from src.sync.bf_client import SyncResult
+        self.bf.send_events.return_value = SyncResult(success=False, error="offline")
+        self._enter_private()
+
+        self.engine.sync()
+
+        self.queue.enqueue.assert_not_called()
+
+    def test_leave_private_final_span_shares_id_with_snapshots(self):
+        """The leave-time event must carry the SAME id as the per-cycle
+        snapshots, otherwise the server would keep both the snapshot row and
+        a separate final row and double-count the private window."""
+        self._enter_private(seconds_ago=300)
+
+        self.engine.sync()
+        snapshot = self.bf.send_events.call_args[0][0][0]
+
+        self.engine.set_private_mode(False)
+        final = self.bf.send_events.call_args[0][0][0]
+        assert final["bucket_type"] == "private_time"
+        assert final["id"] == snapshot["id"]
+        assert final["duration"] >= snapshot["duration"]
+
+    def test_paused_sync_sends_no_private_span(self):
+        """Pause (break/screen lock) is not Private Time — the early return
+        must stay silent."""
+        self.engine._paused = True
+
+        self.engine.sync()
+
+        self.bf.send_events.assert_not_called()
+
+    def test_private_without_start_sends_nothing(self):
+        """Defensive: private flag set but no start timestamp — never send a
+        span with an unbounded start."""
+        self.engine._private_mode = True
+        self.engine._private_start = None
+
+        self.engine.sync()
+
+        self.bf.send_events.assert_not_called()
+
+
 class TestSystemSleepWakeEmitsSleepSpan:
     """on_system_wake must emit a sleep_time event for the sleep span."""
 


### PR DESCRIPTION
## Problem

Ecaterina/Martin (2026-07-07): with Private Time toggled ON, the Activity Timeline showed the private window as sky-blue **"Tracked time / Counted from tracked hours"** instead of a Private Time block.

Root cause (agent side): while private, `sync()` returns before sending anything, and the `private_time` span is only sent **when the user leaves private**. The backend therefore has zero signal that a private session is ongoing — and its tracked-hours trailing grace (20 min) extends the last pre-private activity across the private window, painting it as counted tracked time. It also *bills* that grace window until the leave-time event finally arrives and carves it out.

## Fix

While private, each sync cycle re-sends the span from private-start to now with the **same deterministic id** (`private_<startts>_<engine>`); the server patches the duration in place (same mechanism as growing AFK spans). The timeline flips to Private within one sync cycle (~60s).

- In-progress snapshots are **not** queued on failure — the next cycle's longer span supersedes them. Only the final leave-time send keeps the queue-on-failure retry.
- Side benefit: if the agent dies mid-private-session, the span up to the last cycle is already recorded instead of being lost entirely.

## Companion PR

Requires the backend fix (Better-Quality-Assurance/internal-tool2: `fix/status-span-duration-grow-patch`) — the backend's cache-hit dedup path silently swallowed duration growth for status spans (bucket_id lookup mismatch), so re-sends would have frozen at the first-stored duration.

## Testing

- 5 new tests in `TestPrivateOngoingSpanRefresh` (growing span + stable id, snapshot failure not queued, leave-time id parity, paused stays silent, no-start guard).
- Full suite: 950 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)