### PR TITLE
feat(build): signed+notarized macOS .pkg target for MDM deployment

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -22,6 +22,7 @@ pytest tests/test_sync_engine.py::TestSyncEngine::test_pause_resume -v
 make build            # Build for current platform (requires pyinstaller)
 make build-mac        # Build macOS .app bundle
 make dmg              # Build macOS DMG installer (requires create-dmg)
+make pkg              # Build signed+notarized macOS .pkg for MDM (see docs/SIGNING.md)
 
 # Linux build (run on Linux; needs gobject-introspection + libnotify-bin)
 make build-linux      # Build dist/BetterFlow/ one-dir bundle

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 # BetterFlow - Build Makefile
 
-.PHONY: install install-dev install-mac test lint format clean build build-mac build-windows build-linux appimage run download-aw clean-aw sign-mac notarize-mac staple-mac dmg _dmg-only ship ship-arm64 ship-x86_64 dev icons
+.PHONY: install install-dev install-mac test lint format clean build build-mac build-windows build-linux appimage run download-aw clean-aw sign-mac notarize-mac staple-mac dmg _dmg-only pkg _pkg-only ship ship-arm64 ship-x86_64 dev icons
 
 # Install production dependencies
 install:
@@ -140,6 +140,35 @@ ws = Cocoa.NSWorkspace.sharedWorkspace(); \
 img = Cocoa.NSImage.alloc().initWithContentsOfFile_(os.path.abspath('resources/icon.png')); \
 ws.setIcon_forFile_options_(img, os.path.abspath('$$dmg_path'), 0); \
 print('Custom icon set on', '$$dmg_path')"
+
+# Create an arch-suffixed, signed, notarized and stapled macOS installer
+# package. The DMG stays the download for humans and for the unmanaged
+# devices; the pkg exists solely because macOS MDM (Miradore ->
+# InstallEnterpriseApplication) can only deploy a signed .pkg.
+# See docs/superpowers/specs/2026-07-22-mdm-pkg-deployment-design.md.
+#
+# MDM bootstraps the install ONCE on a new machine; the in-app updater
+# stays the owner of "which version is running". Do not wire this into
+# the release pipeline without deciding that question first — two
+# updaters fighting over one install is a known churn failure mode.
+#
+# The pkg needs its OWN notarization pass: notarizing the .app does not
+# cover the package that contains it.
+pkg: build-mac
+	@$(MAKE) _pkg-only
+	NOTARIZE_DMG=dist/BetterFlow-macOS-$(TARGET_ARCH).pkg $(MAKE) notarize-mac
+	STAPLE_DMG=dist/BetterFlow-macOS-$(TARGET_ARCH).pkg STAPLE_APP= $(MAKE) staple-mac
+	@echo "[pkg] Created dist/BetterFlow-macOS-$(TARGET_ARCH).pkg"
+
+# Internal: wrap whatever is currently in dist/BetterFlow.app as a signed
+# dist/BetterFlow-macOS-$(TARGET_ARCH).pkg. No notarization — the `pkg`
+# target adds that. Identity is hardcoded in scripts/build-pkg.sh:
+# "Developer ID Installer: Better Quality Assurance SRL (87NVC57J44)",
+# a different certificate type from the Application identity sign-mac.sh
+# uses. The script refuses to run if the cert is missing.
+_pkg-only:
+	TARGET_ARCH=$(TARGET_ARCH) ./scripts/build-pkg.sh \
+		dist/BetterFlow.app dist/BetterFlow-macOS-$(TARGET_ARCH).pkg
 
 # Development server (auto-reload)
 dev:

--- a/docs/SIGNING.md
+++ b/docs/SIGNING.md
@@ -133,6 +133,32 @@ security find-identity -v | grep "Developer ID Installer"
 Note `security find-identity -p codesigning` does **not** list installer
 certificates; the default (all-policy) query does.
 
+### Bundle relocation must stay off
+
+`pkgbuild` marks bundles **relocatable by default**. A relocatable package does
+not install to `--install-location`: at install time PackageKit searches the
+machine for any bundle carrying the same identifier (`co.betterqa.betterflow`)
+and installs over **that** copy instead — then reports success. On a Mac holding
+a stray copy (an old install, a Downloads copy, a build artifact) the MDM push
+silently no-ops and `/Applications/BetterFlow.app` never appears.
+
+This was observed for real on 2026-07-22: the installer showed *Install
+Succeeded*, `pkgutil --pkg-info co.betterqa.betterflow` recorded 892 files at
+`location: Applications`, `/Applications/BetterFlow.app` did not exist, and
+`/var/log/install.log` showed the payload landing in a `dist/BetterFlow.app`
+inside a git worktree. It is the macOS twin of the Windows "running from
+Downloads" incident that v1.5.91 added a guard for.
+
+`scripts/build-pkg.sh` therefore builds via `pkgbuild --analyze` → set
+`BundleIsRelocatable=false` → `pkgbuild --root … --component-plist …`, and then
+asserts on the built artifact that no `PackageInfo` lists a bundle inside
+`<relocate>`. To check any pkg by hand:
+
+```bash
+pkgutil --expand BetterFlow-macOS-arm64.pkg /tmp/x
+grep -A2 '<relocate' /tmp/x/*/PackageInfo   # want an empty <relocate/>
+```
+
 The DMG stays the download for anyone outside MDM, including the unmanaged
 devices. **MDM bootstraps the install once; the in-app updater stays the owner of
 which version is running** — see

--- a/docs/SIGNING.md
+++ b/docs/SIGNING.md
@@ -102,6 +102,43 @@ gh release create v1.5.X \
     --notes-from-tag
 ```
 
+## MDM installer package (`make pkg`)
+
+macOS MDM (Miradore → `InstallEnterpriseApplication`) cannot deploy a DMG; it
+needs a **signed `.pkg`**. `make pkg` builds one from the same
+`dist/BetterFlow.app` the DMG uses:
+
+```bash
+make pkg                      # host arch
+TARGET_ARCH=x86_64 make pkg   # explicit arch
+```
+
+It runs `pkgbuild` → `productbuild` → `productsign`, then submits the pkg for
+its **own** notarization pass and staples it. Notarizing the `.app` does not
+cover the package containing it, so this is a separate submission from the one
+`make ship` does for the DMG.
+
+If `dist/BetterFlow.app` is already built and signed, `make _pkg-only` produces
+the signed (not yet notarized) pkg on its own.
+
+Signing needs a **`Developer ID Installer`** certificate — a *different*
+certificate type from the `Developer ID Application` one used above. Having one
+does not give you the other, and creating it is an Apple Developer account-holder
+task. Confirm it is present with:
+
+```bash
+security find-identity -v | grep "Developer ID Installer"
+```
+
+Note `security find-identity -p codesigning` does **not** list installer
+certificates; the default (all-policy) query does.
+
+The DMG stays the download for anyone outside MDM, including the unmanaged
+devices. **MDM bootstraps the install once; the in-app updater stays the owner of
+which version is running** — see
+`docs/superpowers/specs/2026-07-22-mdm-pkg-deployment-design.md` §2. `make pkg`
+is deliberately not wired into `make ship` or the CI release workflow.
+
 ## CI signing (GitHub Actions)
 
 `make ship` signs + notarizes on a developer Mac. CI (`.github/workflows/build.yml`)

--- a/installer/macos/distribution.xml
+++ b/installer/macos/distribution.xml
@@ -1,0 +1,36 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  productbuild distribution definition for the BetterFlow MDM installer.
+
+  The at-sign placeholders below are substituted by scripts/build-pkg.sh;
+  this file is a template and is NOT a valid distribution on its own.
+  Three are substituted: the package identifier (co.betterqa.betterflow),
+  the version read from src/__init__.py, and the filename of the pkgbuild
+  component package.
+
+  customize="never" + a hidden choice means the installer has no
+  component-selection screen: MDM (Miradore -> InstallEnterpriseApplication)
+  installs it unattended, and a human double-clicking it gets a
+  straight-through install.
+-->
+<installer-gui-script minSpecVersion="2">
+    <title>BetterFlow</title>
+    <organization>co.betterqa</organization>
+    <domains enable_anywhere="false" enable_currentUserHome="false" enable_localSystem="true"/>
+    <options customize="never" require-scripts="false" hostArchitectures="arm64,x86_64"/>
+    <volume-check>
+        <allowed-os-versions>
+            <os-version min="10.15"/>
+        </allowed-os-versions>
+    </volume-check>
+    <choices-outline>
+        <line choice="default">
+            <line choice="@IDENTIFIER@"/>
+        </line>
+    </choices-outline>
+    <choice id="default"/>
+    <choice id="@IDENTIFIER@" visible="false">
+        <pkg-ref id="@IDENTIFIER@"/>
+    </choice>
+    <pkg-ref id="@IDENTIFIER@" version="@VERSION@" onConclusion="none">@COMPONENT_PKG@</pkg-ref>
+</installer-gui-script>

--- a/scripts/build-pkg.sh
+++ b/scripts/build-pkg.sh
@@ -1,0 +1,112 @@
+#!/usr/bin/env bash
+# Build a signed macOS installer package (.pkg) from dist/BetterFlow.app.
+#
+# The DMG is the download for humans; the pkg exists because macOS MDM
+# (Miradore -> InstallEnterpriseApplication) can only deploy a signed
+# .pkg. See docs/superpowers/specs/2026-07-22-mdm-pkg-deployment-design.md.
+#
+#   pkgbuild     -> component package (the .app, installed to /Applications)
+#   productbuild -> distribution package (what MDM and Installer.app accept)
+#   productsign  -> signs it with the Developer ID INSTALLER identity
+#
+# The installer identity is a DIFFERENT certificate type from the
+# Developer ID Application identity used by scripts/sign-mac.sh. Both
+# live under Team 87NVC57J44. Identity is hardcoded for the same reason
+# it is in sign-mac.sh: there is exactly one valid one.
+#
+# This script does NOT notarize. The pkg needs its own notarization pass
+# (notarizing the .app does not cover the package containing it) — the
+# `pkg` make target runs scripts/notarize-mac.py and staples afterwards.
+#
+# Usage:
+#   ./scripts/build-pkg.sh [APP] [OUTPUT_PKG]
+# Defaults:
+#   APP=dist/BetterFlow.app  OUTPUT_PKG=dist/BetterFlow-macOS-<arch>.pkg
+
+set -euo pipefail
+
+IDENTITY="Developer ID Installer: Better Quality Assurance SRL (87NVC57J44)"
+PKG_IDENTIFIER="co.betterqa.betterflow"
+DISTRIBUTION_TEMPLATE="installer/macos/distribution.xml"
+
+APP="${1:-dist/BetterFlow.app}"
+DEFAULT_ARCH="$(uname -m | sed 's/aarch64/arm64/')"
+OUTPUT_PKG="${2:-dist/BetterFlow-macOS-${TARGET_ARCH:-$DEFAULT_ARCH}.pkg}"
+
+if [ ! -d "$APP" ]; then
+    echo "[build-pkg] $APP not found — run make build-mac first" >&2
+    exit 1
+fi
+
+if [ ! -f "$DISTRIBUTION_TEMPLATE" ]; then
+    echo "[build-pkg] Distribution template not found: $DISTRIBUTION_TEMPLATE" >&2
+    echo "[build-pkg] Run this script from the repo root, not from scripts/" >&2
+    exit 1
+fi
+
+# `security find-identity -p codesigning` does NOT list installer certs —
+# they carry a different policy. Query the default (all) policy instead.
+if ! security find-identity -v | grep -q "Developer ID Installer: Better Quality Assurance SRL (87NVC57J44)"; then
+    echo "[build-pkg] Developer ID Installer cert for Team 87NVC57J44 not in Keychain" >&2
+    echo "[build-pkg] It is a separate certificate from the Developer ID Application" >&2
+    echo "[build-pkg] one used by sign-mac.sh, and is created by the Apple Developer" >&2
+    echo "[build-pkg] account holder. See docs/SIGNING.md." >&2
+    exit 1
+fi
+
+# Wrapping an unsigned or broken .app produces a pkg that signs fine and
+# then fails notarization ~10 minutes later. Fail here instead.
+if ! codesign --verify --strict "$APP" 2>/dev/null; then
+    echo "[build-pkg] $APP is not validly signed — run ./scripts/sign-mac.sh first" >&2
+    exit 1
+fi
+
+# src/__init__.py is the single source of truth for the version (build.spec
+# reads it the same way).
+VERSION="$(python3 -c "
+import re, pathlib, sys
+m = re.search(r'__version__\s*=\s*[\"\']([^\"\']+)[\"\']', pathlib.Path('src/__init__.py').read_text())
+if not m:
+    sys.exit('could not parse __version__ from src/__init__.py')
+print(m.group(1))
+")"
+
+echo "[build-pkg] App:        $APP"
+echo "[build-pkg] Version:    $VERSION"
+echo "[build-pkg] Identifier: $PKG_IDENTIFIER"
+echo "[build-pkg] Output:     $OUTPUT_PKG"
+
+WORKDIR="$(mktemp -d -t betterflow-pkg)"
+cleanup() { rm -rf "$WORKDIR"; }
+trap cleanup EXIT
+
+COMPONENT_PKG_NAME="BetterFlow-component.pkg"
+
+echo "[build-pkg] pkgbuild — component package"
+pkgbuild \
+    --component "$APP" \
+    --install-location /Applications \
+    --identifier "$PKG_IDENTIFIER" \
+    --version "$VERSION" \
+    "$WORKDIR/$COMPONENT_PKG_NAME"
+
+echo "[build-pkg] productbuild — distribution package"
+sed -e "s|@IDENTIFIER@|$PKG_IDENTIFIER|g" \
+    -e "s|@VERSION@|$VERSION|g" \
+    -e "s|@COMPONENT_PKG@|$COMPONENT_PKG_NAME|g" \
+    "$DISTRIBUTION_TEMPLATE" > "$WORKDIR/distribution.xml"
+
+productbuild \
+    --distribution "$WORKDIR/distribution.xml" \
+    --package-path "$WORKDIR" \
+    "$WORKDIR/BetterFlow-unsigned.pkg"
+
+echo "[build-pkg] productsign — Developer ID Installer"
+mkdir -p "$(dirname "$OUTPUT_PKG")"
+rm -f "$OUTPUT_PKG"
+productsign --sign "$IDENTITY" "$WORKDIR/BetterFlow-unsigned.pkg" "$OUTPUT_PKG"
+
+echo "[build-pkg] Verifying package signature"
+pkgutil --check-signature "$OUTPUT_PKG"
+
+echo "[build-pkg] Created $OUTPUT_PKG (signed, NOT yet notarized)"

--- a/scripts/build-pkg.sh
+++ b/scripts/build-pkg.sh
@@ -5,7 +5,10 @@
 # (Miradore -> InstallEnterpriseApplication) can only deploy a signed
 # .pkg. See docs/superpowers/specs/2026-07-22-mdm-pkg-deployment-design.md.
 #
-#   pkgbuild     -> component package (the .app, installed to /Applications)
+#   pkgbuild     -> component package (the .app, installed to /Applications),
+#                   built from a staging root + a component plist that sets
+#                   BundleIsRelocatable=false (see the long note below —
+#                   without it the install silently no-ops)
 #   productbuild -> distribution package (what MDM and Installer.app accept)
 #   productsign  -> signs it with the Developer ID INSTALLER identity
 #
@@ -82,9 +85,60 @@ trap cleanup EXIT
 
 COMPONENT_PKG_NAME="BetterFlow-component.pkg"
 
+# --- Bundle relocation must be OFF -------------------------------------
+#
+# pkgbuild marks every bundle it packages BundleIsRelocatable=true by
+# default. At install time PackageKit then SEARCHES the machine (Spotlight
+# + the receipt database) for any bundle carrying the same identifier
+# (co.betterqa.betterflow) and installs OVER THAT COPY, silently ignoring
+# --install-location. On a Mac with a stray or old BetterFlow.app anywhere
+# — a Downloads copy, a build artifact, an old install — the MDM push
+# reports "Install Succeeded" and /Applications/BetterFlow.app never
+# appears. Observed 2026-07-22: a real install "succeeded" into a
+# dist/BetterFlow.app inside a git worktree.
+#
+# Relocation cannot be turned off on the pkgbuild command line; it is a
+# property of the component, so we have to --analyze into a component
+# plist, flip the flag, and hand that back with --component-plist. That
+# in turn requires --root (a staging tree) rather than --component.
+STAGING="$WORKDIR/root"
+mkdir -p "$STAGING"
+# ditto, not cp: it preserves the code signature's extended attributes.
+ditto "$APP" "$STAGING/$(basename "$APP")"
+
+COMPONENT_PLIST="$WORKDIR/component.plist"
+echo "[build-pkg] pkgbuild --analyze — component property list"
+pkgbuild --analyze --root "$STAGING" "$COMPONENT_PLIST"
+
+python3 - "$COMPONENT_PLIST" <<'PY'
+import plistlib, sys
+
+path = sys.argv[1]
+with open(path, "rb") as fh:
+    components = plistlib.load(fh)
+if not components:
+    sys.exit("[build-pkg] pkgbuild --analyze produced an empty component list")
+for component in components:
+    component["BundleIsRelocatable"] = False
+with open(path, "wb") as fh:
+    plistlib.dump(components, fh)
+
+# Read it back rather than trusting the write.
+with open(path, "rb") as fh:
+    written = plistlib.load(fh)
+bad = [c for c in written if c.get("BundleIsRelocatable") is not False]
+if bad:
+    sys.exit("[build-pkg] BundleIsRelocatable is still set on: %s" % bad)
+print("[build-pkg] BundleIsRelocatable=false on %d component(s)" % len(written))
+PY
+
+echo "[build-pkg] Component plist:"
+plutil -p "$COMPONENT_PLIST"
+
 echo "[build-pkg] pkgbuild — component package"
 pkgbuild \
-    --component "$APP" \
+    --root "$STAGING" \
+    --component-plist "$COMPONENT_PLIST" \
     --install-location /Applications \
     --identifier "$PKG_IDENTIFIER" \
     --version "$VERSION" \
@@ -108,5 +162,45 @@ productsign --sign "$IDENTITY" "$WORKDIR/BetterFlow-unsigned.pkg" "$OUTPUT_PKG"
 
 echo "[build-pkg] Verifying package signature"
 pkgutil --check-signature "$OUTPUT_PKG"
+
+# Assert against the ARTIFACT, not against the plist we wrote. A relocatable
+# component lists the bundle inside <relocate> in its PackageInfo:
+#     <relocate><bundle id="co.betterqa.betterflow"/></relocate>
+# A non-relocatable one leaves that element empty (<relocate/>). This is the
+# check that would have caught the silent no-op install, so it runs on every
+# build.
+echo "[build-pkg] Verifying the package does not permit bundle relocation"
+EXPANDED="$WORKDIR/expanded"
+pkgutil --expand "$OUTPUT_PKG" "$EXPANDED"
+python3 - "$EXPANDED" <<'PY'
+import pathlib, sys
+import xml.etree.ElementTree as ET
+
+root = pathlib.Path(sys.argv[1])
+package_infos = sorted(root.rglob("PackageInfo"))
+if not package_infos:
+    sys.exit("[build-pkg] FAIL: no PackageInfo found in the expanded package")
+
+offenders = []
+for package_info in package_infos:
+    for relocate in ET.parse(package_info).getroot().iter("relocate"):
+        for bundle in relocate.findall("bundle"):
+            offenders.append("%s: %s" % (package_info.name, bundle.get("id")))
+
+if offenders:
+    sys.stderr.write(
+        "[build-pkg] FAIL: the built package still declares bundles relocatable:\n"
+        + "".join("  %s\n" % o for o in offenders)
+        + "[build-pkg] PackageKit would install over an existing copy of that\n"
+        "[build-pkg] identifier found anywhere on the target Mac and report\n"
+        "[build-pkg] success without ever touching /Applications.\n"
+    )
+    sys.exit(1)
+
+print(
+    "[build-pkg] OK: %d PackageInfo file(s), no bundle marked relocatable"
+    % len(package_infos)
+)
+PY
 
 echo "[build-pkg] Created $OUTPUT_PKG (signed, NOT yet notarized)"


### PR DESCRIPTION
Implements step 2 of `docs/superpowers/specs/2026-07-22-mdm-pkg-deployment-design.md`.

macOS MDM (Miradore → `InstallEnterpriseApplication`) cannot deploy a DMG — it needs a signed `.pkg`. The blocker was the missing **Developer ID Installer** certificate; it was created 2026-07-22 (valid to 2027-02-01, Team 87NVC57J44) and is now in the Keychain.

> **A human still has to run the install test before this ships to Miradore.** What is proven below is that the package now *declares itself non-relocatable* — not that a real install lands in `/Applications`. See the last section.

## The defect this branch shipped with, and the fix (commit `13d00de`)

### Reproduced on a real Mac, not theoretical

The first version of this branch built a package that installed "successfully" and delivered nothing:

- Installer showed **Install Succeeded**
- `pkgutil --pkg-info co.betterqa.betterflow` → `version: 1.5.106`, `volume: /`, `location: Applications`
- `pkgutil --files co.betterqa.betterflow` listed **892 files**
- `/Applications/BetterFlow.app` **did not exist**, and Spotlight found no copy anywhere except a build artifact

`/var/log/install.log` gives the mechanism:

```
PackageKit: Touched bundle /Users/brad/Code2/betterflow-sync/.claude/worktrees/agent-a86b64b46e99ab77e/dist/BetterFlow.app
Installed "BetterFlow" ()
PackageKit: Registered bundle file:///Users/brad/.../dist/BetterFlow.app/ for uid 501
Displaying 'Install Succeeded' UI.
```

### Cause: bundle relocation

`pkgbuild` marks every bundle it packages `BundleIsRelocatable=true` **by default**. At install time PackageKit then searches the machine for an existing bundle carrying the same identifier (`co.betterqa.betterflow`) and installs over **that** copy, ignoring `--install-location`. Here it found a build artifact inside a git worktree and "installed" there.

Confirmed in the pre-fix artifact's own `PackageInfo`:

```
$ pkgutil --expand dist/BetterFlow-macOS-arm64.pkg /tmp/oldpkg
$ grep -A2 '<relocate' /tmp/oldpkg/BetterFlow-component.pkg/PackageInfo
    <relocate>
        <bundle id="co.betterqa.betterflow"/>
    </relocate>
```

This is fleet-critical: on any Mac carrying an old or stray copy of BetterFlow.app anywhere, the MDM install silently no-ops while reporting success. It is the macOS twin of the Windows incident where the agent ran and self-updated out of a Downloads folder (v1.5.91 added a guard for that one).

### The fix

Relocation cannot be turned off on the `pkgbuild` command line — it is a property of the component — so `scripts/build-pkg.sh` now:

1. stages the app into a temp root (`ditto`, which preserves the signature's extended attributes),
2. `pkgbuild --analyze --root <staging>` → component plist,
3. sets `BundleIsRelocatable=false` on every component, then **reads the plist back** to confirm the write,
4. `pkgbuild --root <staging> --component-plist <plist> --install-location /Applications …`,
5. **asserts on the built artifact** that no `PackageInfo` lists a bundle inside `<relocate>`, failing the build if one does.

`--component` and `--component-plist` are mutually exclusive, which is what forces the invocation-style change. Everything else is untouched: identifier, version parsing from `src/__init__.py`, `productbuild --distribution`, `productsign` with `Developer ID Installer: Better Quality Assurance SRL (87NVC57J44)`, and the existing preflight guards.

The payload is unaffected by the switch to `--root`:

```
$ pkgutil --payload-files <pre-fix>.pkg  | wc -l      893
$ pkgutil --payload-files <post-fix>.pkg | wc -l      893
$ pkgutil --payload-files <post-fix>.pkg | head -2
.
./BetterFlow.app
```

## What the branch adds overall

- `make pkg` — `build-mac` → package → **its own** notarization pass → staple. Output `dist/BetterFlow-macOS-$(TARGET_ARCH).pkg`.
- `make _pkg-only` — packages an already-built `dist/BetterFlow.app` without notarizing (mirrors `_dmg-only`).
- `scripts/build-pkg.sh` — non-relocatable `pkgbuild` → `productbuild --distribution` → `productsign`.
- `installer/macos/distribution.xml` — productbuild distribution template, `customize="never"` so the install is unattended.
- `docs/SIGNING.md` §MDM installer package, now including a "Bundle relocation must stay off" subsection, plus one line in `CLAUDE.md`.

Notarizing the `.app` does **not** cover the package containing it, so the pkg is submitted separately via the existing `scripts/notarize-mac.py`.

**Not changed:** the `dmg` target, the auto-updater, `make ship`, and the CI release workflow. Per §2 of the spec, MDM bootstraps the install once and the in-app updater stays the owner of which version is running.

## Verification — fresh `make pkg`, arm64, v1.5.106

Full run from a clean `dist/`, exit code captured to a file rather than trusted from a pipeline: `make pkg > log 2>&1; echo "EXIT=$?" > status` → `EXIT=0`.

Component plist the build generated (`plutil -p`, from the build log):

```
[build-pkg] pkgbuild --analyze — component property list
[build-pkg] BundleIsRelocatable=false on 1 component(s)
[build-pkg] Component plist:
[
  0 => {
    "BundleHasStrictIdentifier" => 1
    "BundleIsRelocatable" => 0
    "BundleIsVersionChecked" => 1
    "BundleOverwriteAction" => "upgrade"
    "ChildBundles" => [ … 3 nested Python.framework entries … ]
    "RootRelativeBundlePath" => "BetterFlow.app"
  }
]
```

The assertion that actually proves the fix — the built package's own `PackageInfo`:

```
$ pkgutil --expand dist/BetterFlow-macOS-arm64.pkg /tmp/newpkg
$ grep -B1 -A3 relocate /tmp/newpkg/BetterFlow-component.pkg/PackageInfo
    </strict-identifier>
    <relocate/>
</pkg-info>
```

Empty `<relocate/>` — nothing for PackageKit to relocate onto. Pre-fix, that element listed `co.betterqa.betterflow`.

The in-build guard discriminates (negative control — the same check run against both artifacts):

```
pre-fix  pkg → FAIL: PackageInfo: co.betterqa.betterflow                  EXIT 1
post-fix pkg → OK: 1 PackageInfo file(s), no bundle marked relocatable    EXIT 0
```

It caught a real mistake on its first run: an earlier, cruder version of the check grepped for the string `<relocate` and fired on the harmless empty `<relocate/>`. It now parses the XML and looks for `<bundle>` children.

Signature, notarization and staple are still good on the fresh artifact:

```
$ spctl -a -vv -t install dist/BetterFlow-macOS-arm64.pkg
dist/BetterFlow-macOS-arm64.pkg: accepted
source=Notarized Developer ID
origin=Developer ID Installer: Better Quality Assurance SRL (87NVC57J44)
EXIT=0

$ pkgutil --check-signature dist/BetterFlow-macOS-arm64.pkg
   Status: signed by a developer certificate issued by Apple for distribution
   Notarization: trusted by the Apple notary service
   Signed with a trusted timestamp on: 2026-07-22 18:11:56 +0000
   Certificate Chain:
    1. Developer ID Installer: Better Quality Assurance SRL (87NVC57J44)
       Expires: 2027-02-01 22:12:15 +0000

$ xcrun stapler validate dist/BetterFlow-macOS-arm64.pkg
The validate action worked!
```

Notary submission `d384c620-52c0-4f91-951d-f76b65967805` — **Accepted**. The Apple account-agreement problem from `memory/apple-agreement-blocks-notarization` is not currently in effect.

## Still requires a human install test — do not ship to Miradore before it

**Not proven here, and it is the spec's step-2 acceptance criterion:** that a real install of this package lands `/Applications/BetterFlow.app`. That needs a Mac and an admin password, so a human has to run it.

Run it ideally on a Mac that **does** carry a stray copy of BetterFlow.app somewhere, since that is exactly the condition the old package failed under, and confirm afterwards:

```bash
sudo installer -pkg BetterFlow-macOS-arm64.pkg -target /
ls -ld /Applications/BetterFlow.app                        # must exist
grep -i "Touched bundle" /var/log/install.log | tail -3    # must name /Applications
pkgutil --pkg-info co.betterqa.betterflow
```

Also still unverified, carried over from the original branch:

- **x86_64.** Only arm64 was built and packaged here. Nothing in the script is arch-specific beyond the filename suffix, but that is inference, not a measurement.
- **That the MDM-installed build still self-updates** (spec §Verification, third bullet).
- Pairing with the `BetterFlow - Accessibility (PPPC)` profile.
