### PR TITLE
feat: meetings never bill as idle — call+mic engagement credit in the AFK stream

### DIFF
--- a/src/__init__.py
+++ b/src/__init__.py
@@ -1,4 +1,4 @@
 """BetterFlow - ActivityWatch to BetterFlow sync companion app."""
 
-__version__ = "1.5.103-beta"
+__version__ = "1.5.104-beta"
 __author__ = "BetterQA"

--- a/src/config.py
+++ b/src/config.py
@@ -373,6 +373,12 @@ class CallDetectionSettings:
 
     enabled: bool = True
     min_call_duration: int = 30  # Seconds; skip accidental opens
+    # Hard ceiling on the AFK credit a single call can inject into the uploaded
+    # AFK stream (a stuck call-matching window title must not keep the stream
+    # not-afk forever). Generous by design: real all-day meetings exist, and the
+    # cap only bites when there is ALSO zero keyboard/mouse input for its whole
+    # length — any real input keeps the stream not-afk on its own.
+    max_credit_minutes: int = 240
 
 
 @dataclass
@@ -1040,6 +1046,16 @@ class Config:
                     self.call_detection.min_call_duration = max(0, int(cd["min_call_duration"]))
                 except (TypeError, ValueError):
                     logger.warning("Invalid min_call_duration from server, ignoring")
+            if "max_credit_minutes" in cd:
+                try:
+                    # Bound the farm window: a call injects AFK credit into the
+                    # billed stream, so never let a server value push the cap
+                    # past 8h (nor below 1min) regardless of what it sends.
+                    self.call_detection.max_credit_minutes = min(
+                        max(int(cd["max_credit_minutes"]), 1), 480
+                    )
+                except (TypeError, ValueError):
+                    logger.warning("Invalid call max_credit_minutes from server, ignoring")
 
         if "foreground_activity" in server_config and not DEFER_UNAPPLIED_SERVER_SETTINGS:
             fa = server_config["foreground_activity"]

--- a/src/config.py
+++ b/src/config.py
@@ -379,6 +379,11 @@ class CallDetectionSettings:
     # cap only bites when there is ALSO zero keyboard/mouse input for its whole
     # length — any real input keeps the stream not-afk on its own.
     max_credit_minutes: int = 240
+    # Microphone-in-use meeting detection (mic_activity.py): the system-level
+    # signal that catches a meeting even when the call window isn't frontmost
+    # (a background Slack huddle while reading docs). Conferencing-gated and
+    # capped by max_credit_minutes; sessions upload as auditable call events.
+    mic_signal: bool = True
 
 
 @dataclass
@@ -1056,6 +1061,8 @@ class Config:
                     )
                 except (TypeError, ValueError):
                     logger.warning("Invalid call max_credit_minutes from server, ignoring")
+            if "mic_signal" in cd:
+                self.call_detection.mic_signal = self._to_bool(cd["mic_signal"])
 
         if "foreground_activity" in server_config and not DEFER_UNAPPLIED_SERVER_SETTINGS:
             fa = server_config["foreground_activity"]

--- a/src/config.py
+++ b/src/config.py
@@ -1048,7 +1048,13 @@ class Config:
                 self.call_detection.enabled = self._to_bool(cd["enabled"])
             if "min_call_duration" in cd:
                 try:
-                    self.call_detection.min_call_duration = max(0, int(cd["min_call_duration"]))
+                    # Upper clamp: a huge server value would suppress every
+                    # call/mic EVENT while short-session AFK credit still
+                    # flows — credited time with no auditable span. 10 min is
+                    # far above any sane "skip accidental opens" threshold.
+                    self.call_detection.min_call_duration = min(
+                        max(0, int(cd["min_call_duration"])), 600
+                    )
                 except (TypeError, ValueError):
                     logger.warning("Invalid min_call_duration from server, ignoring")
             if "max_credit_minutes" in cd:

--- a/src/config.py
+++ b/src/config.py
@@ -1042,6 +1042,17 @@ class Config:
             except (TypeError, ValueError) as e:
                 logger.warning(f"Invalid fraud_detection config from server: {e}")
 
+        if "call_detection" in server_config and DEFER_UNAPPLIED_SERVER_SETTINGS:
+            cd = server_config["call_detection"]
+            # Disable-only exemption from the deferral gate: mic_signal=false
+            # is the PRIVACY KILL SWITCH for the mic probe, and a remote
+            # off-switch must work without waiting for the staged rollout (or
+            # an app release). Enabling stays deferred like everything else —
+            # only "off" passes through.
+            if "mic_signal" in cd and not self._to_bool(cd["mic_signal"]):
+                self.call_detection.mic_signal = False
+                logger.info("Server disabled mic_signal (deferral-exempt kill switch)")
+
         if "call_detection" in server_config and not DEFER_UNAPPLIED_SERVER_SETTINGS:
             cd = server_config["call_detection"]
             if "enabled" in cd:

--- a/src/idle_manager.py
+++ b/src/idle_manager.py
@@ -38,6 +38,13 @@ class IdleManager:
         # post-wake idle pause can never reach back before the machine woke
         # up. See _clamp_to_last_wake for why this matters.
         self._last_wake_ts: Optional[datetime] = None
+        # Most recent instant an engagement context (call / mic meeting / dev
+        # session) was observed active. The AFK stream backdates idle to the
+        # last real INPUT, so a pause entered right after a hands-off meeting
+        # would otherwise send an idle_time span reaching back INTO the
+        # meeting the uploaded AFK stream just credited as active — the two
+        # records contradict, and idle_time spans exist to carve tracked time.
+        self._last_engaged_ts: Optional[datetime] = None
         self._IDLE_SYNC_INTERVAL = 300
         # A healthy AFK watcher heartbeats its current event continuously, so the
         # event's end-time tracks "now". If the latest AFK event ended more than
@@ -185,19 +192,47 @@ class IdleManager:
         session (Claude Code / build / render in the focused window). Any of
         them suppresses the idle pause: the user is engaged even without
         keyboard/mouse input. Defensive: any error means 'not engaged' so idle
-        detection still works."""
+        detection still works.
+
+        A True answer also stamps ``_last_engaged_ts`` so a later idle pause
+        can never backdate its idle_start into the engaged span (see
+        ``_clamp_to_last_engagement``)."""
+        engaged = False
         if self._is_in_call():
-            return True
-        try:
-            if bool(self.sync_engine.is_mic_meeting_active()):
-                return True
-        except Exception as e:
-            logger.debug("_is_engaged_without_input: mic check failed: %s", e)
-        try:
-            return bool(self.sync_engine.is_active_dev_session())
-        except Exception as e:
-            logger.debug("_is_engaged_without_input: dev-session check failed: %s", e)
-            return False
+            engaged = True
+        if not engaged:
+            try:
+                engaged = bool(self.sync_engine.is_mic_meeting_active())
+            except Exception as e:
+                logger.debug("_is_engaged_without_input: mic check failed: %s", e)
+        if not engaged:
+            try:
+                engaged = bool(self.sync_engine.is_active_dev_session())
+            except Exception as e:
+                logger.debug(
+                    "_is_engaged_without_input: dev-session check failed: %s", e
+                )
+        if engaged:
+            with self._state_lock:
+                self._last_engaged_ts = datetime.now(timezone.utc)
+        return engaged
+
+    def _clamp_to_last_engagement(self, idle_start: datetime) -> datetime:
+        """Never let an idle span start before the most recent observed
+        engagement (call / mic meeting / dev session).
+
+        The AFK stream backdates idle to the last real INPUT, so a pause
+        entered right after a hands-off meeting computes idle_start at the
+        meeting's first minute. Sending that idle_time span would carve the
+        very hour the uploaded AFK stream just credited as active — two
+        directly contradictory records for the meeting. A no-op when no
+        engagement was ever observed or the idle_start is already later
+        (mirrors ``_clamp_to_last_wake``)."""
+        with self._state_lock:
+            last_engaged = self._last_engaged_ts
+        if last_engaged is not None and idle_start < last_engaged:
+            return last_engaged
+        return idle_start
 
     def check_idle_status(
         self,
@@ -323,6 +358,16 @@ class IdleManager:
                         logger.info(
                             "idle_start %s clamped to last wake %s — post-suspend idle "
                             "must not reach back across the sleep",
+                            idle_start.isoformat(),
+                            clamped_idle_start.isoformat(),
+                        )
+                    idle_start = clamped_idle_start
+                    clamped_idle_start = self._clamp_to_last_engagement(idle_start)
+                    if clamped_idle_start != idle_start:
+                        logger.info(
+                            "idle_start %s clamped to last engagement %s — "
+                            "post-meeting idle must not reach back into the "
+                            "credited meeting",
                             idle_start.isoformat(),
                             clamped_idle_start.isoformat(),
                         )

--- a/src/idle_manager.py
+++ b/src/idle_manager.py
@@ -179,16 +179,24 @@ class IdleManager:
             return False
 
     def _is_engaged_without_input(self) -> bool:
-        """Whether a non-input engagement context is active — a call/meeting OR
-        an active foreground-CPU session (Claude Code / build / render in the
-        focused window). Either suppresses the idle pause: the user is engaged
-        even without keyboard/mouse input. Defensive: any error means 'not
-        engaged' so idle detection still works."""
+        """Whether a non-input engagement context is active — a call/meeting
+        (window-title detector), a mic-in-use meeting (system-level signal that
+        survives the call window losing focus), OR an active foreground-CPU
+        session (Claude Code / build / render in the focused window). Any of
+        them suppresses the idle pause: the user is engaged even without
+        keyboard/mouse input. Defensive: any error means 'not engaged' so idle
+        detection still works."""
         if self._is_in_call():
             return True
         try:
+            if bool(self.sync_engine.is_mic_meeting_active()):
+                return True
+        except Exception as e:
+            logger.debug("_is_engaged_without_input: mic check failed: %s", e)
+        try:
             return bool(self.sync_engine.is_active_dev_session())
-        except Exception:
+        except Exception as e:
+            logger.debug("_is_engaged_without_input: dev-session check failed: %s", e)
             return False
 
     def check_idle_status(

--- a/src/main.py
+++ b/src/main.py
@@ -1843,6 +1843,8 @@ class BetterFlowApp:
         #     to upload 'afk' after the timeout and paint the whole call Idle
         #     on the dashboard; only the LOCAL pause was suppressed before
         #     (Ecaterina's 49-minute huddle, 2026-07-15).
+        #   * mic detector — the system-level meeting signal: still sees the
+        #     huddle when its window isn't frontmost (title detection drops).
         #   * foreground-CPU detector — active build/Claude/render in focus.
         # Inert on Linux, where the OS idle clock — and thus this whole
         # in-process AFK source — is unreadable; there the uploaded call /
@@ -1850,6 +1852,7 @@ class BetterFlowApp:
         activity_sources = [
             src for src in (
                 self.coordinator.sync_engine._call_detector,
+                self.coordinator.sync_engine._mic_detector,
                 self.coordinator.sync_engine._foreground_detector,
             ) if src is not None
         ]

--- a/src/main.py
+++ b/src/main.py
@@ -1849,13 +1849,7 @@ class BetterFlowApp:
         # Inert on Linux, where the OS idle clock — and thus this whole
         # in-process AFK source — is unreadable; there the uploaded call /
         # dev-session spans carry the credit.
-        activity_sources = [
-            src for src in (
-                self.coordinator.sync_engine._call_detector,
-                self.coordinator.sync_engine._mic_detector,
-                self.coordinator.sync_engine._foreground_detector,
-            ) if src is not None
-        ]
+        activity_sources = self.coordinator.sync_engine.engagement_activity_sources()
         afk_source = AfkSource(
             afk_timeout_seconds=self.config.aw.afk_timeout_minutes * 60,
             hostname=self.coordinator.sync_engine._hostname,

--- a/src/main.py
+++ b/src/main.py
@@ -1836,17 +1836,28 @@ class BetterFlowApp:
             from .sync.afk_source import AfkSource
         except ImportError:
             from sync.afk_source import AfkSource
-        # Register the foreground-CPU detector (created by the sync engine) as a
-        # supplementary AFK activity source so an engaged no-input session keeps
-        # the uploaded AFK stream not-afk (macOS/Windows). Inert on Linux, where
-        # the OS idle clock — and thus this whole in-process AFK source — is
-        # unreadable; there the uploaded dev-session span carries the credit.
-        foreground_detector = self.coordinator.sync_engine._foreground_detector
+        # Register the engagement detectors (created by the sync engine) as
+        # supplementary AFK activity sources so an engaged no-input span keeps
+        # the uploaded AFK stream not-afk (macOS/Windows):
+        #   * call detector — a meeting/huddle with hands off the keyboard used
+        #     to upload 'afk' after the timeout and paint the whole call Idle
+        #     on the dashboard; only the LOCAL pause was suppressed before
+        #     (Ecaterina's 49-minute huddle, 2026-07-15).
+        #   * foreground-CPU detector — active build/Claude/render in focus.
+        # Inert on Linux, where the OS idle clock — and thus this whole
+        # in-process AFK source — is unreadable; there the uploaded call /
+        # dev-session spans carry the credit.
+        activity_sources = [
+            src for src in (
+                self.coordinator.sync_engine._call_detector,
+                self.coordinator.sync_engine._foreground_detector,
+            ) if src is not None
+        ]
         afk_source = AfkSource(
             afk_timeout_seconds=self.config.aw.afk_timeout_minutes * 60,
             hostname=self.coordinator.sync_engine._hostname,
             input_watcher=self.input_watcher,
-            activity_sources=[foreground_detector] if foreground_detector else None,
+            activity_sources=activity_sources or None,
         )
         self.coordinator.sync_engine.afk_source = afk_source
         self.coordinator.aw_manager.set_inproc_afk_active(

--- a/src/sync/afk_source.py
+++ b/src/sync/afk_source.py
@@ -117,13 +117,17 @@ class AfkSource:
             return
         self._consecutive_clock_failures = 0
         last_input_at = self._apply_input_watcher(now - timedelta(seconds=idle))
-        # Fold in supplementary activity sources (foreground-CPU, etc.). They are
-        # passed the current last_input_at as their human-presence anchor and may
-        # only advance it toward `now` — clamped here as a hard backstop so no
-        # source can ever push activity into the future.
+        # Fold in supplementary activity sources (call, mic, foreground-CPU).
+        # Every source receives the same REAL input anchor — the pre-fold
+        # keyboard/mouse instant, never another source's credit — so one
+        # detector's no-input credit can't become the next one's cap anchor
+        # (credit chaining). Each answer may only advance last_input_at toward
+        # `now`, clamped here as a hard backstop so no source can ever push
+        # activity into the future.
+        real_input_anchor = last_input_at
         for src in self._activity_sources:
             try:
-                a = src.get_last_active_at(last_input_at, now)
+                a = src.get_last_active_at(real_input_anchor, now)
             except Exception as e:
                 logger.debug("AfkSource activity source failed: %s", e)
                 a = None

--- a/src/sync/aw_client.py
+++ b/src/sync/aw_client.py
@@ -24,6 +24,13 @@ BUCKET_TYPE_INPUT = "aw-watcher-input"  # Keystroke/click tracking for fraud det
 BUCKET_TYPE_CALL = "call"
 BUCKET_TYPE_DEV_SESSION = "dev-session"  # Foreground-CPU activity (engaged, no input)
 
+# data.status values on call-bucket events (window calls AND mic sessions) —
+# a server contract: "ongoing" = per-cycle live snapshot of a still-open
+# meeting (same deterministic id keeps upserting one growing row); "completed"
+# = the meeting really ended. Constants so a rename can't miss a producer.
+CALL_STATUS_ONGOING = "ongoing"
+CALL_STATUS_COMPLETED = "completed"
+
 
 @dataclass(frozen=True)
 class AWEvent:

--- a/src/sync/call_detector.py
+++ b/src/sync/call_detector.py
@@ -13,6 +13,11 @@ from dataclasses import dataclass
 from datetime import datetime, timedelta
 from typing import Optional
 
+try:
+    from .engagement_credit import capped_credit
+except ImportError:  # PyInstaller bundle (src/ is import root)
+    from sync.engagement_credit import capped_credit
+
 logger = logging.getLogger(__name__)
 
 
@@ -61,6 +66,16 @@ _BROWSER_PATTERNS: list[tuple[str, Optional[re.Pattern], str]] = [
 # Default grace period: if user switches away for less than this many
 # seconds, treat it as still in the same call.
 _DEFAULT_GRACE_PERIOD = 30.0
+
+# AFK credit requires FRESH evidence: the last confirming window event's end
+# must be within this many seconds of `now`, or credit freezes at that end. A
+# healthy window watcher heartbeats the frontmost window every cycle (the AW
+# range fetch re-returns the growing event), so a live call keeps last_seen
+# tracking `now`; a HUNG watcher stops confirming, and without this bound an
+# open call would keep answering `now` — billing up to the full credit cap of
+# zero-input time on no evidence at all (reviewer finding, round 1). Sized to
+# a few sync cycles so a slow cycle can't flap credit off.
+_EVIDENCE_STALENESS_SECONDS = 180.0
 
 
 # Bare aliases matched on a WORD BOUNDARY rather than as a substring, so they
@@ -179,13 +194,22 @@ class CallDetector:
             if self._call_app is None:
                 # IDLE state
                 if matched_name:
-                    self._start_call(matched_name, call_type, timestamp)
+                    self._start_call(
+                        matched_name,
+                        call_type,
+                        timestamp,
+                        last_seen=self._event_end(timestamp, duration),
+                    )
                 return None
 
             # IN_CALL state
             if matched_name and matched_name == self._call_app:
-                # Same call continues
-                self._call_last_seen = timestamp
+                # Same call continues. Track the event's END: the window watcher
+                # heartbeats one growing event per unchanged window (timestamp
+                # fixed, duration growing), so timestamp alone would freeze
+                # last_seen at call start for a single-window meeting — starving
+                # both the snapshot duration and the evidence-freshness bound.
+                self._call_last_seen = self._event_end(timestamp, duration)
                 self._left_at = None
                 return None
 
@@ -193,7 +217,12 @@ class CallDetector:
                 # Switched to a different call app - end the current call
                 # at the switch timestamp, start a new one
                 ended = self._end_call(end_override=timestamp)
-                self._start_call(matched_name, call_type, timestamp)
+                self._start_call(
+                    matched_name,
+                    call_type,
+                    timestamp,
+                    last_seen=self._event_end(timestamp, duration),
+                )
                 return ended
 
             # Non-call event while in a call
@@ -235,7 +264,14 @@ class CallDetector:
             if self._call_app is None or self._call_start is None:
                 return None
             end = self._left_at or self._call_last_seen or self._call_start
-            duration = (end - self._call_start).total_seconds()
+            # Clamp the emitted span to the credit cap: an uncapped growing
+            # snapshot from a stuck call title would eventually exceed the
+            # server's max event duration and 4xx-poison the whole batch it
+            # rides in, every cycle. Credit past the cap is zero anyway, so a
+            # longer event has no audit value.
+            duration = min(
+                (end - self._call_start).total_seconds(), self._max_credit_seconds
+            )
             if duration < self._min_duration:
                 return None
             return CallEvent(
@@ -246,6 +282,16 @@ class CallDetector:
                 call_type=self._call_type or "native",
             )
 
+    @staticmethod
+    def _event_end(timestamp: datetime, duration: float) -> datetime:
+        """End instant of a window event; a missing/negative duration counts
+        as a point event rather than raising or reaching into the past."""
+        try:
+            seconds = max(0.0, float(duration))
+        except (TypeError, ValueError):
+            seconds = 0.0
+        return timestamp + timedelta(seconds=seconds)
+
     def is_in_call(self) -> bool:
         """True while a call/meeting is currently active (incl. grace period).
 
@@ -253,9 +299,23 @@ class CallDetector:
         in a meeting they're engaged (listening/watching) even with no
         keyboard/mouse input, which would otherwise trip the AFK-only idle
         pause — especially on Windows, which has no in-process input watcher.
+
+        Bounded by the credit cap: once the confirmed span exceeds
+        ``max_credit_seconds`` the billed stream stops crediting, and the
+        LOCAL idle guard must not keep suppressing the pause past that — the
+        tray showing "tracking" while the server bills idle is exactly the
+        local-vs-uploaded disagreement this feature exists to kill.
         """
         with self._lock:
-            return self._call_app is not None
+            if self._call_app is None:
+                return False
+            past_cap = (
+                self._call_start is not None
+                and self._call_last_seen is not None
+                and (self._call_last_seen - self._call_start).total_seconds()
+                > self._max_credit_seconds
+            )
+            return not past_cap
 
     def get_last_active_at(
         self, base_last_input: Optional[datetime], now: datetime
@@ -273,32 +333,62 @@ class CallDetector:
 
         Credit rules:
           * None when no call was ever observed — never fabricates activity.
+          * Credit requires FRESH evidence: at most
+            ``_EVIDENCE_STALENESS_SECONDS`` past the last confirming window
+            event's end. A healthy watcher heartbeats the call window every
+            cycle so a live call tracks ``now``; a hung watcher stops
+            confirming and credit freezes instead of running open-ended.
           * During the leave-grace window, credit stops at the instant the user
             left the call window (they produced real input to switch anyway).
           * After a call ends (or is flushed at an AW-outage/shutdown
             boundary), credit freezes at that call's END — the user was
             engaged until then, and that stays true forever after.
-          * Capped at ``max_credit_seconds`` past call start, so a stuck title
-            can't keep the stream not-afk forever. AfkSource additionally
-            clamps any source's answer to ``now``.
+          * Capped at ``max_credit_seconds`` past ``base_last_input`` — the
+            real keyboard/mouse anchor AfkSource passes in — NOT past call
+            start, which would let session cycling re-arm the cap (see
+            ``engagement_credit``). AfkSource additionally clamps any answer
+            to ``now``.
         """
         with self._lock:
             if self._call_start is not None:
-                engaged_until = self._left_at or now
-                cap_end = self._call_start + timedelta(seconds=self._max_credit_seconds)
-                return min(engaged_until, cap_end, now)
+                if self._left_at is not None:
+                    engaged_until = self._left_at
+                else:
+                    last_seen = self._call_last_seen or self._call_start
+                    engaged_until = min(
+                        now,
+                        last_seen + timedelta(seconds=_EVIDENCE_STALENESS_SECONDS),
+                    )
+                return capped_credit(
+                    engaged_until,
+                    base_last_input,
+                    self._call_start,
+                    self._max_credit_seconds,
+                    now,
+                )
             if self._last_call_start is not None and self._last_call_end is not None:
-                cap_end = self._last_call_start + timedelta(seconds=self._max_credit_seconds)
-                return min(self._last_call_end, cap_end, now)
+                return capped_credit(
+                    self._last_call_end,
+                    base_last_input,
+                    self._last_call_start,
+                    self._max_credit_seconds,
+                    now,
+                )
             return None
 
     def _start_call(
-        self, name: str, call_type: Optional[str], timestamp: datetime
+        self,
+        name: str,
+        call_type: Optional[str],
+        timestamp: datetime,
+        last_seen: Optional[datetime] = None,
     ) -> None:
         self._call_app = name
         self._call_type = call_type or "native"
         self._call_start = timestamp
-        self._call_last_seen = timestamp
+        # Like the continuation path, last_seen tracks the confirming event's
+        # END (evidence freshness / snapshot growth both key off it).
+        self._call_last_seen = last_seen or timestamp
         self._left_at = None
         logger.info(f"Call started: {name} ({call_type}) at {timestamp.isoformat()}")
 
@@ -316,7 +406,11 @@ class CallDetector:
         end = end_override or (self._left_at if self._left_at else self._call_last_seen)
         if end is None:
             end = self._call_start
-        duration = (end - self._call_start).total_seconds()
+        # Same clamp as snapshot(): the emitted span must never exceed the
+        # credit cap (server max-duration batch-poison protection).
+        duration = min(
+            (end - self._call_start).total_seconds(), self._max_credit_seconds
+        )
         # Remember the span for AFK credit even when the event itself is
         # discarded as too short — the engagement was real either way.
         self._last_call_start = self._call_start

--- a/src/sync/call_detector.py
+++ b/src/sync/call_detector.py
@@ -8,8 +8,9 @@ avoid splitting a single call when the user briefly switches apps.
 
 import logging
 import re
+import threading
 from dataclasses import dataclass
-from datetime import datetime
+from datetime import datetime, timedelta
 from typing import Optional
 
 logger = logging.getLogger(__name__)
@@ -129,9 +130,20 @@ class CallDetector:
         self,
         min_duration: int = 30,
         grace_period: float = _DEFAULT_GRACE_PERIOD,
+        max_credit_seconds: float = 14400.0,
     ):
         self._min_duration = min_duration
         self._grace_period = grace_period
+        # Hard ceiling on AFK credit per call (get_last_active_at). A window
+        # title stuck matching a call pattern must not keep the uploaded AFK
+        # stream not-afk indefinitely — credit stops max_credit_seconds after
+        # the call started, even if the "call" never ends.
+        self._max_credit_seconds = float(max_credit_seconds)
+
+        # State is mutated on the sync thread (process_event/flush) but read
+        # from the idle thread (is_in_call) and inside AfkSource.record_sample
+        # (get_last_active_at) — guard every access.
+        self._lock = threading.Lock()
 
         # Active call state
         self._call_app: Optional[str] = None
@@ -157,46 +169,48 @@ class CallDetector:
             matched_name = _match_browser(url)
             call_type = "browser" if matched_name else None
 
-        if self._call_app is None:
-            # IDLE state
-            if matched_name:
+        with self._lock:
+            if self._call_app is None:
+                # IDLE state
+                if matched_name:
+                    self._start_call(matched_name, call_type, timestamp)
+                return None
+
+            # IN_CALL state
+            if matched_name and matched_name == self._call_app:
+                # Same call continues
+                self._call_last_seen = timestamp
+                self._left_at = None
+                return None
+
+            if matched_name and matched_name != self._call_app:
+                # Switched to a different call app - end the current call
+                # at the switch timestamp, start a new one
+                ended = self._end_call(end_override=timestamp)
                 self._start_call(matched_name, call_type, timestamp)
+                return ended
+
+            # Non-call event while in a call
+            if self._left_at is None:
+                # First non-call event: start grace timer
+                self._left_at = timestamp
+                return None
+
+            # Check if grace period expired (guard against out-of-order timestamps)
+            gap = max(0.0, (timestamp - self._left_at).total_seconds())
+            if gap >= self._grace_period:
+                # Grace expired: end the call (end time = when user left)
+                return self._end_call()
+
+            # Still within grace period
             return None
-
-        # IN_CALL state
-        if matched_name and matched_name == self._call_app:
-            # Same call continues
-            self._call_last_seen = timestamp
-            self._left_at = None
-            return None
-
-        if matched_name and matched_name != self._call_app:
-            # Switched to a different call app - end the current call
-            # at the switch timestamp, start a new one
-            ended = self._end_call(end_override=timestamp)
-            self._start_call(matched_name, call_type, timestamp)
-            return ended
-
-        # Non-call event while in a call
-        if self._left_at is None:
-            # First non-call event: start grace timer
-            self._left_at = timestamp
-            return None
-
-        # Check if grace period expired (guard against out-of-order timestamps)
-        gap = max(0.0, (timestamp - self._left_at).total_seconds())
-        if gap >= self._grace_period:
-            # Grace expired: end the call (end time = when user left)
-            return self._end_call()
-
-        # Still within grace period
-        return None
 
     def flush(self) -> Optional[CallEvent]:
         """Force-end any active call. Call at sync boundaries."""
-        if self._call_app is not None:
-            return self._end_call()
-        return None
+        with self._lock:
+            if self._call_app is not None:
+                return self._end_call()
+            return None
 
     def is_in_call(self) -> bool:
         """True while a call/meeting is currently active (incl. grace period).
@@ -206,7 +220,37 @@ class CallDetector:
         keyboard/mouse input, which would otherwise trip the AFK-only idle
         pause — especially on Windows, which has no in-process input watcher.
         """
-        return self._call_app is not None
+        with self._lock:
+            return self._call_app is not None
+
+    def get_last_active_at(
+        self, base_last_input: Optional[datetime], now: datetime
+    ) -> Optional[datetime]:
+        """Most recent call-engaged instant, for ``AfkSource`` to fold into its
+        last-input reconciliation (activity-source contract, same as
+        ``ForegroundActivityDetector.get_last_active_at``).
+
+        While a call is active the user is engaged (listening/watching) even
+        with no keyboard/mouse input, so the *uploaded* AFK stream — which the
+        server bills active-vs-idle from — must stay not-afk. Suppressing only
+        the local idle pause (``is_in_call``) never reached that stream, so a
+        long hands-off meeting still painted Idle on the dashboard (Ecaterina's
+        49-minute huddle, 2026-07-15).
+
+        Credit rules:
+          * None when no call is active — never fabricates activity.
+          * During the leave-grace window, credit stops at the instant the user
+            left the call window (they produced real input to switch anyway).
+          * Capped at ``max_credit_seconds`` past call start, so a stuck title
+            can't keep the stream not-afk forever. AfkSource additionally
+            clamps any source's answer to ``now``.
+        """
+        with self._lock:
+            if self._call_start is None:
+                return None
+            engaged_until = self._left_at or now
+            cap_end = self._call_start + timedelta(seconds=self._max_credit_seconds)
+            return min(engaged_until, cap_end, now)
 
     def _start_call(
         self, name: str, call_type: Optional[str], timestamp: datetime

--- a/src/sync/call_detector.py
+++ b/src/sync/call_detector.py
@@ -256,7 +256,8 @@ class CallDetector:
             return None
 
     def flush(self) -> Optional[CallEvent]:
-        """Force-end any active call (shutdown / AW-outage boundaries)."""
+        """Force-end any active call — shutdown, AW-outage, and capture
+        boundaries (pause / private time / working-hours suppression)."""
         with self._lock:
             if self._call_app is not None:
                 return self._end_call()
@@ -337,6 +338,29 @@ class CallDetector:
                 > self._max_credit_seconds
             )
             return not past_cap
+
+    def has_fresh_evidence(self, now: datetime) -> bool:
+        """True when the current call state is backed by RECENT window events.
+
+        Consumed by SyncEngine.is_in_call() next to the state machine's own
+        answer: with AW up but only the window watcher hung mid-call, no event
+        will ever arrive to end the call — the state machine stays IN_CALL
+        forever on evidence nothing confirms, and the local idle guard would
+        stay suppressed indefinitely while the billed stream (already bounded
+        by the staleness rule in get_last_active_at) shows idle. Bounded by
+        the same staleness allowance plus the leave-grace, so a healthy
+        heartbeating watcher never trips it. False when no call is active.
+        """
+        with self._lock:
+            if self._call_app is None:
+                return False
+            ref = self._call_last_seen or self._call_start
+            if self._left_at is not None and (ref is None or self._left_at > ref):
+                ref = self._left_at
+            if ref is None:
+                return False
+            age = (now - ref).total_seconds()
+            return age <= _EVIDENCE_STALENESS_SECONDS + self._grace_period
 
     def get_last_active_at(
         self, base_last_input: Optional[datetime], now: datetime

--- a/src/sync/call_detector.py
+++ b/src/sync/call_detector.py
@@ -152,6 +152,12 @@ class CallDetector:
         self._call_last_seen: Optional[datetime] = None
         # Timestamp when user first left the call app (for grace tracking)
         self._left_at: Optional[datetime] = None
+        # Span of the most recently ENDED call (kept across _reset). AFK credit
+        # (get_last_active_at) stays truthful after a call ends or is flushed:
+        # the user was engaged until that end instant, so credit freezes there
+        # instead of vanishing the moment the state machine resets.
+        self._last_call_start: Optional[datetime] = None
+        self._last_call_end: Optional[datetime] = None
 
     def process_event(
         self,
@@ -206,11 +212,39 @@ class CallDetector:
             return None
 
     def flush(self) -> Optional[CallEvent]:
-        """Force-end any active call. Call at sync boundaries."""
+        """Force-end any active call (shutdown / AW-outage boundaries)."""
         with self._lock:
             if self._call_app is not None:
                 return self._end_call()
             return None
+
+    def snapshot(self) -> Optional[CallEvent]:
+        """Emit the currently-active call as a CallEvent WITHOUT ending it.
+
+        Uploaded each sync cycle for live server-side visibility: the event id
+        derives from (app, start), so the server upserts one growing row across
+        cycles — mirroring ``ForegroundActivityDetector.snapshot``. The old
+        per-cycle ``flush()`` at the sync boundary instead ENDED the call every
+        cycle, which fragmented one meeting into per-cycle call rows, dropped
+        ``is_in_call()`` to False between cycles (the idle-pause suppression
+        raced and mostly never engaged), and reset the state the AFK activity
+        source needs. None when no call is active or it is still shorter than
+        ``min_duration``.
+        """
+        with self._lock:
+            if self._call_app is None or self._call_start is None:
+                return None
+            end = self._left_at or self._call_last_seen or self._call_start
+            duration = (end - self._call_start).total_seconds()
+            if duration < self._min_duration:
+                return None
+            return CallEvent(
+                app=self._call_app,
+                start=self._call_start,
+                end=end,
+                duration=round(duration, 2),
+                call_type=self._call_type or "native",
+            )
 
     def is_in_call(self) -> bool:
         """True while a call/meeting is currently active (incl. grace period).
@@ -238,19 +272,25 @@ class CallDetector:
         49-minute huddle, 2026-07-15).
 
         Credit rules:
-          * None when no call is active — never fabricates activity.
+          * None when no call was ever observed — never fabricates activity.
           * During the leave-grace window, credit stops at the instant the user
             left the call window (they produced real input to switch anyway).
+          * After a call ends (or is flushed at an AW-outage/shutdown
+            boundary), credit freezes at that call's END — the user was
+            engaged until then, and that stays true forever after.
           * Capped at ``max_credit_seconds`` past call start, so a stuck title
             can't keep the stream not-afk forever. AfkSource additionally
             clamps any source's answer to ``now``.
         """
         with self._lock:
-            if self._call_start is None:
-                return None
-            engaged_until = self._left_at or now
-            cap_end = self._call_start + timedelta(seconds=self._max_credit_seconds)
-            return min(engaged_until, cap_end, now)
+            if self._call_start is not None:
+                engaged_until = self._left_at or now
+                cap_end = self._call_start + timedelta(seconds=self._max_credit_seconds)
+                return min(engaged_until, cap_end, now)
+            if self._last_call_start is not None and self._last_call_end is not None:
+                cap_end = self._last_call_start + timedelta(seconds=self._max_credit_seconds)
+                return min(self._last_call_end, cap_end, now)
+            return None
 
     def _start_call(
         self, name: str, call_type: Optional[str], timestamp: datetime
@@ -277,6 +317,10 @@ class CallDetector:
         if end is None:
             end = self._call_start
         duration = (end - self._call_start).total_seconds()
+        # Remember the span for AFK credit even when the event itself is
+        # discarded as too short — the engagement was real either way.
+        self._last_call_start = self._call_start
+        self._last_call_end = end
 
         app = self._call_app or "Unknown"
         call_type = self._call_type or "native"

--- a/src/sync/call_detector.py
+++ b/src/sync/call_detector.py
@@ -209,7 +209,13 @@ class CallDetector:
                 # fixed, duration growing), so timestamp alone would freeze
                 # last_seen at call start for a single-window meeting — starving
                 # both the snapshot duration and the evidence-freshness bound.
-                self._call_last_seen = self._event_end(timestamp, duration)
+                # Monotonic: buckets are fed sequentially and only sorted within
+                # themselves, so an older event from a second bucket must not
+                # REWIND last_seen (shrinking the ongoing snapshot and the
+                # staleness/cap math).
+                event_end = self._event_end(timestamp, duration)
+                if self._call_last_seen is None or event_end > self._call_last_seen:
+                    self._call_last_seen = event_end
                 self._left_at = None
                 return None
 
@@ -231,8 +237,17 @@ class CallDetector:
                 self._left_at = timestamp
                 return None
 
-            # Check if grace period expired (guard against out-of-order timestamps)
-            gap = max(0.0, (timestamp - self._left_at).total_seconds())
+            # Check if grace period expired (guard against out-of-order
+            # timestamps). Measured against the non-call event's END, not its
+            # timestamp: a single unchanged non-call window is heartbeated as
+            # ONE growing event (timestamp fixed at _left_at), so a
+            # timestamp-based gap stays 0 forever and the call never ends —
+            # is_in_call() then suppresses the idle pause all afternoon while
+            # the billed stream (correctly) froze at _left_at.
+            gap = max(
+                0.0,
+                (self._event_end(timestamp, duration) - self._left_at).total_seconds(),
+            )
             if gap >= self._grace_period:
                 # Grace expired: end the call (end time = when user left)
                 return self._end_call()
@@ -305,6 +320,12 @@ class CallDetector:
         LOCAL idle guard must not keep suppressing the pause past that — the
         tray showing "tracking" while the server bills idle is exactly the
         local-vs-uploaded disagreement this feature exists to kill.
+
+        Note the local bound is SESSION-anchored (call span vs cap) while the
+        billed credit is INPUT-anchored (``get_last_active_at``): a zero-input
+        auto-joined call can exhaust its billed credit before this returns
+        False. Approximate on purpose — this method has no access to the
+        real-input anchor, and the divergence is bounded by one cap.
         """
         with self._lock:
             if self._call_app is None:
@@ -361,18 +382,18 @@ class CallDetector:
                     )
                 return capped_credit(
                     engaged_until,
-                    base_last_input,
-                    self._call_start,
-                    self._max_credit_seconds,
-                    now,
+                    anchor=base_last_input,
+                    engagement_start=self._call_start,
+                    cap_seconds=self._max_credit_seconds,
+                    now=now,
                 )
             if self._last_call_start is not None and self._last_call_end is not None:
                 return capped_credit(
                     self._last_call_end,
-                    base_last_input,
-                    self._last_call_start,
-                    self._max_credit_seconds,
-                    now,
+                    anchor=base_last_input,
+                    engagement_start=self._last_call_start,
+                    cap_seconds=self._max_credit_seconds,
+                    now=now,
                 )
             return None
 

--- a/src/sync/engagement_credit.py
+++ b/src/sync/engagement_credit.py
@@ -20,22 +20,38 @@ from typing import Optional
 
 def capped_credit(
     engaged_until: datetime,
+    *,
     anchor: Optional[datetime],
-    fallback_anchor: Optional[datetime],
+    engagement_start: Optional[datetime],
     cap_seconds: float,
     now: datetime,
 ) -> Optional[datetime]:
     """Bound an engagement instant by the credit cap.
 
-    Returns ``min(engaged_until, anchor + cap_seconds, now)``.
+    Returns ``min(engaged_until, anchor + cap_seconds, now)``, floored at
+    ``engagement_start``.
 
-    ``anchor`` is the most recent real input (may be None when the OS idle
-    clock was unreadable); ``fallback_anchor`` (the session/call start) keeps
-    the old per-session bound in that corner rather than granting unbounded
-    credit. None when no anchor of any kind exists.
+    Keyword-only on purpose: four datetime parameters passed positionally
+    would type-check when swapped and silently change billed hours.
+
+    ``anchor`` is the most recent real input (None only when the OS idle
+    clock was unreadable — in production AfkSource skips sampling entirely in
+    that case, so sources are never consulted with a None anchor; the
+    ``engagement_start`` fallback still bounds that corner rather than
+    granting unbounded credit).
+
+    The floor: when the cap expired BEFORE the engagement began
+    (``anchor + cap < engagement_start`` — e.g. a calendar-auto-launched
+    meeting hours after the last real input), the engagement earns nothing —
+    returning the bare cap end would fabricate an activity instant at a time
+    when there was provably no engagement and no input, and AfkSource would
+    fold up to a full afk-timeout of phantom active time around it.
     """
-    effective_anchor = anchor or fallback_anchor
+    effective_anchor = anchor or engagement_start
     if effective_anchor is None:
         return None
     cap_end = effective_anchor + timedelta(seconds=cap_seconds)
-    return min(engaged_until, cap_end, now)
+    credit = min(engaged_until, cap_end, now)
+    if engagement_start is not None and credit < engagement_start:
+        return None
+    return credit

--- a/src/sync/engagement_credit.py
+++ b/src/sync/engagement_credit.py
@@ -1,0 +1,41 @@
+"""Shared AFK-credit math for engagement detectors (call, mic, ...).
+
+One function, used by every detector that injects no-input engagement credit
+into the billed AFK stream, so the anti-fraud bound can never drift between
+them (a one-sided fix here was the reviewer-flagged failure mode of keeping
+per-detector copies).
+
+The bound: credit extends at most ``cap_seconds`` past the ANCHOR — the most
+recent REAL keyboard/mouse input, as passed by ``AfkSource`` to every activity
+source. Anchoring on the session/call START instead let the cap reset by
+cycling sessions (drop the mic for two minutes, or alternate two call-titled
+windows: each new session re-armed a fresh cap → indefinite zero-input
+credit). Anchored on real input, chaining is pointless: one genuine human
+action opens one bounded credit window, shared by all detectors.
+"""
+
+from datetime import datetime, timedelta
+from typing import Optional
+
+
+def capped_credit(
+    engaged_until: datetime,
+    anchor: Optional[datetime],
+    fallback_anchor: Optional[datetime],
+    cap_seconds: float,
+    now: datetime,
+) -> Optional[datetime]:
+    """Bound an engagement instant by the credit cap.
+
+    Returns ``min(engaged_until, anchor + cap_seconds, now)``.
+
+    ``anchor`` is the most recent real input (may be None when the OS idle
+    clock was unreadable); ``fallback_anchor`` (the session/call start) keeps
+    the old per-session bound in that corner rather than granting unbounded
+    credit. None when no anchor of any kind exists.
+    """
+    effective_anchor = anchor or fallback_anchor
+    if effective_anchor is None:
+        return None
+    cap_end = effective_anchor + timedelta(seconds=cap_seconds)
+    return min(engaged_until, cap_end, now)

--- a/src/sync/foreground_activity.py
+++ b/src/sync/foreground_activity.py
@@ -204,8 +204,19 @@ class ForegroundActivityDetector:
         self, base_last_input: Optional[datetime], now: datetime
     ) -> Optional[datetime]:
         """Most recent credit-eligible instant, for ``AfkSource`` to fold into
-        its last-input reconciliation. Signature matches the activity-source
-        contract (base last-input + now) used by ``AfkSource``."""
+        its last-input reconciliation.
+
+        ``base_last_input`` is DELIBERATELY unused here, unlike call/mic
+        (which cap through ``engagement_credit.capped_credit`` with it):
+        this detector anchors credit at ``observe()`` time to the freshest
+        real-input signal the ENGINE has — the max of the input-bucket events
+        and the OS idle clock — which can be fresher than AfkSource's
+        sample-time anchor (a blind OS idle clock with a live input watcher is
+        exactly the failure foreground credit was built around). Re-capping
+        here with the staler anchor would veto credit the observe-time anchor
+        legitimately granted. ``_last_active_at`` is input-anchored by
+        construction; every observe() re-checks eligibility against
+        ``max_credit_seconds``."""
         with self._lock:
             return self._last_active_at
 

--- a/src/sync/mic_activity.py
+++ b/src/sync/mic_activity.py
@@ -43,6 +43,7 @@ Platform probes:
 """
 
 import logging
+import re
 import sys
 import threading
 from dataclasses import dataclass
@@ -50,10 +51,10 @@ from datetime import datetime, timedelta
 from typing import Optional, Protocol
 
 try:
-    from .aw_client import BUCKET_TYPE_CALL
+    from .aw_client import BUCKET_TYPE_CALL, CALL_STATUS_COMPLETED, CALL_STATUS_ONGOING
     from .engagement_credit import capped_credit
 except ImportError:  # PyInstaller bundle (src/ is import root)
-    from sync.aw_client import BUCKET_TYPE_CALL
+    from sync.aw_client import BUCKET_TYPE_CALL, CALL_STATUS_COMPLETED, CALL_STATUS_ONGOING
     from sync.engagement_credit import capped_credit
 
 logger = logging.getLogger(__name__)
@@ -79,9 +80,13 @@ class MicProbe(Protocol):
     def sample(self) -> MicSample: ...
 
 
-# Substring tokens identifying conferencing-capable apps. Browsers are
-# included: a mic-hot browser is almost always a web meeting (Meet, browser
-# Zoom/Teams). Matched case-insensitively against process/exe names.
+# Tokens identifying conferencing-capable apps. Browsers are included: a
+# mic-hot browser is almost always a web meeting (Meet, browser Zoom/Teams).
+# Matched case-insensitively ON A WORD BOUNDARY against process/exe names —
+# bare substrings bleed into unrelated apps ("arc" in "SearchApp"/"archive",
+# "edge" in "ledger"), the exact lesson call_detector's app aliases already
+# encode. Compound process names that a boundary would break get their own
+# token (msedge).
 _CONFERENCING_TOKENS = (
     "zoom",
     "teams",
@@ -93,10 +98,16 @@ _CONFERENCING_TOKENS = (
     "safari",
     "firefox",
     "edge",
+    "msedge",
     "brave",
     "arc",
     "opera",
     "vivaldi",
+)
+
+_CONFERENCING_RE = re.compile(
+    r"\b(?:" + "|".join(re.escape(t) for t in _CONFERENCING_TOKENS) + r")\b",
+    re.IGNORECASE,
 )
 
 # Keep a session open across brief mic drops (device switch, app re-grabbing
@@ -105,8 +116,7 @@ _MIC_OFF_GRACE_SECONDS = 90.0
 
 
 def _matches_conferencing(name: str) -> bool:
-    lowered = name.lower()
-    return any(tok in lowered for tok in _CONFERENCING_TOKENS)
+    return _CONFERENCING_RE.search(name) is not None
 
 
 class MicActivityDetector:
@@ -146,6 +156,12 @@ class MicActivityDetector:
         # the meeting ends (freezes at its end), mirroring CallDetector.
         self._last_session_start: Optional[datetime] = None
         self._last_session_end: Optional[datetime] = None
+        # Latched after a force-close at the credit cap: a mic that never goes
+        # cold must NOT reopen a fresh session every cycle (each one would
+        # suppress the idle pause for another full cap and mint another 4h
+        # audit row — a wedged mic looping forever). Cleared by the first
+        # genuinely cold observation.
+        self._cap_latched = False
 
     # -- Sampling ----------------------------------------------------------
 
@@ -168,6 +184,11 @@ class MicActivityDetector:
 
         with self._lock:
             if hot:
+                if self._cap_latched:
+                    # A cap-force-closed session must not reopen while the mic
+                    # never went cold — that loop would suppress the idle
+                    # pause for a fresh cap period every reopen, forever.
+                    return None
                 if self._session_start is not None and (
                     (now - self._session_start).total_seconds()
                     >= self._max_credit_seconds
@@ -176,9 +197,9 @@ class MicActivityDetector:
                     # the cap the session earns nothing, its growing snapshot
                     # would eventually exceed the server's max event duration
                     # (batch poison), and is_active() would suppress the local
-                    # idle pause indefinitely. A still-live meeting reopens as
-                    # a new session next cycle — the input-anchored cap means
-                    # the new session grants no fresh credit on its own.
+                    # idle pause indefinitely. Latched: reopening requires the
+                    # mic to genuinely go cold first.
+                    self._cap_latched = True
                     return self._close_session_locked()
                 if self._session_start is None:
                     self._session_start = now
@@ -189,6 +210,7 @@ class MicActivityDetector:
                 self._session_last_hot = now
                 return None
 
+            self._cap_latched = False  # a cold read re-arms cap force-close
             if self._session_start is None:
                 return None
             last_hot = self._session_last_hot or self._session_start
@@ -239,7 +261,7 @@ class MicActivityDetector:
         duration = min((end - start).total_seconds(), self._max_credit_seconds)
         if duration < self._min_session_seconds:
             return None
-        return self._make_event(app, start, duration, status="ongoing")
+        return self._make_event(app, start, duration, status=CALL_STATUS_ONGOING)
 
     def flush(self) -> Optional[dict]:
         """Force-close any open session (shutdown / AW-outage boundaries)."""
@@ -275,10 +297,10 @@ class MicActivityDetector:
                 )
                 return capped_credit(
                     engaged_until,
-                    base_last_input,
-                    self._session_start,
-                    self._max_credit_seconds,
-                    now,
+                    anchor=base_last_input,
+                    engagement_start=self._session_start,
+                    cap_seconds=self._max_credit_seconds,
+                    now=now,
                 )
             if (
                 self._last_session_start is not None
@@ -286,10 +308,10 @@ class MicActivityDetector:
             ):
                 return capped_credit(
                     self._last_session_end,
-                    base_last_input,
-                    self._last_session_start,
-                    self._max_credit_seconds,
-                    now,
+                    anchor=base_last_input,
+                    engagement_start=self._last_session_start,
+                    cap_seconds=self._max_credit_seconds,
+                    now=now,
                 )
             return None
 
@@ -316,7 +338,7 @@ class MicActivityDetector:
             )
             return None
         logger.info("Mic meeting session ended: %s duration=%.0fs", app, duration)
-        return self._make_event(app, start, duration, status="completed")
+        return self._make_event(app, start, duration, status=CALL_STATUS_COMPLETED)
 
     def _make_event(
         self, app: str, start: datetime, duration: float, *, status: str
@@ -347,7 +369,16 @@ class MicActivityDetector:
 
 
 class MacosMicProbe:
-    """Default-input-device "running somewhere" via CoreAudio (ctypes)."""
+    """Default-input-device "running somewhere" via CoreAudio (ctypes).
+
+    Known caveat: ``kAudioDevicePropertyDeviceIsRunningSomewhere`` is
+    DEVICE-level, not input-stream-level. On single-device input+output
+    hardware (USB/BT headsets, audio interfaces) playback alone can mark the
+    default input device "running" — music through such a headset reads as a
+    hot mic. The conferencing gate, the input-anchored credit cap, and the
+    cap latch bound the resulting over-credit; per-process stream attribution
+    (macOS 14+ tap APIs) is the eventual fix if this shows up in the field.
+    """
 
     _SYSTEM_OBJECT = 1  # kAudioObjectSystemObject
 
@@ -441,9 +472,18 @@ class WindowsMicProbe:
                                 stop, _ = winreg.QueryValueEx(
                                     sub_key, "LastUsedTimeStop"
                                 )
+                                start, _ = winreg.QueryValueEx(
+                                    sub_key, "LastUsedTimeStart"
+                                )
                         except OSError:
                             continue
-                        if stop == 0:
+                        # In use right now = a real usage started (Start != 0)
+                        # and hasn't stopped (Stop == 0). Start==0 entries are
+                        # granted-but-never-used — not "in use". Known residual:
+                        # an app that CRASHED holding the mic leaves Stop==0
+                        # until its next clean release; the conferencing gate,
+                        # input-anchored cap, and cap latch bound the damage.
+                        if stop == 0 and start != 0:
                             # NonPackaged keys encode the exe path with '#'
                             # separators; the last segment is the exe name.
                             apps.append(sub.rsplit("#", 1)[-1])

--- a/src/sync/mic_activity.py
+++ b/src/sync/mic_activity.py
@@ -210,7 +210,13 @@ class MicActivityDetector:
                 self._session_last_hot = now
                 return None
 
-            self._cap_latched = False  # a cold read re-arms cap force-close
+            # Only a DEFINITE cold read clears the latch. A probe error
+            # (in_use=None) or a gate failure also lands here with hot=False,
+            # but neither proves the mic released — unlatching on those would
+            # let a wedged-hot mic reopen a fresh cap period off every
+            # transient flap, the exact loop the latch exists to stop.
+            if sample.in_use is False:
+                self._cap_latched = False
             if self._session_start is None:
                 return None
             last_hot = self._session_last_hot or self._session_start
@@ -264,7 +270,8 @@ class MicActivityDetector:
         return self._make_event(app, start, duration, status=CALL_STATUS_ONGOING)
 
     def flush(self) -> Optional[dict]:
-        """Force-close any open session (shutdown / AW-outage boundaries)."""
+        """Force-close any open session — shutdown, kill-switch, and capture
+        boundaries (pause / private time / working-hours suppression)."""
         with self._lock:
             if self._session_start is None:
                 return None

--- a/src/sync/mic_activity.py
+++ b/src/sync/mic_activity.py
@@ -1,0 +1,462 @@
+"""Microphone-in-use meeting detection.
+
+The window-title path (``CallDetector``) only sees a meeting while the call
+window is FRONTMOST and titled like a call. In real usage the huddle runs in
+the background — the user reads docs, or just listens with some other window
+focused — the title match drops after the 30s grace, and a hands-off meeting
+is painted idle again (Ecaterina's Slack huddle, 2026-07-15).
+
+The microphone is the system-level signal the window title can't fake or miss:
+it is hot for the entire meeting regardless of focus. This detector samples
+"is the default input device in use" once per sync cycle and turns it into the
+same three consumer feeds every engagement detector here provides:
+
+  * ``get_last_active_at()`` → folded into the in-process AFK stream
+    (``AfkSource``) so the *uploaded* stream stays not-afk and the server
+    bills the meeting as active.
+  * ``is_active()``          → consulted by ``IdleManager`` next to
+    ``is_in_call()`` so the local idle pause doesn't fire mid-meeting.
+  * ``observe()/snapshot()`` → an auditable ``call``-type span
+    (``call_type: "mic"``) uploaded live each cycle, so the SERVER can see,
+    validate, or override every credited mic session. Rides the existing call
+    bucket/event type — no new server-side event shape.
+
+Anti-fraud guardrails:
+
+  * **Conferencing-gated** — the mic must be held by (Windows: attributed via
+    the CapabilityAccessManager consent store) or coexist with (macOS: process
+    scan; per-app attribution isn't exposed) a known conferencing app. A bare
+    open mic on a machine with no conferencing software never counts.
+  * **Capped** — AFK credit stops ``max_credit_seconds`` after the session
+    started, mirroring ``CallDetector``; a wedged mic can't farm hours.
+  * **Server-visible** — every session ships as an upserted call event, the
+    same audit path window-detected calls use.
+
+Platform probes:
+  * macOS  — CoreAudio ``kAudioDevicePropertyDeviceIsRunningSomewhere`` on the
+    default input device (no TCC prompt; it reads a hardware property, not
+    audio).
+  * Windows — ``HKCU ...\\CapabilityAccessManager\\ConsentStore\\microphone``:
+    a subkey with ``LastUsedTimeStop == 0`` is an app holding the mic right
+    now, exe name included.
+  * Linux — no probe; the detector is not constructed.
+"""
+
+import logging
+import sys
+import threading
+from dataclasses import dataclass
+from datetime import datetime, timedelta
+from typing import Optional, Protocol
+
+try:
+    from .aw_client import BUCKET_TYPE_CALL
+except ImportError:  # PyInstaller bundle (src/ is import root)
+    from sync.aw_client import BUCKET_TYPE_CALL
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass
+class MicSample:
+    """A single observation of the default input device.
+
+    ``in_use`` is None when the probe couldn't read the device state (never
+    treated as "in use"). ``apps`` carries per-app attribution where the
+    platform exposes it (Windows consent store); empty on macOS.
+    """
+
+    in_use: Optional[bool]
+    apps: tuple = ()
+
+
+class MicProbe(Protocol):
+    """Samples microphone state. Injected so the session logic is testable
+    without CoreAudio / the Windows registry."""
+
+    def sample(self) -> MicSample: ...
+
+
+# Substring tokens identifying conferencing-capable apps. Browsers are
+# included: a mic-hot browser is almost always a web meeting (Meet, browser
+# Zoom/Teams). Matched case-insensitively against process/exe names.
+_CONFERENCING_TOKENS = (
+    "zoom",
+    "teams",
+    "slack",
+    "discord",
+    "webex",
+    "facetime",
+    "chrome",
+    "safari",
+    "firefox",
+    "edge",
+    "brave",
+    "arc",
+    "opera",
+    "vivaldi",
+)
+
+# Keep a session open across brief mic drops (device switch, app re-grabbing
+# the stream). Well under any real between-meetings gap at a 60s sample cadence.
+_MIC_OFF_GRACE_SECONDS = 90.0
+
+
+def _matches_conferencing(name: str) -> bool:
+    lowered = name.lower()
+    return any(tok in lowered for tok in _CONFERENCING_TOKENS)
+
+
+class MicActivityDetector:
+    """Tracks contiguous mic-in-use spans and turns them into AFK credit and
+    an auditable call-type span.
+
+    Thread-safety: ``observe`` runs on the sync thread; ``get_last_active_at``
+    (inside ``AfkSource.record_sample``) and ``is_active`` (idle thread) read
+    concurrently — all shared state is behind ``_lock``.
+    """
+
+    def __init__(
+        self,
+        *,
+        hostname: str,
+        probe: MicProbe,
+        conferencing_gate=None,
+        min_session_seconds: float = 30.0,
+        max_credit_seconds: float = 14400.0,
+        off_grace_seconds: float = _MIC_OFF_GRACE_SECONDS,
+    ) -> None:
+        self._hostname = hostname
+        self._probe = probe
+        # () -> bool: "is a conferencing app present" fallback when the probe
+        # can't attribute the mic to an app (macOS). None → attribution-only.
+        self._conferencing_gate = conferencing_gate
+        self._min_session_seconds = float(min_session_seconds)
+        self._max_credit_seconds = float(max_credit_seconds)
+        self._off_grace_seconds = float(off_grace_seconds)
+        self._lock = threading.Lock()
+
+        # Open session state.
+        self._session_start: Optional[datetime] = None
+        self._session_last_hot: Optional[datetime] = None
+        self._session_app: str = "Microphone"
+        # Span of the most recently ENDED session: credit stays truthful after
+        # the meeting ends (freezes at its end), mirroring CallDetector.
+        self._last_session_start: Optional[datetime] = None
+        self._last_session_end: Optional[datetime] = None
+
+    # -- Sampling ----------------------------------------------------------
+
+    def observe(self, now: datetime) -> Optional[dict]:
+        """Sample the mic and update session state. Call once per sync cycle.
+
+        Returns a finished call-type event dict when this sample closes a
+        session that was long enough; otherwise None.
+        """
+        try:
+            sample = self._probe.sample()
+        except Exception as e:
+            # A probe failure must never break a sync cycle and is never read
+            # as "in use" — but it doesn't insta-close an open session either;
+            # the off-grace handles a transient blind read.
+            logger.debug("mic probe failed: %s", e)
+            sample = MicSample(None)
+
+        hot = bool(sample.in_use) and self._passes_conferencing_gate(sample)
+
+        with self._lock:
+            if hot:
+                if self._session_start is None:
+                    self._session_start = now
+                    self._session_app = self._attributed_app(sample)
+                    logger.info(
+                        "Mic meeting session started (%s)", self._session_app
+                    )
+                self._session_last_hot = now
+                return None
+
+            if self._session_start is None:
+                return None
+            last_hot = self._session_last_hot or self._session_start
+            if (now - last_hot).total_seconds() < self._off_grace_seconds:
+                return None  # brief drop — keep the session open
+            return self._close_session_locked()
+
+    def _passes_conferencing_gate(self, sample: MicSample) -> bool:
+        """A hot mic counts only in a conferencing context.
+
+        Windows attributes the mic per app — require a conferencing match.
+        macOS can't attribute (``apps`` empty), so fall back to "a conferencing
+        app is running" via the injected gate; a gate ERROR fails open (the hot
+        mic itself is the strong signal — losing a real meeting to a psutil
+        hiccup is the worse failure), but a gate answering False is respected.
+        """
+        if sample.apps:
+            return any(_matches_conferencing(app) for app in sample.apps)
+        if self._conferencing_gate is None:
+            return True
+        try:
+            return bool(self._conferencing_gate())
+        except Exception as e:
+            logger.debug("conferencing gate failed (failing open): %s", e)
+            return True
+
+    @staticmethod
+    def _attributed_app(sample: MicSample) -> str:
+        for app in sample.apps:
+            if _matches_conferencing(app):
+                return app
+        return "Microphone"
+
+    # -- Consumer feeds ----------------------------------------------------
+
+    def snapshot(self) -> Optional[dict]:
+        """Emit the open session as an event WITHOUT closing it (uploaded each
+        cycle; deterministic id → the server upserts one growing row)."""
+        with self._lock:
+            if self._session_start is None:
+                return None
+            start = self._session_start
+            end = self._session_last_hot or start
+            app = self._session_app
+        duration = (end - start).total_seconds()
+        if duration < self._min_session_seconds:
+            return None
+        return self._make_event(app, start, duration)
+
+    def flush(self) -> Optional[dict]:
+        """Force-close any open session (shutdown / AW-outage boundaries)."""
+        with self._lock:
+            if self._session_start is None:
+                return None
+            return self._close_session_locked()
+
+    def is_active(self) -> bool:
+        """True while a mic meeting session is open — consumed by
+        ``IdleManager`` to suppress the idle pause, like ``is_in_call``."""
+        with self._lock:
+            return self._session_start is not None
+
+    def get_last_active_at(
+        self, base_last_input: Optional[datetime], now: datetime
+    ) -> Optional[datetime]:
+        """Most recent mic-engaged instant for ``AfkSource`` (activity-source
+        contract). ``now`` while a session is open, frozen at the session end
+        after it closes; both capped at ``max_credit_seconds`` past start."""
+        with self._lock:
+            if self._session_start is not None:
+                cap_end = self._session_start + timedelta(
+                    seconds=self._max_credit_seconds
+                )
+                return min(now, cap_end)
+            if (
+                self._last_session_start is not None
+                and self._last_session_end is not None
+            ):
+                cap_end = self._last_session_start + timedelta(
+                    seconds=self._max_credit_seconds
+                )
+                return min(self._last_session_end, cap_end, now)
+            return None
+
+    # -- Internals ---------------------------------------------------------
+
+    def _close_session_locked(self) -> Optional[dict]:
+        """Close the open session; caller holds ``_lock``."""
+        start = self._session_start
+        end = self._session_last_hot or start
+        app = self._session_app
+        self._session_start = None
+        self._session_last_hot = None
+        self._session_app = "Microphone"
+        # Credit memory survives the reset — engagement until `end` stays true.
+        self._last_session_start = start
+        self._last_session_end = end
+
+        duration = (end - start).total_seconds()
+        if duration < self._min_session_seconds:
+            logger.debug(
+                "Mic session too short (%.0fs < %.0fs), discarding",
+                duration,
+                self._min_session_seconds,
+            )
+            return None
+        logger.info("Mic meeting session ended: %s duration=%.0fs", app, duration)
+        return self._make_event(app, start, duration)
+
+    def _make_event(self, app: str, start: datetime, duration: float) -> dict:
+        return {
+            # Deterministic id → the server upserts one row per session across
+            # per-cycle snapshots and the final close, mirroring call events.
+            "id": f"micsession_{self._hostname}_{int(start.timestamp())}",
+            "timestamp": start.isoformat(),
+            "duration": round(duration, 2),
+            "bucket_id": f"bf-call-detector_{self._hostname}",
+            "bucket_type": BUCKET_TYPE_CALL,
+            "data": {
+                "app": app,
+                "call_type": "mic",
+                "status": "completed",
+                "synthetic": True,
+            },
+        }
+
+
+# -- Platform probes -----------------------------------------------------
+
+
+class MacosMicProbe:
+    """Default-input-device "running somewhere" via CoreAudio (ctypes)."""
+
+    _SYSTEM_OBJECT = 1  # kAudioObjectSystemObject
+
+    def __init__(self) -> None:
+        import ctypes
+
+        self._ctypes = ctypes
+        self._ca = ctypes.CDLL(
+            "/System/Library/Frameworks/CoreAudio.framework/CoreAudio"
+        )
+
+        class _PropertyAddress(ctypes.Structure):
+            _fields_ = [
+                ("mSelector", ctypes.c_uint32),
+                ("mScope", ctypes.c_uint32),
+                ("mElement", ctypes.c_uint32),
+            ]
+
+        self._PropertyAddress = _PropertyAddress
+
+    @staticmethod
+    def _fourcc(code: str) -> int:
+        return int.from_bytes(code.encode("ascii"), "big")
+
+    def _get_uint32(self, object_id: int, selector: str) -> Optional[int]:
+        ctypes = self._ctypes
+        addr = self._PropertyAddress(
+            self._fourcc(selector), self._fourcc("glob"), 0
+        )
+        value = ctypes.c_uint32(0)
+        size = ctypes.c_uint32(ctypes.sizeof(value))
+        status = self._ca.AudioObjectGetPropertyData(
+            ctypes.c_uint32(object_id),
+            ctypes.byref(addr),
+            0,
+            None,
+            ctypes.byref(size),
+            ctypes.byref(value),
+        )
+        if status != 0:
+            return None
+        return value.value
+
+    def sample(self) -> MicSample:
+        try:
+            # 'dIn ' = kAudioHardwarePropertyDefaultInputDevice
+            device = self._get_uint32(self._SYSTEM_OBJECT, "dIn ")
+            if not device:
+                return MicSample(None)
+            # 'gone' = kAudioDevicePropertyDeviceIsRunningSomewhere
+            running = self._get_uint32(device, "gone")
+            if running is None:
+                return MicSample(None)
+            return MicSample(bool(running))
+        except Exception as e:
+            logger.debug("MacosMicProbe failed: %s", e)
+            return MicSample(None)
+
+
+class WindowsMicProbe:
+    """Apps currently holding the mic, via the CapabilityAccessManager consent
+    store (``LastUsedTimeStop == 0`` means "in use right now")."""
+
+    _ROOT = (
+        r"Software\Microsoft\Windows\CurrentVersion"
+        r"\CapabilityAccessManager\ConsentStore\microphone"
+    )
+
+    def sample(self) -> MicSample:
+        import winreg
+
+        apps: list[str] = []
+        try:
+            for base in (self._ROOT, self._ROOT + r"\NonPackaged"):
+                try:
+                    key = winreg.OpenKey(winreg.HKEY_CURRENT_USER, base)
+                except OSError:
+                    continue
+                with key:
+                    index = 0
+                    while True:
+                        try:
+                            sub = winreg.EnumKey(key, index)
+                        except OSError:
+                            break
+                        index += 1
+                        if sub == "NonPackaged":
+                            continue
+                        try:
+                            with winreg.OpenKey(key, sub) as sub_key:
+                                stop, _ = winreg.QueryValueEx(
+                                    sub_key, "LastUsedTimeStop"
+                                )
+                        except OSError:
+                            continue
+                        if stop == 0:
+                            # NonPackaged keys encode the exe path with '#'
+                            # separators; the last segment is the exe name.
+                            apps.append(sub.rsplit("#", 1)[-1])
+            return MicSample(bool(apps), tuple(apps))
+        except Exception as e:
+            logger.debug("WindowsMicProbe failed: %s", e)
+            return MicSample(None)
+
+
+def _conferencing_process_running() -> bool:
+    """psutil scan for a running conferencing-capable process (macOS gate,
+    where the mic can't be attributed per app)."""
+    import psutil
+
+    for proc in psutil.process_iter(["name"]):
+        try:
+            name = proc.info.get("name") or ""
+        except psutil.Error:
+            continue
+        if _matches_conferencing(name):
+            return True
+    return False
+
+
+def create_mic_detector(config, hostname: str) -> Optional[MicActivityDetector]:
+    """Build a mic detector from config, or None when disabled or unsupported
+    (Linux, or a platform probe that can't be constructed)."""
+    cd = config.call_detection
+    if not (getattr(cd, "enabled", False) and getattr(cd, "mic_signal", False)):
+        return None
+
+    probe: Optional[MicProbe] = None
+    gate = None
+    if sys.platform == "darwin":
+        try:
+            probe = MacosMicProbe()
+        except Exception as e:
+            logger.warning("Mic detection unavailable (CoreAudio load failed): %s", e)
+            return None
+        try:
+            import psutil  # noqa: F401
+
+            gate = _conferencing_process_running
+        except ImportError:
+            gate = None  # no attribution AND no process scan: mic-hot only
+    elif sys.platform == "win32":
+        probe = WindowsMicProbe()
+    else:
+        return None
+
+    return MicActivityDetector(
+        hostname=hostname,
+        probe=probe,
+        conferencing_gate=gate,
+        min_session_seconds=cd.min_call_duration,
+        max_credit_seconds=cd.max_credit_minutes * 60,
+    )

--- a/src/sync/mic_activity.py
+++ b/src/sync/mic_activity.py
@@ -51,8 +51,10 @@ from typing import Optional, Protocol
 
 try:
     from .aw_client import BUCKET_TYPE_CALL
+    from .engagement_credit import capped_credit
 except ImportError:  # PyInstaller bundle (src/ is import root)
     from sync.aw_client import BUCKET_TYPE_CALL
+    from sync.engagement_credit import capped_credit
 
 logger = logging.getLogger(__name__)
 
@@ -166,6 +168,18 @@ class MicActivityDetector:
 
         with self._lock:
             if hot:
+                if self._session_start is not None and (
+                    (now - self._session_start).total_seconds()
+                    >= self._max_credit_seconds
+                ):
+                    # Force-close at the credit cap even while still hot: past
+                    # the cap the session earns nothing, its growing snapshot
+                    # would eventually exceed the server's max event duration
+                    # (batch poison), and is_active() would suppress the local
+                    # idle pause indefinitely. A still-live meeting reopens as
+                    # a new session next cycle — the input-anchored cap means
+                    # the new session grants no fresh credit on its own.
+                    return self._close_session_locked()
                 if self._session_start is None:
                     self._session_start = now
                     self._session_app = self._attributed_app(sample)
@@ -187,9 +201,12 @@ class MicActivityDetector:
 
         Windows attributes the mic per app — require a conferencing match.
         macOS can't attribute (``apps`` empty), so fall back to "a conferencing
-        app is running" via the injected gate; a gate ERROR fails open (the hot
-        mic itself is the strong signal — losing a real meeting to a psutil
-        hiccup is the worse failure), but a gate answering False is respected.
+        app is running" via the injected gate. A gate ERROR fails CLOSED: this
+        signal feeds billing, so an error must never become an unconditional
+        pass (a reproducible gate crash would otherwise be a free bypass). The
+        cost is bounded — a transient error delays session open by one cycle
+        (the mic is still hot next cycle) and a mid-session blip is absorbed by
+        the off-grace window.
         """
         if sample.apps:
             return any(_matches_conferencing(app) for app in sample.apps)
@@ -198,8 +215,8 @@ class MicActivityDetector:
         try:
             return bool(self._conferencing_gate())
         except Exception as e:
-            logger.debug("conferencing gate failed (failing open): %s", e)
-            return True
+            logger.warning("mic conferencing gate failed (failing closed): %s", e)
+            return False
 
     @staticmethod
     def _attributed_app(sample: MicSample) -> str:
@@ -219,10 +236,10 @@ class MicActivityDetector:
             start = self._session_start
             end = self._session_last_hot or start
             app = self._session_app
-        duration = (end - start).total_seconds()
+        duration = min((end - start).total_seconds(), self._max_credit_seconds)
         if duration < self._min_session_seconds:
             return None
-        return self._make_event(app, start, duration)
+        return self._make_event(app, start, duration, status="ongoing")
 
     def flush(self) -> Optional[dict]:
         """Force-close any open session (shutdown / AW-outage boundaries)."""
@@ -241,22 +258,39 @@ class MicActivityDetector:
         self, base_last_input: Optional[datetime], now: datetime
     ) -> Optional[datetime]:
         """Most recent mic-engaged instant for ``AfkSource`` (activity-source
-        contract). ``now`` while a session is open, frozen at the session end
-        after it closes; both capped at ``max_credit_seconds`` past start."""
+        contract).
+
+        While a session is open, credit tracks the last HOT observation plus
+        the off-grace allowance (not bare ``now`` — after the mic actually
+        goes cold, credit must stop growing during the grace window, mirroring
+        CallDetector's leave-instant rule). After close it freezes at the
+        session end. Both are capped at ``max_credit_seconds`` past
+        ``base_last_input`` — the real-input anchor — so cycling the mic
+        off/on can't re-arm the cap (see ``engagement_credit``)."""
         with self._lock:
             if self._session_start is not None:
-                cap_end = self._session_start + timedelta(
-                    seconds=self._max_credit_seconds
+                last_hot = self._session_last_hot or self._session_start
+                engaged_until = min(
+                    now, last_hot + timedelta(seconds=self._off_grace_seconds)
                 )
-                return min(now, cap_end)
+                return capped_credit(
+                    engaged_until,
+                    base_last_input,
+                    self._session_start,
+                    self._max_credit_seconds,
+                    now,
+                )
             if (
                 self._last_session_start is not None
                 and self._last_session_end is not None
             ):
-                cap_end = self._last_session_start + timedelta(
-                    seconds=self._max_credit_seconds
+                return capped_credit(
+                    self._last_session_end,
+                    base_last_input,
+                    self._last_session_start,
+                    self._max_credit_seconds,
+                    now,
                 )
-                return min(self._last_session_end, cap_end, now)
             return None
 
     # -- Internals ---------------------------------------------------------
@@ -273,7 +307,7 @@ class MicActivityDetector:
         self._last_session_start = start
         self._last_session_end = end
 
-        duration = (end - start).total_seconds()
+        duration = min((end - start).total_seconds(), self._max_credit_seconds)
         if duration < self._min_session_seconds:
             logger.debug(
                 "Mic session too short (%.0fs < %.0fs), discarding",
@@ -282,9 +316,11 @@ class MicActivityDetector:
             )
             return None
         logger.info("Mic meeting session ended: %s duration=%.0fs", app, duration)
-        return self._make_event(app, start, duration)
+        return self._make_event(app, start, duration, status="completed")
 
-    def _make_event(self, app: str, start: datetime, duration: float) -> dict:
+    def _make_event(
+        self, app: str, start: datetime, duration: float, *, status: str
+    ) -> dict:
         return {
             # Deterministic id → the server upserts one row per session across
             # per-cycle snapshots and the final close, mirroring call events.
@@ -296,7 +332,12 @@ class MicActivityDetector:
             "data": {
                 "app": app,
                 "call_type": "mic",
-                "status": "completed",
+                # "ongoing" on live snapshots, "completed" on close/flush: the
+                # server must be able to tell a growing live row from a final
+                # one (a queued stale snapshot replayed after the final event
+                # must not masquerade as completed), and monotonic-growth
+                # enforcement server-side needs the distinction.
+                "status": status,
                 "synthetic": True,
             },
         }

--- a/src/sync/sync_engine.py
+++ b/src/sync/sync_engine.py
@@ -609,9 +609,30 @@ class SyncEngine:
             return
         span = ended or live
         if span:
-            all_events.append(span)
+            all_events.append(self._stamp_project(span))
             if ended is not None:
                 stats.calls_detected += 1
+
+    def _stamp_project(self, event: dict) -> dict:
+        """Attach the active project to a detector-built event, exactly as
+        _make_call_bf_event does for window-detected calls — the same meeting
+        must not upsert a projected call row next to an unprojected mic row."""
+        with self._state_lock:
+            project = self._current_project
+        if project:
+            event["project_id"] = project["id"]
+        return event
+
+    def _enqueue_events_best_effort(self, events: list, context: str) -> None:
+        """Queue events for later delivery when they can't be sent now (fully
+        offline paths that bypass _send_events' own queue-on-failure). Best
+        effort: a queue error is logged, never raised into the sync cycle."""
+        try:
+            self.queue.enqueue(events)
+        except Exception as e:
+            logger.warning(
+                "Failed to queue %d event(s) (%s): %s", len(events), context, e
+            )
 
     def _observe_foreground_activity(
         self, all_events: list, stats: "SyncStats", cycle: "_SyncCycleContext"
@@ -822,28 +843,55 @@ class SyncEngine:
             # supersedes this flushed one rather than double-billing.
             if self._call_detector:
                 remaining = self._call_detector.flush()
-                if remaining and self.bf.is_reachable():
-                    # _send_events may set stats.queued_bucket_ids on failure; we
-                    # return immediately and intentionally don't act on it — call
-                    # events go to the synthetic call bucket, not a checkpointed AW
-                    # bucket, so there is no checkpoint to withhold.
-                    self._send_events([self._make_call_bf_event(remaining)], stats)
+                if remaining:
                     stats.calls_detected += 1
+                    ev = self._make_call_bf_event(remaining)
+                    if self.bf.is_reachable():
+                        # _send_events may set stats.queued_bucket_ids on failure;
+                        # we return immediately and intentionally don't act on it —
+                        # call events go to the synthetic call bucket, not a
+                        # checkpointed AW bucket, so there is no checkpoint to
+                        # withhold.
+                        self._send_events([ev], stats)
+                    else:
+                        # Fully offline (AW down AND backend unreachable, e.g. a
+                        # resume off-network): the flush already reset the
+                        # detector, so this event can never be re-emitted — queue
+                        # it or the observed call span is silently lost.
+                        self._enqueue_events_best_effort([ev], "AW-outage call flush")
             # The mic probe doesn't depend on AW — keep observing during the
             # outage so a meeting that ends mid-outage closes its session.
             # Unlike the window-title detector above, no flush is needed: the
             # mic going cold is observable without window events, and a still-
             # hot mic is a still-running meeting that SHOULD keep suppressing
-            # idle. An ended span is still recorded if the backend is reachable.
+            # idle. An ended span is recorded (or queued when offline).
             if self._mic_detector:
                 try:
                     ended = self._mic_detector.observe(datetime.now(timezone.utc))
                 except Exception as e:
                     logger.debug("mic activity observe (AW outage) failed: %s", e)
                     ended = None
-                if ended and self.bf.is_reachable():
-                    self._send_events([ended], stats)
+                if ended:
                     stats.calls_detected += 1
+                    ended = self._stamp_project(ended)
+                    if self.bf.is_reachable():
+                        self._send_events([ended], stats)
+                    else:
+                        self._enqueue_events_best_effort([ended], "AW-outage mic close")
+            # The AFK sample log doesn't depend on AW either (OS idle clock +
+            # in-process sources). Without this, an outage spanning a hands-off
+            # meeting records NO samples, and after recovery the >timeout gap
+            # in the sample log is reconstructed as afk — re-creating the exact
+            # billed-idle-during-meeting failure this feature exists to fix,
+            # any time AW hiccups mid-meeting.
+            if self.afk_source is not None:
+                try:
+                    self.afk_source.record_sample(
+                        datetime.now(timezone.utc),
+                        protect_since=self._afk_inproc_checkpoint,
+                    )
+                except Exception as e:
+                    logger.debug("afk_source.record_sample (AW outage) failed: %s", e)
             return stats
 
         # Start session if needed (attempt directly; no pre-check to avoid TOCTOU).
@@ -1051,7 +1099,7 @@ class SyncEngine:
         if self._call_detector:
             snap = self._call_detector.snapshot()
             if snap:
-                all_events.append(self._make_call_bf_event(snap))
+                all_events.append(self._make_call_bf_event(snap, status="ongoing"))
         if call_events:
             stats.calls_detected += len(call_events)
             all_events.extend(call_events)
@@ -2472,7 +2520,9 @@ class SyncEngine:
             return
         self._send_status_span(kind="private", start=start)
 
-    def _make_call_bf_event(self, call_event: "CallEvent") -> dict:
+    def _make_call_bf_event(
+        self, call_event: "CallEvent", status: str = "completed"
+    ) -> dict:
         """Convert a CallEvent into a BetterFlow event dict.
 
         Includes a deterministic id so the server can dedupe and so the
@@ -2480,6 +2530,11 @@ class SyncEngine:
         event against the server's accepted_ids list. Without an id, a
         partial server reply that omits this event would otherwise be
         ambiguous between "accepted" and "not yet acknowledged".
+
+        ``status`` is "completed" for a call that actually ended (grace
+        expiry, outage flush, shutdown) and "ongoing" for the per-cycle live
+        snapshot of a still-open call — the server must be able to tell a
+        growing live row from a final one.
         """
         hostname = self._hostname
         call_id = f"call_{call_event.app}_{int(call_event.start.timestamp())}"
@@ -2492,7 +2547,7 @@ class SyncEngine:
             "data": {
                 "app": call_event.app,
                 "call_type": call_event.call_type,
-                "status": "completed",
+                "status": status,
             },
         }
         with self._state_lock:
@@ -3790,18 +3845,29 @@ class SyncEngine:
                 self._foreground_detector.flush()
             except Exception as e:
                 logger.debug("foreground detector flush on shutdown failed: %s", e)
-        # Same for any open call: calls stay open across sync boundaries now
-        # (per-cycle snapshot, not flush), so close it here or is_in_call()
-        # survives the logout. The last snapshot already uploaded the span.
+        # Same for any open call / mic session: both stay open across sync
+        # boundaries now (per-cycle snapshot, not flush), so close them here or
+        # is_in_call()/is_mic_meeting_active() survives the logout. The final
+        # event is QUEUED, not discarded: the tail between the last uploaded
+        # snapshot and shutdown (plus its "completed" status) would otherwise
+        # be lost from the audit trail; the next launch delivers it, and the
+        # deterministic id makes the replay an upsert, never a duplicate.
         if self._call_detector is not None:
             try:
-                self._call_detector.flush()
+                remaining = self._call_detector.flush()
+                if remaining:
+                    self._enqueue_events_best_effort(
+                        [self._make_call_bf_event(remaining)], "shutdown call flush"
+                    )
             except Exception as e:
                 logger.debug("call detector flush on shutdown failed: %s", e)
-        # And any open mic-meeting session, for the same reason.
         if self._mic_detector is not None:
             try:
-                self._mic_detector.flush()
+                ended = self._mic_detector.flush()
+                if ended:
+                    self._enqueue_events_best_effort(
+                        [self._stamp_project(ended)], "shutdown mic flush"
+                    )
             except Exception as e:
                 logger.debug("mic detector flush on shutdown failed: %s", e)
         # Close time tracker

--- a/src/sync/sync_engine.py
+++ b/src/sync/sync_engine.py
@@ -669,8 +669,9 @@ class SyncEngine:
 
     def _deliver_final_event(self, event: dict, context: str) -> None:
         """Deliver a final detector event at shutdown: one immediate direct
-        send, queueing only on TRANSIENT failure. Never raises — shutdown must
-        complete regardless.
+        send, queueing on any non-auth failure (a definitive rejection ages
+        out via the queue's retry dead-lettering). Never raises — shutdown
+        must complete regardless.
 
         Deliberately bypasses _send_events: its auth-error path enqueues the
         batch before raising, and an expired token is the LIKELIEST failure at
@@ -4023,9 +4024,10 @@ class SyncEngine:
         # is_in_call()/is_mic_meeting_active() survives the logout. The final
         # event is SENT NOW when possible: shutdown runs on logout, and a row
         # left in the (account-agnostic) offline queue would be delivered
-        # under whoever logs in NEXT on a shared machine. _send_events falls
-        # back to the queue itself only when the send genuinely fails, and the
-        # deterministic id makes any replay an upsert, never a duplicate.
+        # under whoever logs in NEXT on a shared machine. _deliver_final_event
+        # queues only on non-auth send failure (auth errors DROP — see its
+        # docstring), and the deterministic id makes any replay an upsert,
+        # never a duplicate.
         if self._call_detector is not None:
             try:
                 remaining = self._call_detector.flush()

--- a/src/sync/sync_engine.py
+++ b/src/sync/sync_engine.py
@@ -24,7 +24,7 @@ except ImportError:
 try:
     from ..browser_tracker import is_browser_app
     from ..config import Config
-    from .aw_client import AWClientError, AWEvent, BUCKET_TYPE_WINDOW, BUCKET_TYPE_WINDOW_ALT, BUCKET_TYPE_AFK, BUCKET_TYPE_AFK_ALT, BUCKET_TYPE_WEB, BUCKET_TYPE_INPUT, BUCKET_TYPE_CALL
+    from .aw_client import AWClientError, AWEvent, BUCKET_TYPE_WINDOW, BUCKET_TYPE_WINDOW_ALT, BUCKET_TYPE_AFK, BUCKET_TYPE_AFK_ALT, BUCKET_TYPE_WEB, BUCKET_TYPE_INPUT, BUCKET_TYPE_CALL, CALL_STATUS_ONGOING, CALL_STATUS_COMPLETED
     from .bf_client import BetterFlowClientError, BetterFlowAuthError
     from .protocols import AWClientProtocol, BFClientProtocol, OfflineQueueProtocol
     from .activity_analyzer import ActivityAnalyzer, EngagementThresholds
@@ -37,7 +37,7 @@ try:
 except ImportError:
     from browser_tracker import is_browser_app
     from config import Config
-    from sync.aw_client import AWClientError, AWEvent, BUCKET_TYPE_WINDOW, BUCKET_TYPE_WINDOW_ALT, BUCKET_TYPE_AFK, BUCKET_TYPE_AFK_ALT, BUCKET_TYPE_WEB, BUCKET_TYPE_INPUT, BUCKET_TYPE_CALL
+    from sync.aw_client import AWClientError, AWEvent, BUCKET_TYPE_WINDOW, BUCKET_TYPE_WINDOW_ALT, BUCKET_TYPE_AFK, BUCKET_TYPE_AFK_ALT, BUCKET_TYPE_WEB, BUCKET_TYPE_INPUT, BUCKET_TYPE_CALL, CALL_STATUS_ONGOING, CALL_STATUS_COMPLETED
     from sync.bf_client import BetterFlowClientError, BetterFlowAuthError
     from sync.protocols import AWClientProtocol, BFClientProtocol, OfflineQueueProtocol
     from sync.activity_analyzer import ActivityAnalyzer, EngagementThresholds
@@ -463,6 +463,9 @@ class SyncEngine:
             self._session_active = False
         if need_advance:
             self._advance_checkpoints_to_now("pause")
+            # Close any open call/mic session: paused time is not recorded, so
+            # a session left open would bridge the pause into one uploaded span.
+            self.flush_engagement_detectors("pause")
         if need_end_session:
             try:
                 self.bf.end_session("app_quit")
@@ -537,6 +540,11 @@ class SyncEngine:
                 self._session_active = False
         if entering_private:
             self._advance_checkpoints_to_now("private_time")
+            # Close any open call/mic session at the boundary. Without this, a
+            # call spanning the private hour ends AFTER it and uploads one
+            # 'completed' span covering the whole private period — recording
+            # exactly what Private Time contractually never records.
+            self.flush_engagement_detectors("private_time")
         if leaving_private and private_start_snap:
             # Skip the private window AW recorded (active window + not-afk while
             # the user kept working). The enter-time advance set checkpoints to
@@ -600,6 +608,20 @@ class SyncEngine:
         detector = self._mic_detector
         if detector is None:
             return
+        cd = self.config.call_detection
+        if not (cd.enabled and cd.mic_signal):
+            # Server kill switch without an app restart: the detector was
+            # built at startup, but a privacy-sensitive probe must honour a
+            # server-pushed mic_signal=false NOW. Close any open session (the
+            # truthful span still ships) and stop sampling.
+            try:
+                ended = detector.flush()
+            except Exception as e:
+                logger.debug("mic detector kill-switch flush failed: %s", e)
+                ended = None
+            if ended:
+                all_events.append(self._stamp_project(ended))
+            return
         now = datetime.now(timezone.utc)
         try:
             ended = detector.observe(now)
@@ -633,6 +655,67 @@ class SyncEngine:
             logger.warning(
                 "Failed to queue %d event(s) (%s): %s", len(events), context, e
             )
+
+    def _deliver_final_event(self, event: dict, context: str) -> None:
+        """Deliver a final detector event at shutdown: one immediate send
+        attempt (with _send_events' own queue-on-failure as the fallback).
+        Never raises — shutdown must complete regardless."""
+        try:
+            self._send_events([event], SyncStats())
+        except Exception as e:
+            # BetterFlowAuthError re-raises AFTER queueing; anything else may
+            # not have queued — enqueue as last resort (the deterministic id
+            # makes a double-queue converge server-side).
+            logger.warning("final event send failed (%s): %s — queueing", context, e)
+            self._enqueue_events_best_effort([event], context)
+
+    def engagement_activity_sources(self) -> list:
+        """Every engagement detector that feeds AFK credit — THE list main.py
+        registers with AfkSource. Owned by the class that constructs the
+        detectors so adding detector #4 can't silently miss the uploaded
+        stream (a detector wired into the local idle guard but not into
+        AfkSource reproduces this feature's founding bug: tray says tracking,
+        server bills idle)."""
+        return [
+            d
+            for d in (
+                self._call_detector,
+                self._mic_detector,
+                self._foreground_detector,
+            )
+            if d is not None
+        ]
+
+    def flush_engagement_detectors(self, context: str) -> None:
+        """Close any open call/mic session at a capture boundary — pause,
+        private time, working-hours suppression.
+
+        Detector state must NOT stay open across a not-recorded period: the
+        detectors receive no events while capture is off, so the eventual
+        close after resume would emit one span BRIDGING the boundary (a
+        'completed' call covering a whole private hour, or a 4h-capped call
+        spanning the suppressed night). The truthful pre-boundary span is
+        queued for delivery; AFK credit survives via the detectors'
+        ended-session memory, which freezes at the real pre-boundary end.
+        """
+        if self._call_detector is not None:
+            try:
+                remaining = self._call_detector.flush()
+                if remaining:
+                    self._enqueue_events_best_effort(
+                        [self._make_call_bf_event(remaining)], context
+                    )
+            except Exception as e:
+                logger.warning("call detector flush (%s) failed: %s", context, e)
+        if self._mic_detector is not None:
+            try:
+                ended = self._mic_detector.flush()
+                if ended:
+                    self._enqueue_events_best_effort(
+                        [self._stamp_project(ended)], context
+                    )
+            except Exception as e:
+                logger.warning("mic detector flush (%s) failed: %s", context, e)
 
     def _observe_foreground_activity(
         self, all_events: list, stats: "SyncStats", cycle: "_SyncCycleContext"
@@ -812,6 +895,13 @@ class SyncEngine:
         # looking dead every evening.
         if not self.config.working_hours.allows(datetime.now(timezone.utc)):
             stats.capture_suppressed = True
+            # Close any open call/mic session ONCE at the suppression edge
+            # (idempotent — later suppressed cycles find nothing open). A call
+            # title still matching when capture stops at 22:00 would otherwise
+            # stay open all night (trackers down, no events, no flush) and the
+            # morning resume would upload a cap-length span covering hours
+            # that were contractually not recorded.
+            self.flush_engagement_detectors("capture_suppressed")
             if self.bf.is_reachable() and not self.queue.is_empty():
                 if not self._cycle_network_budget_exceeded(self._QUEUE_SKIP_IF_CYCLE_ELAPSED):
                     self._process_queue(stats)
@@ -1099,7 +1189,9 @@ class SyncEngine:
         if self._call_detector:
             snap = self._call_detector.snapshot()
             if snap:
-                all_events.append(self._make_call_bf_event(snap, status="ongoing"))
+                all_events.append(
+                    self._make_call_bf_event(snap, status=CALL_STATUS_ONGOING)
+                )
         if call_events:
             stats.calls_detected += len(call_events)
             all_events.extend(call_events)
@@ -2521,7 +2613,7 @@ class SyncEngine:
         self._send_status_span(kind="private", start=start)
 
     def _make_call_bf_event(
-        self, call_event: "CallEvent", status: str = "completed"
+        self, call_event: "CallEvent", status: str = CALL_STATUS_COMPLETED
     ) -> dict:
         """Convert a CallEvent into a BetterFlow event dict.
 
@@ -3275,6 +3367,27 @@ class SyncEngine:
             if not queued:
                 break
 
+            # Stale live snapshots must never be REPLAYED: a queued 'ongoing'
+            # call-bucket row (a transient failure requeues the whole batch,
+            # snapshots included) replayed after the meeting's final
+            # 'completed' event landed would upsert the same deterministic id
+            # back to a shorter, forever-'ongoing' span. A newer snapshot or
+            # the final event always supersedes a stale snapshot, so dropping
+            # them at drain time loses nothing.
+            stale_snapshot_ids = [
+                q.id
+                for q in queued
+                if q.event_data.get("bucket_type") == BUCKET_TYPE_CALL
+                and (q.event_data.get("data") or {}).get("status")
+                == CALL_STATUS_ONGOING
+            ]
+            if stale_snapshot_ids:
+                self.queue.remove(stale_snapshot_ids)
+                stale_set = set(stale_snapshot_ids)
+                queued = [q for q in queued if q.id not in stale_set]
+                if not queued:
+                    continue
+
             events = [q.event_data for q in queued]
             event_ids = [q.id for q in queued]
 
@@ -3848,16 +3961,17 @@ class SyncEngine:
         # Same for any open call / mic session: both stay open across sync
         # boundaries now (per-cycle snapshot, not flush), so close them here or
         # is_in_call()/is_mic_meeting_active() survives the logout. The final
-        # event is QUEUED, not discarded: the tail between the last uploaded
-        # snapshot and shutdown (plus its "completed" status) would otherwise
-        # be lost from the audit trail; the next launch delivers it, and the
-        # deterministic id makes the replay an upsert, never a duplicate.
+        # event is SENT NOW when possible: shutdown runs on logout, and a row
+        # left in the (account-agnostic) offline queue would be delivered
+        # under whoever logs in NEXT on a shared machine. _send_events falls
+        # back to the queue itself only when the send genuinely fails, and the
+        # deterministic id makes any replay an upsert, never a duplicate.
         if self._call_detector is not None:
             try:
                 remaining = self._call_detector.flush()
                 if remaining:
-                    self._enqueue_events_best_effort(
-                        [self._make_call_bf_event(remaining)], "shutdown call flush"
+                    self._deliver_final_event(
+                        self._make_call_bf_event(remaining), "shutdown call flush"
                     )
             except Exception as e:
                 logger.debug("call detector flush on shutdown failed: %s", e)
@@ -3865,8 +3979,8 @@ class SyncEngine:
             try:
                 ended = self._mic_detector.flush()
                 if ended:
-                    self._enqueue_events_best_effort(
-                        [self._stamp_project(ended)], "shutdown mic flush"
+                    self._deliver_final_event(
+                        self._stamp_project(ended), "shutdown mic flush"
                     )
             except Exception as e:
                 logger.debug("mic detector flush on shutdown failed: %s", e)

--- a/src/sync/sync_engine.py
+++ b/src/sync/sync_engine.py
@@ -401,7 +401,10 @@ class SyncEngine:
 
         # Call/meeting detection
         self._call_detector: Optional[CallDetector] = (
-            CallDetector(min_duration=config.call_detection.min_call_duration)
+            CallDetector(
+                min_duration=config.call_detection.min_call_duration,
+                max_credit_seconds=config.call_detection.max_credit_minutes * 60,
+            )
             if config.call_detection.enabled
             else None
         )

--- a/src/sync/sync_engine.py
+++ b/src/sync/sync_engine.py
@@ -574,7 +574,18 @@ class SyncEngine:
         ends, so it stays True for the duration of a meeting.
         """
         detector = self._call_detector
-        return bool(detector and detector.is_in_call())
+        if not (detector and detector.is_in_call()):
+            return False
+        # Evidence freshness: with AW up but the window watcher hung mid-call,
+        # no event will ever end the call — the raw state machine stays
+        # IN_CALL forever. Don't suppress the idle pause on state nothing has
+        # confirmed for minutes (the billed credit already froze via the same
+        # staleness rule; local and uploaded must agree).
+        try:
+            return detector.has_fresh_evidence(datetime.now(timezone.utc))
+        except Exception as e:
+            logger.debug("is_in_call freshness check failed: %s", e)
+            return True  # defensive: never break the idle guard on a helper error
 
     def is_active_dev_session(self) -> bool:
         """True while the foreground-CPU detector reports an active session.
@@ -657,15 +668,30 @@ class SyncEngine:
             )
 
     def _deliver_final_event(self, event: dict, context: str) -> None:
-        """Deliver a final detector event at shutdown: one immediate send
-        attempt (with _send_events' own queue-on-failure as the fallback).
-        Never raises — shutdown must complete regardless."""
+        """Deliver a final detector event at shutdown: one immediate direct
+        send, queueing only on TRANSIENT failure. Never raises — shutdown must
+        complete regardless.
+
+        Deliberately bypasses _send_events: its auth-error path enqueues the
+        batch before raising, and an expired token is the LIKELIEST failure at
+        logout — the queued row would then be delivered under whoever logs in
+        next on this machine (the queue is account-agnostic). On auth failure
+        the event is dropped with a log line instead, matching
+        _send_status_span's policy for exactly this reason.
+        """
         try:
-            self._send_events([event], SyncStats())
+            result = self.bf.send_events([event])
+            if getattr(result, "success", False):
+                return
+            self._enqueue_events_best_effort([event], context)
+        except BetterFlowAuthError as e:
+            logger.warning(
+                "final event dropped (%s): auth error at shutdown — not queued "
+                "(would deliver under the next login): %s",
+                context,
+                e,
+            )
         except Exception as e:
-            # BetterFlowAuthError re-raises AFTER queueing; anything else may
-            # not have queued — enqueue as last resort (the deterministic id
-            # makes a double-queue converge server-side).
             logger.warning("final event send failed (%s): %s — queueing", context, e)
             self._enqueue_events_best_effort([event], context)
 
@@ -716,6 +742,17 @@ class SyncEngine:
                     )
             except Exception as e:
                 logger.warning("mic detector flush (%s) failed: %s", context, e)
+        # The foreground/dev-session detector too: its upserted span would
+        # otherwise bridge the boundary the same way (session_start pre-pause,
+        # first post-resume observe() extends it across the not-recorded
+        # period) — and on Linux the dev-session span IS the billing path.
+        if self._foreground_detector is not None:
+            try:
+                span = self._foreground_detector.flush()
+                if span:
+                    self._enqueue_events_best_effort([span], context)
+            except Exception as e:
+                logger.warning("foreground detector flush (%s) failed: %s", context, e)
 
     def _observe_foreground_activity(
         self, all_events: list, stats: "SyncStats", cycle: "_SyncCycleContext"
@@ -850,6 +887,17 @@ class SyncEngine:
             private_mode = self._private_mode
             private_start = self._private_start
         if paused or private_mode:
+            # Re-flush the engagement detectors every paused/private cycle
+            # (idempotent — no-op when nothing is open). The boundary flush in
+            # pause()/set_private_mode() runs on the TRAY thread and can race
+            # a sync cycle already in flight: that cycle passed the paused
+            # check before the toggle and keeps feeding pre-boundary window
+            # events into the call detector AFTER the flush, re-opening the
+            # call. Without this, the reopened call stays open across the
+            # whole private period and the first post-resume event closes it
+            # with an end that BRIDGES it — exactly the privacy bug the
+            # boundary flush exists to prevent. Mirrors the suppressed branch.
+            self.flush_engagement_detectors("paused_or_private")
             # While Private Time is on, nothing is synced — so the backend
             # cannot tell an ongoing private session from a network gap, and
             # its tracked-hours trailing grace painted the window as counted
@@ -954,10 +1002,16 @@ class SyncEngine:
             # Unlike the window-title detector above, no flush is needed: the
             # mic going cold is observable without window events, and a still-
             # hot mic is a still-running meeting that SHOULD keep suppressing
-            # idle. An ended span is recorded (or queued when offline).
+            # idle. An ended span is recorded (or queued when offline). The
+            # kill switch applies here exactly as on the normal path — an AW
+            # outage must not keep a server-disabled mic probe sampling.
             if self._mic_detector:
+                cd_cfg = self.config.call_detection
                 try:
-                    ended = self._mic_detector.observe(datetime.now(timezone.utc))
+                    if not (cd_cfg.enabled and cd_cfg.mic_signal):
+                        ended = self._mic_detector.flush()
+                    else:
+                        ended = self._mic_detector.observe(datetime.now(timezone.utc))
                 except Exception as e:
                     logger.debug("mic activity observe (AW outage) failed: %s", e)
                     ended = None
@@ -3373,7 +3427,13 @@ class SyncEngine:
             # 'completed' event landed would upsert the same deterministic id
             # back to a shorter, forever-'ongoing' span. A newer snapshot or
             # the final event always supersedes a stale snapshot, so dropping
-            # them at drain time loses nothing.
+            # them at drain time loses nothing for any meeting that closes
+            # normally. ACCEPTED LOSS: a mic session whose every snapshot was
+            # queued (offline for the whole meeting) AND whose process crashed
+            # before the mic went cold has no other record — unlike window
+            # calls, which re-derive from the un-advanced AW checkpoint after
+            # a crash. Chosen over the alternative (replaying stale snapshots
+            # regresses completed rows forever).
             stale_snapshot_ids = [
                 q.id
                 for q in queued

--- a/src/sync/sync_engine.py
+++ b/src/sync/sync_engine.py
@@ -759,13 +759,15 @@ class SyncEngine:
         # Check ActivityWatch
         if not self.aw.is_running():
             stats.errors.append("ActivityWatch is not running")
-            # Finalize any in-progress call before bailing. Otherwise is_in_call()
-            # stays True for the whole outage (sync returns here every cycle, so
-            # the end-of-sync flush at line ~522 never runs), and the idle guard
-            # in IdleManager keeps suppressing idle long after the call ended —
-            # painting the post-call AFK stretch as worked time. The observed call
-            # portion is still recorded if the backend is reachable; if AW comes
-            # back mid-call a fresh call starts cleanly.
+            # Finalize any in-progress call before bailing. Without window
+            # events the detector can never observe the call ending, so
+            # is_in_call() would stay True for the whole outage and the idle
+            # guard in IdleManager would keep suppressing idle long after the
+            # call ended — painting the post-call AFK stretch as worked time.
+            # (AFK credit is safe either way: get_last_active_at freezes at the
+            # flushed call's END, never tracks `now` for an ended call.) The
+            # observed call portion is still recorded if the backend is
+            # reachable; if AW comes back mid-call a fresh call starts cleanly.
             #
             # That recovery can emit a SECOND event for the same meeting (the
             # continuation is picked up from the un-advanced checkpoint). Both
@@ -969,11 +971,19 @@ class SyncEngine:
             if input_event is not None:
                 all_events.append(input_event)
 
-        # Flush any ongoing call at sync boundary
+        # Live snapshot of any ongoing call — WITHOUT ending it. The id derives
+        # from (app, start), so the server upserts one growing row per meeting.
+        # The old per-cycle flush() here ended the call at every sync boundary:
+        # one meeting fragmented into per-cycle call rows, is_in_call() dropped
+        # to False between cycles (IdleManager's in-call idle suppression raced
+        # a sub-second window and mostly never engaged — Ecaterina's huddle
+        # billed Idle, 2026-07-15), and the AFK activity source found flushed
+        # state at record_sample time. The call now stays open until its real
+        # end (grace expiry), an AW outage, or shutdown.
         if self._call_detector:
-            remaining = self._call_detector.flush()
-            if remaining:
-                call_events.append(self._make_call_bf_event(remaining))
+            snap = self._call_detector.snapshot()
+            if snap:
+                all_events.append(self._make_call_bf_event(snap))
         if call_events:
             stats.calls_detected += len(call_events)
             all_events.extend(call_events)
@@ -3712,5 +3722,13 @@ class SyncEngine:
                 self._foreground_detector.flush()
             except Exception as e:
                 logger.debug("foreground detector flush on shutdown failed: %s", e)
+        # Same for any open call: calls stay open across sync boundaries now
+        # (per-cycle snapshot, not flush), so close it here or is_in_call()
+        # survives the logout. The last snapshot already uploaded the span.
+        if self._call_detector is not None:
+            try:
+                self._call_detector.flush()
+            except Exception as e:
+                logger.debug("call detector flush on shutdown failed: %s", e)
         # Close time tracker
         self._time_tracker.close()

--- a/src/sync/sync_engine.py
+++ b/src/sync/sync_engine.py
@@ -31,6 +31,7 @@ try:
     from .daily_time_tracker import DailyTimeTracker
     from .call_detector import CallDetector, CallEvent
     from .foreground_activity import ForegroundActivityDetector, create_detector
+    from .mic_activity import MicActivityDetector, create_mic_detector
     from .os_idle import get_system_idle_seconds
     from .queue import is_event_storable
 except ImportError:
@@ -43,6 +44,7 @@ except ImportError:
     from sync.daily_time_tracker import DailyTimeTracker
     from sync.call_detector import CallDetector, CallEvent
     from sync.foreground_activity import ForegroundActivityDetector, create_detector
+    from sync.mic_activity import MicActivityDetector, create_mic_detector
     from sync.os_idle import get_system_idle_seconds
     from sync.queue import is_event_storable
 
@@ -409,6 +411,16 @@ class SyncEngine:
             else None
         )
 
+        # Microphone-in-use meeting detection: the system-level companion to
+        # the window-title CallDetector above — it keeps seeing a meeting when
+        # the call window is NOT frontmost (background huddle while reading
+        # docs). None when disabled (call_detection.enabled or mic_signal off)
+        # or unsupported (Linux). Wired into AfkSource as an activity source by
+        # main.py; sessions upload as auditable call events (call_type "mic").
+        self._mic_detector: Optional[MicActivityDetector] = create_mic_detector(
+            config, self._hostname
+        )
+
         # Foreground-CPU activity detection: credits engaged-but-no-input work
         # (an active Claude Code / build / render in the focused window) that the
         # AFK timeout would otherwise mark idle. None when disabled or
@@ -566,6 +578,40 @@ class SyncEngine:
         """
         detector = self._foreground_detector
         return bool(detector and detector.is_active())
+
+    def is_mic_meeting_active(self) -> bool:
+        """True while the mic-in-use detector reports an open meeting session.
+
+        Consulted by idle detection alongside ``is_in_call`` — the mic keeps
+        seeing a meeting the window-title detector loses the moment the call
+        window stops being frontmost. False when disabled or unsupported.
+        """
+        detector = self._mic_detector
+        return bool(detector and detector.is_active())
+
+    def _observe_mic_activity(self, all_events: list, stats: "SyncStats") -> None:
+        """Sample the microphone and append any mic-meeting span.
+
+        Mirrors ``_observe_foreground_activity``: the session stays OPEN across
+        cycles (so ``is_mic_meeting_active`` doesn't flap), a live snapshot is
+        uploaded each cycle under a deterministic id (server upserts one row),
+        and the final span is emitted when the mic goes cold past the grace.
+        """
+        detector = self._mic_detector
+        if detector is None:
+            return
+        now = datetime.now(timezone.utc)
+        try:
+            ended = detector.observe(now)
+            live = detector.snapshot() if ended is None else None
+        except Exception as e:
+            logger.debug("mic activity observe failed: %s", e)
+            return
+        span = ended or live
+        if span:
+            all_events.append(span)
+            if ended is not None:
+                stats.calls_detected += 1
 
     def _observe_foreground_activity(
         self, all_events: list, stats: "SyncStats", cycle: "_SyncCycleContext"
@@ -783,6 +829,21 @@ class SyncEngine:
                     # bucket, so there is no checkpoint to withhold.
                     self._send_events([self._make_call_bf_event(remaining)], stats)
                     stats.calls_detected += 1
+            # The mic probe doesn't depend on AW — keep observing during the
+            # outage so a meeting that ends mid-outage closes its session.
+            # Unlike the window-title detector above, no flush is needed: the
+            # mic going cold is observable without window events, and a still-
+            # hot mic is a still-running meeting that SHOULD keep suppressing
+            # idle. An ended span is still recorded if the backend is reachable.
+            if self._mic_detector:
+                try:
+                    ended = self._mic_detector.observe(datetime.now(timezone.utc))
+                except Exception as e:
+                    logger.debug("mic activity observe (AW outage) failed: %s", e)
+                    ended = None
+                if ended and self.bf.is_reachable():
+                    self._send_events([ended], stats)
+                    stats.calls_detected += 1
             return stats
 
         # Start session if needed (attempt directly; no pre-check to avoid TOCTOU).
@@ -900,6 +961,13 @@ class SyncEngine:
         # the AFK activity-source credit (folded by next cycle's record_sample),
         # and emits an auditable dev-session span when a session ends.
         self._observe_foreground_activity(all_events, stats, cycle)
+
+        # Microphone-in-use meeting detection: the system-level companion to the
+        # window-title call detector — sees a meeting even when the call window
+        # isn't frontmost. Keeps is_mic_meeting_active() current for the idle
+        # guard, advances the AFK activity-source credit, and uploads a live
+        # snapshot / final span (call_type "mic") for server-side audit.
+        self._observe_mic_activity(all_events, stats)
 
         # Clear window-specific AFK context before processing non-window buckets
         # so AFK events from one window bucket don't leak into unrelated buckets.
@@ -3730,5 +3798,11 @@ class SyncEngine:
                 self._call_detector.flush()
             except Exception as e:
                 logger.debug("call detector flush on shutdown failed: %s", e)
+        # And any open mic-meeting session, for the same reason.
+        if self._mic_detector is not None:
+            try:
+                self._mic_detector.flush()
+            except Exception as e:
+                logger.debug("mic detector flush on shutdown failed: %s", e)
         # Close time tracker
         self._time_tracker.close()

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -49,3 +49,21 @@ def _isolate_agent_config(tmp_path, monkeypatch):
     config_module._machine_uuid_cache = None
     yield
     config_module._machine_uuid_cache = None
+
+
+@pytest.fixture(autouse=True)
+def _no_real_mic_probe(monkeypatch):
+    """Never let a test-constructed SyncEngine talk to the REAL microphone.
+
+    call_detection.mic_signal defaults on, so on a macOS/Windows dev machine
+    every `SyncEngine(...)` in the suite would build a live CoreAudio/registry
+    probe — and a developer running the tests while in a meeting (hot mic)
+    would flip mic-session state inside unrelated engine tests. CI (Linux)
+    never constructs one, so this also keeps local runs equal to CI. Tests
+    that want a mic detector inject one with a fake probe.
+    """
+    import src.sync.sync_engine as sync_engine_module
+
+    monkeypatch.setattr(
+        sync_engine_module, "create_mic_detector", lambda *a, **k: None
+    )

--- a/tests/test_call_detector.py
+++ b/tests/test_call_detector.py
@@ -684,13 +684,126 @@ class TestCallPersistsAcrossSyncCycles:
         )
         assert snaps[1]["duration"] > snaps[0]["duration"]
 
-    def test_shutdown_closes_open_call_and_queues_final_event(self):
+    def test_shutdown_closes_open_call_and_sends_final_event(self):
+        # Shutdown runs on logout: the final span is SENT under the owner's
+        # token (queue only as fallback — the queue is account-agnostic and a
+        # leftover row would deliver under the next login on a shared machine).
         engine = self._build_engine()
         t0 = datetime(2026, 7, 15, 17, 7, 0, tzinfo=timezone.utc)
         engine._call_detector.process_event("Slack", "Huddle", None, t0, 60)
         engine.shutdown()
         assert engine.is_in_call() is False
-        assert not engine.queue.is_empty(), (
-            "the final call span (tail since the last snapshot, plus its "
-            "'completed' status) must be queued at shutdown, not discarded"
+        finals = [
+            ev for ev in self._sent_call_events(engine)
+            if ev["data"]["status"] == "completed"
+        ]
+        assert len(finals) == 1, "final call span sent at shutdown"
+        assert engine.queue.is_empty()
+
+
+class TestCaptureBoundariesCloseSessions:
+    """Open call/mic sessions must not bridge not-recorded periods (private
+    time, manual pause, working-hours suppression) into one uploaded span."""
+
+    def _engine_in_call(self):
+        harness = TestCallPersistsAcrossSyncCycles()
+        engine = harness._build_engine()
+        t0 = datetime(2026, 7, 15, 14, 0, 0, tzinfo=timezone.utc)
+        engine._call_detector.process_event("zoom.us", "Zoom Meeting", None, t0, 60)
+        engine._call_detector.process_event(
+            "zoom.us", "Zoom Meeting", None, t0 + timedelta(minutes=10), 60
         )
+        assert engine.is_in_call()
+        return engine, t0
+
+    def _queued_completed_calls(self, engine):
+        rows = engine.queue.dequeue(100)
+        return [
+            q.event_data
+            for q in rows
+            if q.event_data.get("bucket_type") == "call"
+            and q.event_data["data"]["status"] == "completed"
+        ]
+
+    def test_private_time_closes_call_at_boundary(self):
+        engine, t0 = self._engine_in_call()
+        engine.set_private_mode(True)
+        assert engine.is_in_call() is False, (
+            "a call left open across Private Time would later upload one span "
+            "covering the whole private period"
+        )
+        finals = self._queued_completed_calls(engine)
+        assert len(finals) == 1
+        # The queued span ends at the last pre-private evidence, ~14:11.
+        assert finals[0]["duration"] <= 11 * 60 + 1
+
+    def test_pause_closes_call_at_boundary(self):
+        engine, _ = self._engine_in_call()
+        engine.pause()
+        assert engine.is_in_call() is False
+        assert len(self._queued_completed_calls(engine)) == 1
+
+    def test_capture_suppression_closes_call_at_boundary(self):
+        from types import SimpleNamespace
+
+        engine, _ = self._engine_in_call()
+        engine.config.working_hours = SimpleNamespace(
+            known=True, allows=lambda ts: False
+        )
+        stats = engine.sync()
+        assert stats.capture_suppressed is True
+        assert engine.is_in_call() is False, (
+            "a call title still matching when capture stops must not stay "
+            "open all night and manufacture a span over the suppressed hours"
+        )
+        # The suppressed branch drains the queue right after the flush, so the
+        # final span is already SENT (queued only when offline).
+        sent_finals = [
+            ev
+            for call in engine.bf.send_events.call_args_list
+            for ev in call.args[0]
+            if ev.get("bucket_type") == "call"
+            and ev["data"]["status"] == "completed"
+        ]
+        assert len(sent_finals) == 1
+
+
+class TestStaleOngoingSnapshotsNeverReplay:
+    def test_process_queue_drops_ongoing_call_rows(self):
+        harness = TestCallPersistsAcrossSyncCycles()
+        engine = harness._build_engine()
+        t0 = datetime(2026, 7, 15, 17, 0, 0, tzinfo=timezone.utc)
+        stale_snapshot = {
+            "id": "call_Zoom_1784000000",
+            "timestamp": t0.isoformat(),
+            "duration": 120.0,
+            "bucket_id": "bf-call-detector_h",
+            "bucket_type": "call",
+            "data": {"app": "Zoom", "call_type": "native", "status": "ongoing"},
+        }
+        final_event = {
+            "id": "call_Zoom_1784000000",
+            "timestamp": t0.isoformat(),
+            "duration": 600.0,
+            "bucket_id": "bf-call-detector_h",
+            "bucket_type": "call",
+            "data": {"app": "Zoom", "call_type": "native", "status": "completed"},
+        }
+        engine.queue.enqueue([stale_snapshot, final_event])
+
+        from src.sync.sync_engine import SyncStats
+        engine._process_queue(SyncStats())
+
+        sent = [
+            ev
+            for call in engine.bf.send_events.call_args_list
+            for ev in call.args[0]
+        ]
+        statuses = [ev["data"]["status"] for ev in sent]
+        assert "ongoing" not in statuses, (
+            "a stale queued 'ongoing' snapshot replayed after the final "
+            "'completed' event would upsert the row back to a shorter, "
+            "forever-ongoing span"
+        )
+        assert "completed" in statuses
+        assert engine.queue.is_empty(), "stale snapshot removed, not retried"

--- a/tests/test_call_detector.py
+++ b/tests/test_call_detector.py
@@ -661,19 +661,16 @@ class TestCallPersistsAcrossSyncCycles:
 
     def test_call_stays_open_and_snapshots_upsert_one_row(self):
         engine = self._build_engine()
-        t0 = datetime(2026, 7, 15, 17, 7, 0, tzinfo=timezone.utc)
+        t0 = datetime.now(timezone.utc) - timedelta(minutes=10)
         engine._call_detector.process_event("Slack", "Huddle", None, t0, 60)
-        engine._call_detector.process_event(
-            "Slack", "Huddle", None, t0 + timedelta(minutes=2), 60
-        )
+        # Heartbeated growing event: end ≈ now-2min (fresh evidence).
+        engine._call_detector.process_event("Slack", "Huddle", None, t0, 8 * 60)
 
         engine.sync()
         assert engine.is_in_call(), (
             "sync boundary must NOT end an ongoing call anymore"
         )
-        engine._call_detector.process_event(
-            "Slack", "Huddle", None, t0 + timedelta(minutes=4), 60
-        )
+        engine._call_detector.process_event("Slack", "Huddle", None, t0, 9 * 60)
         engine.sync()
         assert engine.is_in_call()
 
@@ -689,7 +686,7 @@ class TestCallPersistsAcrossSyncCycles:
         # token (queue only as fallback — the queue is account-agnostic and a
         # leftover row would deliver under the next login on a shared machine).
         engine = self._build_engine()
-        t0 = datetime(2026, 7, 15, 17, 7, 0, tzinfo=timezone.utc)
+        t0 = datetime.now(timezone.utc) - timedelta(minutes=2)
         engine._call_detector.process_event("Slack", "Huddle", None, t0, 60)
         engine.shutdown()
         assert engine.is_in_call() is False
@@ -708,11 +705,10 @@ class TestCaptureBoundariesCloseSessions:
     def _engine_in_call(self):
         harness = TestCallPersistsAcrossSyncCycles()
         engine = harness._build_engine()
-        t0 = datetime(2026, 7, 15, 14, 0, 0, tzinfo=timezone.utc)
+        t0 = datetime.now(timezone.utc) - timedelta(minutes=10)
         engine._call_detector.process_event("zoom.us", "Zoom Meeting", None, t0, 60)
-        engine._call_detector.process_event(
-            "zoom.us", "Zoom Meeting", None, t0 + timedelta(minutes=10), 60
-        )
+        # Heartbeat: end ≈ now-1min → fresh evidence for is_in_call().
+        engine._call_detector.process_event("zoom.us", "Zoom Meeting", None, t0, 9 * 60)
         assert engine.is_in_call()
         return engine, t0
 
@@ -807,3 +803,87 @@ class TestStaleOngoingSnapshotsNeverReplay:
         )
         assert "completed" in statuses
         assert engine.queue.is_empty(), "stale snapshot removed, not retried"
+
+
+class TestBoundaryFlushRaceAndForeground:
+    def test_paused_cycle_reflushes_call_reopened_by_inflight_sync(self):
+        # pause()/set_private_mode() run on the tray thread; a sync cycle
+        # already in flight keeps feeding pre-boundary window events AFTER the
+        # boundary flush and re-opens the call. Every paused/private cycle
+        # must re-flush (idempotent), or the reopened call bridges the whole
+        # not-recorded period.
+        harness = TestCallPersistsAcrossSyncCycles()
+        engine = harness._build_engine()
+        t0 = datetime.now(timezone.utc) - timedelta(minutes=1)
+        engine.set_private_mode(True)
+        # In-flight cycle delivers a pre-boundary call event after the flush:
+        engine._call_detector.process_event("zoom.us", "Zoom Meeting", None, t0, 60)
+        assert engine.is_in_call(), "precondition: the race re-opened the call"
+
+        engine.sync()  # paused/private early-return branch
+        assert engine.is_in_call() is False, (
+            "the paused/private branch must re-flush like the suppressed one"
+        )
+
+    def test_boundary_flush_closes_foreground_session_too(self):
+        from src.sync.foreground_activity import (
+            ForegroundActivityDetector,
+            ForegroundSample,
+        )
+
+        class HotProbe:
+            def sample(self):
+                return ForegroundSample(pid=1, app="Terminal", cpu_percent=80.0)
+
+        harness = TestCallPersistsAcrossSyncCycles()
+        engine = harness._build_engine()
+        det = ForegroundActivityDetector(
+            hostname="h", probe=HotProbe(), min_session_seconds=30.0
+        )
+        now = datetime.now(timezone.utc)
+        det.observe(now - timedelta(minutes=10), now - timedelta(minutes=10))
+        det.observe(now, now)
+        engine._foreground_detector = det
+        assert det.is_active()
+
+        engine.set_private_mode(True)
+        assert det.is_active() is False, (
+            "an open dev-session would bridge the private period the same way "
+            "a call would — and on Linux it IS the billing path"
+        )
+        assert not engine.queue.is_empty(), "the pre-boundary span is queued"
+
+
+class TestEvidenceFreshness:
+    """has_fresh_evidence / engine is_in_call: a hung window watcher must not
+    suppress the idle pause forever on state nothing confirms."""
+
+    def test_fresh_heartbeat_is_fresh(self):
+        detector = CallDetector()
+        detector.process_event("zoom.us", "Zoom Meeting", None, _ts(0), 10 * 60)
+        # Evidence ends _ts(10); asking at _ts(11) is within staleness+grace.
+        assert detector.has_fresh_evidence(_ts(11)) is True
+
+    def test_stale_evidence_is_not_fresh(self):
+        detector = CallDetector()
+        detector.process_event("zoom.us", "Zoom Meeting", None, _ts(0), 60)
+        # Last evidence ends _ts(1); at _ts(10) the watcher has been silent
+        # for 9 minutes — nothing confirms this call anymore.
+        assert detector.has_fresh_evidence(_ts(10)) is False
+
+    def test_no_call_is_not_fresh(self):
+        assert CallDetector().has_fresh_evidence(_ts(0)) is False
+
+    def test_engine_is_in_call_false_on_stale_evidence(self):
+        harness = TestCallPersistsAcrossSyncCycles()
+        engine = harness._build_engine()
+        stale_t0 = datetime.now(timezone.utc) - timedelta(hours=2)
+        engine._call_detector.process_event(
+            "zoom.us", "Zoom Meeting", None, stale_t0, 60
+        )
+        assert engine._call_detector.is_in_call(), (
+            "state machine itself still says in-call"
+        )
+        assert engine.is_in_call() is False, (
+            "the engine must not suppress idle on 2h-stale evidence"
+        )

--- a/tests/test_call_detector.py
+++ b/tests/test_call_detector.py
@@ -401,6 +401,82 @@ def test_is_in_call_reflects_active_call_state():
     assert det.is_in_call() is False
 
 
+class TestGetLastActiveAt:
+    """Activity-source contract: call engagement folded into the uploaded AFK
+    stream (AfkSource) so a hands-off meeting bills as active, not idle."""
+
+    def _start_zoom_call(self, detector, at_minutes=0.0):
+        detector.process_event("zoom.us", "Zoom Meeting", None, _ts(at_minutes), 60)
+
+    def test_none_when_no_call_active(self):
+        detector = CallDetector()
+        assert detector.get_last_active_at(None, _ts(0)) is None
+
+    def test_returns_now_while_in_call(self):
+        detector = CallDetector()
+        self._start_zoom_call(detector)
+        now = _ts(30)
+        assert detector.get_last_active_at(_ts(-60), now) == now
+
+    def test_none_after_call_ends(self):
+        detector = CallDetector()
+        self._start_zoom_call(detector)
+        detector.flush()
+        assert detector.get_last_active_at(None, _ts(30)) is None
+
+    def test_grace_window_credits_only_up_to_leave_instant(self):
+        # User switched to a non-call window at t=10 — they produced real input
+        # to do that, so call credit must stop there, not keep tracking `now`.
+        detector = CallDetector(grace_period=30.0)
+        self._start_zoom_call(detector)
+        detector.process_event("Finder", "Documents", None, _ts(10), 5)
+        assert detector.get_last_active_at(None, _ts(10.2)) == _ts(10)
+
+    def test_credit_capped_past_max_credit_seconds(self):
+        # A stuck call title must not keep the AFK stream not-afk forever:
+        # credit freezes at call_start + max_credit even while "in call".
+        detector = CallDetector(max_credit_seconds=3600.0)  # 1h cap
+        self._start_zoom_call(detector)
+        # Keep the call alive well past the cap.
+        detector.process_event("zoom.us", "Zoom Meeting", None, _ts(120), 60)
+        assert detector.is_in_call()
+        assert detector.get_last_active_at(None, _ts(120)) == _ts(60)
+
+    def test_never_returns_future_instant(self):
+        detector = CallDetector()
+        self._start_zoom_call(detector)
+        now = _ts(5)
+        result = detector.get_last_active_at(None, now)
+        assert result is not None and result <= now
+
+    def test_afk_source_folds_call_credit_into_samples(self):
+        # End-to-end with AfkSource: a call with zero keyboard/mouse input must
+        # keep the reconstructed (uploaded) AFK stream not-afk for its duration.
+        from src.sync.afk_source import AfkSource
+
+        detector = CallDetector()
+        self._start_zoom_call(detector)
+
+        # OS idle clock: last real input was at t=0 and only ages from there.
+        base = _ts(0)
+        clock_now = {"now": base}
+        afk = AfkSource(
+            afk_timeout_seconds=600.0,
+            hostname="testhost",
+            activity_sources=[detector],
+            idle_clock=lambda: (clock_now["now"] - base).total_seconds(),
+        )
+        # Sample every minute across a 49-minute hands-off meeting.
+        for m in range(0, 50):
+            clock_now["now"] = _ts(m)
+            afk.record_sample(_ts(m))
+
+        events = afk.build_afk_events(_ts(0), _ts(49))
+        statuses = {e["data"]["status"] for e in events}
+        assert statuses == {"not-afk"}, events
+        assert sum(e["duration"] for e in events) == 49 * 60
+
+
 class TestWindowsNativeAppNames:
     """Native call apps report different process names on Windows than macOS.
 

--- a/tests/test_call_detector.py
+++ b/tests/test_call_detector.py
@@ -426,38 +426,65 @@ class TestGetLastActiveAt:
         detector = CallDetector()
         assert detector.get_last_active_at(None, _ts(0)) is None
 
-    def test_returns_now_while_in_call(self):
+    def test_tracks_now_while_evidence_fresh(self):
+        # The starting event covers [_ts(0), _ts(1)); at now=_ts(2) evidence is
+        # well within the staleness allowance → credit tracks now.
         detector = CallDetector()
         self._start_zoom_call(detector)
-        now = _ts(30)
+        now = _ts(2)
         assert detector.get_last_active_at(_ts(-60), now) == now
+
+    def test_credit_freezes_when_window_evidence_goes_stale(self):
+        # Hung window watcher: nothing confirms the call after its last event
+        # (end _ts(1)) → credit must freeze a staleness-allowance later, NOT
+        # keep tracking now for the full credit cap on zero evidence.
+        detector = CallDetector()
+        self._start_zoom_call(detector)
+        got = detector.get_last_active_at(None, _ts(30))
+        assert got == _ts(1) + timedelta(seconds=180)
+
+    def test_cap_anchored_on_real_input_not_call_start(self):
+        # Ending one call and starting another must not re-arm the cap: the
+        # anchor is the REAL input instant AfkSource passes in, so chained
+        # sessions share one bounded window.
+        detector = CallDetector(max_credit_seconds=3600.0)
+        self._start_zoom_call(detector)
+        # Switch to a different call app at _ts(50): ends Zoom, starts Slack.
+        detector.process_event("Slack", "Huddle", None, _ts(50), 60)
+        detector.process_event("Slack", "Huddle", None, _ts(54), 60)
+        # Real input was at _ts(-10) → cap end _ts(50), regardless of the
+        # fresh Slack call (whose own start would re-arm to _ts(110)).
+        got = detector.get_last_active_at(_ts(-10), _ts(55))
+        assert got == _ts(50)
 
     def test_credit_freezes_at_end_after_call_ends(self):
         # After a call ends the user WAS engaged until its end — credit must
         # freeze there (not vanish, not keep tracking now). This also bridges
         # the AW-outage/shutdown flush: the AFK sample taken next cycle still
-        # sees the engagement up to the flushed call's end.
+        # sees the engagement up to the flushed call's end. The last event
+        # covers [_ts(20), _ts(21)) so the call end is _ts(21).
         detector = CallDetector()
         self._start_zoom_call(detector)
         detector.process_event("zoom.us", "Zoom Meeting", None, _ts(20), 60)
         detector.flush()
-        assert detector.get_last_active_at(None, _ts(30)) == _ts(20)
+        assert detector.get_last_active_at(None, _ts(30)) == _ts(21)
 
     def test_ended_call_credit_respects_cap(self):
         detector = CallDetector(max_credit_seconds=600.0)  # 10min cap
         self._start_zoom_call(detector)
         detector.process_event("zoom.us", "Zoom Meeting", None, _ts(20), 60)
         detector.flush()
+        # No real-input anchor → falls back to call start _ts(0) + 10min.
         assert detector.get_last_active_at(None, _ts(30)) == _ts(10)
 
     def test_short_discarded_call_still_credits_engagement(self):
         # min_duration discards the EVENT, but the engagement was real — the
-        # credit memory must still cover it.
+        # credit memory must still cover it (up to the last event's end).
         detector = CallDetector(min_duration=300)
         self._start_zoom_call(detector)
         detector.process_event("zoom.us", "Zoom Meeting", None, _ts(1), 60)
         assert detector.flush() is None  # too short: no event emitted
-        assert detector.get_last_active_at(None, _ts(5)) == _ts(1)
+        assert detector.get_last_active_at(None, _ts(5)) == _ts(2)
 
     def test_grace_window_credits_only_up_to_leave_instant(self):
         # User switched to a non-call window at t=10 — they produced real input
@@ -469,13 +496,23 @@ class TestGetLastActiveAt:
 
     def test_credit_capped_past_max_credit_seconds(self):
         # A stuck call title must not keep the AFK stream not-afk forever:
-        # credit freezes at call_start + max_credit even while "in call".
+        # with no real-input anchor, credit freezes at call_start + max_credit
+        # even while the call keeps being confirmed by fresh events.
         detector = CallDetector(max_credit_seconds=3600.0)  # 1h cap
         self._start_zoom_call(detector)
-        # Keep the call alive well past the cap.
-        detector.process_event("zoom.us", "Zoom Meeting", None, _ts(120), 60)
+        detector.process_event("zoom.us", "Zoom Meeting", None, _ts(60), 60)
+        assert detector.get_last_active_at(None, _ts(61)) == _ts(60)
+
+    def test_is_in_call_bounded_by_credit_cap(self):
+        # The LOCAL idle guard must not outlive the billing cap: a wedged
+        # call-matching title would otherwise suppress the idle pause forever
+        # while the server bills idle.
+        detector = CallDetector(max_credit_seconds=3600.0)
+        detector.process_event("zoom.us", "Zoom Meeting", None, _ts(0), 60)
         assert detector.is_in_call()
-        assert detector.get_last_active_at(None, _ts(120)) == _ts(60)
+        # Heartbeat grows the confirmed span past the cap.
+        detector.process_event("zoom.us", "Zoom Meeting", None, _ts(0), 4000)
+        assert detector.is_in_call() is False
 
     def test_never_returns_future_instant(self):
         detector = CallDetector()
@@ -501,9 +538,16 @@ class TestGetLastActiveAt:
             activity_sources=[detector],
             idle_clock=lambda: (clock_now["now"] - base).total_seconds(),
         )
-        # Sample every minute across a 49-minute hands-off meeting.
+        # Sample every minute across a 49-minute hands-off meeting. The window
+        # watcher heartbeats one growing event per unchanged window (same
+        # timestamp, growing duration) — the detector must keep treating that
+        # as fresh evidence.
         for m in range(0, 50):
             clock_now["now"] = _ts(m)
+            if m > 0:
+                detector.process_event(
+                    "zoom.us", "Zoom Meeting", None, _ts(0), m * 60.0
+                )
             afk.record_sample(_ts(m))
 
         events = afk.build_afk_events(_ts(0), _ts(49))
@@ -640,9 +684,13 @@ class TestCallPersistsAcrossSyncCycles:
         )
         assert snaps[1]["duration"] > snaps[0]["duration"]
 
-    def test_shutdown_closes_open_call(self):
+    def test_shutdown_closes_open_call_and_queues_final_event(self):
         engine = self._build_engine()
         t0 = datetime(2026, 7, 15, 17, 7, 0, tzinfo=timezone.utc)
         engine._call_detector.process_event("Slack", "Huddle", None, t0, 60)
         engine.shutdown()
         assert engine.is_in_call() is False
+        assert not engine.queue.is_empty(), (
+            "the final call span (tail since the last snapshot, plus its "
+            "'completed' status) must be queued at shutdown, not discarded"
+        )

--- a/tests/test_call_detector.py
+++ b/tests/test_call_detector.py
@@ -344,6 +344,20 @@ class TestSyncEngineCallIntegration:
     def test_call_detector_initialized_when_enabled(self):
         assert self.engine._call_detector is not None
 
+    def test_call_detector_credit_cap_plumbed_from_config(self):
+        from src.sync.sync_engine import SyncEngine
+        config = Config()
+        config.call_detection.enabled = True
+        config.call_detection.max_credit_minutes = 60
+
+        engine = SyncEngine(
+            aw=self.aw, bf=self.bf, queue=self.queue,
+            config=config,
+            activity_analyzer=self.activity_analyzer,
+            time_tracker=self.time_tracker,
+        )
+        assert engine._call_detector._max_credit_seconds == 3600.0
+
     def test_call_detector_none_when_disabled(self):
         from src.sync.sync_engine import SyncEngine
         config = Config()

--- a/tests/test_call_detector.py
+++ b/tests/test_call_detector.py
@@ -432,11 +432,32 @@ class TestGetLastActiveAt:
         now = _ts(30)
         assert detector.get_last_active_at(_ts(-60), now) == now
 
-    def test_none_after_call_ends(self):
+    def test_credit_freezes_at_end_after_call_ends(self):
+        # After a call ends the user WAS engaged until its end — credit must
+        # freeze there (not vanish, not keep tracking now). This also bridges
+        # the AW-outage/shutdown flush: the AFK sample taken next cycle still
+        # sees the engagement up to the flushed call's end.
         detector = CallDetector()
         self._start_zoom_call(detector)
+        detector.process_event("zoom.us", "Zoom Meeting", None, _ts(20), 60)
         detector.flush()
-        assert detector.get_last_active_at(None, _ts(30)) is None
+        assert detector.get_last_active_at(None, _ts(30)) == _ts(20)
+
+    def test_ended_call_credit_respects_cap(self):
+        detector = CallDetector(max_credit_seconds=600.0)  # 10min cap
+        self._start_zoom_call(detector)
+        detector.process_event("zoom.us", "Zoom Meeting", None, _ts(20), 60)
+        detector.flush()
+        assert detector.get_last_active_at(None, _ts(30)) == _ts(10)
+
+    def test_short_discarded_call_still_credits_engagement(self):
+        # min_duration discards the EVENT, but the engagement was real — the
+        # credit memory must still cover it.
+        detector = CallDetector(min_duration=300)
+        self._start_zoom_call(detector)
+        detector.process_event("zoom.us", "Zoom Meeting", None, _ts(1), 60)
+        assert detector.flush() is None  # too short: no event emitted
+        assert detector.get_last_active_at(None, _ts(5)) == _ts(1)
 
     def test_grace_window_credits_only_up_to_leave_instant(self):
         # User switched to a non-call window at t=10 — they produced real input
@@ -491,6 +512,40 @@ class TestGetLastActiveAt:
         assert sum(e["duration"] for e in events) == 49 * 60
 
 
+class TestSnapshot:
+    """snapshot(): live emission of an ongoing call without ending it."""
+
+    def test_none_when_no_call(self):
+        assert CallDetector().snapshot() is None
+
+    def test_none_while_below_min_duration(self):
+        detector = CallDetector(min_duration=30)
+        detector.process_event("zoom.us", "Zoom Meeting", None, _ts(0), 10)
+        assert detector.snapshot() is None
+
+    def test_emits_growing_span_with_stable_identity(self):
+        detector = CallDetector(min_duration=30)
+        detector.process_event("zoom.us", "Zoom Meeting", None, _ts(0), 60)
+        detector.process_event("zoom.us", "Zoom Meeting", None, _ts(2), 60)
+        first = detector.snapshot()
+        detector.process_event("zoom.us", "Zoom Meeting", None, _ts(5), 60)
+        second = detector.snapshot()
+
+        # Same (app, start) → _make_call_bf_event derives the same id, so the
+        # server upserts one growing row instead of per-cycle fragments.
+        assert (first.app, first.start) == (second.app, second.start)
+        assert second.duration > first.duration
+        # Snapshot must NOT end the call.
+        assert detector.is_in_call()
+
+    def test_snapshot_during_grace_ends_at_leave_instant(self):
+        detector = CallDetector(min_duration=30, grace_period=60.0)
+        detector.process_event("zoom.us", "Zoom Meeting", None, _ts(0), 60)
+        detector.process_event("Finder", "Documents", None, _ts(5), 5)
+        snap = detector.snapshot()
+        assert snap.end == _ts(5)
+
+
 class TestWindowsNativeAppNames:
     """Native call apps report different process names on Windows than macOS.
 
@@ -515,3 +570,79 @@ class TestWindowsNativeAppNames:
 
     def test_zoom_windows_home_still_no_match(self):
         assert _match_native("Zoom", "Zoom - Home") is None
+
+
+class TestCallPersistsAcrossSyncCycles:
+    """A meeting must survive the sync boundary: snapshot-not-flush keeps
+    is_in_call() True between cycles (so the idle suppression actually works)
+    and uploads one growing call row instead of per-cycle fragments."""
+
+    def _build_engine(self):
+        import tempfile
+        from pathlib import Path
+        from types import SimpleNamespace
+
+        from src.sync.queue import OfflineQueue
+        from src.sync.sync_engine import SyncEngine
+
+        tmp = Path(tempfile.mkdtemp())
+        cfg = Config()
+        cfg.working_hours.known = True  # capture is fail-closed on unknown
+        engine = SyncEngine(
+            aw=Mock(),
+            bf=Mock(),
+            queue=OfflineQueue(db_path=tmp / "q.db", max_size=1000),
+            config=cfg,
+            time_tracker=Mock(),
+        )
+        engine._config_fetched = True
+        engine._backlog_reconciled = True
+        engine.aw.is_running.return_value = True
+        for getter in ("get_window_buckets", "get_web_buckets",
+                       "get_afk_buckets", "get_input_buckets"):
+            getattr(engine.aw, getter).return_value = []
+        engine.bf.is_reachable.return_value = True
+        engine.bf.send_events.return_value = SimpleNamespace(
+            success=True, events_synced=1, accepted_ids=[], error=None
+        )
+        return engine
+
+    def _sent_call_events(self, engine):
+        return [
+            ev
+            for call in engine.bf.send_events.call_args_list
+            for ev in call.args[0]
+            if ev.get("bucket_type") == "call"
+        ]
+
+    def test_call_stays_open_and_snapshots_upsert_one_row(self):
+        engine = self._build_engine()
+        t0 = datetime(2026, 7, 15, 17, 7, 0, tzinfo=timezone.utc)
+        engine._call_detector.process_event("Slack", "Huddle", None, t0, 60)
+        engine._call_detector.process_event(
+            "Slack", "Huddle", None, t0 + timedelta(minutes=2), 60
+        )
+
+        engine.sync()
+        assert engine.is_in_call(), (
+            "sync boundary must NOT end an ongoing call anymore"
+        )
+        engine._call_detector.process_event(
+            "Slack", "Huddle", None, t0 + timedelta(minutes=4), 60
+        )
+        engine.sync()
+        assert engine.is_in_call()
+
+        snaps = self._sent_call_events(engine)
+        assert len(snaps) == 2, "one live snapshot per cycle"
+        assert snaps[0]["id"] == snaps[1]["id"], (
+            "stable id → the server upserts one growing row per meeting"
+        )
+        assert snaps[1]["duration"] > snaps[0]["duration"]
+
+    def test_shutdown_closes_open_call(self):
+        engine = self._build_engine()
+        t0 = datetime(2026, 7, 15, 17, 7, 0, tzinfo=timezone.utc)
+        engine._call_detector.process_event("Slack", "Huddle", None, t0, 60)
+        engine.shutdown()
+        assert engine.is_in_call() is False

--- a/tests/test_capture_boundary.py
+++ b/tests/test_capture_boundary.py
@@ -397,16 +397,23 @@ class TestArmPathLocking:
         c = _coordinator(_restricted_cfg())
 
         def _worker():
-            with patch("src.main.datetime") as dt:
-                dt.now.return_value = IN_HOURS_UTC
-                for _ in range(20):
-                    c.arm_capture_boundary()
+            for _ in range(20):
+                c.arm_capture_boundary()
 
-        threads = [threading.Thread(target=_worker) for _ in range(4)]
-        for t in threads:
-            t.start()
-        for t in threads:
-            t.join()
+        # ONE patch around all threads. mock.patch enter/exit is NOT
+        # thread-safe against itself for the same target: two threads
+        # patching concurrently can save the other thread's MOCK as the
+        # "original", leaving src.main.datetime a leaked frozen MagicMock for
+        # the rest of the pytest process — which made the idle-tracker-health
+        # freshness gate compute a negative input age and flake
+        # test_silent_when_input_is_stale suite-wide.
+        with patch("src.main.datetime") as dt:
+            dt.now.return_value = IN_HOURS_UTC
+            threads = [threading.Thread(target=_worker) for _ in range(4)]
+            for t in threads:
+                t.start()
+            for t in threads:
+                t.join()
 
         assert "capture_boundary" in c.scheduler.jobs
 

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -295,3 +295,13 @@ class TestCallDetectionCreditCap:
 
         cfg.update_from_server({"call_detection": {"max_credit_minutes": "nope"}})
         assert cfg.call_detection.max_credit_minutes == 90, "invalid value ignored"
+
+    def test_min_call_duration_clamped_when_rolled_out(self, monkeypatch):
+        # A huge server value would suppress every call/mic EVENT while
+        # short-session AFK credit still flows — credited time with no
+        # auditable span. Clamped to 10 minutes.
+        from src.config import Config
+        monkeypatch.setattr(config_module, "DEFER_UNAPPLIED_SERVER_SETTINGS", False)
+        cfg = Config()
+        cfg.update_from_server({"call_detection": {"min_call_duration": 999999}})
+        assert cfg.call_detection.min_call_duration == 600

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -261,3 +261,37 @@ class TestMachineUuidIsIsolatedByConftest:
             "conftest fixture is not redirecting module-level user_config_dir"
         )
         assert machine_id_file.read_text().strip() == result
+
+
+class TestCallDetectionCreditCap:
+    """max_credit_minutes: the ceiling on per-call AFK credit (billing-adjacent,
+    so server values are clamped and the whole block stays deferral-gated)."""
+
+    def test_default_is_240_minutes(self):
+        from src.config import Config
+        assert Config().call_detection.max_credit_minutes == 240
+
+    def test_deferred_on_first_delivery(self):
+        # call_detection is a capture/billing block: gated behind
+        # DEFER_UNAPPLIED_SERVER_SETTINGS like the rest of it.
+        from src.config import Config
+        cfg = Config()
+        cfg.update_from_server({"call_detection": {"max_credit_minutes": 5}})
+        assert cfg.call_detection.max_credit_minutes == 240
+
+    def test_server_value_clamped_when_rolled_out(self, monkeypatch):
+        from src.config import Config
+        monkeypatch.setattr(config_module, "DEFER_UNAPPLIED_SERVER_SETTINGS", False)
+        cfg = Config()
+
+        cfg.update_from_server({"call_detection": {"max_credit_minutes": 100000}})
+        assert cfg.call_detection.max_credit_minutes == 480, "cap must never exceed 8h"
+
+        cfg.update_from_server({"call_detection": {"max_credit_minutes": 0}})
+        assert cfg.call_detection.max_credit_minutes == 1, "cap floor is 1 minute"
+
+        cfg.update_from_server({"call_detection": {"max_credit_minutes": 90}})
+        assert cfg.call_detection.max_credit_minutes == 90
+
+        cfg.update_from_server({"call_detection": {"max_credit_minutes": "nope"}})
+        assert cfg.call_detection.max_credit_minutes == 90, "invalid value ignored"

--- a/tests/test_engagement_credit.py
+++ b/tests/test_engagement_credit.py
@@ -1,0 +1,76 @@
+"""Tests for the shared engagement credit-cap math."""
+
+from datetime import datetime, timedelta, timezone
+
+from src.sync.engagement_credit import capped_credit
+
+
+def _ts(minutes: float = 0) -> datetime:
+    return datetime(2026, 7, 15, 17, 0, 0, tzinfo=timezone.utc) + timedelta(
+        minutes=minutes
+    )
+
+
+def test_uncapped_when_within_window():
+    got = capped_credit(
+        _ts(30), anchor=_ts(0), engagement_start=_ts(5), cap_seconds=3600, now=_ts(30)
+    )
+    assert got == _ts(30)
+
+
+def test_caps_past_anchor_plus_cap():
+    got = capped_credit(
+        _ts(90), anchor=_ts(0), engagement_start=_ts(5), cap_seconds=3600, now=_ts(90)
+    )
+    assert got == _ts(60)
+
+
+def test_never_past_now():
+    got = capped_credit(
+        _ts(90), anchor=_ts(0), engagement_start=_ts(5), cap_seconds=7200, now=_ts(80)
+    )
+    assert got == _ts(80)
+
+
+def test_anchor_none_falls_back_to_engagement_start():
+    got = capped_credit(
+        _ts(90), anchor=None, engagement_start=_ts(0), cap_seconds=3600, now=_ts(90)
+    )
+    assert got == _ts(60)
+
+
+def test_no_anchor_at_all_returns_none():
+    assert (
+        capped_credit(
+            _ts(10), anchor=None, engagement_start=None, cap_seconds=3600, now=_ts(10)
+        )
+        is None
+    )
+
+
+def test_floor_no_phantom_credit_before_engagement_started():
+    # Cap expired BEFORE the engagement began: last real input 9:00, a
+    # calendar-auto-launched meeting at 14:00 (zero input), cap 4h. The bare
+    # cap end (13:00) is an instant with provably no engagement and no input —
+    # returning it would inject phantom active time into the billed stream.
+    last_input = _ts(-300)  # 12:00 base → 9:00-ish; use minutes for clarity
+    meeting_start = _ts(0)
+    got = capped_credit(
+        _ts(10),  # engaged_until (meeting running)
+        anchor=last_input,
+        engagement_start=meeting_start,
+        cap_seconds=4 * 3600,  # anchor+cap = _ts(-60) < meeting_start
+        now=_ts(10),
+    )
+    assert got is None
+
+
+def test_floor_boundary_exactly_at_engagement_start_is_allowed():
+    got = capped_credit(
+        _ts(10),
+        anchor=_ts(-60),
+        engagement_start=_ts(0),
+        cap_seconds=3600,  # anchor+cap == engagement_start exactly
+        now=_ts(10),
+    )
+    assert got == _ts(0)

--- a/tests/test_idle_manager.py
+++ b/tests/test_idle_manager.py
@@ -546,3 +546,39 @@ def test_stale_afk_with_no_os_idle_signal_does_not_pause():
             trigger_sync=trigger_sync,
         )
     assert idle_mgr.idle_paused is False
+
+
+def test_idle_start_clamped_to_last_engagement():
+    """A pause entered right after a hands-off meeting must not backdate
+    idle_start into the meeting: the AFK stream credited that hour as active,
+    and the idle_time span sent on resume would carve the same hour back out."""
+    config = Config()
+    meeting_end = datetime.now(timezone.utc) - timedelta(minutes=5)
+
+    sync_engine = Mock()
+    sync_engine.is_paused = False
+    sync_engine.is_private = False
+    sync_engine.is_in_call.return_value = False
+    sync_engine.is_active_dev_session.return_value = False
+    sync_engine.is_mic_meeting_active.return_value = False
+    mgr = IdleManager(sync_engine, Mock(), Mock(), config)
+
+    # Engagement observed until meeting_end…
+    with mgr._state_lock:
+        mgr._last_engaged_ts = meeting_end
+    # …then an idle pause whose AFK evidence reaches back before it.
+    idle_start = meeting_end - timedelta(minutes=45)
+    assert mgr._clamp_to_last_engagement(idle_start) == meeting_end
+    # At-desk idle after the engagement is untouched.
+    later = meeting_end + timedelta(minutes=10)
+    assert mgr._clamp_to_last_engagement(later) == later
+
+
+def test_engaged_check_stamps_last_engaged_ts():
+    config = Config()
+    sync_engine = Mock()
+    sync_engine.is_in_call.return_value = True
+    mgr = IdleManager(sync_engine, Mock(), Mock(), config)
+    assert mgr._last_engaged_ts is None
+    assert mgr._is_engaged_without_input() is True
+    assert mgr._last_engaged_ts is not None

--- a/tests/test_idle_manager.py
+++ b/tests/test_idle_manager.py
@@ -64,6 +64,7 @@ def _make(idle_in_call: bool):
     sync_engine.is_private = False
     sync_engine.is_in_call.return_value = idle_in_call
     sync_engine.is_active_dev_session.return_value = False
+    sync_engine.is_mic_meeting_active.return_value = False
 
     tray = Mock()
     idle_mgr = IdleManager(sync_engine, tray, aw, config)
@@ -239,6 +240,7 @@ def test_stale_afk_bucket_does_not_pause_when_latest_betterflow_bucket_is_active
     sync_engine.is_private = False
     sync_engine.is_in_call.return_value = False
     sync_engine.is_active_dev_session.return_value = False
+    sync_engine.is_mic_meeting_active.return_value = False
 
     tray = Mock()
     idle_mgr = IdleManager(sync_engine, tray, aw, config)
@@ -266,6 +268,7 @@ def _make_with_afk_event(afk_event, *, in_call=False):
     sync_engine.is_private = False
     sync_engine.is_in_call.return_value = in_call
     sync_engine.is_active_dev_session.return_value = False
+    sync_engine.is_mic_meeting_active.return_value = False
     tray = Mock()
     idle_mgr = IdleManager(sync_engine, tray, aw, config)
     return idle_mgr, Mock(), Mock(), tray

--- a/tests/test_mic_activity.py
+++ b/tests/test_mic_activity.py
@@ -265,3 +265,145 @@ class TestFactory:
 
         monkeypatch.setattr(mod.sys, "platform", "linux")
         assert create_mic_detector(Config(), "h") is None
+
+
+class TestSyncEngineMicIntegration:
+    """Engine wiring: per-cycle observe/snapshot, outage behavior, shutdown."""
+
+    def _build_engine(self):
+        import tempfile
+        from pathlib import Path
+        from types import SimpleNamespace
+        from unittest.mock import Mock
+
+        from src.sync.queue import OfflineQueue
+        from src.sync.sync_engine import SyncEngine
+
+        tmp = Path(tempfile.mkdtemp())
+        cfg = Config()
+        cfg.working_hours.known = True  # capture is fail-closed on unknown
+        engine = SyncEngine(
+            aw=Mock(),
+            bf=Mock(),
+            queue=OfflineQueue(db_path=tmp / "q.db", max_size=1000),
+            config=cfg,
+            time_tracker=Mock(),
+        )
+        engine._config_fetched = True
+        engine._backlog_reconciled = True
+        engine.aw.is_running.return_value = True
+        for getter in ("get_window_buckets", "get_web_buckets",
+                       "get_afk_buckets", "get_input_buckets"):
+            getattr(engine.aw, getter).return_value = []
+        engine.bf.is_reachable.return_value = True
+        engine.bf.send_events.return_value = SimpleNamespace(
+            success=True, events_synced=1, accepted_ids=[], error=None
+        )
+        return engine
+
+    def _inject_detector(self, engine, probe, **kwargs):
+        defaults = {
+            "hostname": "testhost",
+            "probe": probe,
+            "min_session_seconds": 30.0,
+            "max_credit_seconds": 14400.0,
+        }
+        defaults.update(kwargs)
+        engine._mic_detector = MicActivityDetector(**defaults)
+        return engine._mic_detector
+
+    def _sent_mic_events(self, engine):
+        return [
+            ev
+            for call in engine.bf.send_events.call_args_list
+            for ev in call.args[0]
+            if ev.get("data", {}).get("call_type") == "mic"
+        ]
+
+    def test_snapshot_uploaded_and_session_persists_across_cycles(self):
+        from datetime import datetime, timezone
+
+        engine = self._build_engine()
+        probe = FakeProbe(MicSample(True, ("zoom.exe",)))
+        det = self._inject_detector(engine, probe)
+        # Meeting has been running for 10 minutes when the first cycle fires.
+        det.observe(datetime.now(timezone.utc) - timedelta(minutes=10))
+
+        engine.sync()
+        assert engine.is_mic_meeting_active()
+        engine.sync()
+        assert engine.is_mic_meeting_active()
+
+        snaps = self._sent_mic_events(engine)
+        assert len(snaps) == 2, "one live mic snapshot per cycle"
+        assert snaps[0]["id"] == snaps[1]["id"], "server upserts one growing row"
+        assert snaps[1]["duration"] >= snaps[0]["duration"]
+
+    def test_session_closes_during_aw_outage(self):
+        from datetime import datetime, timezone
+
+        engine = self._build_engine()
+        probe = FakeProbe(MicSample(True, ("zoom.exe",)))
+        det = self._inject_detector(engine, probe, off_grace_seconds=0.0)
+        det.observe(datetime.now(timezone.utc) - timedelta(minutes=10))
+        det.observe(datetime.now(timezone.utc) - timedelta(minutes=1))
+        assert engine.is_mic_meeting_active()
+
+        engine.aw.is_running.return_value = False  # AW outage
+        probe.current = MicSample(False)  # meeting ended mid-outage
+        stats = engine.sync()
+
+        assert engine.is_mic_meeting_active() is False, (
+            "the mic probe doesn't need AW — the session must close mid-outage "
+            "so idle isn't suppressed for the rest of the outage"
+        )
+        assert stats.calls_detected == 1, "the ended mic span is still recorded"
+        assert len(self._sent_mic_events(engine)) == 1
+
+    def test_shutdown_closes_open_mic_session(self):
+        from datetime import datetime, timezone
+
+        engine = self._build_engine()
+        probe = FakeProbe(MicSample(True, ("zoom.exe",)))
+        det = self._inject_detector(engine, probe)
+        det.observe(datetime.now(timezone.utc) - timedelta(minutes=10))
+        assert engine.is_mic_meeting_active()
+        engine.shutdown()
+        assert engine.is_mic_meeting_active() is False
+
+
+class TestIdleManagerMicSuppression:
+    """A mic meeting suppresses the idle pause like a window-detected call."""
+
+    def _manager(self, sync_engine):
+        from unittest.mock import Mock
+
+        from src.idle_manager import IdleManager
+
+        return IdleManager(sync_engine, tray=Mock(), aw=Mock(), config=Config())
+
+    def test_mic_meeting_counts_as_engaged(self):
+        from unittest.mock import Mock
+
+        eng = Mock()
+        eng.is_in_call.return_value = False
+        eng.is_mic_meeting_active.return_value = True
+        assert self._manager(eng)._is_engaged_without_input() is True
+
+    def test_mic_check_error_falls_through(self):
+        from unittest.mock import Mock
+
+        eng = Mock()
+        eng.is_in_call.return_value = False
+        eng.is_mic_meeting_active.side_effect = RuntimeError("boom")
+        eng.is_active_dev_session.return_value = False
+        assert self._manager(eng)._is_engaged_without_input() is False
+
+    def test_not_engaged_when_all_signals_false(self):
+        from unittest.mock import Mock
+
+        eng = Mock()
+        eng.is_in_call.return_value = False
+        eng.is_mic_meeting_active.return_value = False
+        eng.is_active_dev_session.return_value = False
+        assert self._manager(eng)._is_engaged_without_input() is False

--- a/tests/test_mic_activity.py
+++ b/tests/test_mic_activity.py
@@ -125,13 +125,16 @@ class TestConferencingGate:
         det.observe(_ts(0))
         assert not det.is_active()
 
-    def test_macos_gate_error_fails_open(self):
+    def test_macos_gate_error_fails_closed(self):
+        # This signal feeds billing: a gate error must never become an
+        # unconditional pass (a reproducible gate crash would be a free
+        # bypass). Cost is one delayed cycle — the mic is still hot next time.
         def boom():
             raise RuntimeError("psutil hiccup")
 
         det = _detector(FakeProbe(MicSample(True)), conferencing_gate=boom)
         det.observe(_ts(0))
-        assert det.is_active(), "losing a real meeting to a gate error is the worse failure"
+        assert not det.is_active()
 
     def test_attributed_app_used_as_session_label(self):
         probe = FakeProbe(MicSample(True, ("ms-teams.exe",)))
@@ -150,16 +153,43 @@ class TestAfkCredit:
     def test_none_when_never_observed(self):
         assert _detector().get_last_active_at(None, _ts(0)) is None
 
-    def test_now_while_session_open(self):
+    def test_tracks_now_within_off_grace_of_last_hot(self):
         det = _detector(FakeProbe(MicSample(True)))
         det.observe(_ts(0))
-        assert det.get_last_active_at(_ts(-60), _ts(30)) == _ts(30)
+        assert det.get_last_active_at(_ts(-60), _ts(1)) == _ts(1)
 
-    def test_credit_capped_past_max_credit(self):
+    def test_credit_stops_growing_past_off_grace_of_last_hot(self):
+        # After the last HOT observation, credit may extend at most the
+        # off-grace allowance — an open session must not keep answering `now`
+        # indefinitely between observations.
+        det = _detector(FakeProbe(MicSample(True)), off_grace_seconds=90.0)
+        det.observe(_ts(0))
+        assert det.get_last_active_at(None, _ts(30)) == _ts(0) + timedelta(seconds=90)
+
+    def test_force_closes_at_credit_cap(self):
+        # Past the cap the session earns nothing and its snapshot would grow
+        # unboundedly — it must force-close even while the mic stays hot.
+        probe = FakeProbe(MicSample(True))
+        det = _detector(probe, max_credit_seconds=3600.0)
+        det.observe(_ts(0))
+        det.observe(_ts(30))
+        ended = det.observe(_ts(60))  # 1h since start → cap reached
+        assert ended is not None and ended["duration"] == 30 * 60.0
+        assert not det.is_active()
+        # A genuinely still-live meeting reopens as a NEW session next cycle…
+        det.observe(_ts(61))
+        assert det.is_active()
+
+    def test_cap_anchored_on_real_input_not_session_start(self):
+        # …but the reopened session grants no fresh credit on its own: the cap
+        # anchors on the real-input instant AfkSource passes in, so cycling
+        # the mic can't re-arm it.
         det = _detector(FakeProbe(MicSample(True)), max_credit_seconds=3600.0)
         det.observe(_ts(0))
-        det.observe(_ts(120))
-        assert det.get_last_active_at(None, _ts(120)) == _ts(60)
+        det.observe(_ts(30))
+        # Real input was at _ts(-31) → cap end _ts(29), despite the session
+        # being open and hot at _ts(30).
+        assert det.get_last_active_at(_ts(-31), _ts(30)) == _ts(29)
 
     def test_credit_freezes_at_session_end_after_close(self):
         probe = FakeProbe(MicSample(True))
@@ -407,3 +437,58 @@ class TestIdleManagerMicSuppression:
         eng.is_mic_meeting_active.return_value = False
         eng.is_active_dev_session.return_value = False
         assert self._manager(eng)._is_engaged_without_input() is False
+
+
+class TestOutageAndShutdownDurability:
+    """Ended sessions must survive full-offline outages and shutdown."""
+
+    def test_offline_outage_queues_ended_session(self):
+        harness = TestSyncEngineMicIntegration()
+        engine = harness._build_engine()
+        probe = FakeProbe(MicSample(True, ("zoom.exe",)))
+        det = harness._inject_detector(engine, probe, off_grace_seconds=0.0)
+        now = datetime.now(timezone.utc)
+        det.observe(now - timedelta(minutes=10))
+        det.observe(now - timedelta(minutes=1))
+
+        engine.aw.is_running.return_value = False   # AW outage…
+        engine.bf.is_reachable.return_value = False  # …and fully offline
+        probe.current = MicSample(False)
+        engine.sync()
+
+        assert engine.is_mic_meeting_active() is False
+        assert not engine.queue.is_empty(), (
+            "an ended mic span while fully offline must be QUEUED — the "
+            "session state is already reset, it can never be re-emitted"
+        )
+
+    def test_afk_samples_keep_flowing_during_aw_outage(self):
+        # AfkSource needs only the OS idle clock, not AW. Without outage-branch
+        # sampling, an AW hiccup spanning a hands-off meeting leaves a >timeout
+        # hole in the sample log that reconstructs as afk — the exact
+        # billed-idle-during-meeting failure this feature fixes.
+        from src.sync.afk_source import AfkSource
+
+        harness = TestSyncEngineMicIntegration()
+        engine = harness._build_engine()
+        engine.afk_source = AfkSource(
+            afk_timeout_seconds=600.0, hostname="h", idle_clock=lambda: 5.0
+        )
+        engine.aw.is_running.return_value = False
+        engine.sync()
+        assert len(engine.afk_source.samples) == 1
+
+    def test_shutdown_queues_final_mic_event(self):
+        harness = TestSyncEngineMicIntegration()
+        engine = harness._build_engine()
+        probe = FakeProbe(MicSample(True, ("zoom.exe",)))
+        det = harness._inject_detector(engine, probe)
+        now = datetime.now(timezone.utc)
+        det.observe(now - timedelta(minutes=10))
+        det.observe(now - timedelta(minutes=1))
+
+        engine.shutdown()
+        assert not engine.queue.is_empty(), (
+            "the final mic span (tail since the last snapshot, plus its "
+            "'completed' status) must be queued at shutdown, not discarded"
+        )

--- a/tests/test_mic_activity.py
+++ b/tests/test_mic_activity.py
@@ -166,9 +166,11 @@ class TestAfkCredit:
         det.observe(_ts(0))
         assert det.get_last_active_at(None, _ts(30)) == _ts(0) + timedelta(seconds=90)
 
-    def test_force_closes_at_credit_cap(self):
+    def test_force_closes_at_credit_cap_and_latches(self):
         # Past the cap the session earns nothing and its snapshot would grow
-        # unboundedly — it must force-close even while the mic stays hot.
+        # unboundedly — it must force-close even while the mic stays hot, and
+        # LATCH: reopening every cycle would suppress the idle pause for a
+        # fresh cap period forever (a wedged mic looping 4h sessions).
         probe = FakeProbe(MicSample(True))
         det = _detector(probe, max_credit_seconds=3600.0)
         det.observe(_ts(0))
@@ -176,8 +178,15 @@ class TestAfkCredit:
         ended = det.observe(_ts(60))  # 1h since start → cap reached
         assert ended is not None and ended["duration"] == 30 * 60.0
         assert not det.is_active()
-        # A genuinely still-live meeting reopens as a NEW session next cycle…
+        # Still hot → latched, no reopen…
         det.observe(_ts(61))
+        assert not det.is_active()
+        # …until the mic genuinely goes cold once, then hot again (a real
+        # new meeting) reopens.
+        probe.current = MicSample(False)
+        det.observe(_ts(62))
+        probe.current = MicSample(True)
+        det.observe(_ts(63))
         assert det.is_active()
 
     def test_cap_anchored_on_real_input_not_session_start(self):
@@ -478,7 +487,10 @@ class TestOutageAndShutdownDurability:
         engine.sync()
         assert len(engine.afk_source.samples) == 1
 
-    def test_shutdown_queues_final_mic_event(self):
+    def test_shutdown_sends_final_mic_event_immediately(self):
+        # Shutdown runs on logout: the final span must be SENT under the
+        # owner's token, not left in the account-agnostic queue for whoever
+        # logs in next on a shared machine.
         harness = TestSyncEngineMicIntegration()
         engine = harness._build_engine()
         probe = FakeProbe(MicSample(True, ("zoom.exe",)))
@@ -488,7 +500,55 @@ class TestOutageAndShutdownDurability:
         det.observe(now - timedelta(minutes=1))
 
         engine.shutdown()
-        assert not engine.queue.is_empty(), (
-            "the final mic span (tail since the last snapshot, plus its "
-            "'completed' status) must be queued at shutdown, not discarded"
+        finals = [
+            ev
+            for ev in harness._sent_mic_events(engine)
+            if ev["data"]["status"] == "completed"
+        ]
+        assert len(finals) == 1, "final mic span sent at shutdown"
+        assert engine.queue.is_empty(), "sent, so nothing left for the next user"
+
+    def test_shutdown_queues_final_mic_event_when_send_fails(self):
+        from types import SimpleNamespace
+
+        harness = TestSyncEngineMicIntegration()
+        engine = harness._build_engine()
+        engine.bf.send_events.return_value = SimpleNamespace(
+            success=False, events_synced=0, accepted_ids=[], error="boom",
+            transient=True,
         )
+        probe = FakeProbe(MicSample(True, ("zoom.exe",)))
+        det = harness._inject_detector(engine, probe)
+        now = datetime.now(timezone.utc)
+        det.observe(now - timedelta(minutes=10))
+        det.observe(now - timedelta(minutes=1))
+
+        engine.shutdown()
+        assert not engine.queue.is_empty(), (
+            "send failed → the final span falls back to the queue"
+        )
+
+
+class TestMicKillSwitch:
+    def test_server_mic_signal_off_closes_session_without_restart(self):
+        # The detector is built at startup, but a server-pushed
+        # mic_signal=false must stop the privacy-sensitive probe NOW.
+        harness = TestSyncEngineMicIntegration()
+        engine = harness._build_engine()
+        probe = FakeProbe(MicSample(True, ("zoom.exe",)))
+        det = harness._inject_detector(engine, probe)
+        now = datetime.now(timezone.utc)
+        det.observe(now - timedelta(minutes=10))
+        det.observe(now - timedelta(minutes=1))
+        assert engine.is_mic_meeting_active()
+
+        engine.config.call_detection.mic_signal = False
+        engine.sync()
+
+        assert engine.is_mic_meeting_active() is False
+        finals = [
+            ev
+            for ev in harness._sent_mic_events(engine)
+            if ev["data"]["status"] == "completed"
+        ]
+        assert len(finals) == 1, "the truthful pre-kill span still ships"

--- a/tests/test_mic_activity.py
+++ b/tests/test_mic_activity.py
@@ -1,0 +1,267 @@
+"""Tests for microphone-in-use meeting detection (mic_activity.py)."""
+
+from datetime import datetime, timedelta, timezone
+
+from src.config import Config
+from src.sync.mic_activity import (
+    MicActivityDetector,
+    MicSample,
+    _matches_conferencing,
+    create_mic_detector,
+)
+
+
+def _ts(minutes_offset: float = 0) -> datetime:
+    base = datetime(2026, 7, 15, 17, 0, 0, tzinfo=timezone.utc)
+    return base + timedelta(minutes=minutes_offset)
+
+
+class FakeProbe:
+    """Scriptable probe: set .current before each observe()."""
+
+    def __init__(self, sample: MicSample | None = None):
+        self.current = sample if sample is not None else MicSample(False)
+
+    def sample(self) -> MicSample:
+        return self.current
+
+
+def _detector(probe=None, **kwargs) -> MicActivityDetector:
+    defaults = {
+        "hostname": "testhost",
+        "probe": probe or FakeProbe(),
+        "min_session_seconds": 30.0,
+        "max_credit_seconds": 14400.0,
+        "off_grace_seconds": 90.0,
+    }
+    defaults.update(kwargs)
+    return MicActivityDetector(**defaults)
+
+
+class TestSessionLifecycle:
+    def test_session_opens_when_mic_hot(self):
+        probe = FakeProbe(MicSample(True))
+        det = _detector(probe)
+        assert det.observe(_ts(0)) is None
+        assert det.is_active()
+
+    def test_no_session_while_mic_cold(self):
+        det = _detector(FakeProbe(MicSample(False)))
+        assert det.observe(_ts(0)) is None
+        assert not det.is_active()
+
+    def test_unreadable_probe_never_opens_a_session(self):
+        det = _detector(FakeProbe(MicSample(None)))
+        det.observe(_ts(0))
+        assert not det.is_active()
+
+    def test_brief_mic_drop_survives_off_grace(self):
+        probe = FakeProbe(MicSample(True))
+        det = _detector(probe, off_grace_seconds=90.0)
+        det.observe(_ts(0))
+        probe.current = MicSample(False)  # one cold sample, 60s later
+        assert det.observe(_ts(1)) is None
+        assert det.is_active(), "a <90s drop must not split the meeting"
+        probe.current = MicSample(True)
+        det.observe(_ts(2))
+        assert det.is_active()
+
+    def test_session_closes_after_off_grace_at_last_hot_instant(self):
+        probe = FakeProbe(MicSample(True))
+        det = _detector(probe)
+        det.observe(_ts(0))
+        det.observe(_ts(49))  # 49-minute meeting
+        probe.current = MicSample(False)
+        ended = det.observe(_ts(52))  # 3min cold > 90s grace
+        assert ended is not None
+        assert ended["timestamp"] == _ts(0).isoformat()
+        assert ended["duration"] == 49 * 60.0
+        assert not det.is_active()
+
+    def test_short_session_discarded_but_not_active_after(self):
+        probe = FakeProbe(MicSample(True))
+        det = _detector(probe, min_session_seconds=300.0)
+        det.observe(_ts(0))
+        det.observe(_ts(1))
+        probe.current = MicSample(False)
+        assert det.observe(_ts(5)) is None  # 60s < 300s: event discarded
+        assert not det.is_active()
+
+    def test_probe_exception_does_not_close_session_within_grace(self):
+        class BoomProbe:
+            def sample(self):
+                raise RuntimeError("boom")
+
+        det = _detector(FakeProbe(MicSample(True)))
+        det.observe(_ts(0))
+        det._probe = BoomProbe()
+        assert det.observe(_ts(1)) is None
+        assert det.is_active(), "a transient blind read must not split the meeting"
+
+    def test_flush_closes_open_session(self):
+        probe = FakeProbe(MicSample(True))
+        det = _detector(probe)
+        det.observe(_ts(0))
+        det.observe(_ts(10))
+        ended = det.flush()
+        assert ended is not None and ended["duration"] == 600.0
+        assert not det.is_active()
+        assert det.flush() is None
+
+
+class TestConferencingGate:
+    def test_windows_attribution_conferencing_app_passes(self):
+        det = _detector(FakeProbe(MicSample(True, ("Zoom.exe",))))
+        det.observe(_ts(0))
+        assert det.is_active()
+
+    def test_windows_attribution_non_conferencing_app_blocked(self):
+        det = _detector(FakeProbe(MicSample(True, ("Audacity.exe",))))
+        det.observe(_ts(0))
+        assert not det.is_active(), "a hot mic held by a recorder is not a meeting"
+
+    def test_macos_gate_false_blocks(self):
+        det = _detector(FakeProbe(MicSample(True)), conferencing_gate=lambda: False)
+        det.observe(_ts(0))
+        assert not det.is_active()
+
+    def test_macos_gate_error_fails_open(self):
+        def boom():
+            raise RuntimeError("psutil hiccup")
+
+        det = _detector(FakeProbe(MicSample(True)), conferencing_gate=boom)
+        det.observe(_ts(0))
+        assert det.is_active(), "losing a real meeting to a gate error is the worse failure"
+
+    def test_attributed_app_used_as_session_label(self):
+        probe = FakeProbe(MicSample(True, ("ms-teams.exe",)))
+        det = _detector(probe)
+        det.observe(_ts(0))
+        det.observe(_ts(10))
+        assert det.flush()["data"]["app"] == "ms-teams.exe"
+
+    def test_token_matching(self):
+        assert _matches_conferencing("zoom.us")
+        assert _matches_conferencing("Google Chrome")
+        assert not _matches_conferencing("Audacity")
+
+
+class TestAfkCredit:
+    def test_none_when_never_observed(self):
+        assert _detector().get_last_active_at(None, _ts(0)) is None
+
+    def test_now_while_session_open(self):
+        det = _detector(FakeProbe(MicSample(True)))
+        det.observe(_ts(0))
+        assert det.get_last_active_at(_ts(-60), _ts(30)) == _ts(30)
+
+    def test_credit_capped_past_max_credit(self):
+        det = _detector(FakeProbe(MicSample(True)), max_credit_seconds=3600.0)
+        det.observe(_ts(0))
+        det.observe(_ts(120))
+        assert det.get_last_active_at(None, _ts(120)) == _ts(60)
+
+    def test_credit_freezes_at_session_end_after_close(self):
+        probe = FakeProbe(MicSample(True))
+        det = _detector(probe)
+        det.observe(_ts(0))
+        det.observe(_ts(49))
+        probe.current = MicSample(False)
+        det.observe(_ts(52))  # closes
+        assert det.get_last_active_at(None, _ts(120)) == _ts(49)
+
+    def test_discarded_short_session_still_credits(self):
+        probe = FakeProbe(MicSample(True))
+        det = _detector(probe, min_session_seconds=300.0)
+        det.observe(_ts(0))
+        det.observe(_ts(1))
+        probe.current = MicSample(False)
+        det.observe(_ts(5))
+        assert det.get_last_active_at(None, _ts(6)) == _ts(1)
+
+    def test_afk_source_folds_mic_credit(self):
+        # End-to-end: a background huddle (mic hot, zero input) keeps the
+        # reconstructed uploaded AFK stream not-afk.
+        from src.sync.afk_source import AfkSource
+
+        probe = FakeProbe(MicSample(True))
+        det = _detector(probe)
+
+        base = _ts(0)
+        clock_now = {"now": base}
+        afk = AfkSource(
+            afk_timeout_seconds=600.0,
+            hostname="testhost",
+            activity_sources=[det],
+            idle_clock=lambda: (clock_now["now"] - base).total_seconds(),
+        )
+        for m in range(0, 50):
+            clock_now["now"] = _ts(m)
+            det.observe(_ts(m))
+            afk.record_sample(_ts(m))
+
+        events = afk.build_afk_events(_ts(0), _ts(49))
+        assert {e["data"]["status"] for e in events} == {"not-afk"}
+
+
+class TestSnapshotAndEventShape:
+    def test_snapshot_grows_with_stable_id_and_does_not_close(self):
+        probe = FakeProbe(MicSample(True))
+        det = _detector(probe)
+        det.observe(_ts(0))
+        det.observe(_ts(2))
+        first = det.snapshot()
+        det.observe(_ts(5))
+        second = det.snapshot()
+        assert first["id"] == second["id"]
+        assert second["duration"] > first["duration"]
+        assert det.is_active()
+
+    def test_snapshot_none_below_min_duration(self):
+        det = _detector(FakeProbe(MicSample(True)))
+        det.observe(_ts(0))
+        assert det.snapshot() is None
+
+    def test_event_rides_existing_call_shape_and_is_storable(self):
+        from src.sync.queue import is_event_storable
+
+        probe = FakeProbe(MicSample(True))
+        det = _detector(probe)
+        det.observe(_ts(0))
+        det.observe(_ts(10))
+        ev = det.flush()
+        assert ev["bucket_type"] == "call"
+        assert ev["bucket_id"] == "bf-call-detector_testhost"
+        assert ev["data"]["call_type"] == "mic"
+        assert is_event_storable(ev, stale_cutoff=_ts(-60))
+
+
+class TestFactory:
+    def test_disabled_by_mic_signal_flag(self):
+        cfg = Config()
+        cfg.call_detection.mic_signal = False
+        assert create_mic_detector(cfg, "h") is None
+
+    def test_disabled_when_call_detection_disabled(self):
+        cfg = Config()
+        cfg.call_detection.enabled = False
+        assert create_mic_detector(cfg, "h") is None
+
+    def test_cap_and_min_duration_plumbed(self, monkeypatch):
+        import src.sync.mic_activity as mod
+
+        monkeypatch.setattr(mod.sys, "platform", "darwin")
+        monkeypatch.setattr(mod, "MacosMicProbe", lambda: FakeProbe())
+        cfg = Config()
+        cfg.call_detection.max_credit_minutes = 60
+        cfg.call_detection.min_call_duration = 45
+        det = create_mic_detector(cfg, "h")
+        assert det is not None
+        assert det._max_credit_seconds == 3600.0
+        assert det._min_session_seconds == 45.0
+
+    def test_unsupported_platform_returns_none(self, monkeypatch):
+        import src.sync.mic_activity as mod
+
+        monkeypatch.setattr(mod.sys, "platform", "linux")
+        assert create_mic_detector(Config(), "h") is None

--- a/tests/test_mic_activity.py
+++ b/tests/test_mic_activity.py
@@ -552,3 +552,98 @@ class TestMicKillSwitch:
             if ev["data"]["status"] == "completed"
         ]
         assert len(finals) == 1, "the truthful pre-kill span still ships"
+
+
+class TestCapLatchRobustness:
+    def test_probe_error_does_not_clear_cap_latch(self):
+        # A wedged-hot mic hits the cap and latches; a transient probe error
+        # (in_use=None) must NOT unlatch — only a definite cold read proves
+        # the mic released. Otherwise every flap re-opens a fresh cap period.
+        probe = FakeProbe(MicSample(True))
+        det = _detector(probe, max_credit_seconds=3600.0)
+        det.observe(_ts(0))
+        det.observe(_ts(30))
+        det.observe(_ts(60))  # cap force-close + latch
+        assert not det.is_active()
+
+        probe.current = MicSample(None)  # probe error
+        det.observe(_ts(61))
+        probe.current = MicSample(True)  # wedged mic still "hot"
+        det.observe(_ts(62))
+        assert not det.is_active(), "latch must survive a probe error"
+
+        probe.current = MicSample(False)  # definite cold read
+        det.observe(_ts(63))
+        probe.current = MicSample(True)
+        det.observe(_ts(64))
+        assert det.is_active(), "a real cold-then-hot transition reopens"
+
+
+class TestShutdownAuthPolicy:
+    def test_auth_error_at_shutdown_drops_instead_of_queueing(self):
+        # An expired token is the likeliest failure at logout. The offline
+        # queue is account-agnostic: a queued row would be delivered under
+        # whoever logs in NEXT on this machine. Drop, matching
+        # _send_status_span's policy.
+        from src.sync.bf_client import BetterFlowAuthError
+
+        harness = TestSyncEngineMicIntegration()
+        engine = harness._build_engine()
+        engine.bf.send_events.side_effect = BetterFlowAuthError("token expired")
+        probe = FakeProbe(MicSample(True, ("zoom.exe",)))
+        det = harness._inject_detector(engine, probe)
+        now = datetime.now(timezone.utc)
+        det.observe(now - timedelta(minutes=10))
+        det.observe(now - timedelta(minutes=1))
+
+        engine.shutdown()
+        assert engine.queue.is_empty(), (
+            "auth failure at shutdown must DROP the final span, not queue it "
+            "for the next login"
+        )
+
+
+class TestKillSwitchDeferralExemption:
+    def test_mic_signal_false_applies_despite_deferral_gate(self):
+        # mic_signal=false is the privacy kill switch — it must not wait for
+        # the staged rollout of the call_detection block.
+        cfg = Config()
+        assert cfg.call_detection.mic_signal is True
+        cfg.update_from_server({"call_detection": {"mic_signal": False}})
+        assert cfg.call_detection.mic_signal is False
+
+    def test_mic_signal_true_stays_deferred(self):
+        # Only "off" passes through the gate; enabling is a rollout decision.
+        cfg = Config()
+        cfg.call_detection.mic_signal = False
+        cfg.update_from_server({"call_detection": {"mic_signal": True}})
+        assert cfg.call_detection.mic_signal is False
+
+    def test_kill_switch_applies_during_aw_outage_too(self):
+        harness = TestSyncEngineMicIntegration()
+        engine = harness._build_engine()
+
+        class CountingProbe:
+            def __init__(self):
+                self.samples = 0
+
+            def sample(self):
+                self.samples += 1
+                return MicSample(True, ("zoom.exe",))
+
+        probe = CountingProbe()
+        det = harness._inject_detector(engine, probe)
+        now = datetime.now(timezone.utc)
+        det.observe(now - timedelta(minutes=10))
+        det.observe(now - timedelta(minutes=1))
+        sampled_before = probe.samples
+
+        engine.config.call_detection.mic_signal = False
+        engine.aw.is_running.return_value = False  # AW outage
+        engine.sync()
+
+        assert probe.samples == sampled_before, (
+            "a server-disabled mic probe must not keep sampling during an "
+            "AW outage"
+        )
+        assert engine.is_mic_meeting_active() is False, "open session flushed"

--- a/tests/test_sync_engine_aw_outage_call_flush.py
+++ b/tests/test_sync_engine_aw_outage_call_flush.py
@@ -45,11 +45,13 @@ def _build_engine() -> SyncEngine:
 
 
 def _enter_call(engine: SyncEngine) -> None:
-    """Drive the detector into an active 2-minute Teams call."""
-    t0 = datetime(2026, 6, 17, 13, 0, 0, tzinfo=timezone.utc)
+    """Drive the detector into an active ~10-minute Teams call whose latest
+    evidence ends ~now (engine.is_in_call() requires FRESH window evidence —
+    a stale call no longer suppresses the idle guard)."""
+    t0 = datetime.now(timezone.utc) - timedelta(minutes=10)
     engine._call_detector.process_event("Microsoft Teams", "Meeting with X", None, t0, 60)
     engine._call_detector.process_event(
-        "Microsoft Teams", "Meeting with X", None, t0 + timedelta(minutes=2), 60
+        "Microsoft Teams", "Meeting with X", None, t0, 9 * 60  # heartbeat: end ≈ now-1min
     )
     assert engine.is_in_call(), "precondition: detector should report in-call"
 


### PR DESCRIPTION
## Problem

A hands-off meeting bills as **idle**: the server bills active-vs-idle from the uploaded AFK stream (union of not-afk spans), and that stream only knew about keyboard/mouse input. Call detection existed but only suppressed the *local* idle pause — and even that raced, because `sync()` flushed the call detector every cycle, so `is_in_call()` was False between cycles. Ecaterina's 49-minute Slack huddle on 2026-07-15 painted Idle on the dashboard.

## What this does

**1. Meetings reach the billed stream.** `CallDetector` (window titles) implements the AFK activity-source contract and is registered with `AfkSource`, so the uploaded stream stays not-afk for the duration of a detected meeting. Calls stay open across sync cycles and upload a live `status:"ongoing"` snapshot under one deterministic id (server upserts one growing row); the real close ships `status:"completed"`.

**2. New: microphone-in-use detection** (`mic_activity.py`) — the system-level signal that survives the call window losing focus (background huddle while reading docs). macOS: CoreAudio device-running property (no TCC prompt); Windows: consent-store registry with per-app attribution. Conferencing-gated (word-boundary token match, fails closed), sessions upload as auditable call events (`call_type:"mic"`).

**3. Anti-fraud bounds** (shared `engagement_credit.capped_credit`, keyword-only):
- credit capped past the **real-input anchor** (session cycling can't re-arm the cap)
- floored at engagement start (no phantom pre-meeting credit)
- evidence staleness: a hung window watcher freezes credit 180s after the last confirming event
- durations clamped + mic force-close/latch at cap (no >24h batch-poison events)

**4. Capture boundaries**: open call/mic/dev-session state flushes at pause, Private Time, working-hours suppression (incl. the tray-thread race via per-cycle re-flush), AW outage, and shutdown — a session can never bridge a not-recorded period into one uploaded span.

**5. Attribution & durability**: final events at shutdown are sent immediately (auth failure ⇒ drop, matching `_send_status_span` — never queued for the next login on a shared machine); fully-offline paths queue; stale `ongoing` snapshots are dropped at queue drain so a replay can't regress a completed row. `mic_signal=false` is a deferral-exempt, disable-only server kill switch that applies at the next sync cycle.

**6. IdleManager**: consults mic + dev-session next to `is_in_call` (with evidence-freshness bound), and clamps `idle_start` to the last observed engagement so the post-meeting idle span can't carve out the hour the AFK stream just credited.

## Review process

4 audit rounds with parallel senior-review agents (correctness/concurrency, SOLID/design, billing/fraud, fresh-eyes holistic, adversarial fix-verification). Rounds 1–3 produced ~30 verified findings, all fixed (`e00a5b8`, `df497b8`, `ecd0209`); round 4 came back clean (`7f12723`). Also rooted out a pre-existing suite-wide flake (`mock.patch` is not thread-safe against itself; a concurrent-patch test leaked a frozen `src.main.datetime` MagicMock).

## Backend follow-ups (internal-tool2)

- Call-bucket events now carry `data.status: "ongoing"|"completed"` — prefer completed / enforce monotonic duration per id.
- One meeting can produce both a `call_*` (window) and a `micsession_*` (mic) row in `bf-call-detector_<hostname>` — aggregate by union, not sum.

## Tests

1200 passed (≈90 new), stable across 10 consecutive full runs. Lint clean on all touched files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
