### PR TITLE
feat(watchdog): classify an offline overrun as slow, not hung

### DIFF
--- a/src/__init__.py
+++ b/src/__init__.py
@@ -1,4 +1,4 @@
 """BetterFlow - ActivityWatch to BetterFlow sync companion app."""
 
-__version__ = "1.5.106"
+__version__ = "1.5.107"
 __author__ = "BetterQA"

--- a/src/main.py
+++ b/src/main.py
@@ -29,7 +29,7 @@ try:
     from .display_info import start_display_tracker
     from .reminders import ReminderManager
     from .sync import AWClient, BetterFlowClient, OfflineQueue, SyncEngine
-    from .sync.http_client import BetterFlowAuthError
+    from .sync.http_client import BetterFlowAuthError, transient_failure_count
     from .system_events import start_system_event_listener
     from .ui.permissions import (
         check_accessibility,
@@ -54,7 +54,7 @@ except ImportError:
     from display_info import start_display_tracker
     from reminders import ReminderManager
     from sync import AWClient, BetterFlowClient, OfflineQueue, SyncEngine
-    from sync.http_client import BetterFlowAuthError
+    from sync.http_client import BetterFlowAuthError, transient_failure_count
     from system_events import start_system_event_listener
     from ui.permissions import (
         check_accessibility,
@@ -1355,17 +1355,56 @@ class SyncCoordinator:
         # for cases where the sleep notification was missed.
         watchdog_cancelled = threading.Event()
 
+        # Snapshot the transient-failure counter so the watchdog can tell WHY the
+        # cycle ran long. An unreachable API makes a healthy cycle overrun (the
+        # retry chain plus the send budget legitimately eat ~150s) — that is slow,
+        # not hung, and reporting it as an ERROR "Sync hung" paged humans and drew
+        # the autofix drafter onto a non-problem (2026-07-22, device 18: 150.86s,
+        # no log gap, all three events delivered next cycle). The counter is
+        # incremented by BetterFlowClientError.is_transient — the one place the
+        # codebase classifies network-vs-definitive failures.
+        transient_at_cycle_start = transient_failure_count()
+
         def _watchdog():
             if watchdog_cancelled.is_set():
                 return
-            logger.error("_do_sync watchdog: sync exceeded %ds — resetting sessions", self._DO_SYNC_DEADLINE)
-            if self.error_reporter is not None:
-                self.error_reporter.capture(
-                    f"Sync hung — exceeded {self._DO_SYNC_DEADLINE}s watchdog deadline",
-                    level="error",
-                    tags={"component": "sync-watchdog"},
-                    fingerprint="sync-watchdog-timeout",
+            # Deliberately permissive: ANY transient failure during the cycle
+            # downgrades it. A genuine wedge that coincides with one flaky request
+            # is downgraded at the deadline — acceptable, because
+            # _SYNC_WEDGE_CEILING (420s) still pages it as an error.
+            transient_this_cycle = transient_failure_count() - transient_at_cycle_start
+            if transient_this_cycle > 0:
+                logger.warning(
+                    "_do_sync watchdog: sync exceeded %ss with %d transient API "
+                    "failure(s) — API unreachable, resetting sessions",
+                    self._DO_SYNC_DEADLINE,
+                    transient_this_cycle,
                 )
+                if self.error_reporter is not None:
+                    self.error_reporter.capture(
+                        f"Sync slow — exceeded {self._DO_SYNC_DEADLINE}s while the "
+                        "BetterFlow API was unreachable "
+                        f"({transient_this_cycle} transient "
+                        f"failure{'' if transient_this_cycle == 1 else 's'} this cycle)",
+                        level="warning",
+                        tags={"component": "sync-watchdog"},
+                        fingerprint="sync-watchdog-timeout-offline",
+                    )
+            else:
+                logger.error(
+                    "_do_sync watchdog: sync exceeded %ss — resetting sessions",
+                    self._DO_SYNC_DEADLINE,
+                )
+                if self.error_reporter is not None:
+                    self.error_reporter.capture(
+                        f"Sync hung — exceeded {self._DO_SYNC_DEADLINE}s watchdog deadline",
+                        level="error",
+                        tags={"component": "sync-watchdog"},
+                        fingerprint="sync-watchdog-timeout",
+                    )
+            # Unchanged by design: both resets run in BOTH branches. Discarding
+            # pooled connections after a network outage is the correct recovery,
+            # and the stale-socket backstop was the watchdog's original purpose.
             try:
                 self.bf.reset_session()
                 self.aw.reset_session()

--- a/src/main.py
+++ b/src/main.py
@@ -29,7 +29,7 @@ try:
     from .display_info import start_display_tracker
     from .reminders import ReminderManager
     from .sync import AWClient, BetterFlowClient, OfflineQueue, SyncEngine
-    from .sync.http_client import BetterFlowAuthError, transient_failure_count
+    from .sync.http_client import BetterFlowAuthError, transient_failure_counter
     from .system_events import start_system_event_listener
     from .ui.permissions import (
         check_accessibility,
@@ -54,7 +54,7 @@ except ImportError:
     from display_info import start_display_tracker
     from reminders import ReminderManager
     from sync import AWClient, BetterFlowClient, OfflineQueue, SyncEngine
-    from sync.http_client import BetterFlowAuthError, transient_failure_count
+    from sync.http_client import BetterFlowAuthError, transient_failure_counter
     from system_events import start_system_event_listener
     from ui.permissions import (
         check_accessibility,
@@ -1361,9 +1361,16 @@ class SyncCoordinator:
         # not hung, and reporting it as an ERROR "Sync hung" paged humans and drew
         # the autofix drafter onto a non-problem (2026-07-22, device 18: 150.86s,
         # no log gap, all three events delivered next cycle). The counter is
-        # incremented by BetterFlowClientError.is_transient — the one place the
-        # codebase classifies network-vs-definitive failures.
-        transient_at_cycle_start = transient_failure_count()
+        # maintained by BetterFlowClientError, off is_transient — the one place
+        # the codebase classifies network-vs-definitive failures.
+        #
+        # THIS THREAD's counter, captured as an object. The watchdog runs on a
+        # Timer thread, so it must not re-read the counter itself (it would get
+        # the Timer's own, always zero). Per-thread also means a cycle abandoned
+        # by _acquire_sync_slot keeps incrementing its OWN counter, so its late
+        # failures can't misclassify the cycle that replaced it.
+        cycle_transients = transient_failure_counter()
+        transient_at_cycle_start = cycle_transients.value
 
         def _watchdog():
             if watchdog_cancelled.is_set():
@@ -1372,7 +1379,7 @@ class SyncCoordinator:
             # downgrades it. A genuine wedge that coincides with one flaky request
             # is downgraded at the deadline — acceptable, because
             # _SYNC_WEDGE_CEILING (420s) still pages it as an error.
-            transient_this_cycle = transient_failure_count() - transient_at_cycle_start
+            transient_this_cycle = cycle_transients.value - transient_at_cycle_start
             if transient_this_cycle > 0:
                 logger.warning(
                     "_do_sync watchdog: sync exceeded %ss with %d transient API "

--- a/src/sync/http_client.py
+++ b/src/sync/http_client.py
@@ -33,13 +33,18 @@ logger = logging.getLogger(__name__)
 
 # ---- Transient-failure counter ----------------------------------------------
 #
-# Monotonic count of failures classified as transient (network-shaped) by
-# BetterFlowClientError.is_transient — the codebase's SINGLE "network problem vs
-# definitive rejection" decision point. SyncCoordinator._do_sync snapshots this
-# at cycle start so its watchdog can tell "the API was unreachable and the cycle
-# ran long" (a warning) from "the cycle is genuinely hung" (an error) instead of
-# reporting both as "Sync hung" (2026-07-22, device 18: a 150.86s cycle during an
+# Monotonic count of BetterFlowClientErrors that its is_transient rule — the
+# codebase's SINGLE "network problem vs definitive rejection" decision point —
+# classified as transient. SyncCoordinator._do_sync snapshots this at cycle start
+# so its watchdog can tell "the API was unreachable and the cycle ran long" (a
+# warning) from "the cycle is genuinely hung" (an error) instead of reporting
+# both as "Sync hung" (2026-07-22, device 18: a 150.86s cycle during an
 # hour-long connectivity outage, nothing hung, nothing lost, paged as an ERROR).
+#
+# Incremented once per failure OBJECT, in __init__ — never in the is_transient
+# getter, which stays a pure query. A read-counting metric inflates the moment
+# anyone logs or re-reads the property, and inflation is the fail-open direction:
+# it makes a real hang report as an outage warning.
 #
 # Deliberately NOT a second classifier — see rules/one-rule-one-implementation.md.
 # Lock-free: one writer in practice (the sync thread), and the only consequence
@@ -164,6 +169,18 @@ class BetterFlowClientError(Exception):
     def __init__(self, message: str = "", status_code: Optional[int] = None):
         super().__init__(message)
         self.status_code = status_code
+        # Count the FAILURE, not the classification READ. Incrementing inside the
+        # is_transient getter would make the metric a function of how many times
+        # the property is consulted — one debug log or a second caller and it
+        # inflates, which is the fail-open direction: an inflated count makes the
+        # watchdog report a genuine hang as an outage warning. Counting here is
+        # once per failure object, and every construction site in this module is
+        # a `raise` representing a real failure (checked 2026-07-22). The
+        # transient/definitive RULE still lives in exactly one place — the pure
+        # query below.
+        if self.is_transient:
+            global _TRANSIENT_FAILURE_COUNT
+            _TRANSIENT_FAILURE_COUNT += 1
 
     @property
     def is_transient(self) -> bool:
@@ -175,14 +192,10 @@ class BetterFlowClientError(Exception):
         status — do not set status_code on a retryable 4xx or it becomes
         definitive and its events burn retries during e.g. a rate-limit window.
 
-        Side effect: a transient verdict bumps the module counter read by
-        SyncCoordinator's watchdog (see _TRANSIENT_FAILURE_COUNT). It lives here,
-        and nowhere else, so there is exactly one transient/definitive rule."""
-        global _TRANSIENT_FAILURE_COUNT
-        transient = self.status_code is None or self.status_code >= 500
-        if transient:
-            _TRANSIENT_FAILURE_COUNT += 1
-        return transient
+        Pure query — free to read as often as you like. This is the codebase's
+        ONLY transient/definitive rule; __init__ consults it to maintain the
+        counter SyncCoordinator's watchdog reads (_TRANSIENT_FAILURE_COUNT)."""
+        return self.status_code is None or self.status_code >= 500
 
 
 class BetterFlowAuthError(BetterFlowClientError):

--- a/src/sync/http_client.py
+++ b/src/sync/http_client.py
@@ -25,9 +25,36 @@ __all__ = [
     "BetterFlowClientError",
     "BetterFlowAuthError",
     "resolve_ca_bundle",
+    "transient_failure_count",
 ]
 
 logger = logging.getLogger(__name__)
+
+
+# ---- Transient-failure counter ----------------------------------------------
+#
+# Monotonic count of failures classified as transient (network-shaped) by
+# BetterFlowClientError.is_transient — the codebase's SINGLE "network problem vs
+# definitive rejection" decision point. SyncCoordinator._do_sync snapshots this
+# at cycle start so its watchdog can tell "the API was unreachable and the cycle
+# ran long" (a warning) from "the cycle is genuinely hung" (an error) instead of
+# reporting both as "Sync hung" (2026-07-22, device 18: a 150.86s cycle during an
+# hour-long connectivity outage, nothing hung, nothing lost, paged as an ERROR).
+#
+# Deliberately NOT a second classifier — see rules/one-rule-one-implementation.md.
+# Lock-free: one writer in practice (the sync thread), and the only consequence
+# of a lost increment under a rare interpreter-level interleaving is that one
+# watchdog report is labelled a hang instead of an outage.
+_TRANSIENT_FAILURE_COUNT = 0
+
+
+def transient_failure_count() -> int:
+    """Number of transient failures classified since process start (monotonic).
+
+    Only meaningful as a delta between two reads — callers snapshot it and check
+    whether it moved.
+    """
+    return _TRANSIENT_FAILURE_COUNT
 
 
 # ---- TLS CA bundle resolution -----------------------------------------------
@@ -146,8 +173,16 @@ class BetterFlowClientError(Exception):
         ONLY for a definitive client rejection (a non-retryable 4xx), so "no code"
         means transient. NOTE: this is a rejection classifier, not a raw HTTP
         status — do not set status_code on a retryable 4xx or it becomes
-        definitive and its events burn retries during e.g. a rate-limit window."""
-        return self.status_code is None or self.status_code >= 500
+        definitive and its events burn retries during e.g. a rate-limit window.
+
+        Side effect: a transient verdict bumps the module counter read by
+        SyncCoordinator's watchdog (see _TRANSIENT_FAILURE_COUNT). It lives here,
+        and nowhere else, so there is exactly one transient/definitive rule."""
+        global _TRANSIENT_FAILURE_COUNT
+        transient = self.status_code is None or self.status_code >= 500
+        if transient:
+            _TRANSIENT_FAILURE_COUNT += 1
+        return transient
 
 
 class BetterFlowAuthError(BetterFlowClientError):

--- a/src/sync/http_client.py
+++ b/src/sync/http_client.py
@@ -26,6 +26,7 @@ __all__ = [
     "BetterFlowAuthError",
     "resolve_ca_bundle",
     "transient_failure_count",
+    "transient_failure_counter",
 ]
 
 logger = logging.getLogger(__name__)
@@ -33,9 +34,9 @@ logger = logging.getLogger(__name__)
 
 # ---- Transient-failure counter ----------------------------------------------
 #
-# Monotonic count of BetterFlowClientErrors that its is_transient rule — the
-# codebase's SINGLE "network problem vs definitive rejection" decision point —
-# classified as transient. SyncCoordinator._do_sync snapshots this at cycle start
+# Monotonic count of network-shaped failures, i.e. those the is_transient rule —
+# the codebase's SINGLE "network problem vs definitive rejection" decision point —
+# classified as transient. SyncCoordinator._do_sync snapshots it at cycle start
 # so its watchdog can tell "the API was unreachable and the cycle ran long" (a
 # warning) from "the cycle is genuinely hung" (an error) instead of reporting
 # both as "Sync hung" (2026-07-22, device 18: a 150.86s cycle during an
@@ -46,20 +47,52 @@ logger = logging.getLogger(__name__)
 # anyone logs or re-reads the property, and inflation is the fail-open direction:
 # it makes a real hang report as an outage warning.
 #
+# PER-THREAD, not process-wide. _acquire_sync_slot abandons a cycle that has held
+# the sync lock past _SYNC_WEDGE_CEILING and re-arms a fresh lock — and documents
+# that the stuck thread cannot be killed. So two _do_sync bodies can be live at
+# once, and a single global would let the zombie cycle's late failures classify
+# the healthy cycle's watchdog ("offline" over a genuine wedge). Each cycle's
+# work runs on its own thread, so attribution by thread is attribution by cycle.
+# The watchdog fires on a Timer thread, so _do_sync captures its thread's counter
+# OBJECT and the closure reads that — never transient_failure_count(), which
+# would answer for the Timer thread. Same reason a background HTTP failure (update
+# checker, error-report daemon) no longer classifies a sync cycle.
+#
 # Deliberately NOT a second classifier — see rules/one-rule-one-implementation.md.
-# Lock-free: one writer in practice (the sync thread), and the only consequence
-# of a lost increment under a rare interpreter-level interleaving is that one
-# watchdog report is labelled a hang instead of an outage.
-_TRANSIENT_FAILURE_COUNT = 0
+# Lock-free by construction: a thread's counter is written only by that thread.
+_thread_state = threading.local()
+
+
+class _TransientFailureCounter:
+    """One thread's transient-failure tally. Mutable so a watchdog closure can
+    hold the object and observe increments made after it was captured."""
+
+    __slots__ = ("value",)
+
+    def __init__(self) -> None:
+        self.value = 0
+
+
+def transient_failure_counter() -> _TransientFailureCounter:
+    """The CALLING THREAD's transient-failure counter, created on first use.
+
+    Capture this object (not its value) when the reader runs on another thread —
+    SyncCoordinator's watchdog Timer does exactly that.
+    """
+    counter = getattr(_thread_state, "counter", None)
+    if counter is None:
+        counter = _TransientFailureCounter()
+        _thread_state.counter = counter
+    return counter
 
 
 def transient_failure_count() -> int:
-    """Number of transient failures classified since process start (monotonic).
+    """The calling thread's transient-failure count (monotonic within a thread).
 
-    Only meaningful as a delta between two reads — callers snapshot it and check
-    whether it moved.
+    Only meaningful as a delta between two reads ON THE SAME THREAD — callers
+    snapshot it and check whether it moved.
     """
-    return _TRANSIENT_FAILURE_COUNT
+    return transient_failure_counter().value
 
 
 # ---- TLS CA bundle resolution -----------------------------------------------
@@ -166,6 +199,10 @@ class BetterFlowClientError(Exception):
     server outage against an event's drop threshold (2026-06-30 data loss).
     """
 
+    #: Whether an instance of this class counts toward the watchdog's
+    #: network-shaped failure tally. False for auth errors — see __init__.
+    _COUNTS_AS_NETWORK_FAILURE = True
+
     def __init__(self, message: str = "", status_code: Optional[int] = None):
         super().__init__(message)
         self.status_code = status_code
@@ -173,14 +210,26 @@ class BetterFlowClientError(Exception):
         # is_transient getter would make the metric a function of how many times
         # the property is consulted — one debug log or a second caller and it
         # inflates, which is the fail-open direction: an inflated count makes the
-        # watchdog report a genuine hang as an outage warning. Counting here is
-        # once per failure object, and every construction site in this module is
-        # a `raise` representing a real failure (checked 2026-07-22). The
-        # transient/definitive RULE still lives in exactly one place — the pure
-        # query below.
-        if self.is_transient:
-            global _TRANSIENT_FAILURE_COUNT
-            _TRANSIENT_FAILURE_COUNT += 1
+        # watchdog report a genuine hang as an outage warning. Counting once per
+        # failure object is safe because every construction site in this module
+        # raises immediately (test code does build these speculatively as mock
+        # side-effects, which only shifts a per-thread tally the tests read as a
+        # delta). The transient/definitive RULE still lives in exactly one place:
+        # the pure query below.
+        #
+        # The counter and is_transient DELIBERATELY DISAGREE on auth errors, and
+        # that asymmetry is not an oversight. A 401/403 is definitive for the
+        # WATCHDOG's question ("was the network down?" — no, the token expired;
+        # reporting "API unreachable" would hide the actionable condition), but it
+        # must stay transient for the QUEUE's question ("burn a retry?" — no).
+        # is_transient is load-bearing for offline-queue durability: transient
+        # failures HOLD events without counting toward the drop threshold, so
+        # flipping auth errors to definitive would burn retries and, past the
+        # threshold, drop real activity — the 2026-06-30 data-loss class. The
+        # watchdog's accuracy is not worth billing data, so the exclusion lives
+        # here, in the counter, and never in the classifier.
+        if self._COUNTS_AS_NETWORK_FAILURE and self.is_transient:
+            transient_failure_counter().value += 1
 
     @property
     def is_transient(self) -> bool:
@@ -199,9 +248,17 @@ class BetterFlowClientError(Exception):
 
 
 class BetterFlowAuthError(BetterFlowClientError):
-    """Authentication error."""
+    """Authentication error (401/403).
 
-    pass
+    Excluded from the watchdog's network-failure tally: an expired token or an
+    unauthorized device is a definitive rejection whose fix is re-authentication,
+    not waiting out a network. ``is_transient`` stays True — the offline queue
+    depends on it to hold events without burning retries — so only the COUNTER
+    disagrees. See BetterFlowClientError.__init__ for why that asymmetry is
+    deliberate.
+    """
+
+    _COUNTS_AS_NETWORK_FAILURE = False
 
 
 class _TransientError(Exception):

--- a/tests/test_sync_watchdog_outcome_classification.py
+++ b/tests/test_sync_watchdog_outcome_classification.py
@@ -203,6 +203,31 @@ class TestWatchdogGenuineHang(_CoordinatorHarness):
 class TestTransientFailureCounter:
     """Case 3 — the counter moves on a transient failure and not on a 4xx."""
 
+    def test_counter_counts_failures_not_property_reads(self):
+        """The count must be a function of how many transient failures OCCURRED,
+        not how many times ``is_transient`` was READ.
+
+        Counting inside the property getter inflates the moment anyone logs
+        ``e.is_transient``, asserts on it in a test, or reads it twice in one
+        path — and inflation is the fail-open direction here: it makes a real
+        hang report as an outage warning, which is precisely the signal this
+        feature exists to get right. So the increment belongs at construction and
+        ``is_transient`` stays a pure query.
+        """
+        error = BetterFlowClientError("Cannot connect to BetterFlow API")
+        before = transient_failure_count()
+
+        assert error.is_transient is True
+        assert error.is_transient is True
+        assert error.is_transient is True
+
+        assert transient_failure_count() == before
+
+    def test_one_failure_object_counts_exactly_once(self):
+        before = transient_failure_count()
+        BetterFlowClientError("Cannot connect to BetterFlow API")
+        assert transient_failure_count() == before + 1
+
     def test_counter_increments_on_transient_failure(self):
         before = transient_failure_count()
         result = _unreachable_client().send_events(_one_event())

--- a/tests/test_sync_watchdog_outcome_classification.py
+++ b/tests/test_sync_watchdog_outcome_classification.py
@@ -31,7 +31,11 @@ from src.config import Config
 from src.main import SyncCoordinator
 from src.reminders import ReminderManager
 from src.sync.bf_client import BetterFlowClient
-from src.sync.http_client import BetterFlowClientError, transient_failure_count
+from src.sync.http_client import (
+    BetterFlowAuthError,
+    BetterFlowClientError,
+    transient_failure_count,
+)
 from src.sync.sync_engine import SyncEngine
 
 # Shrunk deadline so the watchdog fires inside a test, not in 150s. The
@@ -199,6 +203,36 @@ class TestWatchdogGenuineHang(_CoordinatorHarness):
         assert self.bf.reset_session.called
         assert self.aw.reset_session.called
 
+    def test_zombie_cycles_failures_do_not_downgrade_this_cycle(self):
+        """A failure raised by an ABANDONED cycle must not classify this one.
+
+        _acquire_sync_slot deliberately abandons a cycle that has held the lock
+        past _SYNC_WEDGE_CEILING and re-arms a fresh lock, and documents that the
+        stuck thread cannot be killed. So two _do_sync bodies can be live at once:
+        the zombie cycle A keeps making requests while cycle B runs. A single
+        process-wide counter has no cycle identity, so A's late transient failure
+        would classify B as "the API was unreachable" — masking a genuine wedge
+        with a warning, on the strength of a failure that was not B's.
+
+        Attribution is per-thread: A's work runs on A's thread, B's on B's.
+        """
+
+        def zombie_failure():
+            # Another thread — as the abandoned cycle's zombie would be —
+            # experiences a transient failure while THIS cycle is running.
+            other = threading.Thread(
+                target=lambda: BetterFlowClientError("Cannot connect to BetterFlow API")
+            )
+            other.start()
+            other.join()
+
+        self._run_overrunning_cycle(before_overrun=zombie_failure)
+
+        hung = self.recorder.by_fingerprint("sync-watchdog-timeout")
+        assert len(hung) == 1, self.recorder.captures
+        assert hung[0]["level"] == "error"
+        assert self.recorder.by_fingerprint("sync-watchdog-timeout-offline") == []
+
 
 class TestTransientFailureCounter:
     """Case 3 — the counter moves on a transient failure and not on a 4xx."""
@@ -233,6 +267,31 @@ class TestTransientFailureCounter:
         result = _unreachable_client().send_events(_one_event())
         assert result.transient is True
         assert transient_failure_count() == before + 1
+
+    def test_auth_failure_does_not_move_the_counter(self):
+        """A 401/403 is a definitive rejection — the fix is re-authentication, not
+        waiting for a network to come back. Counting it would report an expired
+        token as "the API was unreachable", hiding the actionable condition.
+
+        Both live call sites construct BetterFlowAuthError with no status_code,
+        so is_transient is True and only the COUNTER excludes it.
+        """
+        before = transient_failure_count()
+        BetterFlowAuthError("Invalid or expired API token")
+        assert transient_failure_count() == before
+
+    def test_auth_error_is_still_transient_for_the_queue(self):
+        """The counter and is_transient deliberately DISAGREE on auth errors, and
+        this pins the half that must not move.
+
+        is_transient is load-bearing for offline-queue durability: a transient
+        failure HOLDS events without burning a retry. Flipping auth errors to
+        definitive would burn retries and, past the threshold, drop real queued
+        activity — the 2026-06-30 data-loss class (up to ~18h of spans). The
+        watchdog's classification must never buy accuracy with that.
+        """
+        assert BetterFlowAuthError("Invalid or expired API token").is_transient is True
+        assert BetterFlowAuthError("Device not authorized").is_transient is True
 
     def test_counter_does_not_move_on_definitive_4xx(self):
         before = transient_failure_count()

--- a/tests/test_sync_watchdog_outcome_classification.py
+++ b/tests/test_sync_watchdog_outcome_classification.py
@@ -1,0 +1,230 @@
+"""Watchdog outcome classification — offline slowness vs. a genuine wedge.
+
+Origin: 2026-07-22, device 18 (Razvan Zerfas, macOS, agent 1.5.105). A cycle ran
+150.86s — 0.86s past ``_DO_SYNC_DEADLINE`` — purely because the BetterFlow API
+was unreachable from that device for an hour. Nothing was hung (the largest quiet
+stretch inside the "hang" was ~23s) and nothing was lost (the three events went
+out on the next cycle), yet it reported as ``level=error`` /
+``sync-watchdog-timeout`` / "Sync hung", paging humans and drawing the autofix
+drafter onto a non-problem.
+
+Design: docs/superpowers/specs/2026-07-22-watchdog-outcome-classification-design.md
+
+The signal is the transient-failure counter incremented at
+``BetterFlowClientError.is_transient`` — the codebase's single "network problem
+vs. definitive rejection" decision point (``rules/one-rule-one-implementation.md``).
+``_do_sync`` snapshots it at cycle start; the watchdog compares against the live
+value.
+
+These tests drive the REAL ``SyncCoordinator._do_sync`` (real watchdog timer,
+real classifier) with a stubbed transport, and assert on the reports the error
+reporter actually captured — never on arguments forwarded between functions
+(``rules/test-fixture-discipline.md``).
+"""
+
+import threading
+import time
+from types import SimpleNamespace
+from unittest.mock import Mock
+
+from src.config import Config
+from src.main import SyncCoordinator
+from src.reminders import ReminderManager
+from src.sync.bf_client import BetterFlowClient
+from src.sync.http_client import BetterFlowClientError, transient_failure_count
+from src.sync.sync_engine import SyncEngine
+
+# Shrunk deadline so the watchdog fires inside a test, not in 150s. The
+# production value is pinned by tests/test_sync_watchdog_budget.py.
+_TEST_DEADLINE = 0.3
+_OVERRUN = 1.2  # comfortably past _TEST_DEADLINE, so the watchdog always fires
+
+
+def _ok_stats():
+    """A SyncStats-shaped object that drives _do_sync down its success path."""
+    return SimpleNamespace(
+        success=True,
+        events_sent=0,
+        events_queued=0,
+        events_filtered=0,
+        gaps_filled=0,
+        errors=[],
+        aw_bucket_fetch_failed=False,
+    )
+
+
+class _Recorder:
+    """Records what was actually captured, instead of asserting on a Mock's args."""
+
+    def __init__(self):
+        self.captures = []
+
+    def capture(self, message, **kwargs):
+        self.captures.append({"message": message, **kwargs})
+
+    def by_fingerprint(self, fingerprint):
+        return [c for c in self.captures if c.get("fingerprint") == fingerprint]
+
+    def by_level(self, level):
+        return [c for c in self.captures if c.get("level") == level]
+
+
+def _unreachable_client() -> BetterFlowClient:
+    """A real BetterFlowClient whose transport always fails the way an offline
+    device's does: a connection error, raised WITHOUT a status_code."""
+    client = BetterFlowClient(api_url="https://example.invalid/api", token="t", device_id="d")
+    client._request = Mock(
+        side_effect=BetterFlowClientError("Cannot connect to BetterFlow API")
+    )
+    return client
+
+
+def _rejecting_client() -> BetterFlowClient:
+    """A real BetterFlowClient whose transport returns a definitive 4xx."""
+    client = BetterFlowClient(api_url="https://example.invalid/api", token="t", device_id="d")
+    client._request = Mock(
+        side_effect=BetterFlowClientError("Invalid payload", status_code=400)
+    )
+    return client
+
+
+def _one_event():
+    return [{"timestamp": "2026-07-22T12:00:00Z", "duration": 1, "bucket_id": "b", "data": {}}]
+
+
+class _CoordinatorHarness:
+    def setup_method(self):
+        self.config = Config()
+        self.aw = Mock()
+        self.aw.is_running.return_value = True
+        self.bf = Mock()
+        self.queue = Mock()
+        self.queue.get_checkpoint.return_value = None
+        self.queue.size.return_value = 0
+        self.queue.is_near_capacity.return_value = False
+        self.sync_engine = Mock(spec=SyncEngine)
+        self.sync_engine.is_paused = False
+        self.sync_engine.is_private = False
+        self.sync_engine.sync.return_value = _ok_stats()
+        self.tray = Mock()
+        self.tray.model = Mock()
+        self.tray.model.lock = threading.RLock()
+        self.aw_manager = Mock()
+        self.aw_manager.is_managing = False
+        self.reminder = Mock(spec=ReminderManager)
+        self.coord = SyncCoordinator(
+            config=self.config,
+            aw=self.aw,
+            bf=self.bf,
+            queue=self.queue,
+            sync_engine=self.sync_engine,
+            tray=self.tray,
+            aw_manager=self.aw_manager,
+            reminder_manager=self.reminder,
+        )
+        self.coord.scheduler = Mock()
+        self.coord.scheduler.running = True
+        self.recorder = _Recorder()
+        self.coord.error_reporter = self.recorder
+        self.coord._fetch_hours_today = Mock(return_value="1:00")
+        # Instance override only — the class constant stays 150s.
+        self.coord._DO_SYNC_DEADLINE = _TEST_DEADLINE
+
+    def _run_overrunning_cycle(self, before_overrun=None):
+        """Drive one real _do_sync whose body outlives the watchdog deadline."""
+
+        def _slow_sync(*_args, **_kwargs):
+            if before_overrun is not None:
+                before_overrun()
+            time.sleep(_OVERRUN)
+            return _ok_stats()
+
+        self.sync_engine.sync.side_effect = _slow_sync
+        self.coord._do_sync()
+
+
+class TestWatchdogOffline(_CoordinatorHarness):
+    """Case 1 — an overrun with transient failures is offline slowness, not a hang."""
+
+    def test_overrun_with_transient_failures_reports_warning(self):
+        def fail_transiently():
+            # The real classifier runs here: send_events catches the transport
+            # error and consults BetterFlowClientError.is_transient.
+            result = _unreachable_client().send_events(_one_event())
+            assert result.transient is True
+
+        self._run_overrunning_cycle(before_overrun=fail_transiently)
+
+        offline = self.recorder.by_fingerprint("sync-watchdog-timeout-offline")
+        assert len(offline) == 1, self.recorder.captures
+        assert offline[0]["level"] == "warning"
+        assert self.recorder.by_fingerprint("sync-watchdog-timeout") == []
+        assert self.recorder.by_level("error") == []
+        message = offline[0]["message"]
+        assert str(_TEST_DEADLINE) in message
+        assert "1 transient failure" in message
+
+    def test_offline_branch_still_resets_both_sessions(self):
+        # Unchanged by design: discarding pooled connections after a network
+        # outage is the correct recovery and was the watchdog's original purpose.
+        def fail_transiently():
+            _unreachable_client().send_events(_one_event())
+
+        self._run_overrunning_cycle(before_overrun=fail_transiently)
+
+        assert self.bf.reset_session.called
+        assert self.aw.reset_session.called
+
+
+class TestWatchdogGenuineHang(_CoordinatorHarness):
+    """Case 2 — an overrun with NO transient failures still pages as a hang.
+
+    REQUIRED by the design: this is the assertion that catches the rule being
+    implemented backwards (which would leave a real wedge reported as a warning
+    for 270s, until _SYNC_WEDGE_CEILING pages it at 420s).
+    """
+
+    def test_overrun_without_transient_failures_reports_error(self):
+        self._run_overrunning_cycle()
+
+        hung = self.recorder.by_fingerprint("sync-watchdog-timeout")
+        assert len(hung) == 1, self.recorder.captures
+        assert hung[0]["level"] == "error"
+        assert "Sync hung" in hung[0]["message"]
+        assert self.recorder.by_fingerprint("sync-watchdog-timeout-offline") == []
+
+    def test_hang_branch_still_resets_both_sessions(self):
+        self._run_overrunning_cycle()
+
+        assert self.bf.reset_session.called
+        assert self.aw.reset_session.called
+
+
+class TestTransientFailureCounter:
+    """Case 3 — the counter moves on a transient failure and not on a 4xx."""
+
+    def test_counter_increments_on_transient_failure(self):
+        before = transient_failure_count()
+        result = _unreachable_client().send_events(_one_event())
+        assert result.transient is True
+        assert transient_failure_count() == before + 1
+
+    def test_counter_does_not_move_on_definitive_4xx(self):
+        before = transient_failure_count()
+        result = _rejecting_client().send_events(_one_event())
+        assert result.transient is False
+        assert transient_failure_count() == before
+
+
+class TestWatchdogNotFired(_CoordinatorHarness):
+    """A cycle that finishes inside the deadline reports nothing either way."""
+
+    def test_fast_cycle_captures_nothing(self):
+        def fail_transiently(*_args, **_kwargs):
+            _unreachable_client().send_events(_one_event())
+            return _ok_stats()
+
+        self.sync_engine.sync.side_effect = fail_transiently
+        self.coord._do_sync()
+
+        assert self.recorder.captures == []


### PR DESCRIPTION
Implements `docs/superpowers/specs/2026-07-22-watchdog-outcome-classification-design.md` as written. No redesign.

## Problem

`SyncCoordinator._watchdog()` knows only that the cycle passed `_DO_SYNC_DEADLINE` (150s), never why — so an overrun caused by an unreachable API reported identically to a genuine wedge (`level=error`, fingerprint `sync-watchdog-timeout`, "Sync hung"). On 2026-07-22 device 18 ran a 150.86s cycle during an hour-long connectivity outage: no log gap, nothing lost, the three events went out on the next cycle. It still paged as an ERROR and pulled the autofix drafter onto a non-problem.

## Change

Two files.

`src/sync/http_client.py` — a **per-thread** counter of network-shaped failures, incremented **once per `BetterFlowClientError` object, in `__init__`**, which consults the pure `is_transient` query. `is_transient` remains the codebase's single "network problem vs definitive rejection" rule; no second classifier (`rules/one-rule-one-implementation.md`). Readers: `transient_failure_counter()` (the object) and `transient_failure_count()` (its value).

`src/main.py` — `_do_sync` captures its own thread's counter object and snapshots the value at cycle start; `_watchdog` closes over the object and compares:

| Counter | Level | Fingerprint |
|---|---|---|
| moved | `warning` | `sync-watchdog-timeout-offline` — "Sync slow — exceeded 150s while the BetterFlow API was unreachable (N transient failures this cycle)" |
| unmoved | `error` | `sync-watchdog-timeout` — "Sync hung — exceeded 150s watchdog deadline" (unchanged) |

Version bumped 1.5.106 -> 1.5.107.

### Why the count lives in `__init__` and not in the getter

Counting inside the `is_transient` getter makes the metric a function of how many times the property is **read**: one debug log of `e.is_transient`, one test asserting on it, or a second caller reading it twice, and the count inflates. Inflation is the fail-open direction on this exact signal — an inflated count makes the watchdog report a genuine hang as an outage *warning*. Counting at construction makes it once per failure, and gives the property back its purity.

Construction sites: all 11 in `src/` raise immediately, so construction and real failure coincide. Test code *does* build these speculatively as mock side-effect values; that only shifts a per-thread tally which every test reads as a delta.

### Why auth errors are excluded from the counter but NOT from `is_transient`

`BetterFlowAuthError` doesn't override `__init__` and both call sites construct it with no `status_code`, so `is_transient` is True and every 401/403 was counted as "the network was down". A device whose token expired during an overrunning cycle would report "API was unreachable" instead of the actionable condition.

Excluded from the **counter only**, via a `_COUNTS_AS_NETWORK_FAILURE` class flag. `is_transient` semantics are deliberately untouched: the offline queue relies on them to HOLD events without burning a retry, so flipping auth errors to definitive would burn retries and, past the threshold, drop real queued activity — the 2026-06-30 data-loss class (up to ~18h of spans). The counter and the classifier disagree on auth errors on purpose; the `__init__` comment and the subclass docstring both say why, and two tests pin both halves.

### Why the counter is per-thread

`_acquire_sync_slot` abandons a cycle that has held the sync lock past `_SYNC_WEDGE_CEILING` and re-arms a fresh lock, documenting that the stuck thread cannot be killed — so two `_do_sync` bodies can be live at once. A process-wide counter has no cycle identity, so the zombie cycle A's late transient failure would classify cycle B as "offline", masking a genuine wedge with a warning on the strength of a failure that wasn't B's.

Each cycle's work runs on its own thread, so attribution by thread is attribution by cycle. `_do_sync` captures its thread's counter **object** and the watchdog closure reads that — the Timer thread never re-reads a counter of its own. Side benefit: a background HTTP failure (update checker, error-report daemon) no longer classifies a sync cycle.

### Unchanged by design (from the spec, deliberate)

- Both `bf.reset_session()` / `aw.reset_session()` calls still run in **both** branches. Two tests pin this.
- `_SYNC_WEDGE_CEILING` (420s, `sync-wedged`) untouched and still ERROR — that is what makes the permissive 150s rule safe.
- `_DO_SYNC_DEADLINE` stays 150s. Classification change, not tuning.

## Test evidence

`tests/test_sync_watchdog_outcome_classification.py` drives the **real** `SyncCoordinator._do_sync` (real watchdog timer, real `is_transient` classifier via a real `BetterFlowClient` with a stubbed transport) and asserts on the reports the error reporter actually captured — never on arguments forwarded between functions. The deadline is overridden per-instance to 0.3s; the class constant is untouched and still pinned by `tests/test_sync_watchdog_budget.py`.

Every test below was written first and watched fail.

### 1. Classification (commit 1)

Pre-fix — counter landed but classification NOT yet applied, so the failure is behavioural rather than an ImportError:

```
$ PYTHONPATH=. python3 -m pytest tests/test_sync_watchdog_outcome_classification.py -q
___ TestWatchdogOffline.test_overrun_with_transient_failures_reports_warning ___
    assert len(offline) == 1, self.recorder.captures
E   AssertionError: [{'fingerprint': 'sync-watchdog-timeout', 'level': 'error',
E                     'message': 'Sync hung — exceeded 0.3s watchdog deadline',
E                     'tags': {'component': 'sync-watchdog'}}]
E   assert 0 == 1

========================= 1 failed, 6 passed in 5.05s ==========================
```

That capture is the defect verbatim. The required inverse case — overrun with **zero** transient failures still reports ERROR at `sync-watchdog-timeout` — **passed pre-fix and still passes**, which is what catches the rule being implemented backwards.

### 2. Count-per-failure, not count-per-read (commit 2)

Pre-fix (counting in the getter), reading `is_transient` three times on ONE error object moved the counter by three, and constructing an error moved it by zero:

```
_ TestTransientFailureCounter.test_counter_counts_failures_not_property_reads __
    assert transient_failure_count() == before
E   assert 5 == 2

___ TestTransientFailureCounter.test_one_failure_object_counts_exactly_once ____
    assert transient_failure_count() == before + 1
E   assert 5 == (5 + 1)

========================= 2 failed, 7 passed in 5.18s ==========================
```

### 3. Auth exclusion and cross-cycle attribution (commit 3)

Pre-fix, a foreign thread's failure downgraded a genuine hang, and an auth error moved the counter:

```
_ TestWatchdogGenuineHang.test_zombie_cycles_failures_do_not_downgrade_this_cycle _
    assert len(hung) == 1, self.recorder.captures
E   AssertionError: [{'fingerprint': 'sync-watchdog-timeout-offline', 'level': 'warning',
E                     'message': 'Sync slow — exceeded 0.3s while the BetterFlow API was
E                                 unreachable (1 transient failure this cycle)',
E                     'tags': {'component': 'sync-watchdog'}}]
E   assert 0 == 1

____ TestTransientFailureCounter.test_auth_failure_does_not_move_the_counter ____
    assert transient_failure_count() == before
E   assert 7 == 6

========================= 2 failed, 10 passed in 7.01s =========================
```

`test_auth_error_is_still_transient_for_the_queue` passed before and after — it pins the half that must NOT move.

### 4. Post-fix

```
$ PYTHONPATH=. python3 -m pytest tests/test_sync_watchdog_outcome_classification.py tests/test_sync_watchdog_budget.py -q
tests/test_sync_watchdog_outcome_classification.py ............          [ 75%]
tests/test_sync_watchdog_budget.py ....                                  [100%]
============================== 16 passed in 6.88s ==============================

$ PYTHONPATH=. python3 -m pytest -q
============================ 1261 passed in 28.08s =============================
```

Lint: `ruff check` reports **16 errors on `src/main.py` + `src/sync/http_client.py` both before and after** this change (identical I001/SIM105/B904 breakdown, verified against the HEAD copies of both files) — all pre-existing, none introduced. The new test file is clean.

## Called out, not done

- **Logged optional by the review, left alone deliberately:** the "Client has been closed" construction site, and the broader argument for a factory method instead of a constructor side effect. The inaccurate "every construction site is a raise" comment *was* corrected.
- **Scope change worth noting:** counting at construction means the counter now moves for a transient failure on **any** endpoint (heartbeat, `get_config`, ...), not only those whose caller consults `is_transient` (previously just `bf_client.send_events`). More faithful to the question the watchdog asks — "was the API unreachable during this cycle".
- **No `ruff format`** run on the touched files — the repo is not currently format-clean, so reformatting would bury the diff.
- **Not verified in a real environment.** The evidence above is unit-level. The live behaviour that matters (a 150s overrun on an actually-unreachable API producing the warning fingerprint) has not been observed on a device — *inferred* from the tests, not verified in production.
