### PR TITLE
fix(capture): Fable-audit fixes — misfire-safe boundary re-arm, arm-path locking, tray detail

### DIFF
--- a/src/main.py
+++ b/src/main.py
@@ -214,6 +214,14 @@ class SyncCoordinator:
         self._paused_by_network = False
         self._state_lock = threading.Lock()
         self._sync_lock = threading.Lock()
+        # Serialises the capture-boundary arm path. arm_capture_boundary() is called
+        # from three threads — the boundary worker (re-arm), the sync thread
+        # (fetch_server_config → _on_config_updated), and the wake handler — and its
+        # compute → remove_job → add_job sequence is non-atomic against the shared
+        # mutable config, so an interleaving could leave a restricted user with NO
+        # boundary job until the 30-min refetch. Mirrors _apply_capture_policy's
+        # _capture_lock, which guards this exact class of transition.
+        self._boundary_lock = threading.Lock()
         # Wedge self-recovery (Cristian Dragota / sync:67a77a43-787, 2026-06-25):
         # a _do_sync that hangs past the watchdog holds _sync_lock forever, so
         # every later cycle skips and sync freezes while the heartbeat keeps
@@ -413,9 +421,20 @@ class SyncCoordinator:
 
         # Arm the one-shot boundary trigger so capture stops/starts exactly at the
         # next work_start/work_end edge, not up to 60s late on the interval tick.
-        self._arm_capture_boundary()
+        self.arm_capture_boundary()
 
-    def _arm_capture_boundary(self) -> None:
+    def _disarm_capture_boundary(self) -> None:
+        """Remove the one-shot boundary job if one is armed. Idempotent — a missing
+        job is the normal case (unknown/unrestricted schedule) and not an error.
+
+        Extracted so the several remove/JobLookupError sites read the same. Callers
+        that need atomicity against a concurrent arm hold _boundary_lock themselves."""
+        try:
+            self.scheduler.remove_job("capture_boundary")
+        except JobLookupError:
+            pass
+
+    def arm_capture_boundary(self) -> None:
         """Schedule a one-shot job at the next working-hours boundary.
 
         The 60s tick converges capture toward the schedule, but only every 60s, so
@@ -427,42 +446,62 @@ class SyncCoordinator:
         re-arms for the following one. Fleet-friendly: one extra wakeup per boundary
         crossing, not a fast poll across the whole fleet.
 
-        Re-armed by _fire_capture_boundary after each edge, and by the app whenever
-        the schedule changes or first resolves (server config / system wake)."""
+        Public because BetterFlowApp re-arms across the object boundary (server
+        config / system wake). Re-armed by _fire_capture_boundary after each edge,
+        and self-healed by the 60s tick if a misfire discarded the job.
+
+        Thread-safe: the compute → remove → add sequence runs under _boundary_lock
+        because three threads call this (boundary worker, sync thread, wake handler)
+        and an interleaving could otherwise leave a restricted user with no armed
+        boundary until the 30-min refetch."""
         if self.apply_capture_policy is None or not self.scheduler.running:
             return
-        try:
-            boundary = self.config.working_hours.next_boundary_after(
-                datetime.now(timezone.utc)
-            )
-        except Exception:
-            logger.exception("Failed to compute next working-hours boundary")
-            # Drop any boundary job left armed from an EARLIER (successful)
-            # computation: it was scheduled against a now-superseded schedule and
-            # could otherwise fire at a stale instant. Leaving the 60s tick as the
-            # sole enforcement authority until the next successful arm is the
-            # fail-safe reading. (_fire_capture_boundary re-reads allows(now) live,
-            # so a stray fire is harmless today — but a stale job should not linger.)
+        with self._boundary_lock:
             try:
-                self.scheduler.remove_job("capture_boundary")
-            except JobLookupError:
-                pass
-            return
-        if boundary is None:
-            # Unknown or unrestricted schedule: allows() is constant, so there is no
-            # edge. Drop any boundary job left over from a previous restricted one.
+                boundary = self.config.working_hours.next_boundary_after(
+                    datetime.now(timezone.utc)
+                )
+            except Exception:
+                logger.exception("Failed to compute next working-hours boundary")
+                # Drop any boundary job left armed from an EARLIER (successful)
+                # computation: it was scheduled against a now-superseded schedule and
+                # could otherwise fire at a stale instant. Leaving the 60s tick as the
+                # sole enforcement authority until the next successful arm is the
+                # fail-safe reading. (_fire_capture_boundary re-reads allows(now) live,
+                # so a stray fire is harmless — but a stale job should not linger.)
+                self._disarm_capture_boundary()
+                return
             try:
-                self.scheduler.remove_job("capture_boundary")
-            except JobLookupError:
-                pass
-            return
-        self.scheduler.add_job(
-            self._fire_capture_boundary,
-            trigger=DateTrigger(run_date=boundary),
-            id="capture_boundary",
-            replace_existing=True,
-        )
-        logger.info("Capture boundary armed for %s", boundary.isoformat())
+                if boundary is None:
+                    # Unknown or unrestricted schedule: allows() is constant, so there
+                    # is no edge. Drop any job left over from a previous restricted one.
+                    self._disarm_capture_boundary()
+                    return
+                self.scheduler.add_job(
+                    self._fire_capture_boundary,
+                    trigger=DateTrigger(run_date=boundary),
+                    id="capture_boundary",
+                    replace_existing=True,
+                    # Default misfire_grace_time=1 makes APScheduler DISCARD this
+                    # one-shot if the process stalls >1s across the run date (a GIL
+                    # pause, App Nap, a missed wake) — it logs once and never fires,
+                    # so _fire_capture_boundary's finally never runs and the boundary
+                    # stays disarmed until the next config refetch (30 min online,
+                    # unbounded offline), silently reverting to the ~60s recording
+                    # tail this job exists to kill. None = "fire however late"; a late
+                    # fire is safe because _fire_capture_boundary re-reads allows(now)
+                    # live. The 60s tick self-heal is the second backstop.
+                    misfire_grace_time=None,
+                )
+                logger.info("Capture boundary armed for %s", boundary.isoformat())
+            except Exception:
+                # The remove/add is now inside the try too: the scheduler can be shut
+                # down between the .running check above and here (a real TOCTOU), or a
+                # jobstore op can fail. Such an exception must NOT escape — it would
+                # land in _fire_capture_boundary's finally (killing re-arm) and in
+                # _on_config_updated → fetch_server_config (whose except only catches
+                # auth/client errors). Log and return; the 60s tick re-arms.
+                logger.exception("Failed to arm capture boundary")
 
     def _fire_capture_boundary(self) -> None:
         """One-shot boundary job: enforce the policy AT the edge, then re-arm.
@@ -473,7 +512,23 @@ class SyncCoordinator:
             if self.apply_capture_policy is not None:
                 self.apply_capture_policy("boundary")
         finally:
-            self._arm_capture_boundary()
+            self.arm_capture_boundary()
+
+    def _self_heal_capture_boundary(self) -> None:
+        """60s-tick backstop for a boundary job APScheduler discarded on a misfire
+        (a >1s stall across the run date). If the schedule is restricted (an edge
+        exists to align to) but no boundary job is armed, re-arm it. arm is
+        idempotent (replace_existing), so racing a concurrent arm is harmless."""
+        if self.apply_capture_policy is None or not self.scheduler.running:
+            return
+        wh = self.config.working_hours
+        # "Restricted" ⟺ next_boundary_after would return a boundary ⟺ known+enforced
+        # (unknown/unrestricted schedules have no edge and legitimately arm nothing).
+        if not (wh.known and wh.enforced):
+            return
+        if self.scheduler.get_job("capture_boundary") is None:
+            logger.info("Capture boundary job missing — re-arming (60s self-heal)")
+            self.arm_capture_boundary()
 
     def stop(self, wait: bool = False) -> None:
         """Shut down the scheduler if running.
@@ -989,6 +1044,10 @@ class SyncCoordinator:
             # First: a window that closed while the app was running must stop
             # capture promptly, before any sub-task below reads from the trackers.
             (self.apply_capture_policy, "capture_policy"),
+            # Re-arm the one-shot boundary if a misfire discarded it (see
+            # _self_heal_capture_boundary). Runs right after the policy so a healed
+            # boundary re-aligns before the tick's other trackers read state.
+            (self._self_heal_capture_boundary, "boundary_selfheal"),
             (self._reconcile_inproc_afk_flag, "inproc_afk_reconcile"),
             (self.tray.tick_clock, "tick_clock"),
             (self._check_idle_status, "idle_check"),
@@ -1213,6 +1272,40 @@ class SyncCoordinator:
             self._sync_holder = fresh
             return fresh
 
+    def _select_tray_state(
+        self,
+        stats,
+        near_capacity: bool,
+        capacity_pct: int,
+        is_idle: bool,
+        queue_size: int,
+    ) -> "tuple[TrayState, Optional[str]]":
+        """Pure decision for the post-sync tray headline — no side effects, so the
+        precedence is unit-testable without driving a whole sync. The caller applies
+        the result via tray.set_state (None detail is equivalent to omitting it).
+
+        Precedence: suppression > near-capacity > queued > idle > syncing.
+
+        Suppression wins on purpose: the offline queue keeps DRAINING while
+        suppressed, so a user who crosses into private hours with leftover backlog
+        must still see the headline fact (nothing is being recorded), with the drain
+        as a tooltip detail. The drain count is queue_size — the ACTUAL queue depth —
+        NOT stats.events_queued, which only counts events (re)queued THIS cycle."""
+        if stats.capture_suppressed:
+            detail = "Private hours — not recording"
+            if stats.events_queued > 0:
+                detail = f"{detail} (draining {queue_size} queued)"
+            if near_capacity:
+                detail = f"{detail} — queue {capacity_pct}% full"
+            return TrayState.PRIVATE_HOURS, detail
+        if near_capacity:
+            return TrayState.QUEUE_WARNING, f"Queue {capacity_pct}% full"
+        if stats.events_queued > 0:
+            return TrayState.QUEUED, None
+        if is_idle:
+            return TrayState.PAUSED, "Idle"
+        return TrayState.SYNCING, None
+
     def _do_sync(self) -> None:
         """Perform a sync cycle."""
         my_lock = self._acquire_sync_slot()
@@ -1376,41 +1469,12 @@ class SyncCoordinator:
                 if near_capacity:
                     logger.warning(f"Offline queue at {capacity_pct}% capacity")
 
-                if stats.capture_suppressed:
-                    # Outside the enforced window: nothing is being recorded, and the
-                    # tray says so. Someone whose machine has stopped being watched is
-                    # entitled to see that at a glance, without opening a menu — and
-                    # showing SYNCING (or QUEUED) here would be an outright lie.
-                    #
-                    # Suppression is checked BEFORE the queue branches on purpose:
-                    # the offline queue keeps DRAINING while suppressed, so a user who
-                    # crosses into private hours with leftover backlog would otherwise
-                    # see "Queued" and miss the more important fact — nothing is being
-                    # recorded. Suppression wins; the residual drain is a tooltip
-                    # detail, not the headline state.
-                    #
-                    # Set from the STATS rather than by short-circuiting _do_sync,
-                    # because sync() must still run while suppressed: it drains the
-                    # offline queue and, crucially, it is where fetch_server_config()
-                    # retries. Returning early here would recreate the lockout where an
-                    # agent that never learned its schedule could never learn it.
-                    detail = "Private hours — not recording"
-                    if stats.events_queued > 0:
-                        detail = f"{detail} (draining {stats.events_queued} queued)"
-                    if near_capacity:
-                        detail = f"{detail} — queue {capacity_pct}% full"
-                    self.tray.set_state(TrayState.PRIVATE_HOURS, detail)
-                elif near_capacity:
-                    self.tray.set_state(
-                        TrayState.QUEUE_WARNING, f"Queue {capacity_pct}% full"
-                    )
-                elif stats.events_queued > 0:
-                    self.tray.set_state(TrayState.QUEUED)
-                else:
-                    if is_idle:
-                        self.tray.set_state(TrayState.PAUSED, "Idle")
-                    else:
-                        self.tray.set_state(TrayState.SYNCING)
+                state, detail = self._select_tray_state(
+                    stats, near_capacity, capacity_pct, is_idle, self.queue.size()
+                )
+                # set_state(state, None) is identical to set_state(state), so passing
+                # the (possibly None) detail through preserves the prior behaviour.
+                self.tray.set_state(state, detail)
                 if stats.events_sent > 0:
                     logger.info(f"Sync complete: {stats.events_sent} events synced")
             else:
@@ -2736,7 +2800,7 @@ class BetterFlowApp:
         self._apply_capture_policy("system wake")
         # A wake can land on the far side of a boundary the sleeping process
         # slept through — recompute the next edge from the new now().
-        self.coordinator._arm_capture_boundary()
+        self.coordinator.arm_capture_boundary()
         self.sys_events.on_system_wake()
 
     def _on_system_shutdown(self) -> None:
@@ -2807,7 +2871,7 @@ class BetterFlowApp:
         self._apply_capture_policy("server config")
         # The schedule may have just changed or first resolved — re-align the
         # one-shot boundary trigger to the new next edge.
-        self.coordinator._arm_capture_boundary()
+        self.coordinator.arm_capture_boundary()
 
     def _on_preferences(self, key: str, value) -> None:
         """Handle a preference change from tray menu."""

--- a/tests/test_capture_boundary.py
+++ b/tests/test_capture_boundary.py
@@ -6,12 +6,13 @@ window closing at 22:00 kept every in-process recorder running for up to a full 
 exact instant via a live now() read, so nothing left the machine — but local
 RECORDING had a tail, which the enforcement docstrings say must not happen.
 
-These tests pin the one-shot DateTrigger (SyncCoordinator._arm_capture_boundary /
+These tests pin the one-shot DateTrigger (SyncCoordinator.arm_capture_boundary /
 _fire_capture_boundary) that lands the hard stop/start ON the edge and re-arms for
 the next one, and the WorkingHoursConfig.next_boundary_after helper that computes it.
 """
 
-from datetime import datetime, timezone
+import threading
+from datetime import datetime, timedelta, timezone
 from unittest.mock import Mock, patch
 
 import src.main as main
@@ -76,7 +77,7 @@ class _FakeScheduler:
         self.removed = []
 
     def add_job(self, fn, trigger=None, id=None, replace_existing=False, **kw):
-        self.jobs[id] = {"fn": fn, "trigger": trigger}
+        self.jobs[id] = {"fn": fn, "trigger": trigger, "kwargs": kw}
 
     def remove_job(self, id):
         if id not in self.jobs:
@@ -84,12 +85,16 @@ class _FakeScheduler:
         del self.jobs[id]
         self.removed.append(id)
 
+    def get_job(self, id):
+        return self.jobs.get(id)
+
 
 def _coordinator(cfg, running=True):
     c = object.__new__(main.SyncCoordinator)
     c.config = cfg
     c.scheduler = _FakeScheduler(running=running)
     c.apply_capture_policy = Mock()
+    c._boundary_lock = threading.Lock()
     return c
 
 
@@ -108,7 +113,7 @@ class TestArmCaptureBoundary:
 
         with patch("src.main.datetime") as dt:
             dt.now.return_value = IN_HOURS_UTC
-            c._arm_capture_boundary()
+            c.arm_capture_boundary()
 
         assert "capture_boundary" in c.scheduler.jobs
         trig = c.scheduler.jobs["capture_boundary"]["trigger"]
@@ -134,7 +139,7 @@ class TestArmCaptureBoundary:
 
         with patch("src.main.datetime") as dt:
             dt.now.return_value = IN_HOURS_UTC
-            c._arm_capture_boundary()
+            c.arm_capture_boundary()
 
         assert "capture_boundary" not in c.scheduler.jobs
         assert "capture_boundary" in c.scheduler.removed
@@ -152,7 +157,7 @@ class TestArmCaptureBoundary:
 
         with patch("src.main.datetime") as dt:
             dt.now.return_value = IN_HOURS_UTC
-            c._arm_capture_boundary()  # must NOT raise
+            c.arm_capture_boundary()  # must NOT raise
 
         assert "capture_boundary" not in c.scheduler.jobs
         assert "capture_boundary" in c.scheduler.removed
@@ -163,7 +168,7 @@ class TestArmCaptureBoundary:
 
         with patch("src.main.datetime") as dt:
             dt.now.return_value = IN_HOURS_UTC
-            c._arm_capture_boundary()
+            c.arm_capture_boundary()
 
         assert "capture_boundary" not in c.scheduler.jobs
 
@@ -172,6 +177,235 @@ class TestArmCaptureBoundary:
 
         with patch("src.main.datetime") as dt:
             dt.now.return_value = IN_HOURS_UTC
-            c._arm_capture_boundary()
+            c.arm_capture_boundary()
 
         assert "capture_boundary" not in c.scheduler.jobs
+
+
+class TestMisfireSafeArming:
+    """Finding 1 (HIGH): a >1s stall across the run date must NOT let APScheduler
+    silently DISCARD the one-shot (the default misfire_grace_time=1 does), because
+    the re-arm lives only in _fire_capture_boundary's finally — which never runs for
+    a discarded job."""
+
+    def test_boundary_add_job_uses_none_misfire_grace_time(self):
+        c = _coordinator(_restricted_cfg())
+
+        with patch("src.main.datetime") as dt:
+            dt.now.return_value = IN_HOURS_UTC
+            c.arm_capture_boundary()
+
+        # None = "fire however late"; a late fire is safe because
+        # _fire_capture_boundary re-reads allows(now) live at fire time.
+        assert c.scheduler.jobs["capture_boundary"]["kwargs"]["misfire_grace_time"] is None
+
+
+class TestBoundarySelfHeal:
+    """Finding 1: the 60s tick re-arms a boundary that a misfire discarded, so a
+    restricted user is never left with the recording tail until the next refetch."""
+
+    def test_tick_rearms_a_missing_boundary_when_restricted(self):
+        c = _coordinator(_restricted_cfg())
+        assert c.scheduler.get_job("capture_boundary") is None  # discarded by a misfire
+
+        with patch("src.main.datetime") as dt:
+            dt.now.return_value = IN_HOURS_UTC
+            c._self_heal_capture_boundary()
+
+        assert "capture_boundary" in c.scheduler.jobs
+        assert c.scheduler.jobs["capture_boundary"]["trigger"].run_date == WINDOW_CLOSE_UTC
+
+    def test_tick_leaves_an_already_armed_boundary_untouched(self):
+        c = _coordinator(_restricted_cfg())
+        sentinel = {"fn": None, "trigger": None}
+        c.scheduler.jobs["capture_boundary"] = sentinel
+
+        with patch("src.main.datetime") as dt:
+            dt.now.return_value = IN_HOURS_UTC
+            c._self_heal_capture_boundary()
+
+        # No re-arm churn when the job is present.
+        assert c.scheduler.jobs["capture_boundary"] is sentinel
+
+    def test_tick_arms_nothing_for_an_unrestricted_schedule(self):
+        cfg = Config()
+        cfg.update_from_server({"working_hours": {"enforced": False}})
+        c = _coordinator(cfg)
+
+        with patch("src.main.datetime") as dt:
+            dt.now.return_value = IN_HOURS_UTC
+            c._self_heal_capture_boundary()
+
+        assert "capture_boundary" not in c.scheduler.jobs
+
+    def test_tick_arms_nothing_for_an_unknown_schedule(self):
+        c = _coordinator(Config())  # never talked to the server → known=False
+
+        with patch("src.main.datetime") as dt:
+            dt.now.return_value = IN_HOURS_UTC
+            c._self_heal_capture_boundary()
+
+        assert "capture_boundary" not in c.scheduler.jobs
+
+
+class TestArmPathIsFailSafe:
+    """Finding 3 (MEDIUM): the remove/add now sits INSIDE the try. A scheduler shut
+    down between the .running check and the add (a real TOCTOU) — or a jobstore
+    error — must be swallowed, not escape into _fire_capture_boundary's finally
+    (which would kill re-arm) or into fetch_server_config (whose except only catches
+    auth/client errors)."""
+
+    def test_add_job_failure_does_not_escape(self):
+        c = _coordinator(_restricted_cfg())
+        c.scheduler.add_job = Mock(side_effect=RuntimeError("scheduler shut down"))
+
+        with patch("src.main.datetime") as dt:
+            dt.now.return_value = IN_HOURS_UTC
+            c.arm_capture_boundary()  # must NOT raise
+
+    def test_fire_boundary_rearm_failure_does_not_escape(self):
+        c = _coordinator(_restricted_cfg())
+        c.scheduler.add_job = Mock(side_effect=RuntimeError("boom"))
+
+        with patch("src.main.datetime") as dt:
+            dt.now.return_value = WINDOW_CLOSE_UTC
+            c._fire_capture_boundary()  # must NOT raise
+
+        # Enforcement at the edge still ran even though the re-arm failed.
+        c.apply_capture_policy.assert_called_once_with("boundary")
+
+
+class TestArmPathLocking:
+    """Finding 2 (MEDIUM): arm_capture_boundary is called from three threads (boundary
+    worker, sync thread via _on_config_updated, wake handler); its compute→remove→add
+    must run under _boundary_lock so an interleaving can't leave a restricted user with
+    no boundary job."""
+
+    def test_arm_body_runs_under_the_boundary_lock(self):
+        c = _coordinator(_restricted_cfg())
+        events = []
+
+        class TrackingLock:
+            def __enter__(self):
+                events.append("enter")
+                return self
+
+            def __exit__(self, *a):
+                events.append("exit")
+                return False
+
+        c._boundary_lock = TrackingLock()
+
+        # add_job must be observed WHILE the lock is held (between enter and exit).
+        def _record_add(*a, **kw):
+            events.append("add_job")
+
+        c.scheduler.add_job = _record_add
+
+        with patch("src.main.datetime") as dt:
+            dt.now.return_value = IN_HOURS_UTC
+            c.arm_capture_boundary()
+
+        assert events == ["enter", "add_job", "exit"]
+
+    def test_concurrent_arms_leave_a_boundary_armed(self):
+        # Hammer arm from several threads at once against a real lock; the invariant
+        # is that a restricted schedule ALWAYS ends with a boundary job present.
+        c = _coordinator(_restricted_cfg())
+
+        def _worker():
+            with patch("src.main.datetime") as dt:
+                dt.now.return_value = IN_HOURS_UTC
+                for _ in range(20):
+                    c.arm_capture_boundary()
+
+        threads = [threading.Thread(target=_worker) for _ in range(4)]
+        for t in threads:
+            t.start()
+        for t in threads:
+            t.join()
+
+        assert "capture_boundary" in c.scheduler.jobs
+
+
+OVERNIGHT = {
+    "working_hours": {
+        "enforced": True,
+        "work_start": "22:00",
+        "work_end": "06:00",
+        "working_days": [1, 2, 3, 4, 5],
+        "timezone": "Europe/Bucharest",
+    }
+}
+
+
+class TestBoundaryAcrossDstAndOvernight:
+    """Findings 5/6: the minute-walk boundary must land on the right UTC instant
+    across a Bucharest DST transition (the wall-clock edge holds; the offset moves)
+    and for an overnight (start > end) shift."""
+
+    def test_boundary_spans_bucharest_dst_fall_back(self):
+        # Fall-back is Sun 2026-10-25 (EEST UTC+3 → EET UTC+2). From a weekend instant
+        # before it, the next OPEN is Mon 2026-10-26 07:30 LOCAL — by then EET, so
+        # 05:30 UTC (not 04:30, which would be the pre-change offset).
+        wh = _wh()
+        when = datetime(2026, 10, 24, 12, 0, tzinfo=timezone.utc)  # Sat, outside hours
+        b = wh.next_boundary_after(when)
+        assert b == datetime(2026, 10, 26, 5, 30, tzinfo=timezone.utc)
+        assert wh.allows(b) is True
+        assert wh.allows(b - timedelta(minutes=1)) is False
+
+    def test_boundary_spans_bucharest_spring_forward(self):
+        # Spring-forward is Sun 2026-03-29 (EET UTC+2 → EEST UTC+3). Next open Mon
+        # 2026-03-30 07:30 LOCAL is EEST → 04:30 UTC.
+        wh = _wh()
+        when = datetime(2026, 3, 28, 12, 0, tzinfo=timezone.utc)  # Sat, outside hours
+        b = wh.next_boundary_after(when)
+        assert b == datetime(2026, 3, 30, 4, 30, tzinfo=timezone.utc)
+        assert wh.allows(b) is True
+        assert wh.allows(b - timedelta(minutes=1)) is False
+
+    def test_overnight_shift_close_boundary(self):
+        wh = _wh(OVERNIGHT)
+        # Tue 01:00 Bucharest (= the tail of Monday's 22:00–06:00 shift) = Mon 22:00 UTC.
+        mid = datetime(2026, 7, 13, 22, 0, tzinfo=timezone.utc)
+        assert wh.allows(mid) is True
+        b = wh.next_boundary_after(mid)
+        # allows is inclusive through 06:00, so it flips at 06:01 local = 03:01 UTC.
+        assert b == datetime(2026, 7, 14, 3, 1, tzinfo=timezone.utc)
+        assert wh.allows(b) is False
+
+    def test_overnight_shift_open_boundary(self):
+        wh = _wh(OVERNIGHT)
+        # Tue 12:00 Bucharest — the daylight gap between shifts = 09:00 UTC.
+        gap = datetime(2026, 7, 14, 9, 0, tzinfo=timezone.utc)
+        assert wh.allows(gap) is False
+        b = wh.next_boundary_after(gap)
+        # Next open: Tue 22:00 local = 19:00 UTC.
+        assert b == datetime(2026, 7, 14, 19, 0, tzinfo=timezone.utc)
+        assert wh.allows(b) is True
+
+
+class TestRealSchedulerMisfire:
+    """Finding 6/1: an integration proof against a REAL BackgroundScheduler that a
+    one-shot whose run_date is already in the past (a stall past the edge) STILL
+    fires with misfire_grace_time=None. Under the default grace=1 it is discarded."""
+
+    def test_near_past_run_date_still_fires_with_none_grace(self):
+        from apscheduler.schedulers.background import BackgroundScheduler
+        from apscheduler.triggers.date import DateTrigger
+
+        fired = threading.Event()
+        sched = BackgroundScheduler()
+        sched.start()
+        try:
+            run_date = datetime.now(timezone.utc) - timedelta(seconds=3)
+            sched.add_job(
+                fired.set,
+                trigger=DateTrigger(run_date=run_date),
+                id="capture_boundary",
+                misfire_grace_time=None,
+            )
+            assert fired.wait(timeout=5), "past-dated one-shot was discarded despite grace=None"
+        finally:
+            sched.shutdown(wait=False)

--- a/tests/test_capture_suppression.py
+++ b/tests/test_capture_suppression.py
@@ -225,21 +225,35 @@ class TestTrayShowsPrivateHours:
         assert STATE_COLORS[TrayState.PRIVATE_HOURS] != STATE_COLORS[TrayState.PAUSED]
 
     def test_sync_still_runs_while_suppressed(self):
-        """Guards the trap: the tray state is set from stats.capture_suppressed AFTER
-        sync() runs, never by short-circuiting _do_sync. sync() is where the offline
-        queue drains and where fetch_server_config() retries — skipping it would
-        recreate the lockout where an agent that never learned its schedule never can."""
+        """Guards the trap: the tray state is decided from stats.capture_suppressed
+        AFTER sync() runs, never by short-circuiting _do_sync. sync() is where the
+        offline queue drains and where fetch_server_config() retries — skipping it
+        would recreate the lockout where an agent that never learned its schedule
+        never can.
+
+        The decision now lives in the pure _select_tray_state helper, so the guard
+        splits across both: the helper reads stats.capture_suppressed, and _do_sync
+        must NOT short-circuit on suppression before sync()."""
         import inspect
 
         import src.main as main
 
-        src = inspect.getsource(main.SyncCoordinator._do_sync)
-        assert "stats.capture_suppressed" in src, "tray state must come from the sync stats"
+        select_src = inspect.getsource(main.SyncCoordinator._select_tray_state)
+        assert "stats.capture_suppressed" in select_src, (
+            "tray state must come from the sync stats"
+        )
+        do_sync_src = inspect.getsource(main.SyncCoordinator._do_sync)
         # The suppression check must not appear before sync() as an early return.
-        before_sync = src.split("self.sync_engine.sync()")[0]
+        before_sync = do_sync_src.split("self.sync_engine.sync()")[0]
         assert "PRIVATE_HOURS" not in before_sync, (
             "_do_sync short-circuits on suppression — that skips the queue drain and "
             "the config re-fetch"
+        )
+        # NB: `capture_suppressed = not ...allows(...)` legitimately appears before
+        # sync() — it is the INPUT handed to the sync engine, not a tray decision.
+        # The invariant is that the tray SELECTION happens after sync(), with the stats.
+        assert "_select_tray_state" not in before_sync, (
+            "tray state selected before sync() — the stats aren't known yet"
         )
 
 
@@ -305,12 +319,15 @@ class TestSuppressionWinsOverQueueBacklog:
         from src.sync.sync_engine import SyncStats
         from src.ui.tray import TrayState
 
-        # Suppressed outside working hours, but a backlog is still draining.
+        # Suppressed outside working hours, but a backlog is still draining. Set the
+        # per-cycle requeue count (events_queued) DIFFERENT from the actual queue
+        # depth so the detail can only match if it uses queue.size() (finding 8).
         stats = SyncStats()
         stats.capture_suppressed = True
         stats.events_queued = 5
 
         c = self._coordinator(stats)
+        c.queue.size.return_value = 12  # real backlog depth, not the 5 requeued now
 
         with patch("src.main.datetime") as dt:
             dt.now.return_value = OUT_OF_HOURS
@@ -322,9 +339,11 @@ class TestSuppressionWinsOverQueueBacklog:
         assert state == TrayState.PRIVATE_HOURS, (
             f"suppression must win over the queue backlog, got {state}"
         )
-        # The residual drain is a secondary detail, not the headline state.
+        # The residual drain is a secondary detail, not the headline state — and it
+        # reports the ACTUAL depth (12), not the per-cycle requeue count (5).
         detail = call.args[1] if len(call.args) > 1 else ""
-        assert "5 queued" in detail
+        assert "12 queued" in detail
+        assert "5 queued" not in detail
 
     def test_near_capacity_still_logs_when_suppressed(self):
         """Regression: after the round-1 reorder the near-capacity logger.warning
@@ -367,3 +386,79 @@ class TestSuppressionWinsOverQueueBacklog:
         # And the percentage is folded into the private-hours detail.
         detail = c.tray.set_state.call_args.args[1]
         assert "90%" in detail
+
+
+class TestSelectTrayState:
+    """Finding 4/8: the post-sync tray headline is a PURE function, unit-tested
+    directly (no coordinator, no live sync). Precedence: suppression > near-capacity
+    > queued > idle > syncing. Finding 8: the drain detail shows the ACTUAL queue
+    depth (queue_size), not stats.events_queued (only this cycle's requeues)."""
+
+    def _sel(self, stats, near, pct, is_idle, qsize):
+        import src.main as main
+
+        c = object.__new__(main.SyncCoordinator)  # pure method — no deps needed
+        return c._select_tray_state(stats, near, pct, is_idle, qsize)
+
+    def _stats(self, suppressed=False, queued=0):
+        from src.sync.sync_engine import SyncStats
+
+        s = SyncStats()
+        s.capture_suppressed = suppressed
+        s.events_queued = queued
+        return s
+
+    def test_suppression_wins_and_detail_uses_queue_depth_not_cycle_count(self):
+        from src.ui.tray import TrayState
+
+        state, detail = self._sel(
+            self._stats(suppressed=True, queued=3), near=True, pct=90, is_idle=True, qsize=42
+        )
+        assert state == TrayState.PRIVATE_HOURS
+        assert "draining 42 queued" in detail   # queue_size, not the 3 requeued now
+        assert "90% full" in detail
+
+    def test_suppressed_without_backlog_has_no_drain_detail(self):
+        from src.ui.tray import TrayState
+
+        state, detail = self._sel(
+            self._stats(suppressed=True, queued=0), near=False, pct=0, is_idle=False, qsize=0
+        )
+        assert state == TrayState.PRIVATE_HOURS
+        assert detail == "Private hours — not recording"
+
+    def test_near_capacity_beats_queued_and_idle(self):
+        from src.ui.tray import TrayState
+
+        state, detail = self._sel(
+            self._stats(queued=5), near=True, pct=85, is_idle=True, qsize=5
+        )
+        assert state == TrayState.QUEUE_WARNING
+        assert detail == "Queue 85% full"
+
+    def test_queued_beats_idle(self):
+        from src.ui.tray import TrayState
+
+        state, detail = self._sel(
+            self._stats(queued=5), near=False, pct=0, is_idle=True, qsize=5
+        )
+        assert state == TrayState.QUEUED
+        assert detail is None
+
+    def test_idle_when_nothing_queued(self):
+        from src.ui.tray import TrayState
+
+        state, detail = self._sel(
+            self._stats(), near=False, pct=0, is_idle=True, qsize=0
+        )
+        assert state == TrayState.PAUSED
+        assert detail == "Idle"
+
+    def test_syncing_is_the_default(self):
+        from src.ui.tray import TrayState
+
+        state, detail = self._sel(
+            self._stats(), near=False, pct=0, is_idle=False, qsize=0
+        )
+        assert state == TrayState.SYNCING
+        assert detail is None


### PR DESCRIPTION
Fixes from a senior (Fable) audit of the working-hours capture-boundary work in `src/main.py`. All findings verified against the code before fixing.

## HIGH — boundary DateTrigger died silently on a >1s misfire, nothing re-armed
`BackgroundScheduler`'s default `misfire_grace_time=1` makes APScheduler **discard** the one-shot `capture_boundary` job if the process stalls >1s across the run date (GIL pause, App Nap, missed wake) — logging once and never firing. The re-arm lived only in `_fire_capture_boundary`'s `finally`, which never runs for a discarded job, so the boundary stayed disarmed until the next config refetch (30 min online / unbounded offline), silently reverting to the pre-fix ~60s recording tail.

- Pass `misfire_grace_time=None` on the boundary `add_job` (a late fire is safe — `_fire_capture_boundary` re-reads `allows(now)` live).
- Add `_self_heal_capture_boundary`, wired into `_tick_60s`: if the schedule is restricted (`known && enforced`) and `scheduler.get_job("capture_boundary") is None`, re-arm.

## MEDIUM — arm path called from 3 threads with no synchronization
`arm_capture_boundary` runs from the boundary worker (re-arm), the sync thread (`_on_config_updated`) and the wake handler; the compute→remove→add was non-atomic against shared mutable `config`. Wrapped the body in a dedicated `_boundary_lock` (mirrors `_apply_capture_policy`'s `_capture_lock`).

## MEDIUM — `add_job` sat outside the try
A scheduler shut down between the `.running` check and the add (a real TOCTOU) or a jobstore error escaped into `_fire_capture_boundary`'s `finally` (killing re-arm) and into `fetch_server_config` (whose except only catches auth/client errors). Extended the try to cover remove/add; log-and-return on failure (the 60s tick is the backstop).

## LOW
- Extracted the tray-state decision into a pure `_select_tray_state(stats, near_capacity, capacity_pct, is_idle, queue_size)` and unit-tested it directly.
- Extracted the duplicated remove/`JobLookupError` dance into `_disarm_capture_boundary()`; promoted `_arm_capture_boundary` → public `arm_capture_boundary` (`BetterFlowApp` calls it across the object boundary).
- Tray "(draining N queued)" detail now uses `queue.size()` (actual depth), not `stats.events_queued` (only this cycle's requeues).
- New tests: DST fall-back (2026-10-25) + spring-forward (2026-03-29) boundaries, overnight 22:00–06:00 shift close/open, and a real-`BackgroundScheduler` near-past run-date proof that `grace=None` still fires.

Skipped audit #9 (perf micro-opt, harmless) as instructed.

## Verification
- `pytest`: **1108 passed**.
- `ruff`: no new violations (net -1 vs baseline; remaining are pre-existing).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014SfXEhWxr3u97VgreB1ML9