### PR TITLE
fix: audit remediation (13 commits, 2026-07-18)

### DIFF
--- a/.github/workflows/verify-tracker-pins.yml
+++ b/.github/workflows/verify-tracker-pins.yml
@@ -1,0 +1,47 @@
+name: Verify Tracker Asset Pins
+
+# The RELEASE_SHA256 pins in src/aw_manager.py are hand-computed literals, and
+# tests/test_aw_manager_asset_integrity.py only cross-checks them against a
+# second copy of the same literals — so a wrong value passes the unit suite and
+# fails closed on the fleet instead (no trackers installed, zero capture).
+# This job is the independent check: it fetches the real upstream archives and
+# asserts their digests equal the pins. It runs nightly so upstream mutating an
+# asset under a pinned tag is caught here rather than on user machines.
+
+on:
+  schedule:
+    - cron: "17 4 * * *"
+  workflow_dispatch:
+  push:
+    paths:
+      - "src/aw_manager.py"
+      - "tests/test_aw_manager_asset_integrity.py"
+      - "scripts/verify_tracker_pins.py"
+      - ".github/workflows/verify-tracker-pins.yml"
+
+# Read-only: this job downloads public upstream release assets and compares
+# hashes. It never writes to the repo or touches releases.
+permissions:
+  contents: read
+
+jobs:
+  verify-pins:
+    runs-on: ubuntu-latest
+    # The per-read socket timeout in the script does not bound total runtime: a
+    # slow-drip upstream can keep three ~100 MB fetches alive for hours on the
+    # default 6h job limit. Cap the whole job instead.
+    timeout-minutes: 30
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+
+      # platformdirs is the only third-party import src/aw_manager.py pulls in at
+      # module level; the verifier needs nothing else from requirements.txt.
+      - name: Install the one import the constants need
+        run: pip install platformdirs
+
+      - name: Fetch upstream archives and compare against the pins
+        run: python scripts/verify_tracker_pins.py

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ BetterFlow reads activity data from your local [ActivityWatch](https://activityw
 ## Features
 
 - **Automatic syncing** - Events sync every 60 seconds (configurable)
-- **Privacy-first** - Window titles are hashed by default, only domains sent for URLs
+- **Privacy-first** - Excluded apps never leave your device, only domains sent for URLs
 - **Offline support** - Events are queued locally when offline and synced when back online
 - **Activity analysis** - Engagement detection distinguishes active work from idle time
 - **Break & private time reminders** - Configurable notifications to take breaks or end private mode
@@ -81,7 +81,10 @@ Right-click the tray icon for options including pause/resume, private time, proj
 
 BetterFlow is designed with privacy in mind:
 
-- **Window titles** are hashed (SHA-256) by default - only a fingerprint is sent, not the actual title
+- **Window titles** are sent to the BetterFlow server, which applies title handling and
+  categorization. The `hash_titles` preference is forwarded to the server and honoured
+  there - the agent does **not** hash titles on your device. If a title must never leave
+  the machine, exclude its app (below); that is the only client-side title control.
 - **URLs** are stripped to domain-only - no full paths or query parameters
 - **Allowlist** for raw titles - IDEs and terminals can show real titles for project tracking
 - **Exclude apps** - Sensitive apps (1Password, etc.) are never tracked

--- a/scripts/verify_tracker_pins.py
+++ b/scripts/verify_tracker_pins.py
@@ -1,0 +1,125 @@
+#!/usr/bin/env python3
+"""Verify RELEASE_SHA256 against the real upstream ActivityWatch archives.
+
+tests/test_aw_manager_asset_integrity.py can only prove the pins are well-formed
+and that they match a second hand-copied record of the same literals. Both
+copies were authored in the same change, so a wrong digest passes the unit
+suite and only surfaces on user machines — where the download fails closed and
+the device installs no trackers at all.
+
+This script is the independent provenance check: it downloads each asset named
+in RELEASE_ASSETS and asserts the real digest equals the pin. Run by
+.github/workflows/verify-tracker-pins.yml (nightly + on changes to the pins).
+
+Exit code 0 = every pin matches. 1 = at least one mismatch or download failure.
+"""
+
+import hashlib
+import sys
+import urllib.error
+import urllib.request
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
+
+from src.aw_manager import (  # noqa: E402
+    AW_VERSION,
+    RELEASE_ASSETS,
+    RELEASE_BASE,
+    RELEASE_SHA256,
+)
+
+# Upstream archives are ~100 MB. Cap the read so a redirect to something huge
+# can't fill the runner disk before we ever get to compare a digest.
+MAX_ARCHIVE_BYTES = 512 * 1024 * 1024
+CHUNK_BYTES = 1024 * 1024
+DOWNLOAD_TIMEOUT_SECONDS = 300
+
+
+class _HTTPSOnlyRedirectHandler(urllib.request.HTTPRedirectHandler):
+    """Reject any redirect hop that leaves HTTPS.
+
+    Checking only response.geturl() catches the final URL but not the path
+    taken to it: urllib follows redirects itself, so an https -> http -> https
+    chain sends a hop in the clear (and http/ftp/file targets are all allowed
+    by the default handler) before we ever see the last URL. Fail on the hop.
+    """
+
+    def redirect_request(self, req, fp, code, msg, headers, newurl):
+        if not newurl.lower().startswith("https://"):
+            raise ValueError(f"refusing a redirect off HTTPS to: {newurl}")
+        return super().redirect_request(req, fp, code, msg, headers, newurl)
+
+
+_OPENER = urllib.request.build_opener(_HTTPSOnlyRedirectHandler)
+
+
+def _sha256_of_url(url: str) -> str:
+    """Stream a URL through SHA-256 without holding the archive in memory."""
+    # This script exists to prove provenance, so the transport has to be
+    # trustworthy too: a RELEASE_BASE edited down to http://, or a redirect that
+    # downgrades off TLS (or to file://), would let an on-path attacker choose
+    # the bytes we then bless as "verified". Fail closed on both.
+    if not url.lower().startswith("https://"):
+        raise ValueError(f"refusing to fetch over a non-HTTPS URL: {url}")
+    digest = hashlib.sha256()
+    total = 0
+    with _OPENER.open(url, timeout=DOWNLOAD_TIMEOUT_SECONDS) as response:
+        final_url = response.geturl()
+        if not final_url.lower().startswith("https://"):
+            raise ValueError(f"redirected off HTTPS to: {final_url}")
+        while True:
+            chunk = response.read(CHUNK_BYTES)
+            if not chunk:
+                break
+            total += len(chunk)
+            if total > MAX_ARCHIVE_BYTES:
+                raise ValueError(
+                    f"archive exceeded {MAX_ARCHIVE_BYTES} bytes before EOF"
+                )
+            digest.update(chunk)
+    return digest.hexdigest()
+
+
+def main() -> int:
+    missing = set(RELEASE_ASSETS) - set(RELEASE_SHA256)
+    if missing:
+        print(f"FAIL: no pinned hash for platform(s): {sorted(missing)}")
+        return 1
+
+    failures = []
+    for plat in sorted(RELEASE_ASSETS):
+        url = f"{RELEASE_BASE}/{RELEASE_ASSETS[plat]}"
+        expected = RELEASE_SHA256[plat]
+        print(f"[{plat}] fetching {url}")
+        try:
+            actual = _sha256_of_url(url)
+        except (urllib.error.URLError, ValueError, OSError) as exc:
+            failures.append(f"[{plat}] download failed: {exc}")
+            print(f"[{plat}] ERROR: {exc}")
+            continue
+
+        if actual == expected:
+            print(f"[{plat}] OK {actual}")
+        else:
+            failures.append(f"[{plat}] expected {expected}, upstream is {actual}")
+            print(f"[{plat}] MISMATCH expected={expected} actual={actual}")
+
+    if failures:
+        print(
+            f"\nFAIL: {len(failures)} pin(s) unverified for AW_VERSION {AW_VERSION}.\n"
+            "A mismatch means either the pins in src/aw_manager.py are wrong (every "
+            "machine needing a bootstrap installs nothing) or upstream mutated an "
+            "asset under a pinned tag (treat as a supply-chain incident, do NOT "
+            "blindly update the pins)."
+        )
+        for failure in failures:
+            print(f"  - {failure}")
+        return 1
+
+    print(f"\nAll {len(RELEASE_ASSETS)} pins verified for AW_VERSION {AW_VERSION}.")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/src/__init__.py
+++ b/src/__init__.py
@@ -1,4 +1,4 @@
 """BetterFlow - ActivityWatch to BetterFlow sync companion app."""
 
-__version__ = "1.5.105"
+__version__ = "1.5.106"
 __author__ = "BetterQA"

--- a/src/auth/keychain.py
+++ b/src/auth/keychain.py
@@ -134,7 +134,7 @@ class KeychainManager:
             return None
         try:
             return StoredCredentials.from_json(data)
-        except (json.JSONDecodeError, KeyError, TypeError) as e:
+        except (json.JSONDecodeError, ValueError, KeyError, TypeError) as e:
             logger.warning("Invalid credential format in keychain: %s", e)
             return None
 

--- a/src/autostart.py
+++ b/src/autostart.py
@@ -46,7 +46,13 @@ def get_auto_start() -> bool:
             return _get_linux()
         else:
             return False
-    except Exception:
+    except Exception as e:
+        # Its sibling set_auto_start() logs; this one did not. The result drives
+        # both the tray "Launch at Login" checkmark and ensure_synced(), so a
+        # silent failure shows the user "off" while it may be on AND makes
+        # ensure_synced re-bootstrap the LaunchAgent on every startup with no
+        # diagnostic.
+        logger.warning(f"Failed to read auto-start state: {e}")
         return False
 
 
@@ -78,7 +84,14 @@ def _macos_plist_program_args() -> Optional[list[str]]:
     try:
         with open(_plist_path(), "rb") as f:
             data = plistlib.load(f)
-    except Exception:
+    except FileNotFoundError:
+        return None  # No plist installed yet — the normal "not enabled" case.
+    except Exception as e:
+        # A parse/permission error makes _macos_plist_is_current() report "not
+        # current" forever, so ensure_synced() bootout+bootstraps the agent on
+        # every launch and the user sees Launch-at-Login flapping. Distinguish
+        # it from the benign missing-file case above.
+        logger.warning(f"Could not read the LaunchAgent plist: {e}")
         return None
     args = data.get("ProgramArguments")
     return [str(a) for a in args] if isinstance(args, list) else None

--- a/src/aw_manager.py
+++ b/src/aw_manager.py
@@ -235,9 +235,9 @@ def _download_aw_binaries(install_dir: str) -> bool:
     url = f"{RELEASE_BASE}/{asset}"
     # Defense-in-depth: only ever fetch tracker binaries over HTTPS from GitHub.
     try:
-        from .url_safety import is_safe_fetch_url
+        from .url_safety import assert_safe_final_url, is_safe_fetch_url
     except ImportError:
-        from url_safety import is_safe_fetch_url
+        from url_safety import assert_safe_final_url, is_safe_fetch_url
     if not is_safe_fetch_url(url):
         logger.error(f"Refusing unsafe tracker download URL (must be HTTPS from GitHub): {url}")
         return False
@@ -254,11 +254,7 @@ def _download_aw_binaries(install_dir: str) -> bool:
             # only covers the FIRST hop. GitHub legitimately redirects assets to
             # objects.githubusercontent.com; anywhere else means the download was
             # steered off-allowlist, so abort before reading/writing the body.
-            final_url = response.geturl()
-            if not is_safe_fetch_url(final_url):
-                raise ValueError(
-                    f"Tracker download redirected to a disallowed host: {final_url}"
-                )
+            assert_safe_final_url(response.geturl(), "Tracker download")
             try:
                 total = int(response.headers.get("Content-Length") or 0)
             except (ValueError, TypeError):

--- a/src/aw_manager.py
+++ b/src/aw_manager.py
@@ -991,6 +991,9 @@ class AWManager:
             window_blind = self._window_tracker_blind
             inproc = self._inproc_afk_active
             managed_unavailable = self._managed_components_unavailable
+            # Written under this same lock in _start_locked, so read under it too
+            # instead of racing a concurrent start/restart.
+            download_failed = self.tracker_download_failed
 
         window_age = self._get_latest_window_event_age()
         # When the agent owns the AFK stream in-process, the external
@@ -1019,7 +1022,7 @@ class AWManager:
             # True => the tracker binaries could not be installed (fail-closed
             # integrity check or a bad archive), so this device is capturing
             # NOTHING even though the agent looks alive.
-            "tracker_download_failed": self.tracker_download_failed,
+            "tracker_download_failed": download_failed,
             # True => we have no managed watchers of our own. Capture may still
             # be flowing via an external server on the port, but nothing here can
             # restart or self-heal it, so an outage will not recover on its own.

--- a/src/aw_manager.py
+++ b/src/aw_manager.py
@@ -1,5 +1,6 @@
 """Manage bundled tracker processes (ActivityWatch components, white-labeled)."""
 
+import hashlib
 import json
 import logging
 import os
@@ -50,6 +51,18 @@ RELEASE_ASSETS = {
     "darwin": f"activitywatch-{AW_VERSION}-macos-x86_64.zip",
     "windows": f"activitywatch-{AW_VERSION}-windows-x86_64.zip",
     "linux": f"activitywatch-{AW_VERSION}-linux-x86_64.zip",
+}
+
+# SHA-256 of the vetted RELEASE_ASSETS archives above. GitHub release assets on
+# a pinned tag are mutable by the upstream account, so the version pin alone is
+# not an integrity guarantee — a compromised ActivityWatch account could swap
+# the binaries under the same tag. The download is verified against these
+# hashes before extraction (fail closed on mismatch). MUST be recomputed on
+# every AW_VERSION bump (shasum -a 256 on the freshly-vetted zips).
+RELEASE_SHA256 = {
+    "darwin": "e62a76c0ec3c0e69d58ba207bb8da6d8d47d0c7ad1bc871ddf702168f291cf5b",
+    "windows": "a067fa765678a411991826c4da811fd2d8ca260c2db9d6d897957565b61c369f",
+    "linux": "8f62b10babf8a8f108cbdf7267c02fbc1ce2a970fa9535f230b3416b803e3360",
 }
 
 # Mapping from original AW names to our branded names (used during download/extract)
@@ -261,7 +274,27 @@ def _download_aw_binaries(install_dir: str) -> bool:
                         )
 
         size_mb = os.path.getsize(tmp_zip) / (1024 * 1024)
-        logger.info(f"Downloaded {size_mb:.1f} MB, extracting binaries...")
+
+        # Integrity check: the tag is pinned but GitHub release assets are
+        # mutable by the upstream account, so verify the archive against the
+        # vetted hash before extracting (and before any chmod/quarantine-strip).
+        expected_sha = RELEASE_SHA256.get(plat)
+        if not expected_sha:
+            logger.error(f"No pinned SHA-256 for platform {plat}; refusing to install trackers")
+            return False
+        hasher = hashlib.sha256()
+        with open(tmp_zip, "rb") as f:
+            for chunk in iter(lambda: f.read(1024 * 1024), b""):
+                hasher.update(chunk)
+        actual_sha = hasher.hexdigest()
+        if actual_sha != expected_sha:
+            logger.error(
+                f"Tracker archive SHA-256 mismatch for {asset}: "
+                f"expected {expected_sha}, got {actual_sha} — refusing to install"
+            )
+            return False
+
+        logger.info(f"Downloaded {size_mb:.1f} MB (SHA-256 verified), extracting binaries...")
 
         ext = ".exe" if plat == "windows" else ""
         # Find full paths to component launchers in the archive.

--- a/src/aw_manager.py
+++ b/src/aw_manager.py
@@ -658,19 +658,13 @@ class AWManager:
     def _report_download_failure(self) -> None:
         """Notify the user and the ops ingest that tracker components could not
         be installed (so tracking is unavailable). Runs off _lifecycle_lock;
-        throttling is done by _dispatch_download_failure_report."""
-        try:
-            try:
-                from .notifications import send_notification
-            except ImportError:
-                from notifications import send_notification
-            send_notification(
-                "BetterFlow tracking unavailable",
-                "Tracker components could not be installed, so activity is not "
-                "being recorded. Please contact support.",
-            )
-        except Exception:
-            logger.warning("Failed to notify about tracker download failure", exc_info=True)
+        throttling is done by _dispatch_download_failure_report.
+
+        Ops ingest FIRST, user toast last: this failure happens during startup,
+        and the macOS notification path (NSUserNotificationCenter) is documented
+        in main.py to deadlock when driven off the main thread before the Cocoa
+        run loop is up. If it hangs, the ops signal must already be away.
+        """
         reporter = self.error_reporter
         if reporter is not None:
             try:
@@ -683,6 +677,18 @@ class AWManager:
                 )
             except Exception:
                 logger.warning("Failed to report tracker download failure", exc_info=True)
+        try:
+            try:
+                from .notifications import send_notification
+            except ImportError:
+                from notifications import send_notification
+            send_notification(
+                "BetterFlow tracking unavailable",
+                "Tracker components could not be installed, so activity is not "
+                "being recorded. Please contact support.",
+            )
+        except Exception:
+            logger.warning("Failed to notify about tracker download failure", exc_info=True)
 
     def _start_locked(self) -> bool:
         # Every route back to a running tracker funnels through here, so this one

--- a/src/aw_manager.py
+++ b/src/aw_manager.py
@@ -108,6 +108,10 @@ WINDOW_BLIND_RETRY_INTERVAL = 1800  # 30 minutes
 # CONSECUTIVE healthy health-checks (~30s each) before trusting recovery and
 # unlatching, so a flapping source stays backed off instead of churning per flap.
 WINDOW_BLIND_CLEAR_HEALTHY_CYCLES = 3
+# Min gap between "tracker components could not be installed" notifications /
+# error reports. start() is retried from the health-check tick, so without this
+# a fail-closed download would toast the user every cycle.
+DOWNLOAD_FAILURE_REPORT_INTERVAL = 3600  # 1 hour
 
 
 def _get_platform_key() -> str:
@@ -462,6 +466,16 @@ class AWManager:
         # bf-idle-tracker bucket is ignored — don't restart it or raise blind
         # alerts about a tracker we no longer consume.
         self._inproc_afk_active: bool = False
+        # Optional ops-ingest reporter, assigned by the app after construction
+        # (same pattern as sync_engine.error_reporter). A tracker download that
+        # fails closed means ZERO capture, so it must not be log-only.
+        self.error_reporter = None
+        # Set when the tracker bootstrap could not install binaries. Read by the
+        # health telemetry so a silently-idle agent is distinguishable from a
+        # healthy one that simply has nothing to report.
+        self.tracker_download_failed: bool = False
+        # monotonic timestamp of the last download-failure notify/report.
+        self._last_download_failure_report: float = float("-inf")
 
     @property
     def idle_tracker_blind(self) -> bool:
@@ -627,6 +641,53 @@ class AWManager:
         with self._lifecycle_lock:
             return self._start_locked()
 
+    def _dispatch_download_failure_report(self) -> None:
+        """Throttle-check, then hand the notify/report off to a daemon thread.
+
+        The caller holds _lifecycle_lock, and the notification path shells out
+        (osascript/notify-send) — blocking there would stall `is_managing` and
+        set_capture_suppressed, i.e. the watchdog and sync loop, for seconds on
+        a hung helper. Only the cheap throttle bookkeeping stays under the lock.
+        """
+        now = time.monotonic()
+        if now - self._last_download_failure_report < DOWNLOAD_FAILURE_REPORT_INTERVAL:
+            return
+        self._last_download_failure_report = now
+        threading.Thread(
+            target=self._report_download_failure,
+            name="aw-download-failure-report",
+            daemon=True,
+        ).start()
+
+    def _report_download_failure(self) -> None:
+        """Notify the user and the ops ingest that tracker components could not
+        be installed (so tracking is unavailable). Runs off _lifecycle_lock;
+        throttling is done by _dispatch_download_failure_report."""
+        try:
+            try:
+                from .notifications import send_notification
+            except ImportError:
+                from notifications import send_notification
+            send_notification(
+                "BetterFlow tracking unavailable",
+                "Tracker components could not be installed, so activity is not "
+                "being recorded. Please contact support.",
+            )
+        except Exception:
+            logger.warning("Failed to notify about tracker download failure", exc_info=True)
+        reporter = self.error_reporter
+        if reporter is not None:
+            try:
+                reporter.capture(
+                    "Tracker component download failed — capture unavailable",
+                    level="error",
+                    tags={"component": "aw_manager", "platform": _get_platform_key()},
+                    context={"aw_version": AW_VERSION},
+                    fingerprint="aw_manager:tracker_download_failed",
+                )
+            except Exception:
+                logger.warning("Failed to report tracker download failure", exc_info=True)
+
     def _start_locked(self) -> bool:
         # Every route back to a running tracker funnels through here, so this one
         # guard is enough to keep start()/restart_if_needed()/force_restart() from
@@ -639,15 +700,41 @@ class AWManager:
 
         binaries_dir = self._get_binaries_dir()
 
+        if binaries_dir:
+            # Clear the latch on EVERY route that resolves usable binaries, not
+            # just a fresh download — the frozen-bundle path installs trackers
+            # without downloading, so a device that recovered via an app update
+            # would otherwise keep reporting tracker_download_failed forever and
+            # train the ops ingest to ignore the signal.
+            self.tracker_download_failed = False
+
         # Auto-download if binaries not found
         if not binaries_dir:
             logger.info("Tracker components not found, downloading...")
             install_dir = _get_install_dir()
             if _download_aw_binaries(install_dir):
                 binaries_dir = install_dir
+                self.tracker_download_failed = False
             else:
                 logger.error("Failed to download tracker components")
-                return server_already_running
+                if server_already_running:
+                    # An external server is already capturing on this port, so
+                    # this is NOT a "capturing nothing" situation — only our
+                    # managed watchers are unavailable. Log it; don't latch the
+                    # flag or alarm the user, and keep reporting success.
+                    logger.warning(
+                        "Managed tracker components unavailable, but an external "
+                        "server is running on port %s — attaching to it",
+                        self.aw_port,
+                    )
+                    self._using_external = True
+                    return True
+                # Fail-closed download (bad/absent pinned SHA, missing binaries)
+                # means the agent keeps running while capturing NOTHING. Surface
+                # it instead of leaving a lone log line on the user's machine.
+                self.tracker_download_failed = True
+                self._dispatch_download_failure_report()
+                return False
 
         if server_already_running:
             logger.info(
@@ -888,6 +975,10 @@ class AWManager:
             # sub-second precision is irrelevant for a staleness signal.
             "afk_event_age_seconds": int(afk_age) if afk_age is not None else None,
             "window_event_age_seconds": int(window_age) if window_age is not None else None,
+            # True => the tracker binaries could not be installed (fail-closed
+            # integrity check or a bad archive), so this device is capturing
+            # NOTHING even though the agent looks alive.
+            "tracker_download_failed": self.tracker_download_failed,
         }
 
     def restart_if_needed(self) -> bool:

--- a/src/aw_manager.py
+++ b/src/aw_manager.py
@@ -59,6 +59,14 @@ RELEASE_ASSETS = {
 # the binaries under the same tag. The download is verified against these
 # hashes before extraction (fail closed on mismatch). MUST be recomputed on
 # every AW_VERSION bump (shasum -a 256 on the freshly-vetted zips).
+#
+# Provenance: computed 2026-07-08 from the upstream v0.13.2 release assets when
+# the pins were introduced. These literals are NOT self-verifying — the unit
+# test only compares them to a second hand-copied record, so a wrong value
+# passes tests and instead fails closed on the fleet (no trackers installed).
+# scripts/verify_tracker_pins.py fetches the real archives and checks the
+# digests; it runs nightly via .github/workflows/verify-tracker-pins.yml and on
+# any change to this file. Run it locally after every AW_VERSION bump.
 RELEASE_SHA256 = {
     "darwin": "e62a76c0ec3c0e69d58ba207bb8da6d8d47d0c7ad1bc871ddf702168f291cf5b",
     "windows": "a067fa765678a411991826c4da811fd2d8ca260c2db9d6d897957565b61c369f",

--- a/src/aw_manager.py
+++ b/src/aw_manager.py
@@ -112,6 +112,12 @@ WINDOW_BLIND_CLEAR_HEALTHY_CYCLES = 3
 # error reports. start() is retried from the health-check tick, so without this
 # a fail-closed download would toast the user every cycle.
 DOWNLOAD_FAILURE_REPORT_INTERVAL = 3600  # 1 hour
+# Backoff for the DOWNLOAD ITSELF (not just its notification). _start_locked is
+# re-entered from the ~60s capture-policy tick, and every re-entry with no
+# binaries on disk re-fetches a 115-207 MB archive. Without this a device that
+# can never install trackers would pull that archive once a minute forever.
+DOWNLOAD_RETRY_MIN_INTERVAL = 300  # 5 minutes
+DOWNLOAD_RETRY_MAX_INTERVAL = 3600  # 1 hour
 
 
 def _get_platform_key() -> str:
@@ -472,6 +478,15 @@ class AWManager:
         self.tracker_download_failed: bool = False
         # monotonic timestamp of the last download-failure notify/report.
         self._last_download_failure_report: float = float("-inf")
+        # monotonic timestamp of the last tracker-archive download ATTEMPT, plus
+        # the current (exponentially backed off) gap required before retrying.
+        self._last_download_attempt: float = float("-inf")
+        self._download_retry_interval: float = DOWNLOAD_RETRY_MIN_INTERVAL
+        # True while we have no managed watchers of our own (download failed).
+        # Distinct from tracker_download_failed: with an external server on the
+        # port we still capture, but restart_if_needed/force_restart manage
+        # nothing, so the backend should know this device is un-self-healing.
+        self._managed_components_unavailable: bool = False
 
     @property
     def idle_tracker_blind(self) -> bool:
@@ -709,16 +724,39 @@ class AWManager:
             # would otherwise keep reporting tracker_download_failed forever and
             # train the ops ingest to ignore the signal.
             self.tracker_download_failed = False
+            self._managed_components_unavailable = False
 
         # Auto-download if binaries not found
         if not binaries_dir:
+            now = time.monotonic()
+            since_last = now - self._last_download_attempt
+            if since_last < self._download_retry_interval:
+                # Backed off. Report the same outcome the last real attempt did:
+                # an attached external server still captures, nothing else does.
+                logger.debug(
+                    "Skipping tracker download retry (%.0fs since last attempt, "
+                    "backoff %.0fs)",
+                    since_last,
+                    self._download_retry_interval,
+                )
+                self._managed_components_unavailable = True
+                return server_already_running
+            self._last_download_attempt = now
             logger.info("Tracker components not found, downloading...")
             install_dir = _get_install_dir()
             if _download_aw_binaries(install_dir):
                 binaries_dir = install_dir
                 self.tracker_download_failed = False
+                self._managed_components_unavailable = False
+                self._download_retry_interval = DOWNLOAD_RETRY_MIN_INTERVAL
             else:
                 logger.error("Failed to download tracker components")
+                # Escalate 5 min -> 1 h so a permanently-failing device stops
+                # re-pulling a multi-hundred-MB archive on every policy tick.
+                self._download_retry_interval = min(
+                    self._download_retry_interval * 2, DOWNLOAD_RETRY_MAX_INTERVAL
+                )
+                self._managed_components_unavailable = True
                 if server_already_running:
                     # An external server is already capturing on this port, so
                     # this is NOT a "capturing nothing" situation — only our
@@ -952,6 +990,7 @@ class AWManager:
             blind = self._idle_tracker_blind
             window_blind = self._window_tracker_blind
             inproc = self._inproc_afk_active
+            managed_unavailable = self._managed_components_unavailable
 
         window_age = self._get_latest_window_event_age()
         # When the agent owns the AFK stream in-process, the external
@@ -981,6 +1020,10 @@ class AWManager:
             # integrity check or a bad archive), so this device is capturing
             # NOTHING even though the agent looks alive.
             "tracker_download_failed": self.tracker_download_failed,
+            # True => we have no managed watchers of our own. Capture may still
+            # be flowing via an external server on the port, but nothing here can
+            # restart or self-heal it, so an outage will not recover on its own.
+            "managed_components_unavailable": managed_unavailable,
         }
 
     def restart_if_needed(self) -> bool:

--- a/src/aw_manager.py
+++ b/src/aw_manager.py
@@ -233,6 +233,15 @@ def _download_aw_binaries(install_dir: str) -> bool:
         _MAX_AW_DOWNLOAD_BYTES = 500 * 1024 * 1024
         req = urllib.request.Request(url, headers={"User-Agent": "BetterFlow-Sync"})
         with urllib.request.urlopen(req, timeout=120) as response:
+            # urlopen follows 3xx transparently, so the allowlist check above
+            # only covers the FIRST hop. GitHub legitimately redirects assets to
+            # objects.githubusercontent.com; anywhere else means the download was
+            # steered off-allowlist, so abort before reading/writing the body.
+            final_url = response.geturl()
+            if not is_safe_fetch_url(final_url):
+                raise ValueError(
+                    f"Tracker download redirected to a disallowed host: {final_url}"
+                )
             try:
                 total = int(response.headers.get("Content-Length") or 0)
             except (ValueError, TypeError):

--- a/src/main.py
+++ b/src/main.py
@@ -146,6 +146,9 @@ class SyncCoordinator:
         # So a failed logs_requested upload surfaces to the ops ingest (it can't
         # surface via the log itself — that's the file we couldn't fetch).
         self.sync_engine.error_reporter = self.error_reporter
+        # Same reason for the tracker bootstrap: a fail-closed component download
+        # means the agent records nothing, which only the ops ingest can catch.
+        self.aw_manager.error_reporter = self.error_reporter
         # Single source of truth for the in-process-AFK flag: the engine publishes
         # its per-cycle decision straight to aw_manager on the path where the
         # decision is made. The 60s _reconcile_inproc_afk_flag below is now only a

--- a/src/self_updater.py
+++ b/src/self_updater.py
@@ -183,10 +183,21 @@ def _download_to_file(
     # copy must not also break the self-updater, or the app can't download its
     # own fix. resolve_ca_bundle() returns None only when no bundle exists, in
     # which case verify=None falls back to the requests default (logged loudly).
+    try:
+        from .url_safety import is_safe_fetch_url
+    except ImportError:
+        from url_safety import is_safe_fetch_url
+
     with requests.get(
         download_url, stream=True, timeout=120, verify=resolve_ca_bundle()
     ) as resp:
         resp.raise_for_status()
+        # requests follows redirects by default, so the caller's allowlist check
+        # only gated the first hop. Re-validate the URL we actually landed on
+        # (GitHub redirects assets to objects.githubusercontent.com) before
+        # reading a byte of the body.
+        if not is_safe_fetch_url(resp.url):
+            raise ValueError("Download redirected to a disallowed host")
         try:
             # `or 0` guards an empty-string header; the except guards garbage.
             total = int(resp.headers.get("content-length", 0) or 0)

--- a/src/self_updater.py
+++ b/src/self_updater.py
@@ -184,9 +184,9 @@ def _download_to_file(
     # own fix. resolve_ca_bundle() returns None only when no bundle exists, in
     # which case verify=None falls back to the requests default (logged loudly).
     try:
-        from .url_safety import is_safe_fetch_url
+        from .url_safety import assert_safe_final_url
     except ImportError:
-        from url_safety import is_safe_fetch_url
+        from url_safety import assert_safe_final_url
 
     with requests.get(
         download_url, stream=True, timeout=120, verify=resolve_ca_bundle()
@@ -196,8 +196,7 @@ def _download_to_file(
         # only gated the first hop. Re-validate the URL we actually landed on
         # (GitHub redirects assets to objects.githubusercontent.com) before
         # reading a byte of the body.
-        if not is_safe_fetch_url(resp.url):
-            raise ValueError("Download redirected to a disallowed host")
+        assert_safe_final_url(resp.url, "Update download")
         try:
             # `or 0` guards an empty-string header; the except guards garbage.
             total = int(resp.headers.get("content-length", 0) or 0)

--- a/src/sync/afk_source.py
+++ b/src/sync/afk_source.py
@@ -74,7 +74,12 @@ class AfkSource:
 
     @property
     def consecutive_clock_failures(self) -> int:
-        return self._consecutive_clock_failures
+        # Mutated in record_sample under the same lock. A lost increment here
+        # keeps the count under the blind-clock threshold, so the engine does
+        # not hold the checkpoint and finalizes an unobserved span as AFK —
+        # real worked time billed as idle. WindowSource locks its equivalent.
+        with self._lock:
+            return self._consecutive_clock_failures
 
     @property
     def bucket_id(self) -> str:
@@ -90,7 +95,11 @@ class AfkSource:
             return True
         try:
             ok = self._idle_clock() is not None
-        except Exception:
+        except Exception as e:
+            # Every other failure path in this class logs. Without this, a
+            # persistently raising idle clock silently reports the platform
+            # incapable, in-process AFK never engages, and nothing says why.
+            logger.debug("AfkSource idle-clock probe failed: %s", e)
             ok = False
         if ok:
             self._available_latched = True
@@ -110,12 +119,15 @@ class AfkSource:
             idle = self._idle_clock()
         except Exception as e:
             logger.debug("AfkSource idle clock failed: %s", e)
-            self._consecutive_clock_failures += 1
+            with self._lock:
+                self._consecutive_clock_failures += 1
             return
         if idle is None:
-            self._consecutive_clock_failures += 1
+            with self._lock:
+                self._consecutive_clock_failures += 1
             return
-        self._consecutive_clock_failures = 0
+        with self._lock:
+            self._consecutive_clock_failures = 0
         last_input_at = self._apply_input_watcher(now - timedelta(seconds=idle))
         # Fold in supplementary activity sources (call, mic, foreground-CPU).
         # Every source receives the same REAL input anchor — the pre-fold

--- a/src/sync/aw_client.py
+++ b/src/sync/aw_client.py
@@ -1,6 +1,7 @@
 """ActivityWatch client - reads events from local aw-server."""
 
 import logging
+import math
 import threading
 import time
 from dataclasses import dataclass
@@ -43,13 +44,43 @@ class AWEvent:
 
     @classmethod
     def from_dict(cls, data: dict) -> "AWEvent":
-        """Create AWEvent from API response."""
-        timestamp = datetime.fromisoformat(data["timestamp"].replace("Z", "+00:00"))
+        """Create AWEvent from API response.
+
+        Raises ValueError on an event the local tracker server sent that we
+        cannot trust. get_events() skips those individually rather than losing
+        the whole bucket fetch, so this may raise freely.
+        """
+        raw_ts = data.get("timestamp")
+        if not isinstance(raw_ts, str):
+            raise ValueError(f"event timestamp is not a string: {raw_ts!r}")
+        try:
+            timestamp = datetime.fromisoformat(raw_ts.replace("Z", "+00:00"))
+        except ValueError as e:
+            raise ValueError(f"unparseable event timestamp {raw_ts!r}: {e}") from e
+
+        # A negative or non-numeric duration flows straight into span math and
+        # can produce backwards spans, so reject it here rather than bill it.
+        raw_duration = data.get("duration", 0)
+        try:
+            duration = float(raw_duration)
+        except (TypeError, ValueError) as e:
+            raise ValueError(f"non-numeric event duration {raw_duration!r}") from e
+        # NaN/inf slip past a `< 0` check (NaN compares False to everything) and
+        # poison every sum they touch, so reject anything non-finite too.
+        if not math.isfinite(duration):
+            raise ValueError(f"non-finite event duration {raw_duration!r}")
+        if duration < 0:
+            raise ValueError(f"negative event duration {duration!r}")
+
+        event_data = data.get("data", {})
+        if not isinstance(event_data, dict):
+            raise ValueError(f"event data is not a mapping: {type(event_data).__name__}")
+
         return cls(
             id=data.get("id", 0),
             timestamp=timestamp,
-            duration=data.get("duration", 0),
-            data=data.get("data", {}),
+            duration=duration,
+            data=event_data,
         )
 
     @property
@@ -144,6 +175,9 @@ class AWClient:
     # immediately; the later backoff retries ride out a brief server stall.
     _CONNECT_ATTEMPTS = 3
     _CONNECT_BACKOFF = (0.25, 0.5)  # seconds before retry 2 and 3
+
+    # Per-event warnings emitted before falling back to the summary line only.
+    _MALFORMED_LOG_LIMIT = 5
 
     def _request(self, method: str, endpoint: str, timeout: Optional[int] = None, **kwargs) -> dict:
         """Make request to ActivityWatch API.
@@ -291,7 +325,36 @@ class AWClient:
             params["end"] = end.isoformat()
 
         response = self._request("GET", f"buckets/{bucket_id}/events", params=params)
-        return [AWEvent.from_dict(event) for event in response]
+
+        # _request is typed dict but returns whatever the server serialised; a
+        # null/object body would otherwise blow up or silently iterate keys.
+        if not isinstance(response, list):
+            logger.warning(
+                "Bucket %s returned %s, not an event list — treating as empty",
+                bucket_id, type(response).__name__,
+            )
+            return []
+
+        # Per-event, not a comprehension: one malformed event used to raise out
+        # of here and lose the ENTIRE bucket fetch for that cycle. Skipping the
+        # bad event keeps the rest of the user's tracked time.
+        events = []
+        skipped = 0
+        for event in response:
+            try:
+                events.append(AWEvent.from_dict(event))
+            except (ValueError, AttributeError, TypeError) as e:
+                skipped += 1
+                # Bounded: a fully-corrupt bucket is up to `limit` events and
+                # would otherwise flood the log every sync cycle.
+                if skipped <= self._MALFORMED_LOG_LIMIT:
+                    logger.warning("Skipping malformed event from bucket %s: %s", bucket_id, e)
+        if skipped:
+            logger.warning(
+                "Skipped %d malformed event(s) of %d from bucket %s",
+                skipped, len(response), bucket_id,
+            )
+        return events
 
     def get_window_buckets(self) -> list[AWBucket]:
         """Get all window watcher buckets."""

--- a/src/sync/input_source.py
+++ b/src/sync/input_source.py
@@ -162,7 +162,11 @@ class InputSource:
             return False
         try:
             ok = bool(self._backend.available())
-        except Exception:
+        except Exception as e:
+            # Log it: a permanently failing probe silently disables in-process
+            # input capture and hands it back to the external tracker with no
+            # diagnostic trail.
+            logger.debug("InputSource backend probe failed: %s", e)
             ok = False
         if ok:
             self._available_latched = True

--- a/src/sync/macos_input_watcher.py
+++ b/src/sync/macos_input_watcher.py
@@ -27,6 +27,14 @@ _kCGEventRightMouseDown = 3
 _kCGEventOtherMouseDown = 25
 _kCGEventScrollWheel = 22
 _kCGEventTapDisabledByTimeout = 0xFFFFFFFE
+# macOS disables a tap for two reasons, not one. Handling only the timeout case
+# left a tap disabled by user input dead forever: counters frozen at 0 while
+# is_running() still reports True, which reads downstream as "user is idle".
+_kCGEventTapDisabledByUserInput = 0xFFFFFFFF
+_TAP_DISABLED_EVENT_TYPES = (
+    _kCGEventTapDisabledByTimeout,
+    _kCGEventTapDisabledByUserInput,
+)
 
 _EVENT_MASK = (
     (1 << _kCGEventKeyDown)
@@ -269,15 +277,25 @@ class MacOSInputWatcher:
 
     def _event_callback(self, proxy, event_type, event, refcon):
         """CGEventTap callback — increment counters. Never reads key values."""
-        if event_type == _kCGEventTapDisabledByTimeout:
-            # Re-enable the tap if macOS disabled it
+        if event_type in _TAP_DISABLED_EVENT_TYPES:
+            # Re-enable the tap if macOS disabled it. A tap that stays disabled
+            # never increments a counter again, so the agent silently reports
+            # the user idle instead of reporting itself blind — log at warning
+            # so a re-enable that fails is visible in the field.
+            reason = (
+                "timeout"
+                if event_type == _kCGEventTapDisabledByTimeout
+                else "user input"
+            )
             if self._tap_ref is not None:
                 try:
                     from Quartz import CGEventTapEnable
                     CGEventTapEnable(self._tap_ref, True)
-                    logger.debug("Re-enabled CGEventTap after timeout")
+                    logger.warning("Re-enabled CGEventTap after %s disable", reason)
                 except Exception as e:
-                    logger.warning(f"Failed to re-enable CGEventTap: {e}")
+                    logger.warning("Failed to re-enable CGEventTap after %s disable: %s", reason, e)
+            else:
+                logger.warning("CGEventTap disabled by %s but no tap ref to re-enable", reason)
             return event
 
         with self._lock:

--- a/src/sync/macos_window_watcher.py
+++ b/src/sync/macos_window_watcher.py
@@ -77,6 +77,9 @@ class MacOSWindowWatcher:
         # emit a one-shot log on each transition.
         self._last_accessibility: Optional[bool] = None
         self._last_accessibility_check_ts: float = 0.0
+        # One-shot flag: the AX messaging-timeout symbol is either present for
+        # the whole process lifetime or never, so warn about it only once.
+        self._ax_timeout_warned = False
         # Cache terminal tab title to avoid spawning osascript every poll.
         # _terminal_cache_key is (app_name, ax_title); value is the tab title or None.
         self._terminal_cache_key: Optional[tuple[str, str]] = None
@@ -190,8 +193,19 @@ class MacOSWindowWatcher:
             from ApplicationServices import AXUIElementSetMessagingTimeout
 
             AXUIElementSetMessagingTimeout(app_ref, self._AX_MESSAGING_TIMEOUT_S)
-        except Exception:
-            pass
+        except Exception as e:
+            # This is the guard that stops an unresponsive frontmost app from
+            # blocking the poll thread inside AXUIElementCopyAttributeValue.
+            # When it silently fails to install, a hung app freezes window
+            # tracking with no exception and no log — exactly the silent stall
+            # the fallback is meant to bound. Keep the fallback, log the reason.
+            # Poll loop runs every few seconds; log once, not on every poll.
+            if not self._ax_timeout_warned:
+                self._ax_timeout_warned = True
+                logger.warning(
+                    "AX messaging timeout unavailable (%s) — window polling can "
+                    "stall on an unresponsive app", e,
+                )
         err, focused_window = AXUIElementCopyAttributeValue(
             app_ref, "AXFocusedWindow", None,
         )

--- a/src/sync/queue.py
+++ b/src/sync/queue.py
@@ -97,13 +97,14 @@ class QueuedEvent:
         """Create from database row. Returns None if the row is corrupt."""
         try:
             event_data = json.loads(row[1])
-        except (json.JSONDecodeError, TypeError):
+            created_at = datetime.fromisoformat(row[2])
+        except (json.JSONDecodeError, TypeError, ValueError):
             logger.error(f"[queue] Corrupt event row id={row[0]}, discarding")
             return None
         return cls(
             id=row[0],
             event_data=event_data,
-            created_at=datetime.fromisoformat(row[2]),
+            created_at=created_at,
             retry_count=row[3],
         )
 

--- a/src/sync/queue.py
+++ b/src/sync/queue.py
@@ -20,6 +20,7 @@ __all__ = [
     "OfflineQueue",
     "QueuedEvent",
     "is_event_storable",
+    "normalized_project_id",
     "MAX_EVENT_DURATION_SECONDS",
 ]
 
@@ -81,6 +82,22 @@ def is_event_storable(ev: object, *, stale_cutoff: datetime) -> bool:
         return 0 <= duration <= MAX_EVENT_DURATION_SECONDS
     # Missing/non-numeric duration: not our call to evict — leave it to the server.
     return True
+
+
+def normalized_project_id(value: object) -> Optional[int]:
+    """Return a backend-safe project id, or None when the payload should omit it.
+
+    Shared with SyncEngine's stamping path so the queue migration and the live
+    stamp can never disagree about which ids the backend will accept.
+    """
+    if isinstance(value, bool):
+        return None
+    if isinstance(value, int):
+        return value if value > 0 else None
+    if isinstance(value, str) and value.isdecimal():
+        parsed = int(value)
+        return parsed if parsed > 0 else None
+    return None
 
 
 @dataclass
@@ -815,6 +832,50 @@ class OfflineQueue:
             logger.info(
                 "Backfilled bucket_id on %d legacy bucketless status span(s) so "
                 "they deliver instead of being evicted on upgrade",
+                len(updates),
+            )
+        return len(updates)
+
+    def sanitize_project_ids(self) -> int:
+        """Normalize queued ``project_id`` fields to the backend's integer FK.
+
+        Release 1.5.104 stamped the active project onto SyncEngine-built events.
+        If a stale/corrupt project payload put a UUID/string/zero in the queue,
+        the backend could keep rejecting an otherwise valid status span until it
+        exhausted retries and reported ``buckets=bf-status`` real loss. Queued
+        events are account-local and the project id is optional, so the safe
+        migration is: keep positive integer ids, coerce digit strings, and omit
+        anything else before the first queue drain.
+
+        Returns the number of queued rows rewritten.
+        """
+        with self._cursor() as cursor:
+            cursor.execute("SELECT id, event_data FROM queued_events")
+            rows = cursor.fetchall()
+            updates: list[tuple[str, int]] = []
+            for rid, raw in rows:
+                try:
+                    ev = json.loads(raw)
+                except (json.JSONDecodeError, TypeError):
+                    continue
+                if not isinstance(ev, dict) or "project_id" not in ev:
+                    continue
+                normalized = normalized_project_id(ev.get("project_id"))
+                if normalized is None:
+                    ev.pop("project_id", None)
+                else:
+                    ev["project_id"] = normalized
+                updated = json.dumps(ev)
+                if updated != raw:
+                    updates.append((updated, rid))
+            if updates:
+                cursor.executemany(
+                    "UPDATE queued_events SET event_data = ? WHERE id = ?",
+                    updates,
+                )
+        if updates:
+            logger.info(
+                "Sanitized project_id on %d queued event(s) before delivery",
                 len(updates),
             )
         return len(updates)

--- a/src/sync/sync_engine.py
+++ b/src/sync/sync_engine.py
@@ -33,7 +33,7 @@ try:
     from .foreground_activity import ForegroundActivityDetector, create_detector
     from .mic_activity import MicActivityDetector, create_mic_detector
     from .os_idle import get_system_idle_seconds
-    from .queue import is_event_storable
+    from .queue import is_event_storable, normalized_project_id
 except ImportError:
     from browser_tracker import is_browser_app
     from config import Config
@@ -46,9 +46,13 @@ except ImportError:
     from sync.foreground_activity import ForegroundActivityDetector, create_detector
     from sync.mic_activity import MicActivityDetector, create_mic_detector
     from sync.os_idle import get_system_idle_seconds
-    from sync.queue import is_event_storable
+    from sync.queue import is_event_storable, normalized_project_id
 
 logger = logging.getLogger(__name__)
+
+# Sentinel for "no project id has been rejected yet" — distinct from None,
+# which is itself a rejectable value (a project dict with no "id").
+_NO_REJECTED_PROJECT_ID = object()
 
 
 def _is_window_like(bucket_type: str) -> bool:
@@ -229,6 +233,9 @@ class SyncEngine:
         self._private_mode = False
         self._private_start: Optional[datetime] = None
         self._current_project: Optional[dict] = None
+        # Last project id normalization rejected, so the drop is logged once per
+        # distinct value instead of once per stamped event (or — worse — never).
+        self._rejected_project_id: object = _NO_REJECTED_PROJECT_ID
         self._session_active = False
         self._config_fetched = False
         self._last_config_fetch_monotonic: float = 0.0
@@ -348,12 +355,20 @@ class SyncEngine:
         # the server accepts them — a lost billing carve-out. Give them the same
         # bf-status_<host> id current spans use, BEFORE the sync loop starts.
         # Idempotent and best-effort: a migration hiccup must never block startup.
-        try:
-            backfill = getattr(self.queue, "backfill_status_bucket_ids", None)
-            if callable(backfill):
-                backfill(self._hostname)
-        except Exception as e:  # pragma: no cover - defensive; never fatal
-            logger.warning("Legacy status-span bucket_id backfill skipped: %s", e)
+        # Each migration is guarded on its own: they are independent, and a
+        # hiccup in one must not silently skip the other (a shared try would
+        # let a backfill error swallow the project_id sanitize, re-exposing the
+        # rejected-span loss this release fixes).
+        for name, args in (
+            ("backfill_status_bucket_ids", (self._hostname,)),
+            ("sanitize_project_ids", ()),
+        ):
+            try:
+                migrate = getattr(self.queue, name, None)
+                if callable(migrate):
+                    migrate(*args)
+            except Exception as e:  # pragma: no cover - defensive; never fatal
+                logger.warning("Queued-event startup migration %s skipped: %s", name, e)
 
         # Dedup: track (bucket_id, event_id) pairs already sent this session.
         # The lookback window re-fetches recent events for duration updates —
@@ -645,13 +660,31 @@ class SyncEngine:
             if ended is not None:
                 stats.calls_detected += 1
 
-    def _current_project_id(self):
+    def _current_project_id(self) -> Optional[int]:
         """The active project's id, or None. The single locked read of
         _current_project that every event-stamping path shares, so the
-        lock+read rule can't drift between call sites."""
+        lock+read rule can't drift between call sites. Normalization is the
+        queue's shared helper, so a live stamp and the queue migration always
+        agree on which ids the backend accepts."""
         with self._state_lock:
             project = self._current_project
-        return project["id"] if project else None
+            if not project:
+                return None
+            raw = project.get("id")
+            pid = normalized_project_id(raw)
+            # Dropping the id silently would untag every event with no trace —
+            # the failure mode is invisible in logs and only shows up as
+            # unprojected rows in the backend. Warn once per distinct value.
+            if pid is None and raw != self._rejected_project_id:
+                self._rejected_project_id = raw
+                logger.warning(
+                    "Active project id %r is not a backend project id; "
+                    "events will be sent untagged",
+                    raw,
+                )
+            elif pid is not None:
+                self._rejected_project_id = _NO_REJECTED_PROJECT_ID
+        return pid
 
     def _stamp_project(self, event: dict) -> dict:
         """Stamp the active project onto a SyncEngine-built event dict (call,

--- a/src/sync/window_source.py
+++ b/src/sync/window_source.py
@@ -165,7 +165,11 @@ class WindowSource:
             return False
         try:
             ok = self._getter() is not None
-        except Exception:
+        except Exception as e:
+            # Log it: a permanently failing probe silently disables in-process
+            # window capture and hands it back to the external tracker with no
+            # diagnostic trail.
+            logger.debug("WindowSource foreground probe failed: %s", e)
             ok = False
         if ok:
             self._available_latched = True

--- a/src/system_event_handler.py
+++ b/src/system_event_handler.py
@@ -61,6 +61,14 @@ class SystemEventHandler:
 
         with self._pause_state_lock:
             self._pre_sleep_private = self.sync_engine.is_private
+            # Branch on a local, not a re-read of the shared field: the sleep and
+            # screen-lock listeners are separate OS notification threads, and a
+            # lock event interleaving here would make the unlocked read below see
+            # a stale value, skip ending Private Time at the sleep boundary, and
+            # silently mark post-wake work private and uncounted — the exact
+            # regression the comment below describes. on_screen_unlock already
+            # captures its counterpart this way.
+            pre_sleep_private = self._pre_sleep_private
             # Keep the EARLIEST sleep start across a sequence of sleep events
             # without an intervening wake (macOS can fire Display Sleep then
             # System Sleep separately; some lid-close → reopen → reclose
@@ -82,7 +90,7 @@ class SystemEventHandler:
         # true enable→sleep span via the normal leave path (private_time event +
         # checkpoint advance); on wake we resume NORMAL tracking, never auto-
         # restoring private.
-        if self._pre_sleep_private:
+        if pre_sleep_private:
             try:
                 self.sync_engine.set_private_mode(False)
             except Exception as e:

--- a/src/ui/setup_wizard.py
+++ b/src/ui/setup_wizard.py
@@ -556,8 +556,14 @@ class SetupWizard:
             cx,
             344,
             text=(
+                # Do NOT claim on-device title hashing here. There is no
+                # client-side hashing in the agent — titles are sent raw and
+                # handled server-side (see the privacy model in CLAUDE.md).
+                # This screen is the consent boundary on platforms with no OS
+                # permission gate, so it has to describe what actually leaves
+                # the machine.
                 "Your privacy is protected by default:\n"
-                "•  Window titles are hashed on your device\n"
+                "•  Window titles are sent to BetterFlow to categorize your work\n"
                 "•  URLs are reduced to the domain only\n"
                 "•  Excluded apps are never tracked"
             ),

--- a/src/ui/tray.py
+++ b/src/ui/tray.py
@@ -435,6 +435,12 @@ def create_icon_image(
 class TrayIcon:
     """System tray icon with status indicator."""
 
+    # Consecutive failed health probes before the tray is declared dead and the
+    # agent shuts down. A dead NSStatusItem stays dead, so requiring two ticks
+    # costs one tick of latency while stopping a transient AppKit error from
+    # ending the user's tracking day.
+    _TRAY_HEALTH_FAILURES_TO_DIE = 2
+
     def __init__(
         self,
         on_login: Optional[Callable[[], None]] = None,
@@ -494,6 +500,15 @@ class TrayIcon:
         self._on_check_update = on_check_update
         self._on_tray_died = on_tray_died
         self._on_show_hours = on_show_hours
+
+        # Consecutive failed tray health probes. Incremented by tick_clock on the
+        # scheduler thread and reset by the icon-creation paths on the main
+        # thread, so every access takes _tray_health_lock: the increment is a
+        # read-modify-write, and a reset landing inside one would let a stale
+        # count carry onto a fresh status item and kill it a tick early. See
+        # _TRAY_HEALTH_FAILURES_TO_DIE for why the counter exists.
+        self._tray_health_lock = threading.Lock()
+        self._tray_health_failures = 0
 
         self.model = TrayModel()
 
@@ -1285,7 +1300,11 @@ class TrayIcon:
                 button = status_item.button()
                 if button is None:
                     return False
-            except Exception:
+            except Exception as e:
+                # A False here shuts the whole agent down via _on_tray_died, so
+                # never swallow the reason — an unexplained mid-day exit with a
+                # bare "Tray icon is dead" line is undiagnosable in the field.
+                logger.warning("Tray health probe failed: %s", e, exc_info=True)
                 return False
 
         return True
@@ -1293,10 +1312,27 @@ class TrayIcon:
     def tick_clock(self) -> None:
         """Called periodically to advance the clock-face icon hands."""
         if not self._check_tray_health():
+            # Require consecutive failures before declaring death: this path
+            # shuts the agent down and stops capture for the rest of the day,
+            # and a single transient AppKit/pyobjc hiccup is not proof the
+            # status item was deallocated. A genuinely dead icon stays dead and
+            # trips on the next tick.
+            with self._tray_health_lock:
+                self._tray_health_failures += 1
+                failures = self._tray_health_failures
+            if failures < self._TRAY_HEALTH_FAILURES_TO_DIE:
+                logger.warning(
+                    "Tray health check failed (%d/%d) — retrying next tick",
+                    failures,
+                    self._TRAY_HEALTH_FAILURES_TO_DIE,
+                )
+                return
             logger.error("Tray icon is dead — triggering shutdown")
             if self._on_tray_died:
                 self._on_tray_died()
             return
+        with self._tray_health_lock:
+            self._tray_health_failures = 0
         self._update_icon()
 
     def _update_icon(self) -> None:
@@ -1484,6 +1520,12 @@ class TrayIcon:
         if self._icon is not None:
             return
 
+        # A fresh icon gets a fresh streak: stop() nulls _icon, so a tick landing
+        # in a stop→start window (logout/re-login) counts a failure that has
+        # nothing to do with the new status item.
+        with self._tray_health_lock:
+            self._tray_health_failures = 0
+
         from datetime import datetime as _dt
         color = STATE_COLORS[self.model.state]
         # Pin the initial render's clock-time to a captured `now` for the
@@ -1519,6 +1561,11 @@ class TrayIcon:
         max_retries = 3
         for attempt in range(1, max_retries + 1):
             if self._icon is None:
+                # Fresh icon, fresh streak — same reason as start(): failures
+                # counted against the previous (or not-yet-created) status item
+                # must not carry into the new one and shorten its life.
+                with self._tray_health_lock:
+                    self._tray_health_failures = 0
                 color = STATE_COLORS[self.model.state]
                 self._icon = pystray.Icon(
                     "BetterFlow",

--- a/src/ui/tray.py
+++ b/src/ui/tray.py
@@ -807,6 +807,20 @@ class TrayIcon:
             return "Waiting for login..."
         elif state == TrayState.NEEDS_PERMISSIONS:
             return "Permissions needed"
+        elif state == TrayState.PRIVATE_HOURS:
+            # Without this branch a user outside their enforced working-hours
+            # window read "App status: Starting...", which looks like a hung app
+            # rather than a deliberate not-recording state.
+            return "Outside working hours"
+        elif state == TrayState.ON_BREAK:
+            # Normally covered by the on_break flag above; this catches the state
+            # being set without the model flag, which also fell through to
+            # "Starting...".
+            return "On Break"
+        elif state == TrayState.PRIVATE:
+            # Same gap as ON_BREAK: normally covered by the private_mode flag,
+            # but the state alone must not read as "Starting...".
+            return "Private Time"
         else:
             return "Starting..."
 

--- a/src/update_checker.py
+++ b/src/update_checker.py
@@ -9,8 +9,10 @@ import requests
 
 try:
     from .sync.http_client import resolve_ca_bundle
+    from .url_safety import assert_safe_final_url
 except ImportError:  # PyInstaller bundle (src/ is import root)
     from sync.http_client import resolve_ca_bundle
+    from url_safety import assert_safe_final_url
 
 logger = logging.getLogger(__name__)
 
@@ -139,6 +141,10 @@ def check_for_update(
                     timeout=10,
                     verify=resolve_ca_bundle(),
                 )
+                # requests follows redirects transparently; this response is what
+                # produces the download_url the updater's allowlist later guards,
+                # so re-check the host we actually landed on before trusting it.
+                assert_safe_final_url(resp.url, "Update check")
                 if resp.status_code != 200:
                     logger.debug(f"Update check: GitHub API returned {resp.status_code}")
                     return
@@ -156,6 +162,7 @@ def check_for_update(
                     timeout=10,
                     verify=resolve_ca_bundle(),
                 )
+                assert_safe_final_url(resp.url, "Update check")
                 if resp.status_code != 200:
                     logger.debug(f"Update check: GitHub API returned {resp.status_code}")
                     return
@@ -206,6 +213,11 @@ def check_for_update(
             if callback:
                 callback(latest_tag.lstrip("v"), html_url, asset_url)
 
+        except ValueError as e:
+            # The only ValueError that reaches here is the off-allowlist redirect
+            # guard (json/version parsing is caught locally), so log it loudly
+            # rather than burying a hijacked update check at debug level.
+            logger.warning(f"Update check aborted: {e}")
         except Exception as e:
             logger.debug(f"Update check failed: {e}")
 

--- a/src/update_handler.py
+++ b/src/update_handler.py
@@ -71,7 +71,14 @@ class UpdateHandler:
             self.coordinator.sync_engine.shutdown()
         except Exception:
             logger.warning("sync_engine.shutdown() during update exit failed", exc_info=True)
-        self.coordinator.stop()
+        # Guarded: coordinator.stop() shuts the scheduler down, and APScheduler
+        # can raise there (racy `if scheduler.running` check). An exception must
+        # not skip the aw_manager.stop() below — that's the tracker-orphaning
+        # regression described next.
+        try:
+            self.coordinator.stop()
+        except Exception:
+            logger.warning("coordinator.stop() during update exit failed", exc_info=True)
         # Terminate the bundled trackers BEFORE the updater's hard os._exit(0).
         # coordinator.stop() only stops the scheduler; without this the
         # self-update relaunch left bf-idle-tracker orphaned, so the new

--- a/src/update_handler.py
+++ b/src/update_handler.py
@@ -66,11 +66,11 @@ class UpdateHandler:
         try:
             self.coordinator.flush_idle_event()
         except Exception:
-            pass
+            logger.warning("flush_idle_event() during update exit failed", exc_info=True)
         try:
             self.coordinator.sync_engine.shutdown()
         except Exception:
-            pass
+            logger.warning("sync_engine.shutdown() during update exit failed", exc_info=True)
         self.coordinator.stop()
         # Terminate the bundled trackers BEFORE the updater's hard os._exit(0).
         # coordinator.stop() only stops the scheduler; without this the

--- a/src/update_handler.py
+++ b/src/update_handler.py
@@ -263,7 +263,13 @@ class UpdateHandler:
                 if _version_tuple(staged) >= _version_tuple(target_version):
                     return
             except (ValueError, TypeError):
-                pass
+                # Unparseable version: fall through and re-stage, but say so —
+                # otherwise the repeated downloads have no explanation in logs.
+                logger.warning(
+                    "Unparseable staged version %r vs target %r; re-staging",
+                    staged,
+                    target_version,
+                )
 
         now = time.monotonic()
         with self._update_jobs_lock:

--- a/src/url_safety.py
+++ b/src/url_safety.py
@@ -34,3 +34,19 @@ def is_safe_fetch_url(url: str, allowed_suffixes: tuple[str, ...] = ALLOWED_FETC
     if not host:
         return False
     return any(host == suffix or host.endswith("." + suffix) for suffix in allowed_suffixes)
+
+
+def assert_safe_final_url(
+    url: str,
+    what: str,
+    allowed_suffixes: tuple[str, ...] = ALLOWED_FETCH_SUFFIXES,
+) -> None:
+    """Raise ``ValueError`` unless ``url`` passes :func:`is_safe_fetch_url`.
+
+    Both ``requests`` and ``urllib`` follow 3xx transparently, so a caller's
+    pre-flight allowlist check only ever covers the FIRST hop. Every outbound
+    fetch site re-checks the URL it actually landed on through this helper, so
+    the three sites share one posture and one URL-bearing error message.
+    """
+    if not is_safe_fetch_url(url, allowed_suffixes):
+        raise ValueError(f"{what} redirected to a disallowed host: {url}")

--- a/tests/test_aw_client.py
+++ b/tests/test_aw_client.py
@@ -310,3 +310,71 @@ class TestAWClient:
                 client.get_info()
 
         assert calls["n"] == AWClient._CONNECT_ATTEMPTS
+
+
+class TestMalformedEventTolerance:
+    """A malformed event from the local tracker server must cost that event,
+    not the whole bucket fetch. Losing the fetch loses the user's tracked time
+    for the cycle."""
+
+    @responses.activate
+    def test_get_events_skips_bad_events_and_keeps_good_ones(self):
+        responses.add(
+            responses.GET,
+            "http://localhost:5600/api/0/buckets/test-bucket/events",
+            json=[
+                {"id": 1, "timestamp": "2026-02-18T10:00:00Z", "duration": 60,
+                 "data": {"app": "Terminal"}},
+                {"id": 2, "duration": 60, "data": {}},                       # no timestamp
+                {"id": 3, "timestamp": "not-a-timestamp", "duration": 60, "data": {}},
+                {"id": 4, "timestamp": "2026-02-18T10:02:00Z", "duration": "abc",
+                 "data": {}},                                                # bad duration
+                {"id": 5, "timestamp": "2026-02-18T10:03:00Z", "duration": -30,
+                 "data": {}},                                                # negative
+                {"id": 6, "timestamp": "2026-02-18T10:04:00Z", "duration": 30,
+                 "data": {"app": "Code"}},
+            ],
+            status=200,
+        )
+
+        events = AWClient().get_events("test-bucket")
+
+        assert [e.id for e in events] == [1, 6], "good events must survive bad neighbours"
+        assert [e.app for e in events] == ["Terminal", "Code"]
+
+    @responses.activate
+    def test_get_events_survives_an_all_malformed_bucket(self):
+        responses.add(
+            responses.GET,
+            "http://localhost:5600/api/0/buckets/test-bucket/events",
+            json=[{"id": 1, "timestamp": None, "duration": 60, "data": {}}],
+            status=200,
+        )
+
+        assert AWClient().get_events("test-bucket") == []
+
+    def test_from_dict_rejects_negative_duration(self):
+        """A negative duration flows into span math and yields backwards spans."""
+        with pytest.raises(ValueError, match="negative event duration"):
+            AWEvent.from_dict(
+                {"id": 1, "timestamp": "2026-02-18T10:00:00Z", "duration": -1, "data": {}}
+            )
+
+    @pytest.mark.parametrize("bad", ["nan", "inf", "-inf", float("nan"), float("inf")])
+    def test_from_dict_rejects_non_finite_duration(self, bad):
+        """NaN compares False to everything, so `< 0` alone lets it through and
+        it poisons every sum it reaches."""
+        with pytest.raises(ValueError, match="non-finite event duration"):
+            AWEvent.from_dict(
+                {"id": 1, "timestamp": "2026-02-18T10:00:00Z", "duration": bad, "data": {}}
+            )
+
+    def test_from_dict_accepts_zero_and_numeric_string_duration(self):
+        zero = AWEvent.from_dict(
+            {"id": 1, "timestamp": "2026-02-18T10:00:00Z", "duration": 0, "data": {}}
+        )
+        assert zero.duration == 0.0
+        coerced = AWEvent.from_dict(
+            {"id": 2, "timestamp": "2026-02-18T10:00:00Z", "duration": "12.5", "data": {}}
+        )
+        assert coerced.duration == 12.5

--- a/tests/test_aw_manager_asset_integrity.py
+++ b/tests/test_aw_manager_asset_integrity.py
@@ -23,6 +23,11 @@ from src.aw_manager import AW_VERSION, RELEASE_ASSETS, RELEASE_SHA256
 # assets) to produce the RELEASE_SHA256 values in src/aw_manager.py. Bumping
 # AW_VERSION without re-vetting and updating BOTH this constant and the hashes
 # is exactly the silent-outage scenario above, so it must break the build.
+#
+# NOTE: this record is a hand-copy of the same literals, so it catches a
+# forgotten bump but CANNOT catch a wrong digest. The independent check is
+# scripts/verify_tracker_pins.py, which downloads the real upstream archives
+# (nightly CI). Do not treat a green run here as proof the pins are correct.
 VETTED_HASHES = {
     "v0.13.2": {
         "darwin": "e62a76c0ec3c0e69d58ba207bb8da6d8d47d0c7ad1bc871ddf702168f291cf5b",

--- a/tests/test_aw_manager_asset_integrity.py
+++ b/tests/test_aw_manager_asset_integrity.py
@@ -1,0 +1,137 @@
+"""Tracker-archive integrity pins.
+
+`_download_aw_binaries` verifies the downloaded ActivityWatch archive against
+`RELEASE_SHA256` and fails CLOSED on a mismatch or a missing pin. That makes a
+routine `AW_VERSION` bump dangerous: forget to recompute the hashes and every
+machine that needs a bootstrap (or a `_should_reinstall_trackers` reinstall)
+silently installs nothing — no trackers, zero activity captured, one log line.
+
+These tests make that mistake fail in CI instead of on the fleet.
+"""
+
+import os
+import re
+import zipfile
+from unittest.mock import patch
+
+import pytest
+
+from src import aw_manager
+from src.aw_manager import AW_VERSION, RELEASE_ASSETS, RELEASE_SHA256
+
+# The AW_VERSION whose archives were hand-vetted (shasum -a 256 on the release
+# assets) to produce the RELEASE_SHA256 values in src/aw_manager.py. Bumping
+# AW_VERSION without re-vetting and updating BOTH this constant and the hashes
+# is exactly the silent-outage scenario above, so it must break the build.
+VETTED_HASHES = {
+    "v0.13.2": {
+        "darwin": "e62a76c0ec3c0e69d58ba207bb8da6d8d47d0c7ad1bc871ddf702168f291cf5b",
+        "windows": "a067fa765678a411991826c4da811fd2d8ca260c2db9d6d897957565b61c369f",
+        "linux": "8f62b10babf8a8f108cbdf7267c02fbc1ce2a970fa9535f230b3416b803e3360",
+    },
+}
+
+_SHA256_RE = re.compile(r"^[0-9a-f]{64}$")
+
+
+def test_every_release_asset_has_a_pinned_hash():
+    assert set(RELEASE_SHA256) == set(RELEASE_ASSETS)
+
+
+@pytest.mark.parametrize("plat", sorted(RELEASE_SHA256))
+def test_pinned_hashes_are_lowercase_sha256(plat):
+    assert _SHA256_RE.match(RELEASE_SHA256[plat]), (
+        f"RELEASE_SHA256[{plat!r}] is not 64 lowercase hex chars"
+    )
+
+
+def test_pinned_hashes_match_the_vetted_record_for_this_aw_version():
+    assert AW_VERSION in VETTED_HASHES, (
+        f"AW_VERSION {AW_VERSION} has no vetted-hash record. Recompute the "
+        "archive SHA-256s (shasum -a 256) and add them to VETTED_HASHES — a "
+        "version bump without fresh hashes disables tracker installs fleet-wide."
+    )
+    assert RELEASE_SHA256 == VETTED_HASHES[AW_VERSION]
+
+
+def _fake_archive(path):
+    """A zip containing all three expected launchers, so only the hash gate
+    can be what stops the install."""
+    with zipfile.ZipFile(path, "w") as zf:
+        for original in aw_manager.AW_TO_BF_NAMES:
+            zf.writestr(f"activitywatch/{original}/{original}", b"binary")
+
+
+class _FakeResponse:
+    """Minimal stand-in for the urlopen context manager."""
+
+    def __init__(self, body, url):
+        self._body = body
+        self._url = url
+        self._offset = 0
+        self.headers = {"Content-Length": str(len(body))}
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *exc):
+        return False
+
+    def geturl(self):
+        return self._url
+
+    def read(self, size):
+        chunk = self._body[self._offset:self._offset + size]
+        self._offset += len(chunk)
+        return chunk
+
+
+def test_download_refuses_archive_with_wrong_hash(tmp_path):
+    archive = tmp_path / "aw.zip"
+    _fake_archive(archive)
+    body = archive.read_bytes()
+    install_dir = tmp_path / "install"
+
+    url = f"{aw_manager.RELEASE_BASE}/whatever.zip"
+    with patch.object(aw_manager.urllib.request, "urlopen",
+                      return_value=_FakeResponse(body, url)), \
+            patch.object(aw_manager, "RELEASE_SHA256", dict.fromkeys(RELEASE_ASSETS, "0" * 64)):
+        assert _download(str(install_dir)) is False
+
+    # Fail closed: nothing extracted, nothing chmod'ed.
+    assert not os.path.isdir(install_dir)
+
+
+def test_download_refuses_when_platform_has_no_pinned_hash(tmp_path):
+    archive = tmp_path / "aw.zip"
+    _fake_archive(archive)
+    body = archive.read_bytes()
+    install_dir = tmp_path / "install"
+
+    url = f"{aw_manager.RELEASE_BASE}/whatever.zip"
+    with patch.object(aw_manager.urllib.request, "urlopen",
+                      return_value=_FakeResponse(body, url)), \
+            patch.object(aw_manager, "RELEASE_SHA256", {}):
+        assert _download(str(install_dir)) is False
+
+    assert not os.path.isdir(install_dir)
+
+
+def test_download_refuses_redirect_off_the_allowlist(tmp_path):
+    # urlopen follows 3xx transparently, so the pre-flight allowlist check only
+    # covered the first hop. A redirect landing off-GitHub must abort before the
+    # body is read, hashed or extracted.
+    archive = tmp_path / "aw.zip"
+    _fake_archive(archive)
+    body = archive.read_bytes()
+    install_dir = tmp_path / "install"
+
+    with patch.object(aw_manager.urllib.request, "urlopen",
+                      return_value=_FakeResponse(body, "https://evil.example.com/a.zip")):
+        assert _download(str(install_dir)) is False
+
+    assert not os.path.isdir(install_dir)
+
+
+def _download(install_dir):
+    return aw_manager._download_aw_binaries(install_dir)

--- a/tests/test_aw_manager_download_failure_surfacing.py
+++ b/tests/test_aw_manager_download_failure_surfacing.py
@@ -19,12 +19,14 @@ def _join_report_threads():
             thread.join(timeout=5)
 
 
-def _failing_manager(monkeypatch, *, port_in_use=False):
+def _failing_manager(monkeypatch, *, port_in_use=False, download=None):
     mgr = AWManager(aw_port=5600)
     mgr.error_reporter = Mock()
     monkeypatch.setattr(mgr, "_get_binaries_dir", lambda: None)
     monkeypatch.setattr(mgr, "_port_in_use", lambda: port_in_use)
-    monkeypatch.setattr("src.aw_manager._download_aw_binaries", lambda _dir: False)
+    monkeypatch.setattr(
+        "src.aw_manager._download_aw_binaries", download or (lambda _dir: False)
+    )
     notify = Mock()
     monkeypatch.setattr("src.notifications.send_notification", notify)
     return mgr, notify
@@ -97,3 +99,47 @@ def test_flag_clears_when_binaries_resolve_without_download(monkeypatch, tmp_pat
 
     assert mgr.start() is True
     assert mgr.tracker_download_failed is False
+
+
+def test_download_itself_is_backed_off_across_ticks(monkeypatch):
+    """The ~60s capture-policy tick re-enters _start_locked; without a backoff on
+    the DOWNLOAD (not just its notification) every tick re-pulls a 115-207 MB
+    archive forever."""
+    download = Mock(return_value=False)
+    mgr, _notify = _failing_manager(monkeypatch, download=download)
+
+    for _ in range(5):
+        assert mgr.start() is False
+    _join_report_threads()
+
+    assert download.call_count == 1, "retries inside the backoff window must not refetch"
+
+    # Backoff escalates, so honouring only the initial 5 min is not enough.
+    assert mgr._download_retry_interval > 300
+
+
+def test_backoff_expiry_allows_a_retry(monkeypatch):
+    download = Mock(return_value=False)
+    mgr, _notify = _failing_manager(monkeypatch, download=download)
+
+    mgr.start()
+    mgr._last_download_attempt -= mgr._download_retry_interval + 1
+    mgr.start()
+    _join_report_threads()
+
+    assert download.call_count == 2
+
+
+def test_external_attach_is_flagged_as_unmanaged(monkeypatch):
+    """Attaching to an external server returns True, but nothing here can
+    restart it — the backend needs to see that this device cannot self-heal."""
+    mgr, _notify = _failing_manager(monkeypatch, port_in_use=True)
+    monkeypatch.setattr(mgr, "_get_latest_afk_event_age", lambda: None)
+    monkeypatch.setattr(mgr, "_get_latest_window_event_age", lambda: None)
+
+    assert mgr.start() is True
+    _join_report_threads()
+
+    snapshot = mgr.health_snapshot()
+    assert snapshot["managed_components_unavailable"] is True
+    assert snapshot["tracker_download_failed"] is False

--- a/tests/test_aw_manager_download_failure_surfacing.py
+++ b/tests/test_aw_manager_download_failure_surfacing.py
@@ -1,0 +1,99 @@
+"""Surfacing layer for a fail-closed tracker download.
+
+_download_aw_binaries failing closed means the agent runs while capturing
+NOTHING, so it must reach the user (notification) and the ops ingest (error
+report) — and it must be throttled, because start() is retried from the ~30s
+health-check tick and would otherwise toast every 30 seconds for as long as the
+failure lasts.
+"""
+
+import threading
+from unittest.mock import Mock
+
+from src.aw_manager import AWManager
+
+
+def _join_report_threads():
+    for thread in threading.enumerate():
+        if thread.name == "aw-download-failure-report":
+            thread.join(timeout=5)
+
+
+def _failing_manager(monkeypatch, *, port_in_use=False):
+    mgr = AWManager(aw_port=5600)
+    mgr.error_reporter = Mock()
+    monkeypatch.setattr(mgr, "_get_binaries_dir", lambda: None)
+    monkeypatch.setattr(mgr, "_port_in_use", lambda: port_in_use)
+    monkeypatch.setattr("src.aw_manager._download_aw_binaries", lambda _dir: False)
+    notify = Mock()
+    monkeypatch.setattr("src.notifications.send_notification", notify)
+    return mgr, notify
+
+
+def test_download_failure_notifies_reports_and_fails(monkeypatch):
+    mgr, notify = _failing_manager(monkeypatch)
+
+    assert mgr.start() is False
+    _join_report_threads()
+
+    assert mgr.tracker_download_failed is True
+    assert notify.call_count == 1
+    assert mgr.error_reporter.capture.call_count == 1
+    kwargs = mgr.error_reporter.capture.call_args.kwargs
+    assert kwargs["fingerprint"] == "aw_manager:tracker_download_failed"
+
+
+def test_repeat_failure_is_throttled(monkeypatch):
+    """The health-check tick retries start() every ~30s — the second attempt
+    must stay silent on both channels."""
+    mgr, notify = _failing_manager(monkeypatch)
+
+    mgr.start()
+    mgr.start()
+    _join_report_threads()
+
+    assert notify.call_count == 1
+    assert mgr.error_reporter.capture.call_count == 1
+
+
+def test_health_snapshot_carries_the_flag(monkeypatch):
+    mgr, _notify = _failing_manager(monkeypatch)
+    monkeypatch.setattr(mgr, "_get_latest_afk_event_age", lambda: None)
+    monkeypatch.setattr(mgr, "_get_latest_window_event_age", lambda: None)
+
+    mgr.start()
+    _join_report_threads()
+
+    assert mgr.health_snapshot()["tracker_download_failed"] is True
+
+
+def test_external_server_is_not_a_download_failure(monkeypatch):
+    """An external server on the port means capture is happening — only our
+    managed watchers are missing. No toast, no latched flag, and start() must
+    not claim failure."""
+    mgr, notify = _failing_manager(monkeypatch, port_in_use=True)
+
+    assert mgr.start() is True
+    _join_report_threads()
+
+    assert mgr.tracker_download_failed is False
+    assert notify.call_count == 0
+    assert mgr.error_reporter.capture.call_count == 0
+
+
+def test_flag_clears_when_binaries_resolve_without_download(monkeypatch, tmp_path):
+    """A device that recovers via an app update (frozen-bundle install path)
+    never re-enters the download branch, so the latch must clear on any route
+    that resolves a usable binaries dir."""
+    mgr, _notify = _failing_manager(monkeypatch)
+    mgr.start()
+    _join_report_threads()
+    assert mgr.tracker_download_failed is True
+
+    monkeypatch.setattr(mgr, "_get_binaries_dir", lambda: str(tmp_path))
+    monkeypatch.setattr(mgr, "_reap_orphan_processes", lambda *a, **k: None)
+    monkeypatch.setattr(mgr, "_start_component", lambda *a, **k: True)
+    monkeypatch.setattr(mgr, "_wait_for_server", lambda: True)
+
+    assert mgr.start() is True
+    assert mgr.tracker_download_failed is False

--- a/tests/test_corrupt_stored_state.py
+++ b/tests/test_corrupt_stored_state.py
@@ -1,0 +1,78 @@
+"""Corrupt stored state must degrade, not wedge.
+
+Two one-token `except` tuples stand between a bad stored row and a permanently
+stuck agent, and a refactor can undo either with no visible signal:
+
+* `KeychainManager.load()` — a ValueError escaping `StoredCredentials.from_json`
+  propagates through `try_auto_login` into a background thread's fatal
+  excepthook, leaving the app stuck at "Restoring session...".
+* `OfflineQueue.dequeue()` — a row with a non-ISO `created_at` raises inside
+  `QueuedEvent.from_row`, so the drain never completes and the queue never
+  empties.
+
+Both failures only appear on a real user's machine with an already-bad row.
+"""
+
+import json
+from unittest.mock import patch
+
+from src.auth.keychain import KeychainManager
+from src.sync.queue import OfflineQueue
+
+
+def _blob(**overrides):
+    data = {
+        "api_token": "tok",
+        "device_id": "dev-1",
+        "user_email": "user@example.com",
+    }
+    data.update(overrides)
+    return json.dumps(data)
+
+
+def _load_with(blob):
+    with patch("src.auth.keychain.keyring.get_password", return_value=blob):
+        return KeychainManager().load()
+
+
+def test_load_returns_none_for_oversized_token():
+    assert _load_with(_blob(api_token="x" * 5000)) is None
+
+
+def test_load_returns_none_for_token_with_newline():
+    assert _load_with(_blob(api_token="tok\nX-Injected: 1")) is None
+    assert _load_with(_blob(api_token="tok\rX-Injected: 1")) is None
+
+
+def test_load_returns_none_for_non_string_token():
+    assert _load_with(_blob(api_token=1234)) is None
+
+
+def test_load_returns_credentials_for_a_good_blob():
+    creds = _load_with(_blob())
+    assert creds is not None
+    assert creds.api_token == "tok"
+    assert creds.device_id == "dev-1"
+
+
+def test_dequeue_drops_row_with_unparseable_created_at(tmp_path):
+    queue = OfflineQueue(db_path=tmp_path / "queue.db")
+    queue.enqueue([{"id": "first"}, {"id": "second"}])
+
+    # Corrupt the OLDEST row's timestamp: it sorts first, so a raising
+    # from_row would take the whole batch — including the healthy row behind it.
+    with queue._cursor() as cursor:
+        cursor.execute("SELECT id FROM queued_events ORDER BY created_at ASC LIMIT 1")
+        bad_id = cursor.fetchone()[0]
+        cursor.execute(
+            "UPDATE queued_events SET created_at = ? WHERE id = ?",
+            ("not-a-timestamp", bad_id),
+        )
+
+    events = queue.dequeue()
+    assert [e.event_data["id"] for e in events] == ["second"]
+
+    # The corrupt row is removed, not left to shrink every future batch.
+    with queue._cursor() as cursor:
+        cursor.execute("SELECT COUNT(*) FROM queued_events WHERE id = ?", (bad_id,))
+        assert cursor.fetchone()[0] == 0

--- a/tests/test_inproc_afk_hardening.py
+++ b/tests/test_inproc_afk_hardening.py
@@ -148,3 +148,31 @@ def test_blind_clock_holds_and_reports():
     assert events == [], "must not finalize-afk over an unobserved window"
     assert eng._afk_inproc_checkpoint == seed_cp, "checkpoint held while blind"
     assert eng.error_reporter.capture.called, "blind clock surfaced to ops"
+
+
+def test_consecutive_clock_failures_survives_concurrent_samplers():
+    """The blind-clock counter must not lose increments under concurrency.
+
+    main.py can replace a wedged _sync_lock with a fresh one, so two _do_sync
+    cycles can overlap. A lost += 1 keeps the count under the blind threshold,
+    so the engine does not hold the checkpoint and finalizes the unobserved
+    span as AFK — real worked time billed as idle.
+    """
+    import threading
+
+    src = AfkSource(600, "host", idle_clock=lambda: None)  # always a failure
+    threads_count, per_thread = 8, 50
+    barrier = threading.Barrier(threads_count)
+
+    def hammer():
+        barrier.wait()
+        for _ in range(per_thread):
+            src.record_sample(T0)
+
+    threads = [threading.Thread(target=hammer) for _ in range(threads_count)]
+    for t in threads:
+        t.start()
+    for t in threads:
+        t.join()
+
+    assert src.consecutive_clock_failures == threads_count * per_thread

--- a/tests/test_input_source.py
+++ b/tests/test_input_source.py
@@ -1,5 +1,8 @@
+import sys
 import threading
+import types
 from datetime import datetime, timedelta, timezone
+from unittest.mock import patch
 
 from src.sync.aw_client import BUCKET_TYPE_INPUT
 from src.sync.input_source import InputSource, _MacOSTapBackend
@@ -222,3 +225,49 @@ def test_macos_watcher_count_only_skips_emitter_flag():
     from src.sync.macos_input_watcher import MacOSInputWatcher
     assert MacOSInputWatcher(aw_client=object(), count_only=True)._count_only is True
     assert MacOSInputWatcher(aw_client=object())._count_only is False
+
+
+def test_macos_watcher_reenables_tap_for_both_disable_reasons():
+    """macOS disables a CGEventTap for timeout OR user input.
+
+    Handling only the timeout constant left a user-input-disabled tap dead for
+    the rest of the session: counters frozen while is_running() stayed True, so
+    the agent reported the user idle instead of reporting itself blind.
+    """
+    from src.sync import macos_input_watcher as miw
+
+    for event_type in (
+        miw._kCGEventTapDisabledByTimeout,
+        miw._kCGEventTapDisabledByUserInput,
+    ):
+        watcher = miw.MacOSInputWatcher(aw_client=object(), count_only=True)
+        watcher._tap_ref = object()
+        enabled = []
+
+        fake_quartz = types.ModuleType("Quartz")
+        fake_quartz.CGEventTapEnable = lambda tap, on: enabled.append((tap, on))
+
+        with patch.dict(sys.modules, {"Quartz": fake_quartz}):
+            returned = watcher._event_callback(None, event_type, "evt", None)
+
+        assert returned == "evt"
+        assert enabled == [(watcher._tap_ref, True)], (
+            f"tap not re-enabled for event_type {event_type:#x}"
+        )
+
+
+def test_macos_watcher_disable_event_does_not_count_as_input():
+    """A tap-disabled notification must not be mistaken for user activity."""
+    from src.sync import macos_input_watcher as miw
+
+    watcher = miw.MacOSInputWatcher(aw_client=object(), count_only=True)
+    watcher._tap_ref = None  # no ref: exercises the warn-only branch
+
+    watcher._event_callback(None, miw._kCGEventTapDisabledByUserInput, "evt", None)
+
+    with watcher._lock:
+        assert (watcher._presses, watcher._clicks, watcher._scrolls) == (0, 0, 0)
+    # Also must not refresh the freshness timestamp: the idle-tracker health
+    # check reads get_last_input_at() to spot a blind watcher, so a disable
+    # notification that looked like input would mask the very outage it signals.
+    assert watcher.get_last_input_at() is None

--- a/tests/test_project_stamp_single_source.py
+++ b/tests/test_project_stamp_single_source.py
@@ -17,9 +17,12 @@ AfkSource read of `_current_project` (it must stay parameter-fed).
 """
 
 from pathlib import Path
+from unittest.mock import Mock
 
 import src.sync.afk_source as afk_mod
 import src.sync.sync_engine as mod
+from src.config import Config
+from src.sync.sync_engine import SyncEngine
 
 _SOURCE = Path(mod.__file__).read_text()
 _AFK_SOURCE = Path(afk_mod.__file__).read_text()
@@ -49,3 +52,31 @@ def test_afk_source_writes_project_id_once_and_never_reads_current_project():
     # which would re-introduce a second decision source and defeat the dedup.
     assert _AFK_SOURCE.count('["project_id"] = ') == 1
     assert "_current_project" not in _AFK_SOURCE
+
+
+def _engine() -> SyncEngine:
+    return SyncEngine(
+        aw=Mock(),
+        bf=Mock(),
+        queue=Mock(),
+        config=Config(),
+        time_tracker=Mock(),
+    )
+
+
+def test_project_stamp_accepts_integer_project_ids():
+    engine = _engine()
+    engine.set_current_project({"id": "42", "name": "Project"})
+
+    event = engine._stamp_project({"id": "evt"})
+
+    assert event["project_id"] == 42
+
+
+def test_project_stamp_omits_invalid_project_ids():
+    engine = _engine()
+    engine.set_current_project({"id": "4152903c-0894-48ed-ad50-491f97f52a46"})
+
+    event = engine._stamp_project({"id": "evt"})
+
+    assert "project_id" not in event

--- a/tests/test_queue_storability_backfill.py
+++ b/tests/test_queue_storability_backfill.py
@@ -119,6 +119,80 @@ def test_backfill_only_touches_bucketless_status_spans():
     assert engine.queue.backfill_status_bucket_ids(host) == 0
 
 
+def test_sanitize_project_ids_removes_invalid_queued_values():
+    tmp = Path(tempfile.mkdtemp())
+    queue = OfflineQueue(db_path=tmp / "q.db", max_size=1000)
+    try:
+        queue.enqueue([
+            {
+                "id": "idle_bad_project",
+                "timestamp": _now_iso(),
+                "duration": 60.0,
+                "bucket_id": "bf-status_host",
+                "bucket_type": "idle_time",
+                "project_id": "4152903c-0894-48ed-ad50-491f97f52a46",
+                "data": {"status": "idle"},
+            },
+            {
+                "id": "idle_string_project",
+                "timestamp": _now_iso(),
+                "duration": 60.0,
+                "bucket_id": "bf-status_host",
+                "bucket_type": "idle_time",
+                "project_id": "42",
+                "data": {"status": "idle"},
+            },
+        ])
+
+        assert queue.sanitize_project_ids() == 2
+
+        queued = queue.dequeue(batch_size=10)
+        by_id = {q.event_data["id"]: q.event_data for q in queued}
+        assert "project_id" not in by_id["idle_bad_project"]
+        assert by_id["idle_string_project"]["project_id"] == 42
+    finally:
+        queue.close()
+
+
+def test_startup_sanitizes_invalid_project_id_before_status_span_drain():
+    tmp = Path(tempfile.mkdtemp())
+    queue = OfflineQueue(db_path=tmp / "q.db", max_size=1000)
+    queue.enqueue([
+        {
+            "id": "idle_bad_project",
+            "timestamp": _now_iso(),
+            "duration": 60.0,
+            "bucket_id": "bf-status_host",
+            "bucket_type": "idle_time",
+            "project_id": "not-a-backend-project-id",
+            "data": {"status": "idle"},
+        }
+    ])
+
+    engine = SyncEngine(
+        aw=Mock(),
+        bf=Mock(),
+        queue=queue,
+        config=Config(),
+        time_tracker=Mock(),
+    )
+
+    delivered: list[dict] = []
+
+    def _accept(events):
+        delivered.extend(events)
+        return SyncResult(success=True, events_synced=len(events))
+
+    engine.bf.send_events = Mock(side_effect=_accept)
+    engine._queue_backoff_until = datetime.now(timezone.utc) - timedelta(seconds=1)
+    engine._process_queue(SyncStats())
+
+    assert delivered
+    assert "project_id" not in delivered[0]
+    assert engine.queue.size() == 0
+    engine.queue.close()
+
+
 # --- 1b: over-long span is evicted, not left to poison the batch --------------
 
 

--- a/tests/test_self_updater_staging.py
+++ b/tests/test_self_updater_staging.py
@@ -126,10 +126,13 @@ class TestDownloadSizeCap:
     """The download must refuse oversized bodies so a poisoned/misconfigured
     response can't fill the disk (installers are ~60-80 MB; cap is 500 MB)."""
 
-    def _fake_get(self, content_length, chunks):
+    def _fake_get(self, content_length, chunks, final_url="https://github.com/x/ok.bin"):
         from unittest.mock import MagicMock
 
         resp = MagicMock()
+        # The post-redirect URL is re-checked against the host allowlist, so it
+        # has to be a real allowlisted string (a bare MagicMock is not a str).
+        resp.url = final_url
         resp.headers = {"content-length": str(content_length)}
         resp.raise_for_status.return_value = None
         resp.iter_content.return_value = iter(chunks)
@@ -163,6 +166,17 @@ class TestDownloadSizeCap:
         with patch("src.self_updater.requests.get", return_value=ctx):
             su._download_to_file("https://github.com/x/ok.bin", dest)
         assert dest.read_bytes() == b"payload"
+
+    def test_rejects_redirect_off_the_allowlist(self, tmp_path):
+        # requests follows 3xx transparently, so the caller's host gate only
+        # covered the first hop. A redirect landing off-GitHub must abort before
+        # a byte of the body is written.
+        dest = tmp_path / "evil.bin"
+        ctx = self._fake_get(7, [b"payload"], final_url="https://evil.example.com/a.bin")
+        with patch("src.self_updater.requests.get", return_value=ctx):
+            with pytest.raises(ValueError):
+                su._download_to_file("https://github.com/x/ok.bin", dest)
+        assert not dest.exists()
 
 
 class TestArtifactFilename:

--- a/tests/test_tray_icon.py
+++ b/tests/test_tray_icon.py
@@ -56,3 +56,52 @@ class TestReadableFgFor:
         # someone adding a state with an unparseable colour string.
         fg = _readable_fg_for(STATE_COLORS[state])
         assert fg in ("#1a1a1a", "#FFFFFF")
+
+
+def _tray_with_dead_icon(monkeypatch, died):
+    """A TrayIcon whose health probe always fails, wired to record death."""
+    from src.ui.tray import TrayIcon
+
+    tray = TrayIcon(on_tray_died=lambda: died.append(True))
+    monkeypatch.setattr(tray, "_check_tray_health", lambda: False)
+    monkeypatch.setattr(tray, "_update_icon", lambda: None)
+    return tray
+
+
+def test_single_health_failure_does_not_kill_the_agent(monkeypatch):
+    """One failed probe is a transient AppKit hiccup, not a dead status item.
+
+    _on_tray_died shuts the agent down and stops capture for the rest of the
+    day, so it must not fire on a single failure.
+    """
+    died = []
+    tray = _tray_with_dead_icon(monkeypatch, died)
+
+    tray.tick_clock()
+
+    assert died == []
+
+
+def test_consecutive_health_failures_declare_death(monkeypatch):
+    died = []
+    tray = _tray_with_dead_icon(monkeypatch, died)
+
+    for _ in range(tray._TRAY_HEALTH_FAILURES_TO_DIE):
+        tray.tick_clock()
+
+    assert died == [True]
+
+
+def test_recovered_probe_resets_the_failure_streak(monkeypatch):
+    """A healthy tick must clear the streak so isolated blips never accumulate
+    into a shutdown across an entire workday."""
+    died = []
+    tray = _tray_with_dead_icon(monkeypatch, died)
+
+    tray.tick_clock()                                    # fail 1
+    monkeypatch.setattr(tray, "_check_tray_health", lambda: True)
+    tray.tick_clock()                                    # recovered
+    monkeypatch.setattr(tray, "_check_tray_health", lambda: False)
+    tray.tick_clock()                                    # fail 1 again, not 2
+
+    assert died == []

--- a/tests/test_tray_icon.py
+++ b/tests/test_tray_icon.py
@@ -9,6 +9,8 @@ test is cheap insurance.
 """
 from __future__ import annotations
 
+from unittest.mock import patch
+
 import pytest
 
 from src.ui.tray import STATE_COLORS, TrayState, _readable_fg_for
@@ -62,7 +64,8 @@ def _tray_with_dead_icon(monkeypatch, died):
     """A TrayIcon whose health probe always fails, wired to record death."""
     from src.ui.tray import TrayIcon
 
-    tray = TrayIcon(on_tray_died=lambda: died.append(True))
+    with patch("src.ui.tray.pystray"):
+        tray = TrayIcon(on_tray_died=lambda: died.append(True))
     monkeypatch.setattr(tray, "_check_tray_health", lambda: False)
     monkeypatch.setattr(tray, "_update_icon", lambda: None)
     return tray

--- a/tests/test_tray_state_transitions.py
+++ b/tests/test_tray_state_transitions.py
@@ -111,3 +111,22 @@ def test_transition_between_two_healthy_states_preserves_existing_text():
     tray.set_state(TrayState.PAUSED)
 
     assert tray.model.status_text == "Some informational status"
+
+
+def test_status_text_covers_private_hours_and_on_break():
+    """PRIVATE_HOURS and a bare ON_BREAK both fell through to "Starting...",
+    so a user outside their working-hours window saw what looked like a hung
+    app instead of a deliberate not-recording state."""
+    tray = _make_tray()
+
+    def status_for(state):
+        return tray._get_status_text(
+            {"on_break": False, "private_mode": False,
+             "state": state, "break_minutes_left": 0}
+        )
+
+    assert status_for(TrayState.PRIVATE_HOURS) == "Outside working hours"
+    assert status_for(TrayState.ON_BREAK) == "On Break"
+    assert status_for(TrayState.PRIVATE) == "Private Time"
+    # The real starting state must still read as starting.
+    assert status_for(TrayState.STARTING) == "Starting..."


### PR DESCRIPTION
Remediation pass from the 2026-07-18 audit: 13 commits off `main`.

Each commit is self-contained and explains the failure it fixes in its own message; the log below is the index.

## Commits

- fix(keychain): catch ValueError from credential validation
- fix(queue): guard corrupt created_at in QueuedEvent.from_row
- fix(updater): re-check host after download redirect
- fix(update-handler): log flush/shutdown failures during update exit
- fix(update-handler): guard coordinator.stop() during update exit
- fix(update-handler): log unparseable staged version instead of silent pass
- fix(aw-manager): re-check host after tracker download redirect
- fix(aw-manager): verify tracker archives against pinned SHA-256
- fix(aw-manager): surface a fail-closed tracker download
- refactor(url-safety): share one post-redirect host re-check
- fix(aw-manager): report download failure to ops before toasting
- fix(aw-manager): back off the tracker download, not just its toast
- fix(aw-manager): read tracker_download_failed under the lifecycle lock

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TcSd2noNuNxUtTYp9xArv7
