### PR TITLE
fix(ci): stop running the full desktop-packaging matrix on every push/PR

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -15,7 +15,47 @@ permissions:
   contents: read
 
 jobs:
+  # Fast, cheap regression check for every push/PR to main: just the test
+  # suite on a single Linux runner, no packaging. Origin: an Actions-minutes
+  # cost review found `build` below (4-platform matrix incl. macos-14-large,
+  # Windows Inno Setup installer, codesigning/notarization) was running in
+  # full on every push/PR, not just releases - the actual packaging steps
+  # only matter at release-tag time, but were billing full desktop-build cost
+  # on every commit. This job keeps real test coverage on every change;
+  # `build` below is now gated to tags/workflow_dispatch only.
+  test:
+    if: "!startsWith(github.ref, 'refs/tags/v')"
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+
+      - name: Install Linux system dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y --no-install-recommends \
+            libgirepository1.0-dev gir1.2-gtk-3.0 gir1.2-ayatanaappindicator3-0.1 \
+            libcairo2-dev pkg-config python3-dev libnotify-bin
+
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r requirements-dev.txt
+
+      - name: Run tests
+        run: pytest tests/ -v --tb=short
+
   build:
+    # Full packaging (4-platform matrix, signing, notarization, Windows
+    # installer) only for an actual release tag, or on-demand via
+    # workflow_dispatch for an ad-hoc/manual build. See `test` job above for
+    # the cheap per-push/PR regression check that replaces this on ordinary
+    # commits.
+    if: startsWith(github.ref, 'refs/tags/v') || github.event_name == 'workflow_dispatch'
     strategy:
       fail-fast: false
       matrix:


### PR DESCRIPTION
## Summary
- Org-level Actions billing review found `betterflow-sync` as the #2 cost driver this month, largely from `macos-14-large` (zero free allowance, ~$18 net so far) plus Windows/macOS-3-core minutes.
- Root cause: `build.yml`'s `build` job runs the **full 4-platform packaging matrix** (PyInstaller build, macOS codesigning + notarization, Windows Inno Setup installer via `choco install`) on **every push to `main` and every PR**, not just release tags. Verified against real run history: 54 runs this month, ~5.5min average, matching the billed macOS-Large minutes closely.
- Fix: added a cheap `test` job (single `ubuntu-latest` runner, just `pytest tests/`) that runs on every push/PR instead, and gated the expensive `build` job to `refs/tags/v*` pushes or manual `workflow_dispatch` only.

## Tradeoff (stated plainly, please weigh in)
A platform-specific **packaging** break (PyInstaller spec, Inno Setup script, AppImage build) would now surface at release-tag time instead of on every PR. Real **logic** regressions are still caught immediately via the new `test` job — this only removes packaging-level coverage from the PR loop, since that's the expensive part.

## Test plan
- [x] YAML validated (3 jobs: `test`, `build`, `release`)
- [x] Ran the exact relocated test step in a clean venv on a fresh clone: `pytest tests/ -v --tb=short` → 950/950 passing (test step itself is unchanged, only its job placement/trigger changed)
- [ ] Confirm the new `test` job goes green on GitHub Actions once opened