### PR TITLE
fix(auth): surface the server message on a 409 device conflict

### DIFF
--- a/src/sync/bf_client.py
+++ b/src/sync/bf_client.py
@@ -199,7 +199,11 @@ class BetterFlowClient(BaseApiClient):
                 headers=headers,
                 timeout=self.timeout,
             )
-            if response.status_code in (400, 401, 403, 422):
+            # 409 = device already registered to another account (a duplicate
+            # machine_id, e.g. a cloned VM image). Include it here so the user
+            # sees the server's explanatory message instead of a bare
+            # "HTTP error: 409" from the raise_for_status() path below.
+            if response.status_code in (400, 401, 403, 409, 422):
                 try:
                     data = response.json()
                     msg = data.get("message", data.get("error", "Authentication failed"))

--- a/tests/test_bf_client.py
+++ b/tests/test_bf_client.py
@@ -699,6 +699,26 @@ class TestBetterFlowClient:
         assert "Invalid" in result.error
 
     @responses.activate
+    def test_exchange_code_device_conflict_409_surfaces_server_message(self):
+        """A 409 (device_id already registered to another account) must show the
+        server's explanatory message, not a bare 'HTTP error: 409'."""
+        responses.add(
+            responses.POST,
+            "https://betterflow.eu/api/v1/sync/auth/token",
+            json={
+                "error": "device_conflict",
+                "message": "This device is already registered to another account. If this is your machine, contact your administrator.",
+            },
+            status=409,
+        )
+
+        result = self.client.exchange_code(code="code", device_name="device", code_verifier="verifier")
+
+        assert result.success is False
+        assert "already registered to another account" in result.error
+        assert "HTTP error" not in result.error
+
+    @responses.activate
     def test_exchange_code_connection_error(self):
         """Test exchange handles connection errors."""
         responses.add(


### PR DESCRIPTION
## Why
The BetterFlow web app now returns **409** with an explanatory body when a `device_id` is already registered to another account (a duplicate `machine_id` — e.g. a cloned VM image). See the server-side guard in internal-tool2 PR #2069.

`exchange_code()` only pulled the friendly server message for 400/401/403/422, so a 409 fell through to `raise_for_status()` and the user saw a bare **"HTTP error: 409."** instead of *"This device is already registered to another account…"*.

## Change
One line: add `409` to the friendly-message status list in `bf_client.py`. The 409 is terminal either way (the login flow shows a failure + manual tray retry — no retry loop); this only improves the message the user sees.

## Test
`test_exchange_code_device_conflict_409_surfaces_server_message` asserts the server's message is surfaced (and "HTTP error" is not). Fails pre-fix (`'HTTP error: 409'`), passes post-fix. Full `bf_client` suite green (67).

🤖 Generated with [Claude Code](https://claude.com/claude-code)