### PR TITLE
fix(queue): evict unstorable events before batching so poison can't drop storable activity

### DIFF
--- a/src/sync/queue.py
+++ b/src/sync/queue.py
@@ -574,6 +574,129 @@ class OfflineQueue:
                 )
             return count
 
+    def evict_unstorable(
+        self,
+        *,
+        now: Optional[datetime] = None,
+        stale_after_days: int = 7,
+        last_error: Optional[str] = None,
+    ) -> dict:
+        """Move events the server can NEVER accept out of the active queue and
+        into ``dead_letter_events`` BEFORE they are batched with storable events.
+
+        "Unstorable" is the SAME classification ``failed_event_summary`` and
+        ``SyncEngine._batch_has_storable_activity`` already use: an event with no
+        ``bucket_id`` (nowhere to route it) or a ``timestamp`` already past the
+        server's retention window (``stale_after_days``). The only change is
+        WHEN it's applied — proactively, up front — instead of only at the retry
+        ceiling after the damage is done.
+
+        Why up front: ``dequeue`` returns events oldest-first, so an unstorable
+        event sits at the queue head and is batched with storable events behind
+        it. The server 4xx-rejects the whole batch on account of the unstorable
+        "poison", and ``_process_queue``'s whole-batch retry bump then increments
+        EVERY event in the batch — the storable ones in lockstep with the poison.
+        After ``max_retries`` cycles the storable events cross the ceiling and are
+        dropped as "real lost activity" (the 2026-07 warnings: N real
+        aw-watcher-input/window events dropped alongside "M other unstorable").
+        Evicting the unstorable events first keeps every batch storable-only.
+
+        Storable events (``bucket_id`` present AND timestamp within retention) are
+        NEVER touched — a transient outage still holds them for retry. Each evicted
+        row is MOVED (not hard-deleted) to ``dead_letter_events`` in one
+        transaction, so nothing is silently lost.
+
+        Returns a summary shaped like ``failed_event_summary`` so the caller can
+        report it through the same path: ``{count, bucket_ids, oldest, newest,
+        real_loss_count (always 0), unstorable_count}`` — all zero/empty when the
+        queue holds nothing unstorable.
+
+        ``now`` is injectable for deterministic tests (defaults to UTC now).
+        """
+        now = now or datetime.now(timezone.utc)
+        stale_cutoff = now - timedelta(days=stale_after_days)
+        dropped_at = now.isoformat()
+
+        empty = {
+            "count": 0,
+            "bucket_ids": [],
+            "oldest": None,
+            "newest": None,
+            "real_loss_count": 0,
+            "unstorable_count": 0,
+        }
+
+        with self._cursor() as cursor:
+            cursor.execute(
+                "SELECT id, event_data, created_at, retry_count FROM queued_events"
+            )
+            rows = cursor.fetchall()
+            if not rows:
+                return empty
+
+            dead_rows = []
+            evict_ids: list[int] = []
+            bucket_ids: set[str] = set()
+            timestamps: list[str] = []
+            for row in rows:
+                rid, raw, created_at, retry_count = row[0], row[1], row[2], row[3]
+                bucket_id = None
+                ts = None
+                try:
+                    ev = json.loads(raw)
+                    if isinstance(ev, dict):
+                        bucket_id = ev.get("bucket_id")
+                        ts = ev.get("timestamp")
+                except (json.JSONDecodeError, TypeError):
+                    # Unparseable payload → can never be stored → evict it.
+                    pass
+                storable = bool(bucket_id) and self._timestamp_within(ts, stale_cutoff)
+                if storable:
+                    continue
+                evict_ids.append(rid)
+                if bucket_id:
+                    bucket_ids.add(str(bucket_id))
+                if ts:
+                    timestamps.append(str(ts))
+                dead_rows.append(
+                    (rid, raw, bucket_id, created_at, retry_count, last_error, dropped_at)
+                )
+
+            if not evict_ids:
+                return empty
+
+            cursor.executemany(
+                """
+                INSERT INTO dead_letter_events
+                    (original_id, event_data, bucket_id, created_at,
+                     retry_count, last_error, dropped_at)
+                VALUES (?, ?, ?, ?, ?, ?, ?)
+                """,
+                dead_rows,
+            )
+            placeholders = ",".join("?" * len(evict_ids))
+            cursor.execute(
+                f"DELETE FROM queued_events WHERE id IN ({placeholders})",
+                evict_ids,
+            )
+            count = cursor.rowcount
+
+        if count > 0:
+            logger.info(
+                "Evicted %d unstorable queued event(s) (no bucket / past "
+                "retention) to dead_letter before batching",
+                count,
+            )
+        timestamps.sort()
+        return {
+            "count": count,
+            "bucket_ids": sorted(bucket_ids),
+            "oldest": timestamps[0] if timestamps else None,
+            "newest": timestamps[-1] if timestamps else None,
+            "real_loss_count": 0,
+            "unstorable_count": count,
+        }
+
     def dead_letter_count(self) -> int:
         """Number of events currently held in the dead-letter table."""
         with self._cursor() as cursor:

--- a/src/sync/sync_engine.py
+++ b/src/sync/sync_engine.py
@@ -2965,6 +2965,23 @@ class SyncEngine:
 
         Capped at 30s wall-clock time to prevent tying up the sync thread.
         """
+        # Evict genuinely-unstorable events (no bucket to route to, or already
+        # past the server's retention window) from the active queue BEFORE
+        # batching. dequeue() is oldest-first, so an unstorable event sits at the
+        # head and is batched with storable events behind it; the server 4xx's the
+        # whole batch on the poison, and the whole-batch retry bump below then
+        # drags the storable neighbours to the drop ceiling in lockstep — the
+        # 2026-07 "Dropped N ... likely real lost activity (... ; M other
+        # unstorable)" warnings. Removing them first keeps every batch
+        # storable-only, so the server accepts it and no real activity is lost.
+        # They're MOVED to dead_letter (preserved) and reported at info (benign
+        # flush), never as real loss.
+        evicted = self.queue.evict_unstorable(
+            last_error="unstorable (no bucket / past retention) — evicted before batching"
+        )
+        if evicted.get("count", 0) > 0:
+            self._report_dropped_events(evicted)
+
         # Remove events that exceeded retry limit. Surface the drop to ops FIRST
         # — with the server now confirming delivery per-event (accepted_ids),
         # anything that still exhausts its retries is a genuine permanent

--- a/tests/test_queue_mixed_batch_poison.py
+++ b/tests/test_queue_mixed_batch_poison.py
@@ -1,0 +1,127 @@
+"""A single unstorable "poison" event must not drag its storable batch-mates to
+the drop ceiling.
+
+Origin: 2026-07 — production 1.5.95 emitted a steady stream of
+    "Dropped N queued event(s) after max retries — likely real lost activity
+     (buckets=aw-watcher-input,aw-watcher-window, ...; M other unstorable)"
+The tell is the trailing "M other unstorable": the dropped batch mixed real
+aw-watcher-input/window activity with a handful of unstorable events (no
+bucket_id to route to, or already past the server's retention window).
+
+Root cause: `dequeue()` returns events oldest-first, so an unstorable event sits
+at the head of the queue and is batched together with storable events. The server
+4xx-rejects the whole batch on account of the unstorable poison, and
+`_process_queue`'s whole-batch retry bump (`increment_retry(event_ids)` on a
+definitive 4xx) then increments EVERY event in the batch — the storable ones in
+lockstep with the poison. After `max_retries` cycles the whole batch crosses the
+ceiling and the storable events are dropped as "real lost activity", even though
+the server would have accepted them in a clean batch.
+
+Fix: evict genuinely-unstorable events (no bucket / past retention) from the
+active queue BEFORE batching, so every batch is storable-only and the server
+accepts it. `test_mixed_batch_does_not_drop_storable_activity` fails pre-fix
+(the storable events are never delivered and are dropped as real loss).
+"""
+
+import tempfile
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+from unittest.mock import Mock
+
+from src.config import Config
+from src.sync.bf_client import SyncResult
+from src.sync.queue import OfflineQueue
+from src.sync.sync_engine import SyncEngine, SyncStats
+
+
+def _engine(tmp: Path) -> SyncEngine:
+    return SyncEngine(
+        aw=Mock(),
+        bf=Mock(),
+        queue=OfflineQueue(db_path=tmp / "q.db", max_size=10000),
+        config=Config(),
+        time_tracker=Mock(),
+    )
+
+
+def _storable(n: int) -> list[dict]:
+    """n storable events: recent timestamp + a real bucket the server accepts."""
+    now = datetime.now(timezone.utc).isoformat()
+    return [
+        {
+            "id": f"good-{i}",
+            "timestamp": now,
+            "duration": 60.0,
+            "bucket_id": "aw-watcher-window_host",
+            "data": {"app": "Terminal"},
+        }
+        for i in range(n)
+    ]
+
+
+def _unstorable(n: int) -> list[dict]:
+    """n events the server can NEVER store: bucketless (nowhere to route)."""
+    now = datetime.now(timezone.utc).isoformat()
+    return [
+        {"id": f"poison-{i}", "timestamp": now, "duration": 60.0, "data": {}}
+        for i in range(n)
+    ]
+
+
+class _StrictServer:
+    """Models a server that validates the whole batch: if ANY event is
+    unstorable (no bucket_id), it 4xx-rejects the entire batch (a definitive,
+    non-transient rejection with no per-event verdict). A fully-storable batch is
+    accepted and its ids recorded."""
+
+    def __init__(self) -> None:
+        self.delivered: set[str] = set()
+
+    def __call__(self, events: list[dict]) -> SyncResult:
+        if any(not e.get("bucket_id") for e in events):
+            # Definitive 4xx on the whole batch — no accepted_ids, not transient.
+            return SyncResult(
+                success=False, events_queued=len(events), transient=False
+            )
+        for e in events:
+            self.delivered.add(e["id"])
+        return SyncResult(success=True, events_synced=len(events))
+
+
+def _run_cycles(engine: SyncEngine, n: int) -> None:
+    for _ in range(n):
+        engine._queue_backoff_until = datetime.now(timezone.utc) - timedelta(seconds=1)
+        engine._process_queue(SyncStats())
+
+
+def test_mixed_batch_does_not_drop_storable_activity():
+    tmp = Path(tempfile.mkdtemp())
+    engine = _engine(tmp)
+
+    # Unstorable events enqueued FIRST so they sit at the oldest-first dequeue
+    # head, exactly as in production; storable activity right behind them.
+    engine.queue.enqueue(_unstorable(2))
+    engine.queue.enqueue(_storable(9))
+    assert engine.queue.size() == 11
+
+    server = _StrictServer()
+    engine.bf.send_events = Mock(side_effect=server)
+
+    # 8 cycles — well past the max_retries=5 ceiling.
+    _run_cycles(engine, 8)
+
+    # The 9 storable events must reach the server, not be dropped as collateral.
+    good_ids = {f"good-{i}" for i in range(9)}
+    assert good_ids <= server.delivered, (
+        "storable aw-watcher activity must be delivered, not dragged to the drop "
+        f"ceiling by a co-batched unstorable poison event; delivered={server.delivered}"
+    )
+
+    # And none of it is classified as real lost activity.
+    assert engine.queue.failed_event_summary(max_retries=5)["real_loss_count"] == 0, (
+        "no storable event should reach the retry ceiling"
+    )
+
+    # The 2 unstorable poison events are preserved (dead-lettered), not silently
+    # gone, and are out of the active queue.
+    assert engine.queue.dead_letter_count() == 2

--- a/tests/test_sync_engine.py
+++ b/tests/test_sync_engine.py
@@ -26,6 +26,11 @@ class TestSyncEngine:
         self.queue = Mock()
         # Mock the exclude_apps as a list so "in" checks work
         self.queue.get_checkpoint.return_value = None
+        # Default: nothing unstorable to evict (real queue returns this shape).
+        self.queue.evict_unstorable.return_value = {
+            "count": 0, "bucket_ids": [], "oldest": None, "newest": None,
+            "real_loss_count": 0, "unstorable_count": 0,
+        }
         self.config = Config()
 
         # Create mock activity analyzer and time tracker


### PR DESCRIPTION
## What

Stops the recurring production warning
`Dropped N queued event(s) after max retries — likely real lost activity (buckets=aw-watcher-input,aw-watcher-window, ...; M other unstorable)` from dropping **valid** aw-watcher activity.

## Root cause

`dequeue()` returns events oldest-first, so an **unstorable** event (no `bucket_id` to route to, or already past the server's retention window) sits at the queue head and gets batched together with storable events behind it. The server 4xx-rejects the whole batch on account of the unstorable "poison", and `_process_queue`'s whole-batch retry bump (`increment_retry(event_ids)` on a definitive 4xx) then increments **every** event in the batch — the storable ones in lockstep with the poison. After `max_retries=5` cycles the whole batch crosses the ceiling and `remove_failed` drops the storable events as "real lost activity", even though the server would have accepted them in a clean batch.

The trailing `; M other unstorable` in the production warnings is the direct fingerprint of this: each dropped batch was `N` real events + `M` poison events crossing the ceiling together.

PR #129 preserved these dropped events in `dead_letter` but did **not** stop the drop or the false "real lost activity" warning for valid buckets — it addressed the symptom (data preservation), not the mixed-batch cause.

## Fix

`OfflineQueue.evict_unstorable()` moves genuinely-unstorable events (no `bucket_id` OR timestamp past retention — the **same** classification `failed_event_summary` / `_batch_has_storable_activity` already use) out of the active queue into `dead_letter` **before** batching. `_process_queue` calls it up front and reports the eviction at `info` (benign flush), never as real loss.

Result: every batch is storable-only, the server accepts it, and no real activity is dragged to the drop ceiling. Storable events (bucket + recent) are never touched, so a transient outage still holds them for retry.

## Test (fails pre-fix, passes post-fix)

`tests/test_queue_mixed_batch_poison.py` drives the **real** `OfflineQueue` + **real** `_process_queue` against a strict fake server that 4xx-rejects any batch containing a bucketless event (2 poison enqueued at the head, 9 storable behind).

- Assertion `good_ids <= server.delivered` **fails pre-fix** (`delivered=set()` — all 9 storable + 2 poison dead-lettered together after max retries).
- **Passes post-fix** (9 storable delivered, 2 poison dead-lettered).

Pre-fix failure verified by running the new test against `HEAD~1` of the impl (`git checkout HEAD~1 -- src/sync/...`), watching it fail, then restoring.

## Verification

- `pytest` full suite: **958 passed**.
- `ruff check` on changed files: no new errors (only the 2 pre-existing `I001` import-block warnings already on `main`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
