### PR TITLE
fix: watchdog false-trips, dead-letter queue drops, status-span misclassification

### DIFF
--- a/src/sync/queue.py
+++ b/src/sync/queue.py
@@ -161,6 +161,35 @@ class OfflineQueue:
                 """
             )
 
+            # Dead-letter table: events that exhausted their retries are MOVED
+            # here rather than hard-deleted. An event only reaches the retry
+            # ceiling on a DEFINITIVE 4xx (transient 5xx/timeout deliberately
+            # don't increment), which can still be real aw-watcher-afk /
+            # aw-watcher-input activity — so a blind DELETE was permanent data
+            # loss. Preserving event_data (plus bucket_id, timestamps,
+            # retry_count, and dropped_at/last_error) keeps the activity
+            # inspectable and replayable instead of gone.
+            cursor.execute(
+                """
+                CREATE TABLE IF NOT EXISTS dead_letter_events (
+                    id INTEGER PRIMARY KEY AUTOINCREMENT,
+                    original_id INTEGER,
+                    event_data TEXT NOT NULL,
+                    bucket_id TEXT,
+                    created_at TEXT NOT NULL,
+                    retry_count INTEGER,
+                    last_error TEXT,
+                    dropped_at TEXT NOT NULL
+                )
+                """
+            )
+            cursor.execute(
+                """
+                CREATE INDEX IF NOT EXISTS idx_dead_letter_dropped_at
+                ON dead_letter_events(dropped_at)
+                """
+            )
+
             # Also track sync checkpoints
             cursor.execute(
                 """
@@ -463,27 +492,111 @@ class OfflineQueue:
             parsed = parsed.replace(tzinfo=timezone.utc)
         return parsed >= cutoff
 
-    def remove_failed(self, max_retries: int = 5) -> int:
-        """Remove events that have exceeded max retries.
+    def remove_failed(
+        self, max_retries: int = 5, *, last_error: Optional[str] = None
+    ) -> int:
+        """Move events that have exceeded max retries to the dead-letter table.
+
+        Previously this HARD-DELETED exhausted events, permanently losing real
+        activity that hit a definitive 4xx (transient 5xx/timeout don't increment
+        retry_count, so anything here is a genuine rejection — but still real
+        aw-watcher-afk / aw-watcher-input data worth keeping). Now each row is
+        MOVED to ``dead_letter_events`` with its event_data, bucket_id (parsed
+        out for queryability), created_at, retry_count, an optional last_error,
+        and a dropped_at stamp — nothing is silently lost.
+
+        The INSERT and the matching DELETE run inside the SAME ``_cursor()``
+        transaction (committed atomically on exit), so a crash can never both
+        drop the events from the queue AND fail to record the dead letter. The
+        DELETE targets the exact ids that were moved (not the ``>= max_retries``
+        predicate) so a concurrent writer that pushes another event over the
+        ceiling between the SELECT and the DELETE can't have it deleted without
+        first being dead-lettered.
 
         Args:
             max_retries: Maximum retry attempts
+            last_error: Optional context recorded on each dead-lettered row
 
         Returns:
-            Number of events removed
+            Number of events moved out of the queue
         """
+        now = datetime.now(timezone.utc).isoformat()
         with self._cursor() as cursor:
             cursor.execute(
                 """
-                DELETE FROM queued_events
+                SELECT id, event_data, created_at, retry_count
+                FROM queued_events
                 WHERE retry_count >= ?
                 """,
                 (max_retries,),
             )
+            rows = cursor.fetchall()
+            if not rows:
+                return 0
+
+            dead_rows = []
+            for row in rows:
+                bucket_id = None
+                try:
+                    parsed = json.loads(row[1])
+                    if isinstance(parsed, dict):
+                        bucket_id = parsed.get("bucket_id")
+                except (json.JSONDecodeError, TypeError):
+                    # Keep the raw event_data regardless; only the queryable
+                    # bucket_id column is left NULL for an unparseable payload.
+                    bucket_id = None
+                dead_rows.append(
+                    (row[0], row[1], bucket_id, row[2], row[3], last_error, now)
+                )
+
+            cursor.executemany(
+                """
+                INSERT INTO dead_letter_events
+                    (original_id, event_data, bucket_id, created_at,
+                     retry_count, last_error, dropped_at)
+                VALUES (?, ?, ?, ?, ?, ?, ?)
+                """,
+                dead_rows,
+            )
+
+            ids = [row[0] for row in rows]
+            placeholders = ",".join("?" * len(ids))
+            cursor.execute(
+                f"DELETE FROM queued_events WHERE id IN ({placeholders})",
+                ids,
+            )
             count = cursor.rowcount
             if count > 0:
-                logger.warning(f"Removed {count} events that exceeded max retries")
+                logger.warning(
+                    "Moved %d event(s) that exceeded max retries to "
+                    "dead_letter_events",
+                    count,
+                )
             return count
+
+    def dead_letter_count(self) -> int:
+        """Number of events currently held in the dead-letter table."""
+        with self._cursor() as cursor:
+            cursor.execute("SELECT COUNT(*) FROM dead_letter_events")
+            return cursor.fetchone()[0]
+
+    def get_dead_letter_events(self, limit: int = 100) -> list[dict]:
+        """Return dead-lettered events (newest first) for inspection/replay.
+
+        Read-only helper — does not modify the table.
+        """
+        with self._cursor() as cursor:
+            cursor.execute(
+                """
+                SELECT original_id, event_data, bucket_id, created_at,
+                       retry_count, last_error, dropped_at
+                FROM dead_letter_events
+                ORDER BY dropped_at DESC, id DESC
+                LIMIT ?
+                """,
+                (limit,),
+            )
+            return [dict(row) for row in cursor.fetchall()]
 
     def size(self) -> int:
         """Get the current queue size."""

--- a/src/sync/sync_engine.py
+++ b/src/sync/sync_engine.py
@@ -645,8 +645,20 @@ class SyncEngine:
                 )
             return stats
 
-        # Fetch server config on first successful sync
-        if not self._config_fetched and self.bf.is_reachable():
+        # Fetch server config on first successful sync. Gated by the shared
+        # per-cycle network budget: get_config() runs a full retry chain
+        # (~94s against a hung server), so it must count toward the SAME 50s
+        # budget the _do_sync watchdog was sized around. Otherwise it stacks
+        # ahead of the session-start and send chains and the cycle overruns the
+        # 150s deadline ("Sync hung"). The budget-start is stamped at the top of
+        # sync() (self._cycle_start_monotonic), so every per-cycle network call
+        # after it — this fetch, start_session, the send loop, the queue drain —
+        # shares one budget.
+        if (
+            not self._config_fetched
+            and not self._cycle_network_budget_exceeded(self._CYCLE_NETWORK_BUDGET_SECONDS)
+            and self.bf.is_reachable()
+        ):
             self.fetch_server_config()
 
         # Check ActivityWatch
@@ -676,22 +688,31 @@ class SyncEngine:
                     stats.calls_detected += 1
             return stats
 
-        # Start session if needed (attempt directly; no pre-check to avoid TOCTOU)
-        # Retry once on transient failure (N13)
+        # Start session if needed (attempt directly; no pre-check to avoid TOCTOU).
+        # start_session() ALREADY retries internally (retry=True -> up to ~94s
+        # against a hung server). An OUTER `for attempt in range(2)` loop doubled
+        # that to ~188s — enough to blow the 150s _do_sync watchdog on its own
+        # (the "Sync hung" reports). Call it ONCE per cycle: the durable
+        # OfflineQueue plus the next sync cycle already provide cross-cycle retry,
+        # so an outer multiplier buys nothing but watchdog overruns. Also gate it
+        # on the shared per-cycle network budget so a slow config-fetch ahead of
+        # it can't push the combined network time past the watchdog.
         with self._state_lock:
             need_session = not self._session_active
-        if need_session:
-            for attempt in range(2):
-                try:
-                    self.bf.start_session()
-                    with self._state_lock:
-                        self._session_active = True
-                    break
-                except BetterFlowClientError as e:
-                    if attempt == 0:
-                        logger.debug(f"Session start attempt 1 failed: {e}, retrying")
-                    else:
-                        logger.warning(f"Failed to start session after retry: {e}")
+        if need_session and not self._cycle_network_budget_exceeded(
+            self._CYCLE_NETWORK_BUDGET_SECONDS
+        ):
+            try:
+                self.bf.start_session()
+                with self._state_lock:
+                    self._session_active = True
+            except BetterFlowClientError as e:
+                # BetterFlowAuthError is a BetterFlowClientError subclass; the
+                # pre-existing behaviour swallowed both here (logged, not
+                # re-raised) and let the next cycle retry. Preserved to keep the
+                # session-start failure mode unchanged — only the retry MULTIPLIER
+                # is removed.
+                logger.warning(f"Failed to start session: {e}")
 
         # Record an activity sample for the in-process AFK timeline (no-op when
         # no source is wired or the OS idle clock is unavailable). Done every
@@ -2181,6 +2202,17 @@ class SyncEngine:
             "id": f"{kind}_{int(start.timestamp())}_{id(self)}",
             "timestamp": start.isoformat(),
             "duration": round(duration, 2),
+            # Stable synthetic bucket id, mirroring how call events carry
+            # bf-call-detector_<host>. The offline-queue storability classifier
+            # (queue.failed_event_summary / _batch_has_storable_activity) keys on
+            # bucket_id presence: without one, a failed real idle/private/break
+            # span was mislabeled "unstorable ... buckets=unknown" and silently
+            # flushed — even though the happy path proves the server accepts these
+            # spans. Giving them a bucket_id makes them first-class in every
+            # bucket-keyed path, so a failed span now routes through the
+            # dead-letter path instead of being dropped, and reports as bucket
+            # type "bf-status" rather than "unknown".
+            "bucket_id": f"bf-status_{self._hostname}",
             "bucket_type": bucket_type,
             "data": {"status": kind},
         }
@@ -2942,7 +2974,11 @@ class SyncEngine:
         drop_summary = self.queue.failed_event_summary(max_retries=5)
         if drop_summary.get("count", 0) > 0:
             self._report_dropped_events(drop_summary)
-        self.queue.remove_failed(max_retries=5)
+        # Moves (does NOT hard-delete) exhausted events to the dead-letter table
+        # so genuine 4xx-rejected activity is preserved for inspection/replay.
+        self.queue.remove_failed(
+            max_retries=5, last_error="exceeded max retries (5); definitive rejection"
+        )
 
         # Skip queue processing if in backoff period
         now = datetime.now(timezone.utc)

--- a/tests/test_queue.py
+++ b/tests/test_queue.py
@@ -110,6 +110,54 @@ class TestOfflineQueue:
         assert removed == 1
         assert self.queue.is_empty()
 
+    def test_remove_failed_moves_to_dead_letter_not_lost(self):
+        """A 4xx-exhausted event must be MOVED to dead_letter_events, not hard
+        deleted — nothing is lost. Its event_data, bucket_id, retry_count and a
+        dropped_at stamp are preserved, and it leaves queued_events."""
+        event = {
+            "id": "real-activity",
+            "bucket_id": "aw-watcher-afk_host",
+            "timestamp": "2026-07-09T05:00:00+00:00",
+            "duration": 42,
+            "data": {"status": "not-afk"},
+        }
+        self.queue.enqueue([event])
+        queued = self.queue.dequeue(batch_size=1)
+        for _ in range(5):
+            self.queue.increment_retry([q.id for q in queued])
+
+        assert self.queue.dead_letter_count() == 0
+        moved = self.queue.remove_failed(
+            max_retries=5, last_error="definitive 4xx"
+        )
+
+        # Removed from the live queue...
+        assert moved == 1
+        assert self.queue.is_empty()
+        # ...but preserved in the dead-letter table, nothing lost.
+        assert self.queue.dead_letter_count() == 1
+        dead = self.queue.get_dead_letter_events()
+        assert len(dead) == 1
+        row = dead[0]
+        assert row["bucket_id"] == "aw-watcher-afk_host"
+        assert row["retry_count"] >= 5
+        assert row["last_error"] == "definitive 4xx"
+        assert row["dropped_at"] is not None
+        # Original payload is intact and replayable.
+        import json
+        restored = json.loads(row["event_data"])
+        assert restored["id"] == "real-activity"
+        assert restored["data"]["status"] == "not-afk"
+
+    def test_remove_failed_no_events_leaves_dead_letter_empty(self):
+        """Nothing past the ceiling → nothing moved, dead-letter stays empty."""
+        self.queue.enqueue([
+            {"id": "fresh", "timestamp": "2026-07-09T05:00:00+00:00", "data": {}}
+        ])
+        assert self.queue.remove_failed(max_retries=5) == 0
+        assert self.queue.dead_letter_count() == 0
+        assert self.queue.size() == 1
+
     def test_failed_event_summary_reports_buckets_and_span(self):
         """The drop summary carries enough to diagnose the loss: count, the
         distinct bucket_ids affected, and the oldest/newest event timestamps."""

--- a/tests/test_sync_engine.py
+++ b/tests/test_sync_engine.py
@@ -629,7 +629,9 @@ class TestSyncEngine:
         assert self.engine.error_reporter.capture.call_args.kwargs["fingerprint"] == (
             "offline-queue-events-dropped"
         )
-        self.queue.remove_failed.assert_called_once_with(max_retries=5)
+        self.queue.remove_failed.assert_called_once_with(
+            max_retries=5, last_error="exceeded max retries (5); definitive rejection"
+        )
 
     def test_no_dropped_events_does_not_report(self):
         """A clean queue (nothing past the retry ceiling) must not fire a report."""
@@ -1134,6 +1136,55 @@ class TestSyncEngine:
         assert stats.aw_bucket_fetch_failed is True
         assert stats.success is False
 
+    def test_session_start_attempted_once_per_cycle(self):
+        """start_session() retries internally (~94s worst case). The old outer
+        `for attempt in range(2)` loop doubled that to ~188s and blew the 150s
+        watchdog on its own. A cycle must call start_session at most ONCE — the
+        durable OfflineQueue + next cycle provide cross-cycle retry."""
+        from src.sync.aw_client import AWClientError
+        from src.sync.http_client import BetterFlowClientError
+        self.aw.is_running.return_value = True
+        self.bf.is_reachable.return_value = True
+        self.engine._config_fetched = True
+        self.engine._session_active = False
+        self.bf.start_session.side_effect = BetterFlowClientError("session start 503")
+        # Bail out right after the session-start block so the cycle ends cleanly.
+        self.aw.get_window_buckets.side_effect = AWClientError("503")
+
+        self.engine.sync()
+
+        assert self.bf.start_session.call_count == 1, (
+            "session start must be attempted exactly once per cycle (no outer "
+            f"retry multiplier); got {self.bf.start_session.call_count}"
+        )
+        # A failed start must not flip the session active.
+        assert self.engine._session_active is False
+
+    def test_session_start_skipped_when_network_budget_spent(self, monkeypatch):
+        """If the cycle has already spent the shared per-cycle network budget
+        (e.g. a slow config fetch), start_session must be SKIPPED this cycle so
+        the combined network time can't overrun the watchdog — it retries next
+        cycle instead."""
+        import src.sync.sync_engine as se
+        from src.sync.aw_client import AWClientError
+
+        # Monotonic clock that jumps far past the budget on every call after the
+        # cycle-start stamp, so the session-start budget gate sees it exceeded.
+        ticks = iter([1000.0] + [1000.0 + se.SyncEngine._CYCLE_NETWORK_BUDGET_SECONDS
+                                 + 10 + i for i in range(1000)])
+        monkeypatch.setattr(se.time, "monotonic", lambda: next(ticks))
+
+        self.aw.is_running.return_value = True
+        self.bf.is_reachable.return_value = True
+        self.engine._config_fetched = True  # skip the config-fetch branch
+        self.engine._session_active = False
+        self.aw.get_window_buckets.side_effect = AWClientError("503")
+
+        self.engine.sync()
+
+        self.bf.start_session.assert_not_called()
+        assert self.engine._session_active is False
+
     def test_transform_event_delta_time_tracking_on_refetch(self):
         """Test that re-fetched events with grown duration only add the delta."""
         cycle = _SyncCycleContext(has_input_data=True)
@@ -1482,6 +1533,88 @@ class TestStatusSpanEvents:
         assert idle_ev["data"]["status"] == "idle"
         assert sleep_ev["data"]["status"] == "sleep"
         assert break_ev["data"]["status"] == "break"
+
+    def test_status_span_carries_synthetic_bucket_id(self):
+        """Every status span must carry a stable synthetic bucket_id
+        (bf-status_<host>) so it is first-class in every bucket-keyed path
+        (offline-queue storability classifier, blast-radius grouping). Without it
+        a failed real idle/private span was mislabeled "unstorable ...
+        buckets=unknown" and silently dropped."""
+        from src.sync.bf_client import SyncResult
+        self.bf.send_events.return_value = SyncResult(success=True, events_synced=1)
+        start = datetime(2026, 6, 9, 0, 0, 0, tzinfo=timezone.utc)
+        end = start + timedelta(minutes=30)
+
+        for send in (
+            self.engine.send_idle_event,
+            self.engine.send_break_event,
+            self.engine.send_sleep_event,
+        ):
+            self.bf.send_events.reset_mock()
+            send(start, end)
+            ev = self._captured_event()
+            assert ev["bucket_id"] == f"bf-status_{self.engine._hostname}"
+
+
+class TestFailedStatusSpanIsStorable:
+    """A failed real status span (idle/private/break/sleep) must be classified
+    STORABLE — routed through the dead-letter path — not silently flushed as
+    "unstorable ... buckets=unknown". Regression for the 2026 buckets=unknown
+    misclassification: the happy path proves the server accepts these spans, so a
+    failed one is real lost activity, not a benign flush."""
+
+    def setup_method(self):
+        import tempfile
+        from pathlib import Path
+
+        from src.sync.bf_client import SyncResult
+        from src.sync.queue import OfflineQueue
+
+        self.tmp = Path(tempfile.mkdtemp())
+        self.queue = OfflineQueue(db_path=self.tmp / "q.db", max_size=1000)
+        self.aw = Mock()
+        self.bf = Mock()
+        # Force the offline path so the span is queued, not accepted.
+        self.bf.send_events.return_value = SyncResult(success=False, error="offline")
+        self.engine = SyncEngine(
+            aw=self.aw, bf=self.bf, queue=self.queue, config=Config(),
+            activity_analyzer=Mock(spec=ActivityAnalyzer),
+            time_tracker=Mock(spec=DailyTimeTracker),
+        )
+
+    def teardown_method(self):
+        self.queue.close()
+
+    def test_failed_idle_span_classified_storable_and_dead_lettered(self):
+        # A recent idle span whose send fails → queued.
+        start = datetime.now(timezone.utc) - timedelta(minutes=30)
+        end = datetime.now(timezone.utc)
+        self.engine.send_idle_event(start, end)
+        assert self.queue.size() == 1
+
+        # Push it past the retry ceiling (a definitive rejection).
+        queued = self.queue.dequeue(batch_size=1)
+        span_event = queued[0].event_data
+        for _ in range(5):
+            self.queue.increment_retry([q.id for q in queued])
+
+        # The emitted span carries the synthetic bucket id (Fix 3).
+        assert span_event["bucket_id"] == f"bf-status_{self.engine._hostname}"
+
+        # Classifier now treats it as REAL loss (has bucket_id + recent ts),
+        # NOT an unstorable flush, and the bucket label is bf-status, not unknown.
+        summary = self.queue.failed_event_summary(max_retries=5)
+        assert summary["real_loss_count"] == 1
+        assert summary["unstorable_count"] == 0
+        assert summary["bucket_ids"] == [f"bf-status_{self.engine._hostname}"]
+
+        # _batch_has_storable_activity mirrors that verdict for the same event.
+        assert self.engine._batch_has_storable_activity([span_event])
+
+        # And it routes through the dead-letter path — preserved, not lost.
+        moved = self.queue.remove_failed(max_retries=5)
+        assert moved == 1
+        assert self.queue.dead_letter_count() == 1
 
 
 class TestPrivateOngoingSpanRefresh:


### PR DESCRIPTION
Three fixes for the Azorel sync incidents (2026-07 fingerprints: sync-watchdog-timeout, offline-queue-events-dropped, offline-queue-events-flushed-unstorable).

## FIX 1 — "Sync hung — exceeded 150s watchdog deadline"
Per-cycle network calls that ran **before** the gated send section were not counted against the shared `_CYCLE_NETWORK_BUDGET_SECONDS` (50s), so retry chains stacked past the 150s `_do_sync` watchdog.

- **`start_session()`** was wrapped in an OUTER `for attempt in range(2)` loop. It already retries internally (`retry=True` → ~94s worst case against a hung server), so the outer loop made it **~188s alone** — enough to blow the 150s deadline on its own. Removed the retry multiplier: `start_session` is now called **once per cycle**; the durable `OfflineQueue` + next cycle provide cross-cycle retry.
- **`fetch_server_config()`/`get_config()`** and `start_session` are now both gated by `_cycle_network_budget_exceeded()`, so **all** per-cycle network time shares the one 50s budget the watchdog was sized around.
- The 150s deadline is **unchanged** (not raised).

## FIX 2 — Data loss: "Dropped N queued event(s) after max retries"
`OfflineQueue.remove_failed()` did an unconditional hard `DELETE FROM queued_events WHERE retry_count >= 5`. Events only reach that ceiling on a **definitive 4xx** (transient 5xx/timeout correctly don't increment), so real `aw-watcher-afk`/`aw-watcher-input` activity was **permanently deleted**.

- Replaced the DELETE with a **MOVE** into a new `dead_letter_events` table (created via the same `_init_db` `CREATE TABLE IF NOT EXISTS` mechanism), preserving `event_data`, `bucket_id`, `created_at`, `retry_count`, plus `last_error`/`dropped_at`.
- The `INSERT` + `DELETE` run in the **same `_cursor()` transaction** (atomic). The DELETE targets the **exact moved ids**, so a concurrent writer can't push a row over the ceiling and have it deleted without first being dead-lettered.
- Added `dead_letter_count()` / `get_dead_letter_events()` for inspection/replay.

## FIX 3 — Misclassification: "Flushed N unstorable queued event(s) — buckets=unknown"
Status spans (break/idle/sleep/private) were created with a `bucket_type` but **no `bucket_id`**. The storability classifier keys only on `bucket_id` presence, so failed real idle/private spans were mislabeled "unstorable, never server-acceptable (buckets=unknown)" and silently dropped — even though the happy path proves the server accepts them.

- Gave status spans a **stable synthetic `bucket_id`** (`bf-status_<host>`), mirroring how call events use `bf-call-detector_<host>`. This makes them first-class in every bucket-keyed path.
- A failed status span is now classified **storable**, routes through the Fix-2 dead-letter path (not the silent flush), and reports bucket type `bf-status` instead of `unknown`.

## Tests
- `test_remove_failed_moves_to_dead_letter_not_lost` — a 4xx-exhausted event lands in `dead_letter_events` and leaves `queued_events` (nothing lost).
- `test_failed_idle_span_classified_storable_and_dead_lettered` — a failed status span is classified real-loss with bucket `bf-status` and routes to the dead-letter table.
- `test_session_start_attempted_once_per_cycle` — no outer retry multiplier.
- `test_session_start_skipped_when_network_budget_spent` — session start deferred once the shared budget is spent.
- Existing watchdog/send-budget invariant tests still pass.

**Full suite: 957 passing.** Ruff adds no new findings (pre-existing import-ordering/N812/B905 noise untouched).

🤖 Generated with [Claude Code](https://claude.com/claude-code)