### PR TITLE
fix(queue): sanitize project ids before draining status spans

### DIFF
--- a/src/__init__.py
+++ b/src/__init__.py
@@ -1,4 +1,4 @@
 """BetterFlow - ActivityWatch to BetterFlow sync companion app."""
 
-__version__ = "1.5.105"
+__version__ = "1.5.106"
 __author__ = "BetterQA"

--- a/src/sync/queue.py
+++ b/src/sync/queue.py
@@ -20,6 +20,7 @@ __all__ = [
     "OfflineQueue",
     "QueuedEvent",
     "is_event_storable",
+    "normalized_project_id",
     "MAX_EVENT_DURATION_SECONDS",
 ]
 
@@ -81,6 +82,22 @@ def is_event_storable(ev: object, *, stale_cutoff: datetime) -> bool:
         return 0 <= duration <= MAX_EVENT_DURATION_SECONDS
     # Missing/non-numeric duration: not our call to evict — leave it to the server.
     return True
+
+
+def normalized_project_id(value: object) -> Optional[int]:
+    """Return a backend-safe project id, or None when the payload should omit it.
+
+    Shared with SyncEngine's stamping path so the queue migration and the live
+    stamp can never disagree about which ids the backend will accept.
+    """
+    if isinstance(value, bool):
+        return None
+    if isinstance(value, int):
+        return value if value > 0 else None
+    if isinstance(value, str) and value.isdecimal():
+        parsed = int(value)
+        return parsed if parsed > 0 else None
+    return None
 
 
 @dataclass
@@ -814,6 +831,50 @@ class OfflineQueue:
             logger.info(
                 "Backfilled bucket_id on %d legacy bucketless status span(s) so "
                 "they deliver instead of being evicted on upgrade",
+                len(updates),
+            )
+        return len(updates)
+
+    def sanitize_project_ids(self) -> int:
+        """Normalize queued ``project_id`` fields to the backend's integer FK.
+
+        Release 1.5.104 stamped the active project onto SyncEngine-built events.
+        If a stale/corrupt project payload put a UUID/string/zero in the queue,
+        the backend could keep rejecting an otherwise valid status span until it
+        exhausted retries and reported ``buckets=bf-status`` real loss. Queued
+        events are account-local and the project id is optional, so the safe
+        migration is: keep positive integer ids, coerce digit strings, and omit
+        anything else before the first queue drain.
+
+        Returns the number of queued rows rewritten.
+        """
+        with self._cursor() as cursor:
+            cursor.execute("SELECT id, event_data FROM queued_events")
+            rows = cursor.fetchall()
+            updates: list[tuple[str, int]] = []
+            for rid, raw in rows:
+                try:
+                    ev = json.loads(raw)
+                except (json.JSONDecodeError, TypeError):
+                    continue
+                if not isinstance(ev, dict) or "project_id" not in ev:
+                    continue
+                normalized = normalized_project_id(ev.get("project_id"))
+                if normalized is None:
+                    ev.pop("project_id", None)
+                else:
+                    ev["project_id"] = normalized
+                updated = json.dumps(ev)
+                if updated != raw:
+                    updates.append((updated, rid))
+            if updates:
+                cursor.executemany(
+                    "UPDATE queued_events SET event_data = ? WHERE id = ?",
+                    updates,
+                )
+        if updates:
+            logger.info(
+                "Sanitized project_id on %d queued event(s) before delivery",
                 len(updates),
             )
         return len(updates)

--- a/src/sync/sync_engine.py
+++ b/src/sync/sync_engine.py
@@ -33,7 +33,7 @@ try:
     from .foreground_activity import ForegroundActivityDetector, create_detector
     from .mic_activity import MicActivityDetector, create_mic_detector
     from .os_idle import get_system_idle_seconds
-    from .queue import is_event_storable
+    from .queue import is_event_storable, normalized_project_id
 except ImportError:
     from browser_tracker import is_browser_app
     from config import Config
@@ -46,9 +46,13 @@ except ImportError:
     from sync.foreground_activity import ForegroundActivityDetector, create_detector
     from sync.mic_activity import MicActivityDetector, create_mic_detector
     from sync.os_idle import get_system_idle_seconds
-    from sync.queue import is_event_storable
+    from sync.queue import is_event_storable, normalized_project_id
 
 logger = logging.getLogger(__name__)
+
+# Sentinel for "no project id has been rejected yet" — distinct from None,
+# which is itself a rejectable value (a project dict with no "id").
+_NO_REJECTED_PROJECT_ID = object()
 
 
 def _is_window_like(bucket_type: str) -> bool:
@@ -229,6 +233,9 @@ class SyncEngine:
         self._private_mode = False
         self._private_start: Optional[datetime] = None
         self._current_project: Optional[dict] = None
+        # Last project id normalization rejected, so the drop is logged once per
+        # distinct value instead of once per stamped event (or — worse — never).
+        self._rejected_project_id: object = _NO_REJECTED_PROJECT_ID
         self._session_active = False
         self._config_fetched = False
         self._last_config_fetch_monotonic: float = 0.0
@@ -348,12 +355,20 @@ class SyncEngine:
         # the server accepts them — a lost billing carve-out. Give them the same
         # bf-status_<host> id current spans use, BEFORE the sync loop starts.
         # Idempotent and best-effort: a migration hiccup must never block startup.
-        try:
-            backfill = getattr(self.queue, "backfill_status_bucket_ids", None)
-            if callable(backfill):
-                backfill(self._hostname)
-        except Exception as e:  # pragma: no cover - defensive; never fatal
-            logger.warning("Legacy status-span bucket_id backfill skipped: %s", e)
+        # Each migration is guarded on its own: they are independent, and a
+        # hiccup in one must not silently skip the other (a shared try would
+        # let a backfill error swallow the project_id sanitize, re-exposing the
+        # rejected-span loss this release fixes).
+        for name, args in (
+            ("backfill_status_bucket_ids", (self._hostname,)),
+            ("sanitize_project_ids", ()),
+        ):
+            try:
+                migrate = getattr(self.queue, name, None)
+                if callable(migrate):
+                    migrate(*args)
+            except Exception as e:  # pragma: no cover - defensive; never fatal
+                logger.warning("Queued-event startup migration %s skipped: %s", name, e)
 
         # Dedup: track (bucket_id, event_id) pairs already sent this session.
         # The lookback window re-fetches recent events for duration updates —
@@ -645,13 +660,31 @@ class SyncEngine:
             if ended is not None:
                 stats.calls_detected += 1
 
-    def _current_project_id(self):
+    def _current_project_id(self) -> Optional[int]:
         """The active project's id, or None. The single locked read of
         _current_project that every event-stamping path shares, so the
-        lock+read rule can't drift between call sites."""
+        lock+read rule can't drift between call sites. Normalization is the
+        queue's shared helper, so a live stamp and the queue migration always
+        agree on which ids the backend accepts."""
         with self._state_lock:
             project = self._current_project
-        return project["id"] if project else None
+            if not project:
+                return None
+            raw = project.get("id")
+            pid = normalized_project_id(raw)
+            # Dropping the id silently would untag every event with no trace —
+            # the failure mode is invisible in logs and only shows up as
+            # unprojected rows in the backend. Warn once per distinct value.
+            if pid is None and raw != self._rejected_project_id:
+                self._rejected_project_id = raw
+                logger.warning(
+                    "Active project id %r is not a backend project id; "
+                    "events will be sent untagged",
+                    raw,
+                )
+            elif pid is not None:
+                self._rejected_project_id = _NO_REJECTED_PROJECT_ID
+        return pid
 
     def _stamp_project(self, event: dict) -> dict:
         """Stamp the active project onto a SyncEngine-built event dict (call,

--- a/tests/test_project_stamp_single_source.py
+++ b/tests/test_project_stamp_single_source.py
@@ -17,9 +17,12 @@ AfkSource read of `_current_project` (it must stay parameter-fed).
 """
 
 from pathlib import Path
+from unittest.mock import Mock
 
 import src.sync.afk_source as afk_mod
 import src.sync.sync_engine as mod
+from src.config import Config
+from src.sync.sync_engine import SyncEngine
 
 _SOURCE = Path(mod.__file__).read_text()
 _AFK_SOURCE = Path(afk_mod.__file__).read_text()
@@ -49,3 +52,31 @@ def test_afk_source_writes_project_id_once_and_never_reads_current_project():
     # which would re-introduce a second decision source and defeat the dedup.
     assert _AFK_SOURCE.count('["project_id"] = ') == 1
     assert "_current_project" not in _AFK_SOURCE
+
+
+def _engine() -> SyncEngine:
+    return SyncEngine(
+        aw=Mock(),
+        bf=Mock(),
+        queue=Mock(),
+        config=Config(),
+        time_tracker=Mock(),
+    )
+
+
+def test_project_stamp_accepts_integer_project_ids():
+    engine = _engine()
+    engine.set_current_project({"id": "42", "name": "Project"})
+
+    event = engine._stamp_project({"id": "evt"})
+
+    assert event["project_id"] == 42
+
+
+def test_project_stamp_omits_invalid_project_ids():
+    engine = _engine()
+    engine.set_current_project({"id": "4152903c-0894-48ed-ad50-491f97f52a46"})
+
+    event = engine._stamp_project({"id": "evt"})
+
+    assert "project_id" not in event

--- a/tests/test_queue_storability_backfill.py
+++ b/tests/test_queue_storability_backfill.py
@@ -119,6 +119,80 @@ def test_backfill_only_touches_bucketless_status_spans():
     assert engine.queue.backfill_status_bucket_ids(host) == 0
 
 
+def test_sanitize_project_ids_removes_invalid_queued_values():
+    tmp = Path(tempfile.mkdtemp())
+    queue = OfflineQueue(db_path=tmp / "q.db", max_size=1000)
+    try:
+        queue.enqueue([
+            {
+                "id": "idle_bad_project",
+                "timestamp": _now_iso(),
+                "duration": 60.0,
+                "bucket_id": "bf-status_host",
+                "bucket_type": "idle_time",
+                "project_id": "4152903c-0894-48ed-ad50-491f97f52a46",
+                "data": {"status": "idle"},
+            },
+            {
+                "id": "idle_string_project",
+                "timestamp": _now_iso(),
+                "duration": 60.0,
+                "bucket_id": "bf-status_host",
+                "bucket_type": "idle_time",
+                "project_id": "42",
+                "data": {"status": "idle"},
+            },
+        ])
+
+        assert queue.sanitize_project_ids() == 2
+
+        queued = queue.dequeue(batch_size=10)
+        by_id = {q.event_data["id"]: q.event_data for q in queued}
+        assert "project_id" not in by_id["idle_bad_project"]
+        assert by_id["idle_string_project"]["project_id"] == 42
+    finally:
+        queue.close()
+
+
+def test_startup_sanitizes_invalid_project_id_before_status_span_drain():
+    tmp = Path(tempfile.mkdtemp())
+    queue = OfflineQueue(db_path=tmp / "q.db", max_size=1000)
+    queue.enqueue([
+        {
+            "id": "idle_bad_project",
+            "timestamp": _now_iso(),
+            "duration": 60.0,
+            "bucket_id": "bf-status_host",
+            "bucket_type": "idle_time",
+            "project_id": "not-a-backend-project-id",
+            "data": {"status": "idle"},
+        }
+    ])
+
+    engine = SyncEngine(
+        aw=Mock(),
+        bf=Mock(),
+        queue=queue,
+        config=Config(),
+        time_tracker=Mock(),
+    )
+
+    delivered: list[dict] = []
+
+    def _accept(events):
+        delivered.extend(events)
+        return SyncResult(success=True, events_synced=len(events))
+
+    engine.bf.send_events = Mock(side_effect=_accept)
+    engine._queue_backoff_until = datetime.now(timezone.utc) - timedelta(seconds=1)
+    engine._process_queue(SyncStats())
+
+    assert delivered
+    assert "project_id" not in delivered[0]
+    assert engine.queue.size() == 0
+    engine.queue.close()
+
+
 # --- 1b: over-long span is evicted, not left to poison the batch --------------
 
 


### PR DESCRIPTION
## Summary
- normalize project IDs before stamping sync events so only backend-safe positive integer IDs are sent
- sanitize already-queued events on startup so invalid project_id values do not keep poisoning queue drains
- bump app version to 1.5.106 for the beta build

## Tests
- pytest tests/test_project_stamp_single_source.py tests/test_queue_storability_backfill.py tests/test_sync_engine.py::TestFailedStatusSpanIsStorable tests/test_sync_engine.py::TestStatusSpanEvents tests/test_queue_no_drop_on_outage.py tests/test_queue_mixed_batch_poison.py tests/test_release_version.py -q
- pytest -q