### PR TITLE
fix(config): un-defer sync.in_process_input — Windows zero-input remediation

### DIFF
--- a/src/config.py
+++ b/src/config.py
@@ -473,10 +473,13 @@ def _normalize_hhmm(value) -> str:
 # ever (the whole fleet has run on local defaults), this gate now covers EVERY block that
 # changes capture / billing / privacy behaviour, so this first delivery is behaviour-neutral
 # except for the working-hours schedule: privacy, collection, engagement, fraud_detection,
-# call_detection, foreground_activity, and sync.in_process_input are all deferred. Only
-# working_hours (the feature) and benign sync tuning (interval, batch_size, idle_pause,
-# min_window_event_seconds, in_process_window) go live. Roll the rest out deliberately, one
-# block at a time, after confirming the device rows and telling the affected people.
+# call_detection, and foreground_activity are all deferred. Only working_hours (the
+# feature), benign sync tuning (interval, batch_size, idle_pause,
+# min_window_event_seconds, in_process_window), and sync.in_process_input (un-deferred
+# 2026-07-17: it is the shipped remediation for Windows' zero-input fraud false
+# positives, stays opt-in per device, and counts carry no content — see its handler)
+# go live. Roll the rest out deliberately, one block at a time, after confirming the
+# device rows and telling the affected people.
 #
 # working_hours is deliberately NOT gated by this: it is the whole point of the release.
 DEFER_UNAPPLIED_SERVER_SETTINGS = True
@@ -973,13 +976,26 @@ class Config:
                 logger.info(
                     "Server config: in_process_window=%s", self.sync.in_process_window
                 )
-            if "in_process_input" in sync and not DEFER_UNAPPLIED_SERVER_SETTINGS:
+            if "in_process_input" in sync:
                 # Opt-in remote enable of the in-process input source (ships
-                # dormant). Deferred with the other capture/billing flags: a stale
-                # device row must not silently activate input capture on the
-                # first-ever config delivery. Use _to_bool (not bool()) like every
-                # sibling flag: a server payload of the STRING "false"/"0" must
-                # stay off — bool("false") is True and would silently enable it.
+                # dormant). UN-DEFERRED deliberately (2026-07-17): Windows
+                # devices have NO working external input watcher (the bundle
+                # launches only window+idle trackers, and where aw-watcher-input
+                # does run its low-level hook gets blocked by UIPI/AV), so every
+                # Windows agent reports zero keystrokes/clicks all month and the
+                # fraud engine flags every worked day as suspicious (Sachi 23,
+                # Claudia 26 false suspicious days, Fraud Risk 95). This flag IS
+                # the shipped remediation, and it stays opt-in per device: the
+                # server must still send in_process_input=true explicitly, so
+                # the deliberate one-device-at-a-time rollout is preserved — the
+                # deferral gate only made the remediation unreachable. The
+                # original deferral concern (a stale device row silently
+                # activating input capture) is acceptable here: input COUNTS
+                # (presses/clicks/scrolls per window) carry no content, unlike
+                # the still-deferred privacy/title flags. Use _to_bool (not
+                # bool()) like every sibling flag: a server payload of the
+                # STRING "false"/"0" must stay off — bool("false") is True and
+                # would silently enable it.
                 self.sync.in_process_input = self._to_bool(sync["in_process_input"])
                 logger.info(
                     "Server config: in_process_input=%s", self.sync.in_process_input

--- a/tests/test_capture_boundary.py
+++ b/tests/test_capture_boundary.py
@@ -397,16 +397,24 @@ class TestArmPathLocking:
         c = _coordinator(_restricted_cfg())
 
         def _worker():
-            with patch("src.main.datetime") as dt:
-                dt.now.return_value = IN_HOURS_UTC
-                for _ in range(20):
-                    c.arm_capture_boundary()
+            for _ in range(20):
+                c.arm_capture_boundary()
 
-        threads = [threading.Thread(target=_worker) for _ in range(4)]
-        for t in threads:
-            t.start()
-        for t in threads:
-            t.join()
+        # ONE patch around all threads. mock.patch enter/exit is NOT
+        # thread-safe against itself for the same target: two threads
+        # patching concurrently can save the other thread's MOCK as the
+        # "original", leaving src.main.datetime a leaked frozen MagicMock for
+        # the rest of the pytest process — which made the idle-tracker-health
+        # freshness gate compute a negative input age and flake
+        # test_silent_when_input_is_stale suite-wide (reproduced and proven
+        # by instrumentation; same fix as on feat/meeting-afk-credit).
+        with patch("src.main.datetime") as dt:
+            dt.now.return_value = IN_HOURS_UTC
+            threads = [threading.Thread(target=_worker) for _ in range(4)]
+            for t in threads:
+                t.start()
+            for t in threads:
+                t.join()
 
         assert "capture_boundary" in c.scheduler.jobs
 

--- a/tests/test_server_config_deferral_and_refetch.py
+++ b/tests/test_server_config_deferral_and_refetch.py
@@ -65,7 +65,6 @@ def test_capture_and_billing_blocks_do_not_apply_on_upgrade():
     before = (
         cfg.foreground_activity.enabled,
         cfg.call_detection.enabled,
-        cfg.sync.in_process_input,
         cfg.engagement.window_minutes,
         cfg.fraud_detection.min_app_diversity,
     )
@@ -81,12 +80,31 @@ def test_capture_and_billing_blocks_do_not_apply_on_upgrade():
     assert (
         cfg.foreground_activity.enabled,
         cfg.call_detection.enabled,
-        cfg.sync.in_process_input,
         cfg.engagement.window_minutes,
         cfg.fraud_detection.min_app_diversity,
     ) == before, "capture/billing/engagement/fraud blocks must be deferred on upgrade"
     # ...but benign sync tuning in the same payload still applies:
     assert cfg.sync.batch_size == 250
+    # ...and so does in_process_input — UN-DEFERRED on purpose (2026-07-17): it is
+    # the shipped remediation for Windows devices whose external input watcher is
+    # hook-blocked and who report zero keystrokes all month (fraud false
+    # positives). Still opt-in: only an explicit server true enables it.
+    assert cfg.sync.in_process_input is True
+
+
+def test_in_process_input_server_flag_round_trip():
+    # Un-deferred but still strictly server-driven and string-safe.
+    cfg = Config()
+    assert cfg.sync.in_process_input is False, "ships dormant"
+
+    cfg.update_from_server({"sync": {"in_process_input": "false"}})
+    assert cfg.sync.in_process_input is False, 'STRING "false" must not enable'
+
+    cfg.update_from_server({"sync": {"in_process_input": True}})
+    assert cfg.sync.in_process_input is True
+
+    cfg.update_from_server({"sync": {"in_process_input": False}})
+    assert cfg.sync.in_process_input is False, "server can also switch it back off"
 
 
 def test_working_hours_and_sync_tuning_still_apply():


### PR DESCRIPTION
## Problem

Windows devices report **zero keystrokes/clicks all month** while collecting full hours (window + AFK streams healthy). The fraud engine flags every worked day: Sachi 23 suspicious days / Claudia 26, Fraud Risk 95/100 — false positives on people with 98h/52h of real tracked work in July.

Root cause: the Windows bundle launches only window+idle trackers; where an external `aw-watcher-input` exists, Windows UIPI/AV blocks its low-level hook. The shipped remediation — the in-process `InputSource` (ctypes hooks inside the agent, immune to hook blocking) — is on every device but unreachable: its enable flag sat behind `DEFER_UNAPPLIED_SERVER_SETTINGS`.

## Change

Un-defer `sync.in_process_input` only. Still strictly opt-in — the server must send `in_process_input: true` per device — so the deliberate one-device-at-a-time rollout is preserved. Input **counts** (presses/clicks/scrolls) carry no content, unlike the still-deferred privacy/title blocks.

## Rollout

1. Merge + release
2. Enable for Sachi's and Claudia's devices first, confirm keys/min come alive
3. Fleet-wide for Windows

## Companion (separate, internal-tool2)

Fraud scoring should treat *all-days-zero input + healthy window/AFK stream* as a **missing input sensor**, not fraud — suppress the suspicious-day flag for that signature.

Tests: 1114 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)