### PR TITLE
fix(idle): clamp idle_start to last system wake, preventing suspend re-carve

### DIFF
--- a/src/idle_manager.py
+++ b/src/idle_manager.py
@@ -33,6 +33,11 @@ class IdleManager:
         self._idle_paused = False
         self._idle_start: Optional[datetime] = None
         self._idle_pause_threshold = config.sync.idle_pause_minutes * 60
+        # Most recent system-wake instant, set via record_wake() (called by
+        # SystemEventHandler.on_system_wake). Used to clamp idle_start so a
+        # post-wake idle pause can never reach back before the machine woke
+        # up. See _clamp_to_last_wake for why this matters.
+        self._last_wake_ts: Optional[datetime] = None
         self._IDLE_SYNC_INTERVAL = 300
         # A healthy AFK watcher heartbeats its current event continuously, so the
         # event's end-time tracks "now". If the latest AFK event ended more than
@@ -67,6 +72,41 @@ class IdleManager:
             self.sync_engine.send_idle_event(idle_start)
         if was_paused and self._on_idle_pause:
             self._on_idle_pause(False)
+
+    def record_wake(self, wake_ts: Optional[datetime] = None) -> None:
+        """Record the most recent system-wake instant.
+
+        Called by SystemEventHandler.on_system_wake as soon as wake fires.
+        The idle subsystem otherwise has no wake awareness: after a laptop
+        lid-open, if the user doesn't type immediately, bf-idle-tracker
+        resumes heartbeating the SAME 'afk' event it had before the suspend
+        (its start time never moved), so `aw.get_latest_afk_event()` reports
+        an event whose `timestamp` is the last keystroke BEFORE the lid
+        closed while its `duration` stretches to cover ~now. Without a wake
+        anchor, `check_idle_status` would backdate the resulting idle_start
+        to that pre-suspend keystroke, and the idle_time event sent on
+        resume would then reach back across the suspend — re-carving real
+        work the user logged before closing the lid (undoing the
+        server-side sleep-time grace bridge). `_clamp_to_last_wake` uses
+        this timestamp to prevent that.
+        """
+        with self._state_lock:
+            self._last_wake_ts = wake_ts or datetime.now(timezone.utc)
+
+    def _clamp_to_last_wake(self, idle_start: datetime) -> datetime:
+        """Never let an idle span start before the most recent system wake.
+
+        A no-op for ordinary at-desk idle (no intervening suspend): either no
+        wake has ever been recorded, or the idle_start being computed already
+        falls after the last wake, so `max()` returns it unchanged. It only
+        moves idle_start forward for a pause entered shortly after a resume,
+        clamping it to the wake instant instead of a pre-suspend timestamp.
+        """
+        with self._state_lock:
+            last_wake = self._last_wake_ts
+        if last_wake is not None and idle_start < last_wake:
+            return last_wake
+        return idle_start
 
     def flush_idle_event(self) -> None:
         """Send idle_time event for current idle period (e.g. on shutdown)."""
@@ -270,6 +310,15 @@ class IdleManager:
                         return
                     if idle_start is None:
                         idle_start = datetime.now(timezone.utc)
+                    clamped_idle_start = self._clamp_to_last_wake(idle_start)
+                    if clamped_idle_start != idle_start:
+                        logger.info(
+                            "idle_start %s clamped to last wake %s — post-suspend idle "
+                            "must not reach back across the sleep",
+                            idle_start.isoformat(),
+                            clamped_idle_start.isoformat(),
+                        )
+                    idle_start = clamped_idle_start
                     logger.info(
                         f"User idle for {int(afk_duration)}s (>= {self._idle_pause_threshold}s) "
                         f"- backing off sync to {self._IDLE_SYNC_INTERVAL}s"

--- a/src/main.py
+++ b/src/main.py
@@ -313,6 +313,15 @@ class SyncCoordinator:
     def flush_idle_event(self) -> None:
         self.idle_mgr.flush_idle_event()
 
+    def record_wake(self, wake_ts: Optional[datetime] = None) -> None:
+        """Anchor idle detection to a fresh system-wake instant.
+
+        Called by SystemEventHandler.on_system_wake so a post-wake idle
+        pause can never backdate its idle_start before this timestamp.
+        See IdleManager.record_wake for the full rationale.
+        """
+        self.idle_mgr.record_wake(wake_ts)
+
     def start(self) -> None:
         """Start the scheduler and queue startup work without blocking UI."""
         # BackgroundScheduler.shutdown() is terminal -- create a fresh one

--- a/src/system_event_handler.py
+++ b/src/system_event_handler.py
@@ -103,6 +103,13 @@ class SystemEventHandler:
         except ImportError:
             from ui.tray import TrayState
 
+        # Anchor idle detection to this wake instant BEFORE anything else
+        # runs. bf-idle-tracker resumes heartbeating its pre-suspend 'afk'
+        # event on wake without resetting its start time, so the next
+        # check_idle_status() would otherwise backdate idle_start to the
+        # last keystroke before the lid closed and re-carve real work time
+        # across the suspend. See IdleManager.record_wake.
+        self.coordinator.record_wake()
         self.bf.reset_session()
         self.aw.reset_session()
         # Emit the sleep_time event before any early-return paths so even

--- a/tests/test_idle_manager.py
+++ b/tests/test_idle_manager.py
@@ -369,6 +369,162 @@ def test_afk_event_with_none_duration_falls_back_not_crash():
     sysidle.assert_called()
 
 
+def test_idle_start_clamped_to_wake_after_suspend():
+    """The suspend-carving bug: bf-idle-tracker resumes heartbeating its
+    pre-suspend 'afk' event on wake WITHOUT resetting its start time, so the
+    "current" AFK event's timestamp is a keystroke from BEFORE the lid
+    closed even though its duration now reaches ~now. Pre-fix, check_idle_
+    status backdates idle_start to that pre-suspend timestamp; the idle_time
+    event sent on resume then reaches back across the suspend and re-carves
+    real work the user logged before closing the lid.
+
+    Fix: record_wake() anchors the wake instant; idle_start must clamp to it.
+    """
+    now = datetime.now(timezone.utc)
+    wake_ts = now - timedelta(minutes=2)  # woke 2 minutes ago
+    pre_suspend_keystroke = now - timedelta(hours=3)  # last input before lid close
+
+    # AFK event "current" (heartbeating through to ~now) but anchored to the
+    # pre-suspend keystroke — exactly what a resumed tracker reports.
+    afk_event = types.SimpleNamespace(
+        status="afk",
+        duration=(now - pre_suspend_keystroke).total_seconds(),
+        timestamp=pre_suspend_keystroke,
+    )
+    idle_mgr, reschedule, trigger_sync, tray = _make_with_afk_event(afk_event)
+    idle_mgr.record_wake(wake_ts)
+
+    idle_mgr.check_idle_status(
+        logged_in=True,
+        is_on_break=False,
+        reschedule=reschedule,
+        trigger_sync=trigger_sync,
+    )
+
+    assert idle_mgr.idle_paused is True
+    assert idle_mgr._idle_start is not None
+    assert idle_mgr._idle_start >= wake_ts, (
+        "idle_start must never reach back before the recorded wake instant"
+    )
+    assert idle_mgr._idle_start != pre_suspend_keystroke, (
+        "idle_start must not stay pinned to the pre-suspend keystroke"
+    )
+
+
+def test_idle_start_clamped_to_wake_via_os_idle_clock_fallback():
+    """Same suspend-carving risk on the OS-idle-clock fallback path (Windows/
+    no in-process watcher scenario, or a stale-AFK fallback): the OS idle
+    clock can also report elapsed time stretching back before a suspend.
+    idle_start must still clamp to the last recorded wake."""
+    now = datetime.now(timezone.utc)
+    wake_ts = now - timedelta(minutes=1)
+    # No AFK bucket signal at all -> falls back to the OS idle clock, which
+    # (pre-fix) would compute idle_start = now - system_idle, reaching back
+    # to well before the wake.
+    idle_mgr, reschedule, trigger_sync, tray = _make_with_afk_event(None)
+    idle_mgr.aw.get_latest_afk_event.return_value = None
+    idle_mgr.record_wake(wake_ts)
+
+    system_idle_seconds = 3 * 3600.0  # 3h "idle" per OS clock, from before sleep
+    with patch.object(
+        IdleManager, "_get_system_idle_seconds", return_value=system_idle_seconds
+    ):
+        idle_mgr.check_idle_status(
+            logged_in=True,
+            is_on_break=False,
+            reschedule=reschedule,
+            trigger_sync=trigger_sync,
+        )
+
+    assert idle_mgr.idle_paused is True
+    assert idle_mgr._idle_start >= wake_ts, (
+        "OS-idle-clock-derived idle_start must also clamp to the last wake"
+    )
+
+
+def test_at_desk_idle_unchanged_without_a_wake_recorded():
+    """Control: no suspend/wake happened (record_wake never called) — idle_start
+    is exactly the AFK event's own timestamp, unclamped, as before this fix."""
+    now = datetime.now(timezone.utc)
+    afk_start = now - timedelta(minutes=25)
+    afk_event = types.SimpleNamespace(
+        status="afk",
+        duration=25 * 60.0,
+        timestamp=afk_start,
+    )
+    idle_mgr, reschedule, trigger_sync, tray = _make_with_afk_event(afk_event)
+    assert idle_mgr._last_wake_ts is None  # no wake recorded this session
+
+    idle_mgr.check_idle_status(
+        logged_in=True,
+        is_on_break=False,
+        reschedule=reschedule,
+        trigger_sync=trigger_sync,
+    )
+
+    assert idle_mgr.idle_paused is True
+    assert idle_mgr._idle_start == afk_start, (
+        "at-desk idle with no intervening suspend must be unaffected by the clamp"
+    )
+
+
+def test_at_desk_idle_unchanged_when_idle_start_is_after_an_old_wake():
+    """A wake recorded much earlier in the session must not distort a later,
+    unrelated at-desk idle stretch — the clamp is a max(), a no-op once
+    idle_start already falls after the last wake."""
+    now = datetime.now(timezone.utc)
+    old_wake = now - timedelta(hours=5)  # woke up 5h ago, long since active
+    afk_start = now - timedelta(minutes=25)  # genuine idle stretch, much later
+    afk_event = types.SimpleNamespace(
+        status="afk",
+        duration=25 * 60.0,
+        timestamp=afk_start,
+    )
+    idle_mgr, reschedule, trigger_sync, tray = _make_with_afk_event(afk_event)
+    idle_mgr.record_wake(old_wake)
+
+    idle_mgr.check_idle_status(
+        logged_in=True,
+        is_on_break=False,
+        reschedule=reschedule,
+        trigger_sync=trigger_sync,
+    )
+
+    assert idle_mgr.idle_paused is True
+    assert idle_mgr._idle_start == afk_start, (
+        "idle_start already after the last wake must pass through unclamped"
+    )
+
+
+def test_clamped_idle_start_is_what_gets_sent_on_resume():
+    """End-to-end: the idle_time event actually emitted to the server (via
+    clear_idle_pause -> send_idle_event) carries the CLAMPED start, not the
+    pre-suspend keystroke — this is the payroll-facing half of the fix."""
+    now = datetime.now(timezone.utc)
+    wake_ts = now - timedelta(minutes=2)
+    pre_suspend_keystroke = now - timedelta(hours=3)
+    afk_event = types.SimpleNamespace(
+        status="afk",
+        duration=(now - pre_suspend_keystroke).total_seconds(),
+        timestamp=pre_suspend_keystroke,
+    )
+    idle_mgr, reschedule, trigger_sync, tray = _make_with_afk_event(afk_event)
+    idle_mgr.record_wake(wake_ts)
+
+    idle_mgr.check_idle_status(
+        logged_in=True,
+        is_on_break=False,
+        reschedule=reschedule,
+        trigger_sync=trigger_sync,
+    )
+    idle_mgr.clear_idle_pause(send_event=True)
+
+    idle_mgr.sync_engine.send_idle_event.assert_called_once()
+    sent_start = idle_mgr.sync_engine.send_idle_event.call_args[0][0]
+    assert sent_start >= wake_ts
+    assert sent_start != pre_suspend_keystroke
+
+
 def test_stale_afk_with_no_os_idle_signal_does_not_pause():
     """Stale AFK + no OS idle clock (Linux, or a Windows API failure -> None):
     is_afk stays False and the user is not paused. Guards the None-fallback

--- a/tests/test_sync_engine.py
+++ b/tests/test_sync_engine.py
@@ -1822,6 +1822,21 @@ class TestSystemSleepWakeEmitsSleepSpan:
 
         sync_engine.set_private_mode.assert_not_called()
 
+    def test_wake_records_wake_time_on_coordinator_before_resume(self):
+        """on_system_wake must anchor idle detection to this wake instant.
+
+        Without this the idle subsystem has no wake awareness: bf-idle-tracker
+        resumes heartbeating its pre-suspend 'afk' event on wake, so the next
+        check_idle_status() would backdate idle_start to a keystroke before
+        the lid closed and re-carve real work time across the suspend. See
+        IdleManager.record_wake / _clamp_to_last_wake for the consuming side.
+        """
+        handler, sync_engine = self._make_handler()
+
+        handler.on_system_wake()
+
+        handler.coordinator.record_wake.assert_called_once()
+
 
 class TestSyncCoordinatorBreak:
     """Tests for SyncCoordinator break state management."""


### PR DESCRIPTION
## Summary
- Payroll-affecting bug: on laptop wake, `bf-idle-tracker` resumes heartbeating its pre-suspend `afk` event without resetting the event's start timestamp. `IdleManager.check_idle_status` then backdated `idle_start` to that pre-suspend keystroke, so the `idle_time` event sent on resume reached back across the suspend and re-carved real work time the user logged before closing the lid — undoing the server-side sleep-time grace bridge (fixed in a companion server-side PR).
- `sleep_time` emission itself (`system_event_handler.py` `on_system_sleep`/`on_system_wake`) was already correct and is untouched.
- Fix: `IdleManager` now tracks the most recent wake instant via a new `record_wake()` method, wired from `SystemEventHandler.on_system_wake` (`coordinator.record_wake()`) through a `SyncCoordinator` delegate. Every `idle_start` computed in `check_idle_status` — both the AFK-event path and the OS-idle-clock fallback path — is clamped through `_clamp_to_last_wake()` before being stored/sent, so it can never predate the last recorded wake. At-desk idle with no intervening suspend is unaffected (the clamp is a no-op `max()`).
- **Deferred as a follow-up** (not in this PR): the ~30s in-proc AFK tail dropped by `sync_engine.pause()`'s `_advance_checkpoints_to_now("pause")` on sleep entry. `pause()` is shared by multiple call sites (screen lock, network offline, private mode) and a synchronous flush from the sleep handler risks not completing before the OS actually suspends — needs its own careful design.

## Test plan
- [x] Added 5 new tests to `tests/test_idle_manager.py`: clamp on the AFK-event path, clamp on the OS-idle-clock fallback path, at-desk idle unaffected with no wake recorded, at-desk idle unaffected when an old wake predates the idle stretch, and an end-to-end check that the *clamped* start is what actually gets sent via `send_idle_event`.
- [x] Added 1 new test to `tests/test_sync_engine.py` (`TestSystemSleepWakeEmitsSleepSpan`) proving `on_system_wake` calls `coordinator.record_wake()`.
- [x] Proof-of-failure: reverted `src/idle_manager.py`, `src/main.py`, `src/system_event_handler.py` to pre-fix (`HEAD~1`) with the new tests kept — all 6 new tests failed (`AttributeError: 'IdleManager' object has no attribute 'record_wake'`, and the coordinator wiring assertion). Restored the fix — all tests pass again.
- [x] Full suite: `python3 -m pytest tests/ -q` → **964 passed**, no regressions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)