### PR TITLE
fix(capture): round-2 Fable polish — no self-heal churn on edgeless schedules, tray drain gate

### DIFF
--- a/src/main.py
+++ b/src/main.py
@@ -222,6 +222,15 @@ class SyncCoordinator:
         # boundary job until the 30-min refetch. Mirrors _apply_capture_policy's
         # _capture_lock, which guards this exact class of transition.
         self._boundary_lock = threading.Lock()
+        # True once an arm resolved to "no boundary" for a schedule the 60s self-heal
+        # still considers restricted (known+enforced but EDGELESS — allows() never
+        # flips within the 8-day walk cap, e.g. a full 00:00-23:59 all-days window or a
+        # hand-edited working_days=[]). Without this, the self-heal would see
+        # get_job()==None every tick and re-arm+log forever (~1440 lines/day + an 8-day
+        # allows() re-walk each time). Set under _boundary_lock in arm_capture_boundary:
+        # True when boundary is None, False when a boundary IS armed. Config updates
+        # flow through arm, so the flag self-corrects when the schedule changes.
+        self._boundary_edgeless = False
         # Wedge self-recovery (Cristian Dragota / sync:67a77a43-787, 2026-06-25):
         # a _do_sync that hangs past the watchdog holds _sync_lock forever, so
         # every later cycle skips and sync freezes while the heartbeat keeps
@@ -473,8 +482,14 @@ class SyncCoordinator:
                 return
             try:
                 if boundary is None:
-                    # Unknown or unrestricted schedule: allows() is constant, so there
-                    # is no edge. Drop any job left over from a previous restricted one.
+                    # No edge to align to: either allows() is constant (unknown or
+                    # unrestricted) OR the schedule is known+enforced but EDGELESS —
+                    # allows() never flips within the 8-day walk (full all-day window,
+                    # or hand-edited working_days=[]). Drop any job left from a previous
+                    # restricted schedule, and remember the edgeless state so the 60s
+                    # self-heal doesn't re-arm+log every tick against a schedule that
+                    # legitimately arms nothing.
+                    self._boundary_edgeless = True
                     self._disarm_capture_boundary()
                     return
                 self.scheduler.add_job(
@@ -493,6 +508,9 @@ class SyncCoordinator:
                     # live. The 60s tick self-heal is the second backstop.
                     misfire_grace_time=None,
                 )
+                # A real edge exists: clear any prior edgeless state so the self-heal
+                # resumes re-arming a genuinely missing (misfire-discarded) job.
+                self._boundary_edgeless = False
                 logger.info("Capture boundary armed for %s", boundary.isoformat())
             except Exception:
                 # The remove/add is now inside the try too: the scheduler can be shut
@@ -525,6 +543,14 @@ class SyncCoordinator:
         # "Restricted" ⟺ next_boundary_after would return a boundary ⟺ known+enforced
         # (unknown/unrestricted schedules have no edge and legitimately arm nothing).
         if not (wh.known and wh.enforced):
+            return
+        # A known+enforced schedule can still be EDGELESS (allows() never flips within
+        # the 8-day walk: a full 00:00-23:59 all-days window, or a hand-edited
+        # working_days=[]). Such a schedule legitimately arms no job, so re-arming here
+        # would churn — an 8-day allows() re-walk plus a misleading "job missing" log —
+        # every 60s forever. arm_capture_boundary records that state; skip both the
+        # re-arm and the log while it holds.
+        if getattr(self, "_boundary_edgeless", False):
             return
         if self.scheduler.get_job("capture_boundary") is None:
             logger.info("Capture boundary job missing — re-arming (60s self-heal)")
@@ -1293,7 +1319,12 @@ class SyncCoordinator:
         NOT stats.events_queued, which only counts events (re)queued THIS cycle."""
         if stats.capture_suppressed:
             detail = "Private hours — not recording"
-            if stats.events_queued > 0:
+            # Gate on queue_size (the ACTUAL depth we display), NOT stats.events_queued
+            # (this cycle's requeues). They disagree at both edges: a suppressed user
+            # with a standing backlog but no requeue THIS cycle would otherwise see no
+            # drain detail, and a cycle that fully drained an existing backlog would
+            # render the nonsensical "(draining 0 queued)".
+            if queue_size > 0:
                 detail = f"{detail} (draining {queue_size} queued)"
             if near_capacity:
                 detail = f"{detail} — queue {capacity_pct}% full"

--- a/tests/test_capture_boundary.py
+++ b/tests/test_capture_boundary.py
@@ -28,6 +28,20 @@ RESTRICTED = {
     }
 }
 
+# Known + enforced but EDGELESS: a full 00:00-23:59 window on every day means
+# allows() is constant-True, so next_boundary_after finds no flip in its 8-day walk
+# and returns None — the same None an unknown/unrestricted schedule yields, but here
+# the self-heal still treats the schedule as restricted (known+enforced).
+FULL_WINDOW = {
+    "working_hours": {
+        "enforced": True,
+        "work_start": "00:00",
+        "work_end": "23:59",
+        "working_days": [1, 2, 3, 4, 5, 6, 7],
+        "timezone": "Europe/Bucharest",
+    }
+}
+
 # 2026-07-13 is a Monday; Europe/Bucharest is UTC+3 (EEST) in July.
 IN_HOURS_UTC = datetime(2026, 7, 13, 18, 0, tzinfo=timezone.utc)        # 21:00 Bucharest
 # allows() is inclusive of 22:00, so it flips False at 22:01 Bucharest = 19:01 UTC.
@@ -66,6 +80,15 @@ class TestNextBoundaryAfter:
         wh = _wh({"working_hours": {"enforced": False}})
         assert wh.next_boundary_after(IN_HOURS_UTC) is None
 
+    def test_edgeless_enforced_schedule_has_no_boundary(self):
+        # A full 00:00-23:59 all-days window is known+enforced yet allows() never
+        # flips, so the 8-day walk finds no edge and returns None — the root cause of
+        # the self-heal churn the coordinator guard fixes.
+        wh = _wh(FULL_WINDOW)
+        assert wh.known is True and wh.enforced is True
+        assert wh.allows(IN_HOURS_UTC) is True
+        assert wh.next_boundary_after(IN_HOURS_UTC) is None
+
 
 class _FakeScheduler:
     """Records add/remove so the boundary job can be inspected without a real
@@ -101,6 +124,12 @@ def _coordinator(cfg, running=True):
 def _restricted_cfg():
     cfg = Config()
     cfg.update_from_server(RESTRICTED)
+    return cfg
+
+
+def _edgeless_cfg():
+    cfg = Config()
+    cfg.update_from_server(FULL_WINDOW)
     return cfg
 
 
@@ -246,6 +275,60 @@ class TestBoundarySelfHeal:
             c._self_heal_capture_boundary()
 
         assert "capture_boundary" not in c.scheduler.jobs
+
+    def test_tick_does_not_churn_or_log_for_an_edgeless_enforced_schedule(self):
+        """Round-2 (MEDIUM): a known+enforced but EDGELESS schedule (full all-day
+        window) legitimately arms no boundary. The self-heal must NOT re-arm+log every
+        tick — that was ~1440 misleading 'job missing' lines/day plus an 8-day allows()
+        re-walk under _boundary_lock each tick, forever."""
+        c = _coordinator(_edgeless_cfg())
+
+        # The real arm resolves to no boundary and records the edgeless state.
+        with patch("src.main.datetime") as dt:
+            dt.now.return_value = IN_HOURS_UTC
+            c.arm_capture_boundary()
+        assert "capture_boundary" not in c.scheduler.jobs
+        assert c._boundary_edgeless is True
+
+        # Now hammer the tick: it passes the known+enforced gate but must stop at the
+        # edgeless guard — no re-arm attempt, no "job missing" log.
+        c.arm_capture_boundary = Mock()
+        with patch("src.main.datetime") as dt, patch("src.main.logger") as log:
+            dt.now.return_value = IN_HOURS_UTC
+            for _ in range(5):
+                c._self_heal_capture_boundary()
+
+        c.arm_capture_boundary.assert_not_called()
+        missing_logs = [
+            call for call in log.info.call_args_list if "missing" in str(call)
+        ]
+        assert not missing_logs, f"self-heal churned a log while edgeless: {missing_logs}"
+
+    def test_tick_resumes_rearming_after_schedule_gains_an_edge(self):
+        """The edgeless latch must clear when the schedule regains a real edge, so a
+        genuinely misfire-discarded job is still re-armed. Arm edgeless first (latch
+        set), then swap in a restricted schedule and arm (latch cleared), then let a
+        misfire discard the job — the next tick must re-arm."""
+        c = _coordinator(_edgeless_cfg())
+        with patch("src.main.datetime") as dt:
+            dt.now.return_value = IN_HOURS_UTC
+            c.arm_capture_boundary()
+        assert c._boundary_edgeless is True
+
+        # Schedule changes to a bounded window; arm clears the latch and arms a job.
+        c.config = _restricted_cfg()
+        with patch("src.main.datetime") as dt:
+            dt.now.return_value = IN_HOURS_UTC
+            c.arm_capture_boundary()
+        assert c._boundary_edgeless is False
+        assert "capture_boundary" in c.scheduler.jobs
+
+        # Simulate a misfire discarding the job; the tick must re-arm it now.
+        c._disarm_capture_boundary()
+        with patch("src.main.datetime") as dt:
+            dt.now.return_value = IN_HOURS_UTC
+            c._self_heal_capture_boundary()
+        assert "capture_boundary" in c.scheduler.jobs
 
 
 class TestArmPathIsFailSafe:

--- a/tests/test_capture_suppression.py
+++ b/tests/test_capture_suppression.py
@@ -427,6 +427,31 @@ class TestSelectTrayState:
         assert state == TrayState.PRIVATE_HOURS
         assert detail == "Private hours — not recording"
 
+    def test_standing_backlog_with_no_requeue_this_cycle_still_shows_drain(self):
+        """Round-2 (LOW): the drain detail must gate on the value it DISPLAYS
+        (queue_size), not on this cycle's requeues (events_queued). A suppressed user
+        with a standing backlog that had no requeue this cycle (events_queued=0,
+        queue_size>0) previously saw NO drain detail — the depth was hidden."""
+        from src.ui.tray import TrayState
+
+        state, detail = self._sel(
+            self._stats(suppressed=True, queued=0), near=False, pct=0, is_idle=False, qsize=7
+        )
+        assert state == TrayState.PRIVATE_HOURS
+        assert "draining 7 queued" in detail
+
+    def test_backlog_fully_drained_this_cycle_shows_no_nonsense_zero_detail(self):
+        """The reverse edge: a cycle that requeued events but drained the backlog to
+        empty (events_queued>0, queue_size=0) must NOT render '(draining 0 queued)'."""
+        from src.ui.tray import TrayState
+
+        state, detail = self._sel(
+            self._stats(suppressed=True, queued=4), near=False, pct=0, is_idle=False, qsize=0
+        )
+        assert state == TrayState.PRIVATE_HOURS
+        assert detail == "Private hours — not recording"
+        assert "draining" not in detail
+
     def test_near_capacity_beats_queued_and_idle(self):
         from src.ui.tray import TrayState
 


### PR DESCRIPTION
Round-2 Fable review polish on the boundary-capture round-1 fix. No critical/recording issues were found; these are the two actionable items.

## F1 (MEDIUM) — self-heal churn on edgeless enforced schedules

A known+enforced schedule can still be **edgeless**: `allows()` never flips within `next_boundary_after`'s 8-day walk. Two ways to get there — a full `00:00`-`23:59` window over all 7 days (constant-True), or a hand-edited `working_days: []` (constant-False).

`arm_capture_boundary` correctly resolves to "no boundary" and disarms, but `_self_heal_capture_boundary` passed its `known and enforced` gate and then saw `get_job("capture_boundary") is None` on **every 60s tick**. It re-armed and logged `Capture boundary job missing — re-arming` each time:

- ~1440 misleading INFO lines/day
- an 8-day `allows()` re-walk (~11,520 `astimezone`/`strftime` calls) under `_boundary_lock` every tick, forever

Not a recording bug — constant-True legitimately records, constant-False legitimately suppresses.

**Fix:** `arm_capture_boundary` records the edgeless state in `self._boundary_edgeless` (set `True` when the resolved boundary is `None`, cleared to `False` when a boundary is actually armed). Config updates already flow through `arm`, so the flag self-corrects when the schedule regains an edge. The self-heal skips both the re-arm and the log while the flag holds.

## F2 (LOW) — tray drain detail gate disagreed with its value

The private-hours drain detail gated on `stats.events_queued` (this cycle's requeues) but **displays** `queue_size` (actual depth). They disagree at both edges:

- suppressed user with a standing backlog but no requeue this cycle → saw no drain detail
- a cycle that fully drained an existing backlog → rendered the nonsensical `(draining 0 queued)`

**Fix:** gate on `queue_size > 0` to match the displayed value.

## Not fixed (per review scope)
Cosmetic self-heal log during an in-flight fire (harmless — same job id + `replace_existing`).

## Tests
Proof-of-failure handshake: the 4 new behavior tests fail against a `git checkout HEAD -- src/main.py` of the pre-fix code (2 on the missing `_boundary_edgeless` mechanism + churn assertions, 2 on the exact tray-detail bugs) and all pass post-fix. A config-layer characterization test documents the root cause (`next_boundary_after` returns `None` for a full window) and passes both sides by design.

- Full suite: **1113 passed**
- Ruff: no new findings (the 8 reported on touched files are pre-existing import-order + unrelated `try/except/pass` debt)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014SfXEhWxr3u97VgreB1ML9