### PR TITLE
fix(sync): make project-stamp guard honest about the AfkSource write

### DIFF
--- a/src/sync/sync_engine.py
+++ b/src/sync/sync_engine.py
@@ -654,11 +654,15 @@ class SyncEngine:
         return project["id"] if project else None
 
     def _stamp_project(self, event: dict) -> dict:
-        """Attach the active project id to a detector/synth-built event. The one
-        place that writes project_id onto an event dict, so call, mic, window,
-        status-span and synthetic-AFK rows can't drift in how they are tagged
-        (the same meeting must never upsert a projected row next to an
-        unprojected one)."""
+        """Stamp the active project onto a SyncEngine-built event dict (call,
+        mic, window, status-span, synthetic-active-AFK). The single place the
+        engine reads-and-writes the project, so these rows can't drift in how
+        they are tagged (the same meeting must never upsert a projected row
+        next to an unprojected one). AfkSource-built AFK events don't pass
+        through here: they receive the id as a parameter (from
+        _current_project_id()) and assign it in AfkSource._event() — so the
+        project DECISION is still single-sourced (_current_project_id), even
+        though the dict write happens in two modules."""
         pid = self._current_project_id()
         if pid is not None:
             event["project_id"] = pid

--- a/tests/test_project_stamp_single_source.py
+++ b/tests/test_project_stamp_single_source.py
@@ -1,22 +1,28 @@
-"""Callsite guard: project stamping is single-sourced.
+"""Callsite guard: the project DECISION is single-sourced.
 
 The active project is attached to outgoing events in several places (window,
-status-span, call, mic, synthetic-AFK, salvaged-AFK). Historically each read
-`self._current_project` under the lock and wrote `project_id` inline, so the
-copies could drift — the same meeting upserting a projected row next to an
-unprojected one (one-rule-one-implementation, the #1 audit defect class).
+status-span, call, mic, synthetic-active-AFK inside SyncEngine; plus the
+salvaged/in-process AFK events built by AfkSource). Historically each SyncEngine
+site read `self._current_project` under the lock and wrote `project_id` inline,
+so the copies could drift — the same meeting upserting a projected row next to
+an unprojected one (one-rule-one-implementation, the #1 audit defect class).
 
-These tests fail if any call site re-rolls the rule inline instead of going
-through `_current_project_id()` / `_stamp_project()`. They fail against the
-pre-dedup code (7 locked reads, 5 inline writes) and pass once every path
-routes through the two helpers.
+The thing that must be single-sourced is the DECISION "what is the active
+project" — `_current_project_id()`. The dict WRITE itself legitimately happens
+in two modules: `_stamp_project` (SyncEngine-built events) and
+`AfkSource._event()` (AFK events, which receive the id as a parameter, NOT by
+reading `_current_project` themselves). These tests enforce exactly that: one
+locked read of `_current_project` in SyncEngine, one write per module, and no
+AfkSource read of `_current_project` (it must stay parameter-fed).
 """
 
 from pathlib import Path
 
+import src.sync.afk_source as afk_mod
 import src.sync.sync_engine as mod
 
 _SOURCE = Path(mod.__file__).read_text()
+_AFK_SOURCE = Path(afk_mod.__file__).read_text()
 
 
 def test_current_project_is_read_in_exactly_one_place():
@@ -34,3 +40,12 @@ def test_no_inline_conditional_project_id_arg():
     # The old constructor-arg shape `project_id=project["id"] if project else
     # None` must be gone — those sites call `_current_project_id()` now.
     assert 'project_id=project["id"] if project else None' not in _SOURCE
+
+
+def test_afk_source_writes_project_id_once_and_never_reads_current_project():
+    # AfkSource is the OTHER module that writes project_id (the AFK path named
+    # in _stamp_project's docstring). It must write it exactly once and only
+    # from its passed-in parameter — never by reading _current_project itself,
+    # which would re-introduce a second decision source and defeat the dedup.
+    assert _AFK_SOURCE.count('["project_id"] = ') == 1
+    assert "_current_project" not in _AFK_SOURCE


### PR DESCRIPTION
## Why (round-1 audit finding)

A gaps/correctness review of this session's work flagged that `_stamp_project`'s docstring claimed to be "the one place that writes `project_id`... so synthetic-AFK rows can't drift", and the callsite guard (`test_project_stamp_single_source`) only grepped `sync_engine.py`. But `AfkSource._event()` also writes `project_id` — receiving it as a parameter (`self._current_project_id()`). No live bug (both assign the same value), but the claim and the guard didn't match the code: the AFK write site the docstring *named* was uncovered.

## What

The property that must be single-sourced is the project **decision** (`_current_project_id`), not the dict write — the write legitimately happens in two modules because AFK events are built by `AfkSource` with the id passed in.

- Reworded `_stamp_project`'s docstring to scope its claim to SyncEngine-built events and state AFK events are parameter-fed (decision still single-sourced).
- Extended the guard: `AfkSource` must write `project_id` exactly once **and never read `_current_project`** itself (which would re-introduce a second decision source).

Doc + test only, no production logic change. Guard 4 passed, full suite **1207 passed**, ruff clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
