### PR TITLE
chore(style): comment cleanup — no blank-gap comment runs

### DIFF
--- a/src/browser_tracker.py
+++ b/src/browser_tracker.py
@@ -126,7 +126,6 @@ class BrowserURLTracker:
 # ---------------------------------------------------------------------------
 # macOS implementation
 # ---------------------------------------------------------------------------
-
 # Resolve the frontmost app once, then read the URL from the matching browser.
 # `System Events` gives the frontmost process name; we only script a browser we
 # recognise so we never send Apple Events to unrelated apps.
@@ -237,7 +236,6 @@ def _start_macos_tracker(
 #
 # Everything is fail-closed: missing UIA libs, no permission, or any traversal
 # error returns None. Opt-in via privacy.track_browser_urls, same as macOS.
-
 # Foreground process basenames (lowercased) we treat as Chromium browsers.
 _WINDOWS_BROWSER_PROCS = {
     "chrome.exe",

--- a/src/main.py
+++ b/src/main.py
@@ -2903,7 +2903,6 @@ class BetterFlowApp:
         # The schedule is already on disk by now: update_from_server() ends with
         # self.save(), which is what lets the NEXT cold start know the window
         # before it can reach the server. No second save here.
-
         # Re-evaluate immediately rather than waiting up to 60s for the next tick:
         # this is the moment a restricted user's agent first learns it is
         # restricted, and it may already be outside their window.

--- a/src/sync/http_client.py
+++ b/src/sync/http_client.py
@@ -247,7 +247,6 @@ class BaseApiClient:
         self._throttle_lock = threading.Lock()
 
     # ---- Global rate-limit backoff -------------------------------------------
-
     # Default backoff when a 429 carries no usable Retry-After header.
     _DEFAULT_THROTTLE_SECONDS = 30.0
     # Cap so a hostile/buggy Retry-After can't park the agent for minutes.

--- a/src/sync/sync_engine.py
+++ b/src/sync/sync_engine.py
@@ -314,7 +314,6 @@ class SyncEngine:
         # NB: the per-cycle "pending" checkpoint is a LOCAL in sync() (threaded
         # build -> commit), not an instance field — see _build_inproc_window for
         # why (wedge re-arm can run two sync()s concurrently).
-
         # Optional in-process INPUT source (set by the SyncCoordinator), the
         # keystroke/click/scroll-count analogue of window_source. When present,
         # enabled by config, and an in-process counting backend is usable


### PR DESCRIPTION
## What

Applies ace's comment-style rule (2026-07-17): inline comments must be a single line or one contiguous multi-line block — no comment-only groups separated by blank lines.

## Scope

- 5 sites across 4 files: `src/browser_tracker.py` (2), `src/main.py`, `src/sync/http_client.py`, `src/sync/sync_engine.py`.
- Comment/blank-line-only diff: 5 blank-line deletions, 0 additions, zero code changes.

## Verification

- `python -m py_compile` on all 4 changed files — OK
- Detector re-run scoped to this repo: 0 sites remaining

🤖 Generated with [Claude Code](https://claude.com/claude-code)