### PR TITLE
refactor(sync): single-source project-id stamping

### DIFF
--- a/src/sync/sync_engine.py
+++ b/src/sync/sync_engine.py
@@ -645,14 +645,23 @@ class SyncEngine:
             if ended is not None:
                 stats.calls_detected += 1
 
-    def _stamp_project(self, event: dict) -> dict:
-        """Attach the active project to a detector-built event, exactly as
-        _make_call_bf_event does for window-detected calls — the same meeting
-        must not upsert a projected call row next to an unprojected mic row."""
+    def _current_project_id(self):
+        """The active project's id, or None. The single locked read of
+        _current_project that every event-stamping path shares, so the
+        lock+read rule can't drift between call sites."""
         with self._state_lock:
             project = self._current_project
-        if project:
-            event["project_id"] = project["id"]
+        return project["id"] if project else None
+
+    def _stamp_project(self, event: dict) -> dict:
+        """Attach the active project id to a detector/synth-built event. The one
+        place that writes project_id onto an event dict, so call, mic, window,
+        status-span and synthetic-AFK rows can't drift in how they are tagged
+        (the same meeting must never upsert a projected row next to an
+        unprojected one)."""
+        pid = self._current_project_id()
+        if pid is not None:
+            event["project_id"] = pid
         return event
 
     def _enqueue_events_best_effort(self, events: list, context: str) -> None:
@@ -2307,10 +2316,7 @@ class SyncEngine:
         }
 
         # Tag with current project if set
-        with self._state_lock:
-            project = self._current_project
-        if project:
-            result["project_id"] = project["id"]
+        result = self._stamp_project(result)
 
         # Add activity classification + counted time for window events
         # (fraud assessment is batched per cycle in _transform_and_checkpoint)
@@ -2611,10 +2617,7 @@ class SyncEngine:
             "bucket_type": bucket_type,
             "data": {"status": kind},
         }
-        with self._state_lock:
-            project = self._current_project
-        if project:
-            event["project_id"] = project["id"]
+        event = self._stamp_project(event)
         # bf.send_events() returns SyncResult(success=False) on network errors —
         # it does NOT raise BetterFlowClientError — so the previous `except`
         # block was unreachable and break/idle/private events were silently
@@ -2696,11 +2699,7 @@ class SyncEngine:
                 "status": status,
             },
         }
-        with self._state_lock:
-            project = self._current_project
-        if project:
-            result["project_id"] = project["id"]
-        return result
+        return self._stamp_project(result)
 
     def _synthesize_active_afk_event(
         self, latest_afk, afk_bucket_id: str, now: Optional[datetime] = None
@@ -2761,11 +2760,7 @@ class SyncEngine:
             "bucket_type": BUCKET_TYPE_AFK,
             "data": {"status": "not-afk", "synthetic": True},
         }
-        with self._state_lock:
-            project = self._current_project
-        if project:
-            result["project_id"] = project["id"]
-        return result
+        return self._stamp_project(result)
 
     @staticmethod
     def _get_system_idle_seconds() -> Optional[float]:
@@ -2875,11 +2870,9 @@ class SyncEngine:
             # the unobserved window uncovered, exactly as before) and re-seed
             # past it. Emitted one-shot: the queue is the durability layer, and
             # the checkpoint is reset to `now` so nothing is rebuilt.
-            with self._state_lock:
-                project = self._current_project
             salvaged = self.afk_source.build_afk_events(
                 cp, self.afk_source.finalize_point(now),
-                project_id=project["id"] if project else None,
+                project_id=self._current_project_id(),
                 cover_unsampled=False,
             )
             logger.info(
@@ -2917,11 +2910,9 @@ class SyncEngine:
         finalize_to = self.afk_source.finalize_point(now)
         if finalize_to <= cp:
             return []
-        with self._state_lock:
-            project = self._current_project
         events = self.afk_source.build_afk_events(
             cp, finalize_to,
-            project_id=project["id"] if project else None,
+            project_id=self._current_project_id(),
         )
         # Defer the checkpoint advance to _commit_inproc_afk_checkpoint (finding B).
         self._afk_inproc_pending = finalize_to

--- a/tests/test_project_stamp_single_source.py
+++ b/tests/test_project_stamp_single_source.py
@@ -1,0 +1,36 @@
+"""Callsite guard: project stamping is single-sourced.
+
+The active project is attached to outgoing events in several places (window,
+status-span, call, mic, synthetic-AFK, salvaged-AFK). Historically each read
+`self._current_project` under the lock and wrote `project_id` inline, so the
+copies could drift — the same meeting upserting a projected row next to an
+unprojected one (one-rule-one-implementation, the #1 audit defect class).
+
+These tests fail if any call site re-rolls the rule inline instead of going
+through `_current_project_id()` / `_stamp_project()`. They fail against the
+pre-dedup code (7 locked reads, 5 inline writes) and pass once every path
+routes through the two helpers.
+"""
+
+from pathlib import Path
+
+import src.sync.sync_engine as mod
+
+_SOURCE = Path(mod.__file__).read_text()
+
+
+def test_current_project_is_read_in_exactly_one_place():
+    # The locked read `project = self._current_project` must live only in
+    # `_current_project_id`; every consumer calls that accessor.
+    assert _SOURCE.count("project = self._current_project") == 1
+
+
+def test_project_id_is_written_onto_events_in_exactly_one_place():
+    # The dict write `x["project_id"] = ...` must live only in `_stamp_project`.
+    assert _SOURCE.count('["project_id"] = ') == 1
+
+
+def test_no_inline_conditional_project_id_arg():
+    # The old constructor-arg shape `project_id=project["id"] if project else
+    # None` must be gone — those sites call `_current_project_id()` now.
+    assert 'project_id=project["id"] if project else None' not in _SOURCE


### PR DESCRIPTION
## What

Six event paths (window, status-span, call, mic, synthetic-AFK, salvaged-AFK) each read `self._current_project` under the lock and applied `project_id` inline — four as `x["project_id"] = project["id"]`, two as a `build_afk_events(..., project_id=...)` arg. Identical copies that could drift, so the same meeting could upsert a projected row next to an unprojected one (flagged in the #137 mic-credit audit; one-rule-one-implementation, our #1 defect class).

Now single-sourced:
- new `_current_project_id()` — the one locked read of `_current_project`.
- `_stamp_project()` — the one place that writes `project_id` onto an event dict; the four dict sites call it.
- the two `build_afk_events` sites pass `project_id=self._current_project_id()`.

No behaviour change.

## Test

`test_project_stamp_single_source` (callsite guard): asserts exactly one locked read and one inline write remain, and the old conditional-arg shape is gone. **Proof-of-failure verified**: all three assertions fail against the pre-refactor code (7 reads / 5 writes) and pass after. Full suite **1206 passed**. Ruff: no new errors (the 7 pre-existing in `sync_engine.py` are on main too).

Pure refactor, no version bump — rides the next release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)