### PR TITLE
fix(capture): senior audit of working-hours suppression (3 rounds)

### DIFF
--- a/src/auth/config_access.py
+++ b/src/auth/config_access.py
@@ -1,11 +1,27 @@
 """Minimal config directory access to avoid circular imports with config.py."""
 
 from pathlib import Path
-from platformdirs import user_config_dir
-
-APP_NAME = "BetterFlow"
-APP_AUTHOR = "BetterQA"
 
 
 def get_config_dir() -> Path:
-    return Path(user_config_dir(APP_NAME, APP_AUTHOR))
+    """Return the config directory, delegating to ``Config.get_config_dir()``.
+
+    This is the ONLY platformdirs-backed config-dir reader outside ``config.py``,
+    and it deliberately does not call ``platformdirs.user_config_dir`` itself.
+    Delegating keeps a single source of truth and — critically — means test
+    isolation is automatic: ``tests/conftest.py`` monkeypatches
+    ``Config.get_config_dir`` for the whole session, so a test that exercises a
+    real ``KeychainManager`` (which reads this via ``_legacy_credentials_file``)
+    is redirected to the temp dir instead of the developer's real
+    ``~/Library/.../BetterFlow/.credentials``.
+
+    ``Config`` is imported inside the function body, not at module top, because
+    this module exists to avoid the circular import that a top-level
+    ``from ..config import Config`` would risk. By call time ``config`` is fully
+    loaded, so the deferred import resolves cleanly.
+    """
+    try:
+        from ..config import Config
+    except ImportError:
+        from config import Config
+    return Config.get_config_dir()

--- a/src/config.py
+++ b/src/config.py
@@ -610,6 +610,14 @@ class WorkingHoursConfig:
         tz = _resolve_schedule_tz(self.timezone)
         local = start.astimezone(tz) if tz else start.astimezone()
         end_h, end_m = (int(p) for p in self.work_end.split(":"))
+        # NB: this clamps to work_end:00 exactly, which is ONE MINUTE EARLIER than
+        # the instant allows() stops permitting recording. allows() compares HH:MM
+        # strings inclusively (`hhmm <= work_end`), so it stays True through
+        # work_end:59 and only flips False at work_end+1 min — and
+        # next_boundary_after() mirrors that inclusive edge. window_close_after()
+        # deliberately does NOT mirror it: clamping a span slightly earlier can only
+        # discard in-window data, never leak the minute after close, so the
+        # one-minute disagreement is the safe direction and intentional.
         close = local.replace(hour=end_h, minute=end_m, second=0, microsecond=0)
 
         # For an overnight window the close belongs to the NEXT local day whenever

--- a/src/config.py
+++ b/src/config.py
@@ -619,6 +619,40 @@ class WorkingHoursConfig:
 
         return close.astimezone(timezone.utc)
 
+    def next_boundary_after(self, when: "datetime") -> "Optional[datetime]":
+        """The next UTC instant strictly after ``when`` at which ``allows()`` flips.
+
+        Used to arm a one-shot capture stop/start EXACTLY at the window edge rather
+        than waiting up to a full 60s enforcement tick — sync() already stops
+        uploading at the boundary via a live now() read, but local recording had a
+        tail of up to a tick past e.g. 22:00.
+
+        Returns None when the schedule has no boundaries — an unknown schedule
+        (``allows`` is always False) or an unrestricted one (always True). In both
+        cases there is nothing for a one-shot trigger to align to.
+
+        Computed by walking allows() at minute resolution (its own granularity —
+        work_start/work_end are HH:MM and seconds are ignored), so the boundary is
+        by construction consistent with the suppression and upload gates that read
+        the same allows(). Capped at 8 days so a degenerate schedule (e.g. a
+        hand-edited empty working_days, where allows() is always False) yields None
+        instead of looping.
+        """
+        if not self.known or not self.enforced:
+            return None
+
+        current = self.allows(when)
+        # Boundaries land on HH:MM:00 in the schedule's zone; stepping in UTC by
+        # whole minutes from the next minute still lands on every local flip
+        # (including across a DST change, which only shifts the wall-clock offset).
+        probe = when.astimezone(timezone.utc).replace(second=0, microsecond=0) + timedelta(minutes=1)
+        limit = probe + timedelta(days=8)
+        while probe <= limit:
+            if self.allows(probe) != current:
+                return probe
+            probe += timedelta(minutes=1)
+        return None
+
 
 @dataclass
 class Config:

--- a/src/main.py
+++ b/src/main.py
@@ -13,6 +13,7 @@ from datetime import datetime, timedelta, timezone
 from pathlib import Path
 from typing import Any, Callable, Optional
 
+from apscheduler.jobstores.base import JobLookupError
 from apscheduler.schedulers.background import BackgroundScheduler
 from apscheduler.triggers.date import DateTrigger
 from apscheduler.triggers.interval import IntervalTrigger
@@ -409,6 +410,60 @@ class SyncCoordinator:
             id="startup_permissions",
             replace_existing=True,
         )
+
+        # Arm the one-shot boundary trigger so capture stops/starts exactly at the
+        # next work_start/work_end edge, not up to 60s late on the interval tick.
+        self._arm_capture_boundary()
+
+    def _arm_capture_boundary(self) -> None:
+        """Schedule a one-shot job at the next working-hours boundary.
+
+        The 60s tick converges capture toward the schedule, but only every 60s, so
+        a window that closes at 22:00 kept every in-process recorder running for up
+        to a full tick past the edge. sync() already stops UPLOADING at the exact
+        instant (a live now() read against the same allows()), so nothing leaves the
+        machine — but local RECORDING had a tail, which the enforcement docstrings
+        say must not happen. This lands the hard stop/start ON the boundary and
+        re-arms for the following one. Fleet-friendly: one extra wakeup per boundary
+        crossing, not a fast poll across the whole fleet.
+
+        Re-armed by _fire_capture_boundary after each edge, and by the app whenever
+        the schedule changes or first resolves (server config / system wake)."""
+        if self.apply_capture_policy is None or not self.scheduler.running:
+            return
+        try:
+            boundary = self.config.working_hours.next_boundary_after(
+                datetime.now(timezone.utc)
+            )
+        except Exception:
+            logger.exception("Failed to compute next working-hours boundary")
+            return
+        if boundary is None:
+            # Unknown or unrestricted schedule: allows() is constant, so there is no
+            # edge. Drop any boundary job left over from a previous restricted one.
+            try:
+                self.scheduler.remove_job("capture_boundary")
+            except JobLookupError:
+                pass
+            return
+        self.scheduler.add_job(
+            self._fire_capture_boundary,
+            trigger=DateTrigger(run_date=boundary),
+            id="capture_boundary",
+            replace_existing=True,
+        )
+        logger.info("Capture boundary armed for %s", boundary.isoformat())
+
+    def _fire_capture_boundary(self) -> None:
+        """One-shot boundary job: enforce the policy AT the edge, then re-arm.
+
+        Fail-closed: a re-arm failure can't wedge enforcement because the 60s tick
+        still runs the same policy as the backstop."""
+        try:
+            if self.apply_capture_policy is not None:
+                self.apply_capture_policy("boundary")
+        finally:
+            self._arm_capture_boundary()
 
     def stop(self, wait: bool = False) -> None:
         """Shut down the scheduler if running.
@@ -1298,24 +1353,34 @@ class SyncCoordinator:
                 if stats.errors:
                     for err in stats.errors:
                         logger.warning(f"Partial sync: {err}")
-                if self.queue.is_near_capacity():
-                    pct = int(self.queue.capacity_percent() * 100)
-                    self.tray.set_state(TrayState.QUEUE_WARNING, f"Queue {pct}% full")
-                    logger.warning(f"Offline queue at {pct}% capacity")
-                elif stats.events_queued > 0:
-                    self.tray.set_state(TrayState.QUEUED)
-                elif stats.capture_suppressed:
+                if stats.capture_suppressed:
                     # Outside the enforced window: nothing is being recorded, and the
                     # tray says so. Someone whose machine has stopped being watched is
                     # entitled to see that at a glance, without opening a menu — and
-                    # showing SYNCING here would be an outright lie.
+                    # showing SYNCING (or QUEUED) here would be an outright lie.
+                    #
+                    # Suppression is checked BEFORE the queue branches on purpose:
+                    # the offline queue keeps DRAINING while suppressed, so a user who
+                    # crosses into private hours with leftover backlog would otherwise
+                    # see "Queued" and miss the more important fact — nothing is being
+                    # recorded. Suppression wins; the residual drain is a tooltip
+                    # detail, not the headline state.
                     #
                     # Set from the STATS rather than by short-circuiting _do_sync,
                     # because sync() must still run while suppressed: it drains the
                     # offline queue and, crucially, it is where fetch_server_config()
                     # retries. Returning early here would recreate the lockout where an
                     # agent that never learned its schedule could never learn it.
-                    self.tray.set_state(TrayState.PRIVATE_HOURS, "Private hours — not recording")
+                    detail = "Private hours — not recording"
+                    if stats.events_queued > 0:
+                        detail = f"{detail} (draining {stats.events_queued} queued)"
+                    self.tray.set_state(TrayState.PRIVATE_HOURS, detail)
+                elif self.queue.is_near_capacity():
+                    pct = int(self.queue.capacity_percent() * 100)
+                    self.tray.set_state(TrayState.QUEUE_WARNING, f"Queue {pct}% full")
+                    logger.warning(f"Offline queue at {pct}% capacity")
+                elif stats.events_queued > 0:
+                    self.tray.set_state(TrayState.QUEUED)
                 else:
                     if is_idle:
                         self.tray.set_state(TrayState.PAUSED, "Idle")
@@ -2644,6 +2709,9 @@ class BetterFlowApp:
         # would otherwise come back with every recorder running and keep them up
         # until the next 60s tick noticed.
         self._apply_capture_policy("system wake")
+        # A wake can land on the far side of a boundary the sleeping process
+        # slept through — recompute the next edge from the new now().
+        self.coordinator._arm_capture_boundary()
         self.sys_events.on_system_wake()
 
     def _on_system_shutdown(self) -> None:
@@ -2712,6 +2780,9 @@ class BetterFlowApp:
         # this is the moment a restricted user's agent first learns it is
         # restricted, and it may already be outside their window.
         self._apply_capture_policy("server config")
+        # The schedule may have just changed or first resolved — re-align the
+        # one-shot boundary trigger to the new next edge.
+        self.coordinator._arm_capture_boundary()
 
     def _on_preferences(self, key: str, value) -> None:
         """Handle a preference change from tray menu."""

--- a/src/main.py
+++ b/src/main.py
@@ -437,6 +437,16 @@ class SyncCoordinator:
             )
         except Exception:
             logger.exception("Failed to compute next working-hours boundary")
+            # Drop any boundary job left armed from an EARLIER (successful)
+            # computation: it was scheduled against a now-superseded schedule and
+            # could otherwise fire at a stale instant. Leaving the 60s tick as the
+            # sole enforcement authority until the next successful arm is the
+            # fail-safe reading. (_fire_capture_boundary re-reads allows(now) live,
+            # so a stray fire is harmless today — but a stale job should not linger.)
+            try:
+                self.scheduler.remove_job("capture_boundary")
+            except JobLookupError:
+                pass
             return
         if boundary is None:
             # Unknown or unrestricted schedule: allows() is constant, so there is no
@@ -1353,6 +1363,19 @@ class SyncCoordinator:
                 if stats.errors:
                     for err in stats.errors:
                         logger.warning(f"Partial sync: {err}")
+                # Near-capacity is evaluated and LOGGED independently of which
+                # state wins the tray below. Suppression correctly owns the tray
+                # headline during private hours, but a backlog stuck near the cap
+                # overnight (e.g. the network is down while suppressed) still has to
+                # surface in fleet monitoring — folding the warning into the tray
+                # if/elif hid it whenever suppression won, losing that visibility.
+                near_capacity = self.queue.is_near_capacity()
+                capacity_pct = (
+                    int(self.queue.capacity_percent() * 100) if near_capacity else 0
+                )
+                if near_capacity:
+                    logger.warning(f"Offline queue at {capacity_pct}% capacity")
+
                 if stats.capture_suppressed:
                     # Outside the enforced window: nothing is being recorded, and the
                     # tray says so. Someone whose machine has stopped being watched is
@@ -1374,11 +1397,13 @@ class SyncCoordinator:
                     detail = "Private hours — not recording"
                     if stats.events_queued > 0:
                         detail = f"{detail} (draining {stats.events_queued} queued)"
+                    if near_capacity:
+                        detail = f"{detail} — queue {capacity_pct}% full"
                     self.tray.set_state(TrayState.PRIVATE_HOURS, detail)
-                elif self.queue.is_near_capacity():
-                    pct = int(self.queue.capacity_percent() * 100)
-                    self.tray.set_state(TrayState.QUEUE_WARNING, f"Queue {pct}% full")
-                    logger.warning(f"Offline queue at {pct}% capacity")
+                elif near_capacity:
+                    self.tray.set_state(
+                        TrayState.QUEUE_WARNING, f"Queue {capacity_pct}% full"
+                    )
                 elif stats.events_queued > 0:
                     self.tray.set_state(TrayState.QUEUED)
                 else:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -16,6 +16,7 @@ session, so no individual test has to remember to monkeypatch it.
 
 import pytest
 
+import src.config as config_module
 from src.config import Config
 
 
@@ -33,4 +34,18 @@ def _isolate_agent_config(tmp_path, monkeypatch):
     monkeypatch.setattr(
         Config, "get_config_file", classmethod(lambda cls: cfg_dir / "config.json")
     )
+
+    # Config's classmethods above are not the only readers of the real
+    # platformdirs location. get_machine_uuid() and _load_dotenv() call the
+    # module-level `user_config_dir` directly, bypassing Config — so a test that
+    # exercises them (e.g. exchange_code -> get_machine_uuid in test_bf_client)
+    # would read/write the developer's REAL ~/.../BetterFlow/.machine_id and leak
+    # the cached value across the session. Redirect the module-level function too,
+    # and clear the process-wide UUID cache before and after each test so no real
+    # machine id can bleed in or out.
+    monkeypatch.setattr(
+        config_module, "user_config_dir", lambda *a, **k: str(cfg_dir)
+    )
+    config_module._machine_uuid_cache = None
     yield
+    config_module._machine_uuid_cache = None

--- a/tests/test_capture_boundary.py
+++ b/tests/test_capture_boundary.py
@@ -1,0 +1,159 @@
+"""Working-hours boundary trigger — capture must stop/start AT the window edge.
+
+The 60s enforcement tick converged capture toward the schedule only every 60s, so a
+window closing at 22:00 kept every in-process recorder running for up to a full tick
+(plus scheduler jitter) past the boundary. sync() already stopped UPLOADING at the
+exact instant via a live now() read, so nothing left the machine — but local
+RECORDING had a tail, which the enforcement docstrings say must not happen.
+
+These tests pin the one-shot DateTrigger (SyncCoordinator._arm_capture_boundary /
+_fire_capture_boundary) that lands the hard stop/start ON the edge and re-arms for
+the next one, and the WorkingHoursConfig.next_boundary_after helper that computes it.
+"""
+
+from datetime import datetime, timezone
+from unittest.mock import Mock, patch
+
+import src.main as main
+from src.config import Config
+
+RESTRICTED = {
+    "working_hours": {
+        "enforced": True,
+        "work_start": "07:30",
+        "work_end": "22:00",
+        "working_days": [1, 2, 3, 4, 5],
+        "timezone": "Europe/Bucharest",
+    }
+}
+
+# 2026-07-13 is a Monday; Europe/Bucharest is UTC+3 (EEST) in July.
+IN_HOURS_UTC = datetime(2026, 7, 13, 18, 0, tzinfo=timezone.utc)        # 21:00 Bucharest
+# allows() is inclusive of 22:00, so it flips False at 22:01 Bucharest = 19:01 UTC.
+WINDOW_CLOSE_UTC = datetime(2026, 7, 13, 19, 1, tzinfo=timezone.utc)
+OUT_OF_HOURS_UTC = datetime(2026, 7, 13, 20, 55, tzinfo=timezone.utc)   # 23:55 Bucharest
+# Next open after that night: Tue 07:30 Bucharest = 04:30 UTC.
+NEXT_OPEN_UTC = datetime(2026, 7, 14, 4, 30, tzinfo=timezone.utc)
+
+
+def _wh(payload=RESTRICTED):
+    cfg = Config()
+    cfg.update_from_server(payload)
+    return cfg.working_hours
+
+
+class TestNextBoundaryAfter:
+    def test_window_close_is_the_next_boundary_from_inside_hours(self):
+        wh = _wh()
+        b = wh.next_boundary_after(IN_HOURS_UTC)
+        assert b == WINDOW_CLOSE_UTC
+        assert wh.allows(IN_HOURS_UTC) is True
+        assert wh.allows(b) is False  # capture must be OFF at (and past) the edge
+
+    def test_next_open_is_the_next_boundary_from_outside_hours(self):
+        wh = _wh()
+        b = wh.next_boundary_after(OUT_OF_HOURS_UTC)
+        assert b == NEXT_OPEN_UTC
+        assert wh.allows(OUT_OF_HOURS_UTC) is False
+        assert wh.allows(b) is True
+
+    def test_unknown_schedule_has_no_boundary(self):
+        # Fail-closed schedule: allows() is always False, so there is no edge.
+        assert Config().working_hours.next_boundary_after(IN_HOURS_UTC) is None
+
+    def test_unrestricted_schedule_has_no_boundary(self):
+        wh = _wh({"working_hours": {"enforced": False}})
+        assert wh.next_boundary_after(IN_HOURS_UTC) is None
+
+
+class _FakeScheduler:
+    """Records add/remove so the boundary job can be inspected without a real
+    APScheduler thread."""
+
+    def __init__(self, running=True):
+        self.running = running
+        self.jobs = {}
+        self.removed = []
+
+    def add_job(self, fn, trigger=None, id=None, replace_existing=False, **kw):
+        self.jobs[id] = {"fn": fn, "trigger": trigger}
+
+    def remove_job(self, id):
+        if id not in self.jobs:
+            raise main.JobLookupError(id)
+        del self.jobs[id]
+        self.removed.append(id)
+
+
+def _coordinator(cfg, running=True):
+    c = object.__new__(main.SyncCoordinator)
+    c.config = cfg
+    c.scheduler = _FakeScheduler(running=running)
+    c.apply_capture_policy = Mock()
+    return c
+
+
+def _restricted_cfg():
+    cfg = Config()
+    cfg.update_from_server(RESTRICTED)
+    return cfg
+
+
+class TestArmCaptureBoundary:
+    def test_boundary_is_armed_at_the_window_close_not_60s_later(self):
+        """THE fix: a one-shot job is scheduled at the EXACT window edge. Pre-fix
+        there is no boundary trigger at all, so capture only stopped whenever the
+        next 60s tick happened to fire — up to a full tick past 22:00."""
+        c = _coordinator(_restricted_cfg())
+
+        with patch("src.main.datetime") as dt:
+            dt.now.return_value = IN_HOURS_UTC
+            c._arm_capture_boundary()
+
+        assert "capture_boundary" in c.scheduler.jobs
+        trig = c.scheduler.jobs["capture_boundary"]["trigger"]
+        assert trig.run_date == WINDOW_CLOSE_UTC
+
+    def test_firing_the_boundary_applies_policy_and_re_arms(self):
+        c = _coordinator(_restricted_cfg())
+
+        # The job fires AT the window-close instant, so that is what now() reads.
+        with patch("src.main.datetime") as dt:
+            dt.now.return_value = WINDOW_CLOSE_UTC
+            c._fire_capture_boundary()
+
+        # Enforcement runs AT the edge, tagged so logs/telemetry can tell it apart.
+        c.apply_capture_policy.assert_called_once_with("boundary")
+        # ...and it re-arms for the following edge (the next window open).
+        assert "capture_boundary" in c.scheduler.jobs
+        assert c.scheduler.jobs["capture_boundary"]["trigger"].run_date == NEXT_OPEN_UTC
+
+    def test_unknown_schedule_arms_nothing_and_clears_a_stale_job(self):
+        c = _coordinator(Config())  # never talked to the server
+        c.scheduler.jobs["capture_boundary"] = {"fn": None, "trigger": None}  # stale
+
+        with patch("src.main.datetime") as dt:
+            dt.now.return_value = IN_HOURS_UTC
+            c._arm_capture_boundary()
+
+        assert "capture_boundary" not in c.scheduler.jobs
+        assert "capture_boundary" in c.scheduler.removed
+
+    def test_no_arming_when_policy_is_unwired(self):
+        c = _coordinator(_restricted_cfg())
+        c.apply_capture_policy = None
+
+        with patch("src.main.datetime") as dt:
+            dt.now.return_value = IN_HOURS_UTC
+            c._arm_capture_boundary()
+
+        assert "capture_boundary" not in c.scheduler.jobs
+
+    def test_no_arming_when_scheduler_stopped(self):
+        c = _coordinator(_restricted_cfg(), running=False)
+
+        with patch("src.main.datetime") as dt:
+            dt.now.return_value = IN_HOURS_UTC
+            c._arm_capture_boundary()
+
+        assert "capture_boundary" not in c.scheduler.jobs

--- a/tests/test_capture_boundary.py
+++ b/tests/test_capture_boundary.py
@@ -139,6 +139,24 @@ class TestArmCaptureBoundary:
         assert "capture_boundary" not in c.scheduler.jobs
         assert "capture_boundary" in c.scheduler.removed
 
+    def test_boundary_computation_error_clears_a_stale_job(self):
+        # next_boundary_after raises (e.g. schedule superseded mid-computation).
+        # A boundary job left armed from an EARLIER successful compute was scheduled
+        # against a now-stale instant; it must be dropped so the 60s tick is the sole
+        # enforcement authority until the next successful arm. No exception may escape.
+        c = _coordinator(_restricted_cfg())
+        c.config.working_hours.next_boundary_after = Mock(
+            side_effect=RuntimeError("schedule superseded")
+        )
+        c.scheduler.jobs["capture_boundary"] = {"fn": None, "trigger": None}  # stale
+
+        with patch("src.main.datetime") as dt:
+            dt.now.return_value = IN_HOURS_UTC
+            c._arm_capture_boundary()  # must NOT raise
+
+        assert "capture_boundary" not in c.scheduler.jobs
+        assert "capture_boundary" in c.scheduler.removed
+
     def test_no_arming_when_policy_is_unwired(self):
         c = _coordinator(_restricted_cfg())
         c.apply_capture_policy = None

--- a/tests/test_capture_suppression.py
+++ b/tests/test_capture_suppression.py
@@ -325,3 +325,45 @@ class TestSuppressionWinsOverQueueBacklog:
         # The residual drain is a secondary detail, not the headline state.
         detail = call.args[1] if len(call.args) > 1 else ""
         assert "5 queued" in detail
+
+    def test_near_capacity_still_logs_when_suppressed(self):
+        """Regression: after the round-1 reorder the near-capacity logger.warning
+        sat in an `elif` under the suppression branch, so a backlog stuck near the
+        cap during private hours (e.g. the network is down overnight) was never
+        logged — losing fleet-monitoring visibility. The warning must fire
+        independent of which state wins the tray. Suppression still wins the tray."""
+        from src.sync.sync_engine import SyncStats
+        from src.ui.tray import TrayState
+
+        stats = SyncStats()
+        stats.capture_suppressed = True
+        stats.events_queued = 900
+
+        c = self._coordinator(stats)
+        c.queue.is_near_capacity.return_value = True
+        c.queue.capacity_percent.return_value = 0.9  # 90% full
+
+        with patch("src.main.datetime") as dt, \
+             patch("src.main.logger") as log:
+            dt.now.return_value = OUT_OF_HOURS
+            c._do_sync()
+
+        # Suppression still owns the tray headline.
+        state = c.tray.set_state.call_args.args[0]
+        assert state == TrayState.PRIVATE_HOURS, (
+            f"suppression must still win the tray, got {state}"
+        )
+
+        # The near-capacity warning fired despite suppression winning the tray.
+        capacity_warnings = [
+            call for call in log.warning.call_args_list if "capacity" in str(call)
+        ]
+        assert capacity_warnings, (
+            "near-capacity backlog must still be logged while suppressed — "
+            "fleet monitoring depends on it"
+        )
+        assert "90%" in str(capacity_warnings[0])
+
+        # And the percentage is folded into the private-hours detail.
+        detail = c.tray.set_state.call_args.args[1]
+        assert "90%" in detail

--- a/tests/test_capture_suppression.py
+++ b/tests/test_capture_suppression.py
@@ -241,3 +241,87 @@ class TestTrayShowsPrivateHours:
             "_do_sync short-circuits on suppression — that skips the queue drain and "
             "the config re-fetch"
         )
+
+
+# 2026-07-13 is a Monday; Europe/Bucharest is UTC+3 (EEST) in July.
+OUT_OF_HOURS = datetime(2026, 7, 13, 20, 55, tzinfo=timezone.utc)  # 23:55 Bucharest
+
+
+class TestSuppressionWinsOverQueueBacklog:
+    """The offline queue keeps draining while suppressed, so a user who crosses into
+    private hours with a leftover backlog used to see 'Queued' instead of 'Private
+    hours — not recording'. Suppression is the more important fact and must win.
+
+    Drives the real _do_sync tray-state selection end-to-end (not a source grep), so
+    the ordering bug is observable in the state actually set on the tray."""
+
+    def _coordinator(self, stats):
+        import threading
+
+        import src.main as main
+
+        c = object.__new__(main.SyncCoordinator)
+        cfg = Config()
+        cfg.update_from_server(RESTRICTED)
+        c.config = cfg
+
+        lock = threading.Lock()
+        lock.acquire()
+        c._acquire_sync_slot = Mock(return_value=lock)
+        c._sync_takeover_lock = threading.Lock()
+        c._sync_holder = lock
+        c._sync_started_at = 0.0
+        c._DO_SYNC_DEADLINE = 60
+        c._state_lock = threading.Lock()
+        c._paused_by_network = False
+
+        c.error_reporter = None
+        c.bf = Mock()
+        c.aw = Mock()
+        c.aw.is_running.return_value = True
+        c.aw_manager = Mock()
+        c.aw_manager.is_managing = False
+        c.sync_engine = Mock()
+        c.sync_engine.is_private = False
+        c.sync_engine.sync.return_value = stats
+        c.sync_engine.send_heartbeat_if_due.return_value = None
+        c.break_mgr = Mock()
+        c.break_mgr.is_on_break = False
+        c.idle_mgr = Mock()
+        c.idle_mgr.idle_paused = False
+        c.queue = Mock()
+        c.queue.is_near_capacity.return_value = False
+        c.queue.size.return_value = 5
+        c.tray = Mock()
+        c._aw_unreachable_streak = 0
+        c._aw_buckets_failed_streak = 0
+        c._consecutive_sync_failures = 0
+        c._consecutive_auth_failures = 0
+        c._last_successful_sync = None
+        c._fetch_hours_today = Mock(return_value="1h 0m")
+        return c
+
+    def test_private_hours_wins_when_suppressed_and_queue_still_draining(self):
+        from src.sync.sync_engine import SyncStats
+        from src.ui.tray import TrayState
+
+        # Suppressed outside working hours, but a backlog is still draining.
+        stats = SyncStats()
+        stats.capture_suppressed = True
+        stats.events_queued = 5
+
+        c = self._coordinator(stats)
+
+        with patch("src.main.datetime") as dt:
+            dt.now.return_value = OUT_OF_HOURS
+            c._do_sync()
+
+        c.tray.set_state.assert_called_once()
+        call = c.tray.set_state.call_args
+        state = call.args[0]
+        assert state == TrayState.PRIVATE_HOURS, (
+            f"suppression must win over the queue backlog, got {state}"
+        )
+        # The residual drain is a secondary detail, not the headline state.
+        detail = call.args[1] if len(call.args) > 1 else ""
+        assert "5 queued" in detail

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -234,3 +234,30 @@ def test_foreground_enabled_is_not_persisted(tmp_path, monkeypatch):
     cfg_file.write_text(json.dumps(written))
     reloaded = Config._from_dict(json.loads(cfg_file.read_text()))
     assert reloaded.foreground_activity.enabled is False
+
+
+class TestMachineUuidIsIsolatedByConftest:
+    """Regression guard for the autouse conftest fixture.
+
+    get_machine_uuid() and _load_dotenv() call the module-level `user_config_dir`
+    directly, bypassing Config's get_config_dir/get_data_dir classmethods. Before
+    the fixture was extended, it patched only those classmethods — so a test that
+    triggered get_machine_uuid (several exchange_code paths in test_bf_client do)
+    read/wrote the developer's REAL ~/.../BetterFlow/.machine_id and leaked the
+    cached value across the session.
+
+    This test relies ONLY on the autouse fixture (no per-test monkeypatch), so it
+    fails if that module-level redirect is ever dropped again."""
+
+    def test_uuid_is_written_into_the_isolated_config_dir(self):
+        from src.config import Config, get_machine_uuid
+
+        result = get_machine_uuid()
+        uuid.UUID(result, version=4)  # must be a valid uuid4
+
+        machine_id_file = Config.get_config_dir() / ".machine_id"
+        assert machine_id_file.exists(), (
+            "get_machine_uuid wrote OUTSIDE the isolated temp config dir — the "
+            "conftest fixture is not redirecting module-level user_config_dir"
+        )
+        assert machine_id_file.read_text().strip() == result

--- a/tests/test_config_access_isolation.py
+++ b/tests/test_config_access_isolation.py
@@ -1,0 +1,41 @@
+"""Finding 1: config_access.get_config_dir() must be redirected by the autouse
+test-isolation fixture.
+
+`src/auth/config_access.py` used to have its OWN `platformdirs.user_config_dir()`
+reader — a 4th reader of the developer's real config dir that the conftest fixture
+(which only patches `Config.get_config_dir` / `src.config.user_config_dir`) did NOT
+cover. A test exercising a real `KeychainManager` (whose `_purge_legacy_file` /
+`_legacy_credentials_file` resolve through config_access) would therefore
+read/write the developer's real `~/Library/.../BetterFlow/.credentials` — the exact
+incident class the fixture claims to close.
+
+config_access now delegates to `Config.get_config_dir()`, so the fixture's existing
+patch covers it automatically. These tests pin that redirection.
+"""
+
+from src.auth import config_access
+from src.auth.keychain import _legacy_credentials_file
+from src.config import Config
+
+
+def test_config_access_get_config_dir_is_redirected(tmp_path):
+    """The autouse `_isolate_agent_config` fixture (tests/conftest.py) redirects
+    Config.get_config_dir() to tmp_path/"config"; config_access must follow it,
+    proving there is no longer an independent platformdirs reader here."""
+    got = config_access.get_config_dir()
+
+    # Single source of truth: it resolves to exactly what Config resolves to.
+    assert got == Config.get_config_dir()
+    # And that is the fixture's temp dir, never the developer's real home.
+    assert got == tmp_path / "config"
+    assert tmp_path in got.parents
+
+
+def test_legacy_credentials_path_lands_in_temp_dir(tmp_path):
+    """The concrete incident surface: keychain._legacy_credentials_file() (called by
+    _purge_legacy_file on every store()/delete()) must resolve under the temp dir,
+    not the real ~/.../BetterFlow/.credentials."""
+    legacy = _legacy_credentials_file()
+
+    assert legacy == tmp_path / "config" / ".credentials"
+    assert tmp_path in legacy.parents


### PR DESCRIPTION
Three rounds of senior review + fix over the recently-merged working-hours capture-suppression work (v1.5.97-1.5.99). The gate was already well-hardened; these close the residual gaps.

## Round 1
- **HIGH** — ~60s local-recording tail past the working-hours boundary: trackers were stopped only on the fixed 60s tick, not at the actual edge. Upload already stopped precisely, but local *recording* lagged. Added a boundary-aligned one-shot trigger (`next_boundary_after`) armed at the exact edge, re-armed on config + system-wake; 60s tick stays as backstop.
- **MEDIUM** — tray showed "Queued/Offline" instead of "Private hours" when backlog existed at the boundary (suppression now wins).
- **MEDIUM** — test-isolation fix was incomplete (a `platformdirs` reader bypassed it).

## Round 2
- **MEDIUM** — a 4th `platformdirs` reader (keychain) still wasn't isolated; resolved by making it delegate to the canonical config path.
- **MEDIUM** — the tray reorder silently dropped the near-capacity *log line* while suppressed (restored).
- Stale boundary-job cleared on the exception path.

## Round 3
- Round-2 fixes verified correct (boundary math confirmed DST-safe via UTC-instant stepping, race-free under the capture lock).
- Added the missing test for the exception-path stale-job removal.

Full suite **1088 passed**, each behavioral fix proven fail-before/pass-after.

Note: this app releases on a version tag, not on merge — merging this does not ship a build.

🤖 Generated with [Claude Code](https://claude.com/claude-code)