### PR TITLE
feat(telemetry): report window-title capture state on the heartbeat [DO NOT MERGE — needs server-side reader]

### DIFF
--- a/src/__init__.py
+++ b/src/__init__.py
@@ -1,4 +1,4 @@
 """BetterFlow - ActivityWatch to BetterFlow sync companion app."""
 
-__version__ = "1.5.110"
+__version__ = "1.5.111"
 __author__ = "BetterQA"

--- a/src/aw_manager.py
+++ b/src/aw_manager.py
@@ -17,7 +17,7 @@ import urllib.parse
 import urllib.request
 import urllib.error
 import zipfile
-from datetime import datetime, timezone
+from datetime import datetime, timedelta, timezone
 from pathlib import Path
 from typing import Optional
 
@@ -116,6 +116,20 @@ WINDOW_BLIND_RETRY_INTERVAL = 1800  # 30 minutes
 # CONSECUTIVE healthy health-checks (~30s each) before trusting recovery and
 # unlatching, so a flapping source stays backed off instead of churning per flap.
 WINDOW_BLIND_CLEAR_HEALTHY_CYCLES = 3
+# Window-title capture telemetry (see
+# docs/superpowers/specs/2026-07-22-window-title-capture-telemetry-design.md).
+# "Did ANY window event in the last 15 minutes carry a non-empty title?" — a
+# platform-independent symptom check for the fault whose cause differs per OS
+# (macOS Accessibility not granted / Windows bf-window-tracker blind / Linux X11
+# watcher dead). A boolean, deliberately not a ratio: some apps legitimately
+# report an empty title (screensaver, login window, app mid-launch), so any
+# ratio threshold needs per-platform tuning and then drifts silently. On a
+# working machine the answer is yes within one tick; on a broken one it is no,
+# forever. This is VISIBILITY ONLY and must never influence tracked/billed time.
+WINDOW_TITLE_CAPTURE_LOOKBACK = 900  # 15 minutes
+# Cap the fetch: one poll every couple of seconds for 15 min is well under this,
+# and we only need to know whether ANY title arrived.
+WINDOW_TITLE_EVENT_LIMIT = 500
 # Min gap between "tracker components could not be installed" notifications /
 # error reports. start() is retried from the health-check tick, so without this
 # a fail-closed download would toast the user every cycle.
@@ -1011,6 +1025,9 @@ class AWManager:
         # tracker is still running but irrelevant). The restart count + blind flag
         # are already 0/False on this path (the restart loop is suppressed).
         afk_age = None if inproc else self._get_latest_afk_event_age()
+        # Same rule as the ages above: tracker-server I/O, no shared mutable
+        # state, so it stays OUTSIDE the lifecycle lock.
+        titles_recent = self._window_titles_captured_recently()
         return {
             # idle-tracker-only — window-tracker restarts are excluded so this
             # figure isn't inflated by an unrelated flapping window watcher.
@@ -1027,6 +1044,15 @@ class AWManager:
             # sub-second precision is irrelevant for a staleness signal.
             "afk_event_age_seconds": int(afk_age) if afk_age is not None else None,
             "window_event_age_seconds": int(window_age) if window_age is not None else None,
+            # True  => at least one window event in the last 15 min had a
+            #          non-empty title.
+            # False => window events exist but every title is empty (macOS
+            #          Accessibility missing / Windows tracker blind / Linux
+            #          watcher dead). This is the finding.
+            # None  => no window events in the period, or the probe couldn't run.
+            #          NEVER collapse None into False — "not tracking" is a
+            #          different fault, already covered by the age field above.
+            "window_titles_captured_recently": titles_recent,
             # True => the tracker binaries could not be installed (fail-closed
             # integrity check or a bad archive), so this device is capturing
             # NOTHING even though the agent looks alive.
@@ -1463,6 +1489,80 @@ class AWManager:
     def _get_latest_window_event_age(self) -> Optional[float]:
         """Return seconds since the most recent window event, or None on error."""
         return self._get_latest_event_age("aw-watcher-window")
+
+    def _window_bucket_id(self) -> str:
+        """The host's window bucket id (both the bundled bf-window-tracker and
+        the in-process macOS watcher register under this id)."""
+        return f"aw-watcher-window_{platform.node()}"
+
+    def _get_recent_window_events(self, lookback_seconds: float) -> Optional[list]:
+        """Window events whose range overlaps the last ``lookback_seconds``.
+
+        Returns None on any fetch/parse failure — an unreachable tracker server
+        must never be reported as "titles are broken" (that's a different fault,
+        already covered by ``window_event_age_seconds``).
+        """
+        now = datetime.now(timezone.utc)
+        start = now - timedelta(seconds=lookback_seconds)
+        try:
+            url = (
+                f"http://localhost:{self.aw_port}/api/0/buckets/"
+                f"{urllib.parse.quote(self._window_bucket_id(), safe='')}/events"
+                f"?limit={WINDOW_TITLE_EVENT_LIMIT}"
+                f"&start={urllib.parse.quote(start.isoformat(), safe='')}"
+                f"&end={urllib.parse.quote(now.isoformat(), safe='')}"
+            )
+            req = urllib.request.Request(url)
+            with urllib.request.urlopen(req, timeout=3) as resp:
+                events = json.loads(resp.read())
+            return events if isinstance(events, list) else None
+        except Exception as e:
+            logger.debug("_get_recent_window_events failed: %s", e)
+            return None
+
+    def _window_titles_captured_recently(self) -> Optional[bool]:
+        """Whether ANY window event in the last 15 minutes carried a title.
+
+        True  => titles are arriving (platform- and cause-independent).
+        False => window events exist but every title is empty. THIS is the
+                 finding: macOS Accessibility missing, Windows tracker blind,
+                 Linux watcher dead — one symptom, three causes, no per-platform
+                 detector needed.
+        None  => no window events in the period (or the probe could not run).
+                 Kept DISTINCT from False on purpose: "not tracking" is a
+                 different fault from "tracking without titles", and
+                 ``window_event_age_seconds`` already covers the former.
+        """
+        events = self._get_recent_window_events(WINDOW_TITLE_CAPTURE_LOOKBACK)
+        if not events:
+            return None
+
+        cutoff = time.time() - WINDOW_TITLE_CAPTURE_LOOKBACK
+        saw_event_in_window = False
+        for event in events:
+            if not isinstance(event, dict):
+                continue
+            # The server should have honoured start/end, but don't rely on it:
+            # an older AW build that ignores the params would otherwise let a
+            # title captured yesterday claim capture is healthy today.
+            try:
+                ts = datetime.fromisoformat(
+                    str(event["timestamp"]).replace("Z", "+00:00")
+                )
+                event_end = ts.timestamp() + (event.get("duration") or 0)
+            except Exception:
+                continue
+            if event_end < cutoff:
+                continue
+            saw_event_in_window = True
+            data = event.get("data")
+            if not isinstance(data, dict):
+                continue
+            title = data.get("title")
+            if isinstance(title, str) and title.strip():
+                return True
+
+        return False if saw_event_in_window else None
 
     def _component_running_seconds(self, name: str) -> Optional[float]:
         """Seconds since we last (re)started ``name``, or None if we never did."""

--- a/src/sync/bf_client.py
+++ b/src/sync/bf_client.py
@@ -382,6 +382,11 @@ class BetterFlowClient(BaseApiClient):
         "consecutive_sync_failures",
         "idle_while_active_detections",
         "sync_stale_seconds",
+        # Tri-state (True/False/null) — null means "no window events to
+        # judge", which is NOT the same as False ("events but no titles").
+        # Forwarded verbatim; the membership test is `in`, not truthiness,
+        # so a null survives the wire.
+        "window_titles_captured_recently",
         # Stable hardware identifier joining this device to the MDM asset
         # inventory. str | None — see src/hardware_serial.py.
         "hardware_serial",

--- a/tests/test_window_title_capture_telemetry.py
+++ b/tests/test_window_title_capture_telemetry.py
@@ -1,0 +1,276 @@
+"""Window-title capture telemetry — `window_titles_captured_recently`.
+
+Design: docs/superpowers/specs/2026-07-22-window-title-capture-telemetry-design.md
+
+Nothing tells us when an agent stops capturing window TITLES. Tracked time keeps
+flowing and app attribution keeps working, so every existing health field stays
+green while the title detail silently goes missing. On 2026-07-22 a manual sweep
+found 14 of the 18 measurable macOS devices running without Accessibility
+permission — `AXIsProcessTrusted()` false, every title empty, no signal anywhere.
+
+The field reports the SYMPTOM, not the per-platform cause:
+
+- ``True``  — at least one window event in the last 15 min had a non-empty title.
+- ``False`` — window events exist in that period but every title is empty.
+               (macOS Accessibility missing / Windows tracker blind / Linux
+               watcher dead — all the same user-visible fault.)
+- ``None``  — no window events at all. Deliberately DISTINCT from ``False``:
+               "not tracking" is a different fault from "tracking without
+               titles", and ``window_event_age_seconds`` already covers it.
+
+These assert on the built heartbeat payload, and drive the real HTTP/JSON parse
+path (only the *transport* is faked), so they cannot pass by inspecting an
+argument handed between two functions.
+"""
+
+import json
+import urllib.request
+from datetime import datetime, timedelta, timezone
+
+import pytest
+
+from src.aw_manager import AWManager
+
+
+class _FakeResponse:
+    def __init__(self, payload):
+        self._body = json.dumps(payload).encode()
+
+    def read(self):
+        return self._body
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *exc):
+        return False
+
+
+def _event(app, title, *, age_seconds=30.0, duration=5.0):
+    """An AW window event whose END is ``age_seconds`` ago."""
+    end = datetime.now(timezone.utc) - timedelta(seconds=age_seconds)
+    start = end - timedelta(seconds=duration)
+    return {
+        "id": 1,
+        "timestamp": start.isoformat(),
+        "duration": duration,
+        "data": {"app": app, "title": title},
+    }
+
+
+def _manager_serving(monkeypatch, events):
+    """AWManager whose window bucket serves ``events`` over the real fetch path.
+
+    The AFK/window *age* helpers are stubbed out the way the existing
+    health_snapshot tests do it — this file is about the title field only.
+    """
+    mgr = AWManager(aw_port=5600)
+    monkeypatch.setattr(mgr, "_get_latest_afk_event_age", lambda: 5.0)
+    monkeypatch.setattr(mgr, "_get_latest_window_event_age", lambda: 5.0)
+
+    seen_urls = []
+
+    def fake_urlopen(req, *args, **kwargs):
+        seen_urls.append(getattr(req, "full_url", req))
+        return _FakeResponse(events)
+
+    monkeypatch.setattr(urllib.request, "urlopen", fake_urlopen)
+    return mgr, seen_urls
+
+
+def test_true_when_a_window_event_carries_a_title(monkeypatch):
+    mgr, _ = _manager_serving(monkeypatch, [_event("Slack", "#general — BetterQA")])
+
+    assert mgr.health_snapshot()["window_titles_captured_recently"] is True
+
+
+def test_false_when_events_exist_but_every_title_is_empty(monkeypatch):
+    """The finding. App names are correct, only the TITLE is gone.
+
+    This is exactly the shape a macOS device without Accessibility permission
+    emits: `MacOSWindowWatcher._get_active_window` gets the app name from
+    NSWorkspace (no permission needed) and leaves `title` as "" because the
+    AXFocusedWindow/AXTitle round-trip fails. Same shape as a blind
+    bf-window-tracker on Windows and a dead X11 watcher on Linux.
+    """
+    mgr, _ = _manager_serving(
+        monkeypatch,
+        [
+            _event("Slack", "", age_seconds=30.0),
+            _event("Google Chrome", "", age_seconds=120.0),
+            _event("Terminal", "   ", age_seconds=200.0),  # whitespace is empty
+        ],
+    )
+
+    snap = mgr.health_snapshot()
+
+    assert snap["window_titles_captured_recently"] is False
+    # Must not be collapsed into the "not tracking at all" signal.
+    assert snap["window_titles_captured_recently"] is not None
+
+
+def test_none_when_there_are_no_window_events(monkeypatch):
+    mgr, _ = _manager_serving(monkeypatch, [])
+
+    assert mgr.health_snapshot()["window_titles_captured_recently"] is None
+
+
+def test_events_older_than_the_lookback_do_not_count(monkeypatch):
+    """A title captured yesterday says nothing about capture right now."""
+    mgr, _ = _manager_serving(
+        monkeypatch, [_event("Slack", "#general", age_seconds=3600.0)]
+    )
+
+    assert mgr.health_snapshot()["window_titles_captured_recently"] is None
+
+
+def test_recent_title_wins_over_older_empty_ones(monkeypatch):
+    mgr, _ = _manager_serving(
+        monkeypatch,
+        [
+            _event("Slack", "", age_seconds=600.0),
+            _event("Slack", "#general", age_seconds=60.0),
+        ],
+    )
+
+    assert mgr.health_snapshot()["window_titles_captured_recently"] is True
+
+
+def test_probe_failure_reports_none_not_false(monkeypatch):
+    """An unreachable tracker server must not be reported as "titles broken"."""
+    mgr = AWManager(aw_port=5600)
+    monkeypatch.setattr(mgr, "_get_latest_afk_event_age", lambda: 5.0)
+    monkeypatch.setattr(mgr, "_get_latest_window_event_age", lambda: None)
+
+    def boom(*args, **kwargs):
+        raise OSError("connection refused")
+
+    monkeypatch.setattr(urllib.request, "urlopen", boom)
+
+    assert mgr.health_snapshot()["window_titles_captured_recently"] is None
+
+
+def test_probe_asks_the_window_bucket_for_a_bounded_recent_window(monkeypatch):
+    mgr, seen_urls = _manager_serving(monkeypatch, [_event("Slack", "x")])
+
+    mgr.health_snapshot()
+
+    assert any("aw-watcher-window" in url for url in seen_urls), seen_urls
+    assert any("limit=" in url for url in seen_urls), seen_urls
+
+
+def test_field_reaches_the_heartbeat_wire():
+    """Envelope round-trip.
+
+    See memory/heartbeat-response-envelope-bug: a whole generation of heartbeat
+    features silently no-op'd because the field never survived the payload
+    boundary while the tests asserted on the wrong shape. bf_client forwards
+    only whitelisted keys, so a new health key is dropped unless it is added
+    there — assert on the request BODY.
+    """
+    responses = pytest.importorskip("responses")
+
+    from src.sync.bf_client import BetterFlowClient
+
+    @responses.activate
+    def _run():
+        responses.add(
+            responses.POST,
+            "https://betterflow.eu/api/agent/heartbeat",
+            json={"status": "active", "commands": []},
+            status=200,
+        )
+        client = BetterFlowClient(
+            api_url="https://betterflow.eu/api/agent",
+            token="test-token",
+            device_id="test-device",
+        )
+        try:
+            client.heartbeat(health={"window_titles_captured_recently": False})
+        finally:
+            client.close()
+        return json.loads(responses.calls[-1].request.body)
+
+    body = _run()
+    assert body["window_titles_captured_recently"] is False
+
+
+def test_field_reaches_the_heartbeat_wire_as_null():
+    """``None`` must survive too — it is a distinct state, not "absent"."""
+    responses = pytest.importorskip("responses")
+
+    from src.sync.bf_client import BetterFlowClient
+
+    @responses.activate
+    def _run():
+        responses.add(
+            responses.POST,
+            "https://betterflow.eu/api/agent/heartbeat",
+            json={"status": "active", "commands": []},
+            status=200,
+        )
+        client = BetterFlowClient(
+            api_url="https://betterflow.eu/api/agent",
+            token="test-token",
+            device_id="test-device",
+        )
+        try:
+            client.heartbeat(health={"window_titles_captured_recently": None})
+        finally:
+            client.close()
+        return json.loads(responses.calls[-1].request.body)
+
+    body = _run()
+    assert "window_titles_captured_recently" in body
+    assert body["window_titles_captured_recently"] is None
+
+
+# --- macOS: the exact fault the sweep found -------------------------------
+
+
+def test_macos_accessibility_denied_produces_empty_title_with_app_name(monkeypatch):
+    """The realism check behind the ``False`` fixture above.
+
+    With Accessibility denied, `AXIsProcessTrusted()` is false and every
+    `AXUIElementCopyAttributeValue` call fails — but NSWorkspace still names the
+    frontmost app. So the watcher emits {"app": <real>, "title": ""}, which is
+    what makes ``False`` (not ``None``) the right answer for that device.
+    """
+    pytest.importorskip("AppKit", reason="PyObjC not installed — macOS-only")
+    import platform as _platform
+
+    if _platform.system() != "Darwin":
+        pytest.skip("macOS-only watcher")
+
+    import ApplicationServices
+
+    from src.sync.macos_window_watcher import MacOSWindowWatcher
+
+    monkeypatch.setattr(
+        ApplicationServices, "AXIsProcessTrusted", lambda: False, raising=False
+    )
+    # Denied AX => every attribute read errors out.
+    monkeypatch.setattr(
+        ApplicationServices,
+        "AXUIElementCopyAttributeValue",
+        lambda *a, **k: (-25211, None),
+        raising=False,
+    )
+
+    from unittest.mock import MagicMock
+
+    watcher = MacOSWindowWatcher(MagicMock(), poll_interval=0.05)
+    window = watcher._get_active_window()
+
+    if window is None:
+        pytest.skip("no frontmost application in this environment")
+
+    assert window["title"] == "", window
+    assert window["app"], "app name must still be captured without Accessibility"
+
+
+def test_macos_accessibility_denied_shape_reports_false(monkeypatch):
+    """End-to-end: AX-denied event shape -> payload says ``False``, not ``None``."""
+    mgr, _ = _manager_serving(monkeypatch, [_event("Slack", "")])
+
+    assert mgr.health_snapshot()["window_titles_captured_recently"] is False


### PR DESCRIPTION
## DO NOT MERGE YET — waiting on the server-side reader

The consumer (persist `window_titles_captured_recently` on `agent_devices`, surface it as a column on `/admin/agents/fleet`) lives in **internal-tool2** and is **not built**. The design says it explicitly, and so does `rules/one-rule-one-implementation.md`: a telemetry field with no reader is the write-with-no-reader defect. Merge this only once the dashboard column ships.

Design: `docs/superpowers/specs/2026-07-22-window-title-capture-telemetry-design.md`. Agent side only, no redesign.

## What this adds

One field on the existing `AWManager.health_snapshot()` heartbeat payload:

```
"window_titles_captured_recently": true | false | null
```

| Value | Meaning |
|---|---|
| `true` | at least one window event in the last 15 minutes carried a non-empty title |
| `false` | window events exist in that period but **every** title is empty — macOS Accessibility not granted, Windows `bf-window-tracker` blind, Linux X11 watcher dead |
| `null` | no window events at all in the period, or the probe could not run |

`null` is kept strictly distinct from `false`. "Not tracking" and "tracking without titles" are different faults, and `window_event_age_seconds` already covers the former.

Boolean, not a ratio, per the spec: some apps legitimately report an empty title (screensaver, login window, app mid-launch), so any ratio threshold needs per-platform tuning and then drifts silently. "Did ANY title arrive in 15 minutes" has no threshold to get wrong.

## Files

- `src/aw_manager.py` — `_get_recent_window_events()` + `_window_titles_captured_recently()`, and the new key in `health_snapshot()`. Counters/flags stay read under `_lifecycle_lock`; the probe is tracker-server I/O with no shared mutable state, so it sits **outside** the lock next to the existing event-age fetches, same as the comments there require.
- `src/sync/bf_client.py` — the key added to the heartbeat forwarding whitelist. Without this the field is silently dropped at the payload boundary (`memory/heartbeat-response-envelope-bug`). Membership is tested with `in`, not truthiness, so a `null` survives the wire.
- `tests/test_window_title_capture_telemetry.py` — 11 tests.
- `src/__init__.py` — `1.5.106` → `1.5.107`.

Nothing in the AFK/billing path is touched. This field is visibility only and must never influence tracked or billed time.

## Test evidence

The tests assert on the **built payload** and drive the real HTTP/JSON parse path (only the transport is faked), so they cannot pass by inspecting an argument handed between two functions.

### Before (pre-implementation, tests written first)

```
$ PYTHONPATH=. python3 -m pytest tests/test_window_title_capture_telemetry.py -q
EXIT: 1
...
E   KeyError: 'window_titles_captured_recently'
E   AssertionError: assert 'window_titles_captured_recently' in {'agent_version': '1.5.106', 'timezone': 'Europe/Istanbul'}
FAILED tests/test_window_title_capture_telemetry.py::test_true_when_a_window_event_carries_a_title
FAILED tests/test_window_title_capture_telemetry.py::test_false_when_events_exist_but_every_title_is_empty
FAILED tests/test_window_title_capture_telemetry.py::test_none_when_there_are_no_window_events
FAILED tests/test_window_title_capture_telemetry.py::test_events_older_than_the_lookback_do_not_count
FAILED tests/test_window_title_capture_telemetry.py::test_recent_title_wins_over_older_empty_ones
FAILED tests/test_window_title_capture_telemetry.py::test_probe_failure_reports_none_not_false
FAILED tests/test_window_title_capture_telemetry.py::test_probe_asks_the_window_bucket_for_a_bounded_recent_window
FAILED tests/test_window_title_capture_telemetry.py::test_field_reaches_the_heartbeat_wire
FAILED tests/test_window_title_capture_telemetry.py::test_field_reaches_the_heartbeat_wire_as_null
FAILED tests/test_window_title_capture_telemetry.py::test_macos_accessibility_denied_shape_reports_false
========================= 10 failed, 1 passed in 0.38s =========================
```

The one pre-existing pass is `test_macos_accessibility_denied_produces_empty_title_with_app_name` — a **control**, not a proof of the new field. It patches `AXIsProcessTrusted` false and makes every `AXUIElementCopyAttributeValue` error, then calls the real `MacOSWindowWatcher._get_active_window()` and asserts the result is `{"app": <real app name>, "title": ""}`. That is what makes the `false` fixture realistic: without Accessibility the app name still arrives via NSWorkspace and only the TITLE is empty. It runs for real on this machine (macOS + PyObjC), not skipped.

### After

```
$ PYTHONPATH=. python3 -m pytest tests/test_window_title_capture_telemetry.py -v
tests/test_window_title_capture_telemetry.py::test_true_when_a_window_event_carries_a_title PASSED
tests/test_window_title_capture_telemetry.py::test_false_when_events_exist_but_every_title_is_empty PASSED
tests/test_window_title_capture_telemetry.py::test_none_when_there_are_no_window_events PASSED
tests/test_window_title_capture_telemetry.py::test_events_older_than_the_lookback_do_not_count PASSED
tests/test_window_title_capture_telemetry.py::test_recent_title_wins_over_older_empty_ones PASSED
tests/test_window_title_capture_telemetry.py::test_probe_failure_reports_none_not_false PASSED
tests/test_window_title_capture_telemetry.py::test_probe_asks_the_window_bucket_for_a_bounded_recent_window PASSED
tests/test_window_title_capture_telemetry.py::test_field_reaches_the_heartbeat_wire PASSED
tests/test_window_title_capture_telemetry.py::test_field_reaches_the_heartbeat_wire_as_null PASSED
tests/test_window_title_capture_telemetry.py::test_macos_accessibility_denied_produces_empty_title_with_app_name PASSED
tests/test_window_title_capture_telemetry.py::test_macos_accessibility_denied_shape_reports_false PASSED
============================== 11 passed in 0.36s ==============================
```

Full suite, no regressions:

```
$ PYTHONPATH=. python3 -m pytest
EXIT: 0
============================ 1260 passed in 21.23s =============================
```

### The tests are not phantoms — two deliberate mutations

```
# 1. collapse null into false
-        return False if saw_event_in_window else None
+        return False  # MUTATION
FAILED test_events_older_than_the_lookback_do_not_count  (assert False is None)

# 2. accept an empty string as a title
-            if isinstance(title, str) and title.strip():
+            if isinstance(title, str):  # MUTATION
FAILED test_false_when_events_exist_but_every_title_is_empty  (assert True is False)
FAILED test_macos_accessibility_denied_shape_reports_false
```

Both were reverted; the suite is green on the committed tree.

### Lint

`ruff` on the changed files introduces **zero** new findings. `src/aw_manager.py` goes 5 → 4 pre-existing errors (the previously-unused `datetime.timezone` import is now used); `src/sync/bf_client.py` keeps its 3 pre-existing `I001` import-order findings in blocks this PR does not touch; the new test file is clean.

## What I chose not to do

- **No server side.** internal-tool2 is occupied by another task. The column + persistence are the deliverable that makes this field readable, and they are not in this PR.
- **No alerting.** The spec is explicit: with ~78% of the Mac fleet currently failing, a day-one alert is a 14-device page storm. Ship the column, fix the backlog by hand, consider a threshold later.
- **No macOS Accessibility onboarding fix.** The spec scopes it as a separate change (stop the bleeding vs. stop new bleeding), and shipping them together makes both harder to verify. `src/sync/macos_window_watcher.py:358` already re-checks `AXIsProcessTrusted()` and logs the transition, and nothing acts on it — still true after this PR.
- **No real-fleet validation.** The spec names Sachi's device 16 (stalled `bf-window-tracker`) as the first validation case: it should light up `false` rather than being inferred from an alert. That cannot be checked until a build ships and the server stores the field. If it does **not** light up for her, the field is not measuring what the spec claims — treat that as the acceptance test, not this PR's green suite.

## Cost note

`health_snapshot()` now makes one extra localhost request per heartbeat (3s timeout, `limit=500`, bounded by `start`/`end`). Failures are swallowed to `null`, so an unreachable tracker server reports "unknown", never "titles broken".
