### PR TITLE
fix(mic): make mic meeting-credit Windows-only (macOS over-billing)

### DIFF
--- a/src/__init__.py
+++ b/src/__init__.py
@@ -1,4 +1,4 @@
 """BetterFlow - ActivityWatch to BetterFlow sync companion app."""
 
-__version__ = "1.5.104"
+__version__ = "1.5.105"
 __author__ = "BetterQA"

--- a/src/sync/mic_activity.py
+++ b/src/sync/mic_activity.py
@@ -516,35 +516,34 @@ def _conferencing_process_running() -> bool:
 
 
 def create_mic_detector(config, hostname: str) -> Optional[MicActivityDetector]:
-    """Build a mic detector from config, or None when disabled or unsupported
-    (Linux, or a platform probe that can't be constructed)."""
+    """Build a mic detector from config, or None when disabled or unsupported.
+
+    Mic credit is WINDOWS-ONLY. macOS and Linux return None — see the platform
+    gate below for why macOS is off (over-billing via CoreAudio's device-level
+    signal + process-scan gate)."""
     cd = config.call_detection
     if not (getattr(cd, "enabled", False) and getattr(cd, "mic_signal", False)):
         return None
 
-    probe: Optional[MicProbe] = None
-    gate = None
-    if sys.platform == "darwin":
-        try:
-            probe = MacosMicProbe()
-        except Exception as e:
-            logger.warning("Mic detection unavailable (CoreAudio load failed): %s", e)
-            return None
-        try:
-            import psutil  # noqa: F401
-
-            gate = _conferencing_process_running
-        except ImportError:
-            gate = None  # no attribution AND no process scan: mic-hot only
-    elif sys.platform == "win32":
-        probe = WindowsMicProbe()
-    else:
+    if sys.platform != "win32":
+        # macOS (and every non-win32 platform) is intentionally OFF. On macOS
+        # the only available signals over-credit: CoreAudio's
+        # kAudioDevicePropertyDeviceIsRunningSomewhere is DEVICE-level, so
+        # playback through a combined input+output device (AirPods, most USB/BT
+        # headsets) marks the *input* device "running" even with no capture;
+        # and the conferencing gate can only fall back to a process-existence
+        # scan (no per-app mic attribution on macOS), which nearly any running
+        # browser/Slack process satisfies. Together those bill idle media
+        # playback as active work. Windows attributes the mic per app and is
+        # safe. Re-enable macOS via per-process CoreAudio taps (macOS 14+);
+        # MacosMicProbe / _conferencing_process_running are kept for that. See
+        # workspace memory macos-mic-credit-overbilling-killswitch.
         return None
 
     return MicActivityDetector(
         hostname=hostname,
-        probe=probe,
-        conferencing_gate=gate,
+        probe=WindowsMicProbe(),
+        conferencing_gate=None,
         min_session_seconds=cd.min_call_duration,
         max_credit_seconds=cd.max_credit_minutes * 60,
     )

--- a/src/sync/mic_activity.py
+++ b/src/sync/mic_activity.py
@@ -1,5 +1,11 @@
 """Microphone-in-use meeting detection.
 
+STATUS: WINDOWS-ONLY. ``create_mic_detector`` returns None on macOS/Linux — the
+macOS signals below (CoreAudio device-level "running somewhere" + a
+process-existence conferencing gate) over-credit idle media playback as active
+work, so macOS mic credit is disabled until per-process CoreAudio taps land.
+The macOS probe/gate are kept for that re-enable. See ``create_mic_detector``.
+
 The window-title path (``CallDetector``) only sees a meeting while the call
 window is FRONTMOST and titled like a call. In real usage the huddle runs in
 the background — the user reads docs, or just listens with some other window

--- a/tests/test_foreground_activity.py
+++ b/tests/test_foreground_activity.py
@@ -217,6 +217,40 @@ def test_base_last_input_at_excludes_activity_sources():
     assert src.base_last_input_at(T0) == T0 - timedelta(seconds=30)
 
 
+def test_second_activity_source_gets_the_real_input_anchor_not_the_first_ones_credit():
+    """Credit-chaining guard: with two engagement sources folded in one cycle,
+    the SECOND must be anchored on the real keyboard/mouse instant, never on the
+    FIRST source's no-input credit. Otherwise one detector's credit re-arms the
+    next detector's cap (the exact failure engagement_credit / afk_source's
+    real_input_anchor fix prevents). The production wiring
+    (engagement_activity_sources: call + mic + foreground) always folds 2+
+    sources; every other test uses a single source, so only this exercises the
+    fix. Break it by reverting afk_source to pass the mutating `last_input_at`
+    and this fails; the single-source tests stay green."""
+    seen = {}
+
+    class Advancer:
+        """Source A: grants no-input credit, advancing last_input_at to T0."""
+
+        def get_last_active_at(self, base, now):
+            return now  # == T0; > the idle-clock anchor, so it folds in
+
+    class Spy:
+        """Source B: records the anchor it was handed, credits nothing."""
+
+        def get_last_active_at(self, base, now):
+            seen["base"] = base
+            return None
+
+    src = AfkSource(
+        afk_timeout_seconds=600, hostname="host",
+        idle_clock=lambda: 30.0, activity_sources=[Advancer(), Spy()],
+    )
+    src.record_sample(T0)
+    # B must see the pre-fold real-input anchor (T0 - 30s), NOT A's credit (T0).
+    assert seen["base"] == T0 - timedelta(seconds=30)
+
+
 def test_base_last_input_at_none_on_linux_like_clock():
     src = AfkSource(afk_timeout_seconds=600, hostname="host", idle_clock=lambda: None)
     assert src.base_last_input_at(T0) is None

--- a/tests/test_mic_activity.py
+++ b/tests/test_mic_activity.py
@@ -289,8 +289,10 @@ class TestFactory:
     def test_cap_and_min_duration_plumbed(self, monkeypatch):
         import src.sync.mic_activity as mod
 
-        monkeypatch.setattr(mod.sys, "platform", "darwin")
-        monkeypatch.setattr(mod, "MacosMicProbe", lambda: FakeProbe())
+        # Windows is the supported platform for mic credit (see
+        # test_macos_returns_none_until_per_process_taps for why macOS is off).
+        monkeypatch.setattr(mod.sys, "platform", "win32")
+        monkeypatch.setattr(mod, "WindowsMicProbe", lambda: FakeProbe())
         cfg = Config()
         cfg.call_detection.max_credit_minutes = 60
         cfg.call_detection.min_call_duration = 45
@@ -298,6 +300,21 @@ class TestFactory:
         assert det is not None
         assert det._max_credit_seconds == 3600.0
         assert det._min_session_seconds == 45.0
+
+    def test_macos_returns_none_until_per_process_taps(self, monkeypatch):
+        """macOS mic credit is disabled: the CoreAudio device-level
+        'running somewhere' signal can't tell mic capture from playback on a
+        combined-device headset, and the conferencing gate is satisfied by any
+        running browser process — together an over-billing path (idle media
+        playback billed as active). Windows attributes the mic per app and is
+        unaffected. Re-enable when per-process CoreAudio taps (macOS 14+) land."""
+        import src.sync.mic_activity as mod
+
+        monkeypatch.setattr(mod.sys, "platform", "darwin")
+        # Even with a constructible probe, macOS must not build a detector.
+        monkeypatch.setattr(mod, "MacosMicProbe", lambda: FakeProbe())
+        cfg = Config()  # enabled + mic_signal default True
+        assert create_mic_detector(cfg, "h") is None
 
     def test_unsupported_platform_returns_none(self, monkeypatch):
         import src.sync.mic_activity as mod


### PR DESCRIPTION
## Why

macOS mic meeting-credit (agent #137, v1.5.104) can bill **idle time as active work**. Two macOS-only signals combine:

- CoreAudio `kAudioDevicePropertyDeviceIsRunningSomewhere` is **device-level** — playback through a combined input+output device (AirPods, most USB/BT headsets) marks the *input* device "running" with no actual capture.
- The conferencing gate falls back to a bare process-existence scan (macOS exposes no per-app mic attribution), satisfied by nearly any running browser/Slack process — **verified 21 matching processes on an ordinary Mac**, including Apple's own Safari background services.

Together, a macOS user listening to media while away from the keyboard gets up to `max_credit_minutes` (4h default) of idle billed as active. Windows attributes the mic per app and is safe.

## What

`create_mic_detector` returns `None` on every non-win32 platform. `MacosMicProbe` / `_conferencing_process_running` are **kept** for the eventual re-enable via per-process CoreAudio taps (macOS 14+). Window-title call detection is untouched — this removes only the macOS *mic* signal.

Also adds the missing regression guard for the `afk_source` real-input anchor fix from #137: the multi-source credit-chaining property was never tested (every existing `AfkSource` test uses a single source). New two-source test asserts the second engagement source is anchored on real input, not the first source's credit.

## Test evidence (`PYTHONPATH=. pytest`)

- `test_macos_returns_none_until_per_process_taps`: **fails pre-fix** (darwin built a detector), **passes post-fix**.
- anchor guard: **fails** against a reverted (chaining) `afk_source`, **passes** with the fix — verified by break-on-purpose, so it's a real guard not a phantom.
- Full suite: **1203 passed**. Ruff clean.

## Relationship to the kill switch

internal-tool2 #2150 already disabled mic-credit fleet-wide via the server flag (default off). This is the durable code-side fix. Re-enabling mic credit on Windows would come with this release; macOS stays off until per-process taps.

## Decision recorded

Chose Windows-only (fail-closed) over a best-effort macOS heuristic: browsers are both media players and conferencing apps, so a frontmost-app gate can't distinguish YouTube-in-Chrome-while-AFK from a real Meet call. No reliable macOS signal exists without per-process taps.

Version 1.5.104 -> 1.5.105.

🤖 Generated with [Claude Code](https://claude.com/claude-code)