### PR TITLE
feat(telemetry): report the hardware serial on the heartbeat, and show it in the tray

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -92,6 +92,32 @@ The OS keychain holds the auth token (never on disk / in config). If raw titles
 must never leave the device, that requires client-side hashing/redaction, which
 is **not implemented** — track it as a feature, not an assumed guarantee.
 
+#### Device identifiers sent on the heartbeat
+
+Alongside activity data the agent reports identifiers describing the *machine*,
+not the person using it:
+
+- `device_id` — a `sync:<uuid>` generated on this device at first run.
+- `hardware_serial` (`src/hardware_serial.py`) — the machine's hardware serial:
+  `IOPlatformSerialNumber` on macOS, `Win32_BIOS.SerialNumber` on Windows,
+  `/sys/class/dmi/id/product_serial` on Linux. Read once at startup and cached;
+  no permission is requested or required, and an unreadable serial is reported
+  as `null` rather than retried. **Why it is collected:** the MDM asset
+  inventory keys company laptops by serial while the agent keyed itself by a
+  random UUID, so the two systems could not be joined and "is this machine
+  managed?" could only be guessed at by matching people's names. **Scope:**
+  asset correlation only. It identifies hardware, never an individual, it does
+  not affect tracked or billed time, and it must not reach a client-facing
+  surface. A VM, a container or a locked-down Linux box legitimately reports
+  `null`.
+- `timezone`, `agent_version`, and the tracker-health telemetry (restart counts,
+  event ages, sync staleness).
+
+`src/sync/bf_client.py`'s `HEARTBEAT_HEALTH_KEYS` is the complete, enforced list
+of what the heartbeat forwards — a field missing from it never leaves the
+machine. Treat that tuple as the source of truth when auditing egress, and
+update this section whenever it changes.
+
 ### Configuration Storage
 
 - **Config**: `~/Library/Application Support/BetterFlow/config.json` (macOS) or `%APPDATA%\BetterQA\BetterFlow\config.json` (Windows)

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -113,6 +113,13 @@ not the person using it:
 - `timezone`, `agent_version`, and the tracker-health telemetry (restart counts,
   event ages, sync staleness).
 
+The serial is shown back to the user in the tray under **Diagnostics > Device
+serial**, next to the Privacy Policy link, and clicking it copies the value.
+Displaying the literal string we hold is the disclosure that actually carries
+weight — a first-run wizard bullet is read once and forgotten. It renders as
+`Device serial: unavailable` when the probe found nothing, never blank and never
+`None`. Keep that row in step with what is actually sent.
+
 `src/sync/bf_client.py`'s `HEARTBEAT_HEALTH_KEYS` is the complete, enforced list
 of what the heartbeat forwards — a field missing from it never leaves the
 machine. Treat that tuple as the source of truth when auditing egress, and

--- a/src/__init__.py
+++ b/src/__init__.py
@@ -1,4 +1,4 @@
 """BetterFlow - ActivityWatch to BetterFlow sync companion app."""
 
-__version__ = "1.5.109"
+__version__ = "1.5.110"
 __author__ = "BetterQA"

--- a/src/clipboard.py
+++ b/src/clipboard.py
@@ -1,0 +1,87 @@
+"""Minimal clipboard writer for the tray's copyable menu items.
+
+No new dependency: this shells out to the platform's own clipboard tool. The
+tray runs headless-ish inside pystray, and the obvious alternative — spinning a
+tkinter root purely to reach ``clipboard_append`` — is unsafe off the main
+thread on macOS. Small subprocess, no import-time cost, nothing to bundle.
+
+``clipboard_available()`` exists so callers can decide whether to *offer* a copy
+affordance at all. A menu item that looks clickable and silently does nothing is
+worse than an inert one, and on Linux a clipboard tool genuinely may not be
+installed (a bare Wayland/X session with neither wl-copy nor xclip nor xsel).
+"""
+
+import logging
+import platform
+import shutil
+import subprocess
+from typing import Optional
+
+logger = logging.getLogger(__name__)
+
+# Linux has no single answer; try Wayland first, then the two X11 classics.
+# Each entry is (executable, full argv).
+_LINUX_CANDIDATES = (
+    ("wl-copy", ["wl-copy"]),
+    ("xclip", ["xclip", "-selection", "clipboard"]),
+    ("xsel", ["xsel", "--clipboard", "--input"]),
+)
+
+
+def _clipboard_command() -> Optional[list]:
+    """Resolve the argv that writes stdin to the clipboard, or None."""
+    system = platform.system()
+
+    if system == "Darwin":
+        # Absolute path: pbcopy is always here, and the agent's PATH under a
+        # LaunchAgent is not the user's shell PATH.
+        return ["/usr/bin/pbcopy"] if shutil.which("/usr/bin/pbcopy") else None
+
+    if system == "Windows":
+        exe = shutil.which("clip")
+        return [exe] if exe else None
+
+    if system == "Linux":
+        for name, argv in _LINUX_CANDIDATES:
+            if shutil.which(name):
+                return argv
+        return None
+
+    return None
+
+
+def clipboard_available() -> bool:
+    """True when this machine has a clipboard tool we can drive."""
+    return _clipboard_command() is not None
+
+
+def copy_to_clipboard(text: str) -> bool:
+    """Put ``text`` on the system clipboard. Returns success, never raises.
+
+    A failed copy is a cosmetic disappointment, not an incident — the value is
+    also rendered in the menu label the user just clicked.
+    """
+    cmd = _clipboard_command()
+    if cmd is None:
+        logger.debug("no clipboard tool available on this platform")
+        return False
+
+    kwargs = {}
+    if platform.system() == "Windows":
+        startupinfo = subprocess.STARTUPINFO()
+        startupinfo.dwFlags |= subprocess.STARTF_USESHOWWINDOW
+        kwargs["startupinfo"] = startupinfo
+        kwargs["creationflags"] = subprocess.CREATE_NO_WINDOW
+
+    try:
+        result = subprocess.run(
+            cmd, input=text, text=True, capture_output=True, timeout=5, **kwargs
+        )
+    except Exception as e:  # noqa: BLE001 — a copy is never worth a crash
+        logger.debug("clipboard write failed: %s", e)
+        return False
+
+    if result.returncode != 0:
+        logger.debug("clipboard tool %s exited %s", cmd[0], result.returncode)
+        return False
+    return True

--- a/src/hardware_serial.py
+++ b/src/hardware_serial.py
@@ -1,0 +1,228 @@
+"""Hardware serial number probe — the fleet's join key to the MDM inventory.
+
+The MDM (Miradore) identifies a laptop by its hardware serial; the agent
+identifies itself as ``sync:<uuid>`` generated at first run. Nothing joined the
+two, so "which agent devices are not managed?" could only be answered by fuzzy
+name matching across two systems that disagree on name order — exactly the kind
+of instrument that produces a confident wrong answer. Reporting the serial makes
+that question a join.
+
+Design notes that matter:
+
+- **``None`` is a first-class value, not an error.** A VM, a container, a
+  locked-down Linux box (``/sys/class/dmi/id/product_serial`` is usually
+  root-only) and a plain failed probe all legitimately have no serial. Nothing
+  here may raise into the sync or heartbeat path.
+- **Probed once and cached, including a failure.** The serial cannot change for
+  the life of the machine, so a per-heartbeat probe is pure waste — and a failed
+  probe that retried would spawn a subprocess every heartbeat forever.
+- This is hardware identification only. It says nothing about the person using
+  the machine and never touches tracked or billed time.
+
+See ``docs/superpowers/specs/2026-07-22-hardware-serial-reporting-design.md``.
+"""
+
+import logging
+import platform
+import subprocess
+import threading
+from typing import Optional
+
+logger = logging.getLogger(__name__)
+
+# Values firmware vendors and hypervisors write when no serial was ever
+# programmed. They are placeholders, not identifiers, and joining on them would
+# merge unrelated machines into one MDM row.
+_PLACEHOLDER_SERIALS = {
+    "",
+    "0",
+    "00000000",
+    "default string",
+    "none",
+    "not applicable",
+    "not available",
+    "not specified",
+    "n/a",
+    "o.e.m.",
+    "system serial number",
+    "to be filled by o.e.m.",
+    "unknown",
+}
+
+_LINUX_DMI_PATH = "/sys/class/dmi/id/product_serial"
+
+# Guards the memo below. Probing is cheap but not free (a subprocess on
+# Windows), and the heartbeat can be driven from two scheduler threads.
+_lock = threading.Lock()
+_cached: Optional[str] = None
+_probed = False
+
+
+def get_hardware_serial() -> Optional[str]:
+    """Return this machine's hardware serial, or ``None``.
+
+    Probed at most once per process. Never raises: any failure — unsupported
+    platform, missing permission, absent firmware field — is a ``None``.
+    """
+    global _cached, _probed
+
+    with _lock:
+        if _probed:
+            return _cached
+        try:
+            raw = _probe_serial()
+        except Exception as e:  # noqa: BLE001 — a serial is never worth a crash
+            logger.debug("hardware serial probe failed: %s", e)
+            raw = None
+        _cached = _normalise(raw)
+        _probed = True
+        if _cached is None:
+            logger.debug("no hardware serial available on this machine")
+        return _cached
+
+
+def reset_cache_for_tests() -> None:
+    """Drop the memo. Tests only — the serial never changes at runtime."""
+    global _cached, _probed
+    with _lock:
+        _cached = None
+        _probed = False
+
+
+def _normalise(raw: Optional[str]) -> Optional[str]:
+    """Trim, then reject firmware placeholders. Junk in, ``None`` out."""
+    if raw is None:
+        return None
+    value = raw.strip()
+    if not value or value.lower() in _PLACEHOLDER_SERIALS:
+        return None
+    return value
+
+
+def _probe_serial() -> Optional[str]:
+    """Dispatch to the per-platform probe. May raise; the caller absorbs it."""
+    system = platform.system()
+    if system == "Darwin":
+        return _probe_macos()
+    if system == "Windows":
+        return _probe_windows()
+    if system == "Linux":
+        return _probe_linux()
+    return None
+
+
+def _probe_macos() -> Optional[str]:
+    """Read ``IOPlatformSerialNumber`` off ``IOPlatformExpertDevice``.
+
+    Straight IOKit via ctypes rather than pyobjc-framework-IOKit: it is the same
+    registry read, needs no permission and no extra dependency in the bundle.
+    """
+    import ctypes
+    import ctypes.util
+
+    iokit_path = ctypes.util.find_library("IOKit")
+    cf_path = ctypes.util.find_library("CoreFoundation")
+    if not iokit_path or not cf_path:
+        return None
+
+    iokit = ctypes.CDLL(iokit_path)
+    cf = ctypes.CDLL(cf_path)
+
+    cf.CFStringCreateWithCString.restype = ctypes.c_void_p
+    cf.CFStringCreateWithCString.argtypes = [
+        ctypes.c_void_p, ctypes.c_char_p, ctypes.c_uint32
+    ]
+    cf.CFStringGetCString.restype = ctypes.c_bool
+    cf.CFStringGetCString.argtypes = [
+        ctypes.c_void_p, ctypes.c_char_p, ctypes.c_long, ctypes.c_uint32
+    ]
+    cf.CFRelease.argtypes = [ctypes.c_void_p]
+
+    iokit.IOServiceMatching.restype = ctypes.c_void_p
+    iokit.IOServiceMatching.argtypes = [ctypes.c_char_p]
+    iokit.IOServiceGetMatchingService.restype = ctypes.c_uint32
+    iokit.IOServiceGetMatchingService.argtypes = [ctypes.c_uint32, ctypes.c_void_p]
+    iokit.IORegistryEntryCreateCFProperty.restype = ctypes.c_void_p
+    iokit.IORegistryEntryCreateCFProperty.argtypes = [
+        ctypes.c_uint32, ctypes.c_void_p, ctypes.c_void_p, ctypes.c_uint32
+    ]
+    iokit.IOObjectRelease.restype = ctypes.c_int
+    iokit.IOObjectRelease.argtypes = [ctypes.c_uint32]
+
+    k_cf_string_encoding_utf8 = 0x08000100
+
+    # IOServiceGetMatchingService CONSUMES the matching dictionary — do not
+    # release it ourselves or this is a double-free.
+    matching = iokit.IOServiceMatching(b"IOPlatformExpertDevice")
+    if not matching:
+        return None
+    # kIOMainPortDefault is 0 (a.k.a. the deprecated kIOMasterPortDefault).
+    service = iokit.IOServiceGetMatchingService(0, matching)
+    if not service:
+        return None
+
+    key = None
+    prop = None
+    try:
+        key = cf.CFStringCreateWithCString(
+            None, b"IOPlatformSerialNumber", k_cf_string_encoding_utf8
+        )
+        if not key:
+            return None
+        prop = iokit.IORegistryEntryCreateCFProperty(service, key, None, 0)
+        if not prop:
+            return None
+        buf = ctypes.create_string_buffer(128)
+        if not cf.CFStringGetCString(
+            prop, buf, ctypes.sizeof(buf), k_cf_string_encoding_utf8
+        ):
+            return None
+        return buf.value.decode("utf-8", errors="replace")
+    finally:
+        if prop:
+            cf.CFRelease(ctypes.c_void_p(prop))
+        if key:
+            cf.CFRelease(ctypes.c_void_p(key))
+        iokit.IOObjectRelease(service)
+
+
+def _probe_windows() -> Optional[str]:
+    """Read ``Win32_BIOS.SerialNumber`` via WMI.
+
+    Goes through PowerShell's CIM cmdlet rather than ``wmic``, which is
+    deprecated and absent from recent Windows builds. No console window: this
+    runs on the startup path of a tray app.
+    """
+    startupinfo = subprocess.STARTUPINFO()
+    startupinfo.dwFlags |= subprocess.STARTF_USESHOWWINDOW
+
+    result = subprocess.run(
+        [
+            "powershell", "-NoProfile", "-NonInteractive", "-Command",
+            "(Get-CimInstance -ClassName Win32_BIOS).SerialNumber",
+        ],
+        capture_output=True,
+        text=True,
+        timeout=20,
+        startupinfo=startupinfo,
+        creationflags=subprocess.CREATE_NO_WINDOW,
+    )
+    if result.returncode != 0:
+        logger.debug("Win32_BIOS query failed (rc=%s)", result.returncode)
+        return None
+    return result.stdout.strip()
+
+
+def _probe_linux() -> Optional[str]:
+    """Read the DMI product serial.
+
+    Usually mode 0400 root-only, so a PermissionError here is the ordinary case
+    on a hardened box, not an incident — it becomes ``None`` like any other
+    unreadable serial.
+    """
+    try:
+        with open(_LINUX_DMI_PATH, "r", encoding="utf-8", errors="replace") as fh:
+            return fh.read()
+    except (PermissionError, FileNotFoundError, OSError) as e:
+        logger.debug("DMI serial unreadable: %s", e)
+        return None

--- a/src/main.py
+++ b/src/main.py
@@ -27,6 +27,7 @@ try:
     from . import error_reporter
     from .browser_tracker import start_browser_tracker
     from .display_info import start_display_tracker
+    from .hardware_serial import get_hardware_serial
     from .reminders import ReminderManager
     from .sync import AWClient, BetterFlowClient, OfflineQueue, SyncEngine
     from .sync.http_client import BetterFlowAuthError, transient_failure_counter
@@ -52,6 +53,7 @@ except ImportError:
     import error_reporter
     from browser_tracker import start_browser_tracker
     from display_info import start_display_tracker
+    from hardware_serial import get_hardware_serial
     from reminders import ReminderManager
     from sync import AWClient, BetterFlowClient, OfflineQueue, SyncEngine
     from sync.http_client import BetterFlowAuthError, transient_failure_counter
@@ -1648,6 +1650,12 @@ class SyncCoordinator:
         telemetry: dict = {
             "consecutive_sync_failures": self._consecutive_sync_failures,
             "idle_while_active_detections": blind_window,
+            # Hardware serial: the join key between this fleet and the MDM asset
+            # inventory. Probed once per process and cached (including a failed
+            # probe), so this is a memo read, not a per-heartbeat syscall. Always
+            # sent, even as None — "no readable serial" is the answer for a VM or
+            # a locked-down box, and the server must be able to see it.
+            "hardware_serial": get_hardware_serial(),
         }
         # Seconds since the last successful sync round-trip. Lets the server flag
         # "alive but sync stale" (heartbeat fresh, uploads frozen) directly rather
@@ -2361,6 +2369,13 @@ class BetterFlowApp:
         # bootloader or Rosetta 2 translation can reset it to SIG_DFL.
         if hasattr(signal, "SIGPIPE"):
             signal.signal(signal.SIGPIPE, signal.SIG_IGN)
+
+        # Warm the hardware-serial memo here rather than letting the first
+        # heartbeat pay for it. On Windows the probe shells out to PowerShell,
+        # which would otherwise land on the sync thread and could push a
+        # heartbeat past its 5s budget. Probed once for the life of the process,
+        # failures included; never raises.
+        get_hardware_serial()
 
         # Apply an update staged in a previous session before anything else —
         # a fast local replace + relaunch into the new version. No-op if nothing

--- a/src/sync/bf_client.py
+++ b/src/sync/bf_client.py
@@ -367,6 +367,26 @@ class BetterFlowClient(BaseApiClient):
     # Lightweight retry for heartbeat (N14): 1 retry, 5s timeout
     _HEARTBEAT_RETRY = RetryConfig(max_retries=1, base_delay=1.0, max_delay=5.0)
 
+    # Health/metadata keys forwarded from the caller's dict onto the heartbeat
+    # body. Anything not listed here is dropped at this boundary — a field can be
+    # collected, logged and unit-tested end to end and still never reach the
+    # server because its name is missing from this tuple. Membership is tested
+    # with ``in``, never truthiness: ``hardware_serial: None`` is a meaningful
+    # report ("this device has no readable serial"), not an absent value.
+    HEARTBEAT_HEALTH_KEYS = (
+        "idle_tracker_stale_restarts",
+        "idle_tracker_blind",
+        "inproc_afk",
+        "afk_event_age_seconds",
+        "window_event_age_seconds",
+        "consecutive_sync_failures",
+        "idle_while_active_detections",
+        "sync_stale_seconds",
+        # Stable hardware identifier joining this device to the MDM asset
+        # inventory. str | None — see src/hardware_serial.py.
+        "hardware_serial",
+    )
+
     def heartbeat(
         self,
         agent_version: str = AGENT_VERSION,
@@ -389,16 +409,7 @@ class BetterFlowClient(BaseApiClient):
             "timezone": self._detect_timezone(),
         }
         if health is not None:
-            for key in (
-                "idle_tracker_stale_restarts",
-                "idle_tracker_blind",
-                "inproc_afk",
-                "afk_event_age_seconds",
-                "window_event_age_seconds",
-                "consecutive_sync_failures",
-                "idle_while_active_detections",
-                "sync_stale_seconds",
-            ):
+            for key in self.HEARTBEAT_HEALTH_KEYS:
                 if key in health:
                     data[key] = health[key]
 

--- a/src/ui/setup_wizard.py
+++ b/src/ui/setup_wizard.py
@@ -565,7 +565,12 @@ class SetupWizard:
                 "Your privacy is protected by default:\n"
                 "•  Window titles are sent to BetterFlow to categorize your work\n"
                 "•  URLs are reduced to the domain only\n"
-                "•  Excluded apps are never tracked"
+                "•  Excluded apps are never tracked\n"
+                # A hardware serial is a durable device identifier, so it is
+                # named here rather than left to the privacy policy PDF. It
+                # describes the machine, not the person.
+                "•  This computer's serial number identifies the hardware,\n"
+                "    so IT can match it to the company asset list"
             ),
             font=FONT_SMALL,
             fill="#9a87c4",
@@ -710,6 +715,10 @@ class SetupWizard:
             "Counts of keys / clicks / scrolls",
             "Active app name & window title",
             "Idle vs. active state",
+            # macOS users never see the Windows/Linux consent screen — this gate
+            # is their equivalent boundary, so any new identifier leaving the
+            # device has to be named here too or it goes undisclosed.
+            "This computer's hardware serial",
         ]
         dont_items = [
             "The keys you press or text you type",

--- a/src/ui/tray.py
+++ b/src/ui/tray.py
@@ -59,6 +59,15 @@ except ImportError:
         import _build_info  # noqa: F401 — ensure bundle path detection runs first
     from config import PRIVACY_POLICY_URL  # type: ignore[no-redef]
 
+try:
+    from ..clipboard import clipboard_available, copy_to_clipboard
+    from ..hardware_serial import get_hardware_serial
+    from ..notifications import send_notification
+except ImportError:
+    from clipboard import clipboard_available, copy_to_clipboard  # type: ignore[no-redef]
+    from hardware_serial import get_hardware_serial  # type: ignore[no-redef]
+    from notifications import send_notification  # type: ignore[no-redef]
+
 
 def _prevent_termination() -> None:
     """Prevent macOS from silently killing the tray app.
@@ -719,6 +728,7 @@ class TrayIcon:
             Item(f"Queue: {s['queue_size']} events", None, enabled=False),
             Item(f"Last sync: {s['last_sync']}", None, enabled=False),
             Item("─" * 20, None, enabled=False),
+            self._serial_menu_item(),
             Item("Privacy Policy", self._handle_open_privacy),
         ]
         items.append(Item("Diagnostics", pystray.Menu(*diag_items), enabled=logged_in))
@@ -777,6 +787,51 @@ class TrayIcon:
         items.append(Item("Quit", self._handle_quit))
 
         return pystray.Menu(*items)
+
+    def _serial_menu_item(self) -> "Item":
+        """The device-serial row: readable value, copyable when we can copy.
+
+        Sits in Diagnostics next to the Privacy Policy link on purpose. The agent
+        reports this serial to the server, so the honest thing is to show the
+        user the exact value we hold about their machine rather than describe it
+        in a first-run wizard they clicked through months ago. Seeing the literal
+        string also makes it self-evident that this identifies the hardware and
+        not them.
+
+        Reads the cached probe from src/hardware_serial.py — the same call site
+        the heartbeat uses, memoised for the life of the process, so rebuilding
+        the menu on every state change costs nothing.
+        """
+        serial = get_hardware_serial()
+
+        if serial is None:
+            # Explicitly "unavailable", never blank and never the repr "None".
+            # A VM, a container or a root-only /sys/class/dmi/id/product_serial
+            # genuinely has no readable serial; that should read as an honest
+            # absence, not as a broken app.
+            return Item("Device serial: unavailable", None, enabled=False)
+
+        label = f"Device serial: {serial}"
+        if not clipboard_available():
+            # No clipboard tool on this box (a bare Linux session with no
+            # wl-copy/xclip/xsel). Render the value as plain info rather than a
+            # button that silently does nothing — the label still carries the
+            # string the user needs to read off.
+            return Item(label, None, enabled=False)
+        return Item(label, self._handle_copy_serial)
+
+    def _handle_copy_serial(self, icon, item) -> None:
+        """Copy the device serial to the clipboard, with a brief confirmation."""
+        serial = get_hardware_serial()
+        if serial is None:
+            return
+        if copy_to_clipboard(serial):
+            send_notification("BetterFlow", f"Device serial {serial} copied.")
+        else:
+            # Don't claim success we didn't get. The value is still on screen.
+            send_notification(
+                "BetterFlow", f"Could not copy. Your device serial is {serial}."
+            )
 
     def _get_status_text(self, s: Optional[dict] = None) -> str:
         """Get short status text for the menu.

--- a/src/ui/tray.py
+++ b/src/ui/tray.py
@@ -237,6 +237,41 @@ except Exception:
 logger = logging.getLogger(__name__)
 
 
+def serial_menu_row() -> tuple:
+    """Build the (label, copyable) pair for the tray's device-serial row.
+
+    Pure: no pystray, no TrayIcon, no display backend. That is deliberate —
+    pystray's backend binds at import time and fails on a headless CI runner,
+    which leaves ``pystray = None`` (see the import guard above) and makes
+    ``TrayIcon()`` unconstructable there. A row-building rule that could only be
+    exercised through a live TrayIcon would therefore be untestable in the one
+    environment that gates merges, and per test-fixture-discipline.md a guard
+    that skips where it matters is not a guard.
+
+    ``TrayIcon._serial_menu_item`` is the only consumer and does nothing except
+    turn this pair into a MenuItem, so the production menu and the test assert
+    on the same string.
+
+    Returns:
+        (label, copyable). ``copyable`` is True only when there is a serial to
+        copy AND a clipboard tool exists to copy it with.
+    """
+    serial = get_hardware_serial()
+
+    if serial is None:
+        # Explicitly "unavailable", never blank and never the repr "None". A VM,
+        # a container or a root-only /sys/class/dmi/id/product_serial genuinely
+        # has no readable serial; that must read as an honest absence rather
+        # than as a broken app.
+        return ("Device serial: unavailable", False)
+
+    # No clipboard tool on this box (a bare Linux session with no
+    # wl-copy/xclip/xsel) => not copyable. A menu row that looks clickable and
+    # silently does nothing is worse than an inert one, and the label still
+    # carries the string the user needs to read off.
+    return (f"Device serial: {serial}", clipboard_available())
+
+
 class TrayState(Enum):
     """Tray icon states."""
 
@@ -798,25 +833,17 @@ class TrayIcon:
         string also makes it self-evident that this identifies the hardware and
         not them.
 
-        Reads the cached probe from src/hardware_serial.py — the same call site
-        the heartbeat uses, memoised for the life of the process, so rebuilding
-        the menu on every state change costs nothing.
+        The label/copyable decision lives in the module-level serial_menu_row()
+        so it can be asserted without a live pystray backend; this method only
+        wraps that pair in a MenuItem. Do not re-derive the label here — a
+        second copy is how the test and the menu drift apart.
+
+        serial_menu_row() reads the cached probe from src/hardware_serial.py,
+        the same call site the heartbeat uses, memoised for the life of the
+        process, so rebuilding the menu on every state change costs nothing.
         """
-        serial = get_hardware_serial()
-
-        if serial is None:
-            # Explicitly "unavailable", never blank and never the repr "None".
-            # A VM, a container or a root-only /sys/class/dmi/id/product_serial
-            # genuinely has no readable serial; that should read as an honest
-            # absence, not as a broken app.
-            return Item("Device serial: unavailable", None, enabled=False)
-
-        label = f"Device serial: {serial}"
-        if not clipboard_available():
-            # No clipboard tool on this box (a bare Linux session with no
-            # wl-copy/xclip/xsel). Render the value as plain info rather than a
-            # button that silently does nothing — the label still carries the
-            # string the user needs to read off.
+        label, copyable = serial_menu_row()
+        if not copyable:
             return Item(label, None, enabled=False)
         return Item(label, self._handle_copy_serial)
 

--- a/tests/test_hardware_serial.py
+++ b/tests/test_hardware_serial.py
@@ -1,0 +1,165 @@
+"""Hardware serial probe + its trip to the wire.
+
+The serial is the join key between the agent fleet and the MDM asset
+inventory (docs/superpowers/specs/2026-07-22-hardware-serial-reporting-design.md).
+
+``None`` is a first-class value here — a VM, a container, a locked-down Linux
+box and a failed probe all legitimately have no serial — so these tests pin
+that ``None`` travels all the way to the request body rather than being
+silently dropped at the heartbeat whitelist (the #152 defect).
+"""
+
+import json
+import subprocess
+import sys
+
+import pytest
+import responses
+
+from src import hardware_serial as hw
+from src.sync.bf_client import BetterFlowClient
+
+
+@pytest.fixture(autouse=True)
+def _clear_serial_cache():
+    hw.reset_cache_for_tests()
+    yield
+    hw.reset_cache_for_tests()
+
+
+# ── The probe ───────────────────────────────────────────────────────────
+
+@pytest.mark.skipif(sys.platform != "darwin", reason="macOS IOKit probe")
+def test_macos_probe_matches_ioreg():
+    """Control: the IOKit read must equal what ioreg reports.
+
+    Without this cross-check the probe could return a plausible-looking string
+    from the wrong registry key and nothing would notice.
+    """
+    serial = hw.get_hardware_serial()
+    assert serial, "expected a real serial on a physical Mac"
+
+    out = subprocess.run(
+        ["/usr/sbin/ioreg", "-rd1", "-c", "IOPlatformExpertDevice"],
+        capture_output=True, text=True, timeout=15,
+    ).stdout
+    line = next(
+        row for row in out.splitlines() if "IOPlatformSerialNumber" in row
+    )
+    expected = line.split('=', 1)[1].strip().strip('"')
+
+    assert serial == expected
+
+
+def test_failed_probe_yields_none_and_is_cached_not_retried(monkeypatch):
+    """A raising probe degrades to None, caches it, and does NOT re-probe."""
+    calls = []
+
+    def boom():
+        calls.append(1)
+        raise OSError("no such registry entry")
+
+    monkeypatch.setattr(hw, "_probe_serial", boom)
+
+    assert hw.get_hardware_serial() is None
+    assert hw.get_hardware_serial() is None
+    assert hw.get_hardware_serial() is None
+    assert len(calls) == 1, f"probe re-ran {len(calls)}× — cache is not holding None"
+
+
+def test_successful_probe_is_cached(monkeypatch):
+    calls = []
+
+    def probe():
+        calls.append(1)
+        return "C02Z60U3LVCJ"
+
+    monkeypatch.setattr(hw, "_probe_serial", probe)
+
+    assert hw.get_hardware_serial() == "C02Z60U3LVCJ"
+    assert hw.get_hardware_serial() == "C02Z60U3LVCJ"
+    assert len(calls) == 1
+
+
+def test_blank_and_placeholder_serials_normalise_to_none(monkeypatch):
+    """VMs and unconfigured DMI report junk; that is a None, not a serial."""
+    for raw in ("", "   ", "To Be Filled By O.E.M.", "Default string", "None", "0"):
+        hw.reset_cache_for_tests()
+        monkeypatch.setattr(hw, "_probe_serial", lambda raw=raw: raw)
+        assert hw.get_hardware_serial() is None, f"{raw!r} should normalise to None"
+
+
+# ── The wire ────────────────────────────────────────────────────────────
+
+def _make_client():
+    return BetterFlowClient(
+        api_url="https://betterflow.eu/api/agent",
+        token="test-token",
+        device_id="test-device",
+    )
+
+
+def test_hardware_serial_is_in_the_heartbeat_whitelist():
+    """Membership, not truthiness — a key absent here is dropped at the wire."""
+    assert "hardware_serial" in BetterFlowClient.HEARTBEAT_HEALTH_KEYS
+
+
+@responses.activate
+def test_serial_reaches_the_request_body():
+    responses.add(
+        responses.POST,
+        "https://betterflow.eu/api/agent/heartbeat",
+        json={"status": "active"}, status=200,
+    )
+    client = _make_client()
+    try:
+        client.heartbeat(health={"hardware_serial": "C02Z60U3LVCJ"})
+    finally:
+        client.close()
+
+    body = json.loads(responses.calls[-1].request.body)
+    assert body["hardware_serial"] == "C02Z60U3LVCJ"
+
+
+def test_health_telemetry_carries_the_serial(monkeypatch):
+    """The builder must actually put the field on the heartbeat dict."""
+    import threading
+    import types
+
+    from src.main import SyncCoordinator
+
+    monkeypatch.setattr(hw, "_probe_serial", lambda: "C02Z60U3LVCJ")
+
+    stub = types.SimpleNamespace(
+        _idle_tracker_warn_lock=threading.Lock(),
+        _blind_tracker_window=0,
+        _consecutive_sync_failures=0,
+        _last_successful_sync=None,
+        aw_manager=types.SimpleNamespace(health_snapshot=lambda: {}),
+    )
+    telemetry = SyncCoordinator._build_health_telemetry(stub)
+    assert telemetry["hardware_serial"] == "C02Z60U3LVCJ"
+
+
+@responses.activate
+def test_none_serial_survives_the_heartbeat_envelope():
+    """The #152 trap: a falsy value must still be forwarded.
+
+    A ``None`` serial is meaningful (this device has no readable serial); if the
+    whitelist filtered on truthiness the server could never tell "not reported"
+    from "reported as absent".
+    """
+    responses.add(
+        responses.POST,
+        "https://betterflow.eu/api/agent/heartbeat",
+        json={"status": "active"}, status=200,
+    )
+    client = _make_client()
+    try:
+        client.heartbeat(health={"hardware_serial": None})
+    finally:
+        client.close()
+
+    body = json.loads(responses.calls[-1].request.body)
+    assert "hardware_serial" in body, "None serial was dropped at the wire boundary"
+    assert body["hardware_serial"] is None

--- a/tests/test_tray_hardware_serial.py
+++ b/tests/test_tray_hardware_serial.py
@@ -6,16 +6,29 @@ device identifier, so showing the user the exact value we hold is a stronger
 honesty signal than a wizard bullet they clicked past months ago. It also makes
 the collection self-evidently about the machine rather than about them.
 
-These drive the real ``_create_menu()`` and read the labels it produced — the
-label string is never mocked, or the test would only prove that a format string
-formats.
+**These must run headless.** pystray binds its display backend at import time,
+so on a CI Linux runner ``src.ui.tray.pystray`` is ``None`` and ``TrayIcon()``
+raises — the repo already works around this in ``test_tray_state_transitions``
+and ``test_tray_icon`` by patching ``src.ui.tray.pystray``. A test that skips or
+errors in the only environment that gates merges is not a guard, so nothing here
+needs a live backend:
+
+- the label/copyable rule is asserted on ``serial_menu_row()``, which is pure;
+- the callsite guard renders the REAL ``_create_menu()`` with ``Item`` swapped
+  for a recorder, so dropping the row from the production menu fails a test.
+
+The second half is what keeps the first honest: without it ``serial_menu_row``
+could be perfect and unreferenced (test-fixture-discipline.md, Phantom 3).
 """
+
+import inspect
+from unittest.mock import MagicMock, patch
 
 import pytest
 
 from src import hardware_serial as hw
 from src.ui import tray as tray_mod
-from src.ui.tray import TrayIcon
+from src.ui.tray import TrayIcon, serial_menu_row
 
 
 @pytest.fixture(autouse=True)
@@ -25,44 +38,54 @@ def _clear_serial_cache():
     hw.reset_cache_for_tests()
 
 
-def _menu_labels(icon) -> list[str]:
-    """Flatten every label in the menu, submenus included."""
-    labels: list[str] = []
+class _RecordedItem:
+    """Stand-in for pystray.MenuItem that records what production asked for.
 
-    def walk(menu):
-        for item in menu.items:
-            labels.append(str(item.text))
-            submenu = getattr(item, "submenu", None)
-            if submenu is not None:
-                walk(submenu)
+    Mirrors the bits of the real MenuItem the menu code and these tests touch:
+    ``text``, ``enabled``, and calling the item to fire its action.
+    """
 
-    walk(icon._create_menu())
-    return labels
+    instances: list = []
 
+    def __init__(self, text, action=None, enabled=True, **kwargs):
+        self.text = text
+        self.action = action
+        self.enabled = enabled
+        _RecordedItem.instances.append(self)
 
-def _serial_items(icon):
-    """Every menu item whose label mentions the device serial."""
-    found = []
-
-    def walk(menu):
-        for item in menu.items:
-            if "Device serial" in str(item.text):
-                found.append(item)
-            submenu = getattr(item, "submenu", None)
-            if submenu is not None:
-                walk(submenu)
-
-    walk(icon._create_menu())
-    return found
+    def __call__(self, icon=None):
+        if self.action is not None:
+            self.action(icon, self)
 
 
-def test_menu_shows_the_real_serial(monkeypatch):
+def _render_real_menu(icon) -> list:
+    """Drive the production _create_menu() and return every item it built."""
+    _RecordedItem.instances = []
+    with patch.object(tray_mod, "Item", _RecordedItem), \
+            patch.object(tray_mod, "pystray", MagicMock()):
+        icon._create_menu()
+    return list(_RecordedItem.instances)
+
+
+def _make_tray() -> TrayIcon:
+    """Construct a TrayIcon without a display backend (repo-standard pattern)."""
+    with patch.object(tray_mod, "pystray", MagicMock()):
+        return TrayIcon()
+
+
+def _serial_items(icon) -> list:
+    return [i for i in _render_real_menu(icon) if "Device serial" in str(i.text)]
+
+
+# ── The rule: serial_menu_row() ─────────────────────────────────────────
+
+def test_row_shows_the_real_serial(monkeypatch):
     monkeypatch.setattr(hw, "_probe_serial", lambda: "C02Z60U3LVCJ")
-    labels = _menu_labels(TrayIcon())
-    assert "Device serial: C02Z60U3LVCJ" in labels
+    monkeypatch.setattr(tray_mod, "clipboard_available", lambda: True)
+    assert serial_menu_row() == ("Device serial: C02Z60U3LVCJ", True)
 
 
-def test_menu_says_unavailable_when_there_is_no_serial(monkeypatch):
+def test_row_says_unavailable_when_there_is_no_serial(monkeypatch):
     """A VM or a locked-down Linux box must read as "not readable", not broken.
 
     Specifically NOT blank, not an empty tail after the colon, and never the
@@ -70,20 +93,31 @@ def test_menu_says_unavailable_when_there_is_no_serial(monkeypatch):
     absence.
     """
     monkeypatch.setattr(hw, "_probe_serial", lambda: None)
-    labels = _menu_labels(TrayIcon())
+    monkeypatch.setattr(tray_mod, "clipboard_available", lambda: True)
 
-    assert "Device serial: unavailable" in labels
-    assert "Device serial: None" not in labels
-    assert "Device serial: " not in labels
+    label, copyable = serial_menu_row()
+    assert label == "Device serial: unavailable"
+    assert label != "Device serial: None"
+    assert label != "Device serial: "
+    # Nothing to copy, so no affordance — clicking would copy the word
+    # "unavailable" and look like it had worked.
+    assert copyable is False
 
 
-def test_serial_item_is_rendered_once(monkeypatch):
-    """One rule, one implementation — no second call site for the UI."""
+def test_row_is_not_copyable_without_a_clipboard(monkeypatch):
+    """No clipboard tool on this box => an info row, not a dead button.
+
+    The label still carries the value to read off.
+    """
     monkeypatch.setattr(hw, "_probe_serial", lambda: "C02Z60U3LVCJ")
-    assert len(_serial_items(TrayIcon())) == 1
+    monkeypatch.setattr(tray_mod, "clipboard_available", lambda: False)
+
+    label, copyable = serial_menu_row()
+    assert "C02Z60U3LVCJ" in label
+    assert copyable is False
 
 
-def test_menu_does_not_reprobe_per_render(monkeypatch):
+def test_row_does_not_reprobe(monkeypatch):
     """The menu rebuilds on every state change; the probe must not follow it."""
     calls = []
 
@@ -92,49 +126,83 @@ def test_menu_does_not_reprobe_per_render(monkeypatch):
         return "C02Z60U3LVCJ"
 
     monkeypatch.setattr(hw, "_probe_serial", probe)
-    icon = TrayIcon()
-    _menu_labels(icon)
-    _menu_labels(icon)
-    _menu_labels(icon)
+    serial_menu_row()
+    serial_menu_row()
+    serial_menu_row()
     assert len(calls) == 1
 
 
-def test_serial_item_copies_when_a_clipboard_exists(monkeypatch):
-    """Clicking hands the REAL serial to the clipboard writer."""
+# ── The callsite guard: the production menu really uses it ──────────────
+
+def test_production_menu_renders_the_serial_row(monkeypatch):
+    """Fails if the row is dropped from _create_menu, not only if the rule breaks."""
     monkeypatch.setattr(hw, "_probe_serial", lambda: "C02Z60U3LVCJ")
     monkeypatch.setattr(tray_mod, "clipboard_available", lambda: True)
+
+    (item,) = _serial_items(_make_tray())
+    assert str(item.text) == "Device serial: C02Z60U3LVCJ"
+    assert item.enabled, "a copyable serial should not render greyed out"
+
+
+def test_production_menu_renders_unavailable(monkeypatch):
+    monkeypatch.setattr(hw, "_probe_serial", lambda: None)
+    monkeypatch.setattr(tray_mod, "clipboard_available", lambda: True)
+
+    (item,) = _serial_items(_make_tray())
+    assert str(item.text) == "Device serial: unavailable"
+    assert not item.enabled
+
+
+def test_production_menu_label_agrees_with_the_row_builder(monkeypatch):
+    """The rendered label matches serial_menu_row()'s output."""
+    monkeypatch.setattr(hw, "_probe_serial", lambda: "C02Z60U3LVCJ")
+    monkeypatch.setattr(tray_mod, "clipboard_available", lambda: True)
+
+    (item,) = _serial_items(_make_tray())
+    assert str(item.text) == serial_menu_row()[0]
+
+
+def test_serial_item_delegates_instead_of_re_deriving_the_label():
+    """Callsite guard — the menu must not grow its own copy of the rule.
+
+    Comparing outputs cannot catch this: a parallel builder that happens to emit
+    the same string passes every behavioural assertion above (verified — a
+    hand-rolled f-string lookalike kept all 11 of them green). Only reading the
+    consumer's source sees it, which is the pattern
+    one-rule-one-implementation.md prescribes. The failure this prevents is the
+    two copies drifting later, when only one of them gets a fix.
+    """
+    source = inspect.getsource(TrayIcon._serial_menu_item)
+    # Assert on code, not prose — the docstring is free to discuss the probe.
+    doc = TrayIcon._serial_menu_item.__doc__
+    if doc:
+        source = source.replace(doc, "")
+
+    assert "serial_menu_row()" in source, "the menu stopped calling the shared builder"
+    assert "Device serial" not in source, "label text re-derived at the callsite"
+    assert "get_hardware_serial" not in source, "probe read a second time at the callsite"
+
+
+def test_clicking_the_row_copies_the_real_serial(monkeypatch):
+    monkeypatch.setattr(hw, "_probe_serial", lambda: "C02Z60U3LVCJ")
+    monkeypatch.setattr(tray_mod, "clipboard_available", lambda: True)
+    monkeypatch.setattr(tray_mod, "send_notification", lambda *a, **k: None)
     copied = []
     monkeypatch.setattr(
         tray_mod, "copy_to_clipboard", lambda text: (copied.append(text), True)[1]
     )
 
-    (item,) = _serial_items(TrayIcon())
-    assert item.enabled, "a copyable serial should not render greyed out"
-
-    item(None)  # pystray invokes the item with the icon; it forwards to the action
+    (item,) = _serial_items(_make_tray())
+    item(None)
     assert copied == ["C02Z60U3LVCJ"]
 
 
-def test_serial_item_is_inert_without_a_clipboard(monkeypatch):
-    """No clipboard tool on this box => an info row, not a dead button.
-
-    Offering a Copy affordance that silently does nothing is worse than not
-    offering one; the label still carries the value to read off.
-    """
+def test_uncopyable_row_has_no_action(monkeypatch):
     monkeypatch.setattr(hw, "_probe_serial", lambda: "C02Z60U3LVCJ")
     monkeypatch.setattr(tray_mod, "clipboard_available", lambda: False)
 
-    (item,) = _serial_items(TrayIcon())
-    assert not item.enabled
-    assert "C02Z60U3LVCJ" in str(item.text)
-
-
-def test_unavailable_serial_is_never_copyable(monkeypatch):
-    """Nothing to copy, so no affordance — clicking would copy the word "unavailable"."""
-    monkeypatch.setattr(hw, "_probe_serial", lambda: None)
-    monkeypatch.setattr(tray_mod, "clipboard_available", lambda: True)
-
-    (item,) = _serial_items(TrayIcon())
+    (item,) = _serial_items(_make_tray())
+    assert item.action is None
     assert not item.enabled
 
 

--- a/tests/test_tray_hardware_serial.py
+++ b/tests/test_tray_hardware_serial.py
@@ -1,0 +1,169 @@
+"""The hardware serial as a visible, readable thing in the tray menu.
+
+Two jobs. Support ("read me your serial" instead of a System Information
+walkthrough) and, the bigger one, transparency: the agent now reports a durable
+device identifier, so showing the user the exact value we hold is a stronger
+honesty signal than a wizard bullet they clicked past months ago. It also makes
+the collection self-evidently about the machine rather than about them.
+
+These drive the real ``_create_menu()`` and read the labels it produced — the
+label string is never mocked, or the test would only prove that a format string
+formats.
+"""
+
+import pytest
+
+from src import hardware_serial as hw
+from src.ui import tray as tray_mod
+from src.ui.tray import TrayIcon
+
+
+@pytest.fixture(autouse=True)
+def _clear_serial_cache():
+    hw.reset_cache_for_tests()
+    yield
+    hw.reset_cache_for_tests()
+
+
+def _menu_labels(icon) -> list[str]:
+    """Flatten every label in the menu, submenus included."""
+    labels: list[str] = []
+
+    def walk(menu):
+        for item in menu.items:
+            labels.append(str(item.text))
+            submenu = getattr(item, "submenu", None)
+            if submenu is not None:
+                walk(submenu)
+
+    walk(icon._create_menu())
+    return labels
+
+
+def _serial_items(icon):
+    """Every menu item whose label mentions the device serial."""
+    found = []
+
+    def walk(menu):
+        for item in menu.items:
+            if "Device serial" in str(item.text):
+                found.append(item)
+            submenu = getattr(item, "submenu", None)
+            if submenu is not None:
+                walk(submenu)
+
+    walk(icon._create_menu())
+    return found
+
+
+def test_menu_shows_the_real_serial(monkeypatch):
+    monkeypatch.setattr(hw, "_probe_serial", lambda: "C02Z60U3LVCJ")
+    labels = _menu_labels(TrayIcon())
+    assert "Device serial: C02Z60U3LVCJ" in labels
+
+
+def test_menu_says_unavailable_when_there_is_no_serial(monkeypatch):
+    """A VM or a locked-down Linux box must read as "not readable", not broken.
+
+    Specifically NOT blank, not an empty tail after the colon, and never the
+    Python repr "None" — which reads as a bug in the app rather than an honest
+    absence.
+    """
+    monkeypatch.setattr(hw, "_probe_serial", lambda: None)
+    labels = _menu_labels(TrayIcon())
+
+    assert "Device serial: unavailable" in labels
+    assert "Device serial: None" not in labels
+    assert "Device serial: " not in labels
+
+
+def test_serial_item_is_rendered_once(monkeypatch):
+    """One rule, one implementation — no second call site for the UI."""
+    monkeypatch.setattr(hw, "_probe_serial", lambda: "C02Z60U3LVCJ")
+    assert len(_serial_items(TrayIcon())) == 1
+
+
+def test_menu_does_not_reprobe_per_render(monkeypatch):
+    """The menu rebuilds on every state change; the probe must not follow it."""
+    calls = []
+
+    def probe():
+        calls.append(1)
+        return "C02Z60U3LVCJ"
+
+    monkeypatch.setattr(hw, "_probe_serial", probe)
+    icon = TrayIcon()
+    _menu_labels(icon)
+    _menu_labels(icon)
+    _menu_labels(icon)
+    assert len(calls) == 1
+
+
+def test_serial_item_copies_when_a_clipboard_exists(monkeypatch):
+    """Clicking hands the REAL serial to the clipboard writer."""
+    monkeypatch.setattr(hw, "_probe_serial", lambda: "C02Z60U3LVCJ")
+    monkeypatch.setattr(tray_mod, "clipboard_available", lambda: True)
+    copied = []
+    monkeypatch.setattr(
+        tray_mod, "copy_to_clipboard", lambda text: (copied.append(text), True)[1]
+    )
+
+    (item,) = _serial_items(TrayIcon())
+    assert item.enabled, "a copyable serial should not render greyed out"
+
+    item(None)  # pystray invokes the item with the icon; it forwards to the action
+    assert copied == ["C02Z60U3LVCJ"]
+
+
+def test_serial_item_is_inert_without_a_clipboard(monkeypatch):
+    """No clipboard tool on this box => an info row, not a dead button.
+
+    Offering a Copy affordance that silently does nothing is worse than not
+    offering one; the label still carries the value to read off.
+    """
+    monkeypatch.setattr(hw, "_probe_serial", lambda: "C02Z60U3LVCJ")
+    monkeypatch.setattr(tray_mod, "clipboard_available", lambda: False)
+
+    (item,) = _serial_items(TrayIcon())
+    assert not item.enabled
+    assert "C02Z60U3LVCJ" in str(item.text)
+
+
+def test_unavailable_serial_is_never_copyable(monkeypatch):
+    """Nothing to copy, so no affordance — clicking would copy the word "unavailable"."""
+    monkeypatch.setattr(hw, "_probe_serial", lambda: None)
+    monkeypatch.setattr(tray_mod, "clipboard_available", lambda: True)
+
+    (item,) = _serial_items(TrayIcon())
+    assert not item.enabled
+
+
+# ── The clipboard writer itself ─────────────────────────────────────────
+
+def test_clipboard_writer_feeds_the_platform_command(monkeypatch):
+    from src import clipboard
+
+    seen = {}
+
+    def fake_run(cmd, **kwargs):
+        seen["cmd"] = cmd
+        seen["input"] = kwargs.get("input")
+
+        class R:
+            returncode = 0
+        return R()
+
+    monkeypatch.setattr(clipboard, "_clipboard_command", lambda: ["/usr/bin/pbcopy"])
+    monkeypatch.setattr(clipboard.subprocess, "run", fake_run)
+
+    assert clipboard.copy_to_clipboard("C02Z60U3LVCJ") is True
+    assert seen["cmd"] == ["/usr/bin/pbcopy"]
+    assert seen["input"] == "C02Z60U3LVCJ"
+
+
+def test_clipboard_writer_reports_failure_rather_than_raising(monkeypatch):
+    from src import clipboard
+
+    monkeypatch.setattr(clipboard, "_clipboard_command", lambda: None)
+    assert clipboard.copy_to_clipboard("C02Z60U3LVCJ") is False
+    assert clipboard.clipboard_available() is False


### PR DESCRIPTION
Implements the agent side of `docs/superpowers/specs/2026-07-22-hardware-serial-reporting-design.md`.

## Status

The original DO-NOT-MERGE reason is **gone**: the internal-tool2 columns are merged and the production migration has run (`2026_07_22_140000_add_hardware_serial_and_title_capture_to_agent_devices_table [145] Ran`), so the server reader now exists and this is no longer a write with no reader.

CI is **green** on the current head — `1267 passed, 8 skipped`, run [29954043372](https://github.com/Better-Quality-Assurance/betterflow-sync/actions/runs/29954043372). Left unmerged for the coordinator to merge.

## What it does

Collects the machine's hardware serial once at startup, caches it, and reports it on the existing heartbeat as `hardware_serial: str | None`.

| Platform | Source |
|---|---|
| macOS | `IOPlatformSerialNumber` off `IOPlatformExpertDevice`, straight IOKit via `ctypes` (no permission, no new dependency in the bundle) |
| Windows | `Win32_BIOS.SerialNumber` via PowerShell's `Get-CimInstance` (`wmic` is deprecated and absent from recent builds), no console window |
| Linux | `/sys/class/dmi/id/product_serial`, usually root-only — degrades to `None` |

`None` is a first-class value, not an error. A VM, a container, a hardened Linux box and a raised probe all produce `None`. The probe never raises into the sync path, never blocks a heartbeat, and never touches tracked or billed time. Firmware placeholders (`To Be Filled By O.E.M.`, `Default string`, …) normalise to `None` too — joining the MDM on those would merge unrelated machines into one row.

Probed once per process and cached, failures included, so a failed probe does not re-shell every heartbeat forever. Warmed in `run()` rather than lazily on the first heartbeat: on Windows the probe shells out, and that would otherwise land on the sync thread inside its 5s heartbeat budget.

### The wire boundary

`bf_client`'s inline whitelist literal is now the named `BetterFlowClient.HEARTBEAT_HEALTH_KEYS` tuple, so a test can assert membership directly. The filter stays an `in` check and never a truthiness check — #152 found the hard way that a falsy value silently vanishes there, and `hardware_serial: None` is a meaningful report ("this device has no readable serial"), not an absent value.

## Test evidence

### Proof-of-failure handshake

Before wiring (probe module present, `bf_client`/`main.py` untouched):

```
$ PYTHONPATH=. python3 -m pytest tests/test_hardware_serial.py -q
tests/test_hardware_serial.py ....FFFF                                   [100%]

E   AttributeError: type object 'BetterFlowClient' has no attribute 'HEARTBEAT_HEALTH_KEYS'
E   KeyError: 'hardware_serial'
E   KeyError / AttributeError on the telemetry builder: 'hardware_serial' absent from _build_health_telemetry
E   AssertionError: None serial was dropped at the wire boundary
E   assert 'hardware_serial' in {'agent_version': '1.5.107', 'timezone': 'Europe/Bucharest'}

========================= 4 failed, 4 passed in 0.74s ==========================
```

After:

```
$ PYTHONPATH=. python3 -m pytest tests/test_hardware_serial.py -q
tests/test_hardware_serial.py ........                                   [100%]
============================== 8 passed in 0.21s ===============================
```

The four probe-only tests passed in both runs by design — they exercise correct behaviour that already existed once the module landed, so only the defect-specific cases (the ones about the wire) flip. That is the shape `test-fixture-discipline.md` asks for.

### `ioreg` cross-check (the control)

```
$ PYTHONPATH=. python3 -c "from src.hardware_serial import get_hardware_serial; print('probe:', get_hardware_serial())"
probe: Q912C75VWY

$ /usr/sbin/ioreg -rd1 -c IOPlatformExpertDevice | grep IOPlatformSerialNumber
      "IOPlatformSerialNumber" = "Q912C75VWY"
```

They match, and `test_macos_probe_matches_ioreg` asserts it rather than eyeballing it.

**Negative control on the instrument** — the test would be worthless if it passed on any plausible-looking string. Repointing the probe at `IOPlatformUUID` and re-running:

```
E     - Q912C75VWY
E     + 739BD53F-870A-5C15-A2A3-51028DA0C0E7
FAILED tests/test_hardware_serial.py::test_macos_probe_matches_ioreg
```

Restored, passes again. The test measures the right registry key.

### Caching

`test_failed_probe_yields_none_and_is_cached_not_retried` patches `_probe_serial` to raise, calls `get_hardware_serial()` three times, asserts all three are `None` and that the underlying probe ran **exactly once**.

### Full suite

Locally (macOS): `1281 passed`, no skips.

In CI (ubuntu-latest, the environment that gates merges): `1267 passed, 8 skipped`. Seven of those skips are pre-existing macOS-only tests; the eighth is discussed under "Making the tray tests run in CI" below.

(Before the rebase this branch showed one failure, `test_call_detector.py::TestStaleOngoingSnapshotsNeverReplay::test_process_queue_drops_ongoing_call_rows` — confirmed pre-existing by reverting all five modified source files to HEAD and watching it fail identically, and since fixed on `main` by #156.)

Lint: `ruff check` on all four new files (`src/hardware_serial.py`, `src/clipboard.py`, and both test modules) → `All checks passed!`. The 7 findings on `src/ui/tray.py` and the repo-wide baseline are pre-existing import-ordering and naming noise; none point at added lines.

## Surfacing it in the agent's own UI

Added in a second commit: **Diagnostics > Device serial** in the tray menu, sitting directly above the Privacy Policy link.

The support case is the small one ("read me your serial" is now a menu item, not a walk through System Information). The transparency case is the real one: the agent now reports a durable device identifier, and showing someone the literal value we hold about their machine is a much stronger honesty signal than a wizard bullet they clicked past months ago. Seeing the actual string is also what makes it self-evident that this identifies hardware and not them.

- **Reads the existing cached probe.** No second call site, no re-probe for the UI. Pinned by a test that renders the menu three times and asserts the underlying probe ran once — the menu rebuilds on every state change, so a naive implementation would have shelled out per render on Windows.
- **`None` renders as `Device serial: unavailable`.** Never blank, never a dangling colon, never the repr `None`. Asserted explicitly against all three. A VM or a root-only `/sys/class/dmi/id/product_serial` is an honest absence and has to read as one rather than as a broken app.
- **Clicking copies**, via a new `src/clipboard.py` shelling out to `pbcopy` / `clip` / `wl-copy`|`xclip`|`xsel`. No new dependency, and no tkinter root spun up off the main thread (unsafe on macOS inside pystray).

On the "skip it rather than half-implement it" instruction: I implemented it, because the gap is gateable rather than silent. `clipboard_available()` decides whether the affordance appears at all — where no clipboard tool exists (a bare Linux session with none of the three) the row renders as inert info and the label still carries the value to read off. An unavailable serial is never clickable either; clicking would otherwise copy the word "unavailable". Both are asserted.

Real round-trip on this machine, unmocked:

```
$ PYTHONPATH=. python3 -c "from src.clipboard import *; from src.hardware_serial import get_hardware_serial; import subprocess; print(clipboard_available()); print(copy_to_clipboard(get_hardware_serial())); print(subprocess.run(['/usr/bin/pbpaste'],capture_output=True,text=True).stdout)"
True
True
Q912C75VWY
```

And the row as actually rendered by `_create_menu()`:

```
'Diagnostics'
  'Device serial: Q912C75VWY' enabled= True
  'Privacy Policy' enabled= True
```

Handshake: `tests/test_tray_hardware_serial.py` — **9 failed** before the change, **9 passed** after. The tests drive the real `_create_menu()` and read the labels it produced; the label string is never mocked, or they would only prove that a format string formats.

## Making the tray tests run in CI

The first version of the tray tests instantiated a real `TrayIcon()`. They passed on macOS and failed on the runner with `ImportError: pystray is required for system tray support`.

**The cause is not a missing package.** `requirements-dev.txt` line 2 is `-r requirements.txt`, which declares `pystray>=0.19,<0.20` — so pystray *is* installed in CI. pystray binds its display backend at **import** time; that bind fails with no X display; `src/ui/tray.py`'s import guard then sets `pystray = None`, and `TrayIcon.__init__` refuses on exactly that. Adding pystray to `requirements-dev.txt` would have left CI just as red. The repo already knew this — `test_tray_state_transitions._make_tray` patches `src.ui.tray.pystray` with the comment *"The icon/menu refresh paths import PIL + AppKit + pystray; on CI Linux those aren't available."*

Fixed by route 2, not `importorskip`. A test that skips in the only environment that gates merges is a guard nobody watches, and these exist to prove a disclosure surface renders.

- The label/copyable decision moved to a module-level `serial_menu_row()` — pure, no pystray, no TrayIcon.
- `_serial_menu_item()` now does nothing but wrap that pair in a `MenuItem`, so the production menu and the tests assert on the same string.

A pure helper on its own would be Phantom 3, so two callsite guards back it. The first renders the **real** `_create_menu()` with `Item` swapped for a recorder. The second reads `_serial_menu_item`'s source and asserts it calls `serial_menu_row()` and does not re-derive the label or re-read the probe.

The second guard earned its place immediately. I introduced a deliberate parallel f-string builder — the exact Phantom 3 shape — and **all 11 behavioural tests stayed green**, because comparing outputs cannot distinguish a lookalike that emits the same string. Only the source guard caught it:

```
E   AssertionError: the menu stopped calling the shared builder
```

Controls run:

| Control | Result |
|---|---|
| Force `pystray = None`, confirm `TrayIcon()` raises the same `ImportError`, then run the tests | reproduced, then **20 passed** |
| Remove the row from `_create_menu()` | **5 failures** |
| Parallel label builder, source guard removed | 0 failures (the gap) |
| Parallel label builder, source guard present | **1 failure** |

CI, on the run that gates this PR — all twelve executed, none skipped:

```
tests/test_tray_hardware_serial.py::test_row_shows_the_real_serial PASSED
tests/test_tray_hardware_serial.py::test_row_says_unavailable_when_there_is_no_serial PASSED
tests/test_tray_hardware_serial.py::test_row_is_not_copyable_without_a_clipboard PASSED
tests/test_tray_hardware_serial.py::test_row_does_not_reprobe PASSED
tests/test_tray_hardware_serial.py::test_production_menu_renders_the_serial_row PASSED
tests/test_tray_hardware_serial.py::test_production_menu_renders_unavailable PASSED
tests/test_tray_hardware_serial.py::test_production_menu_label_agrees_with_the_row_builder PASSED
tests/test_tray_hardware_serial.py::test_serial_item_delegates_instead_of_re_deriving_the_label PASSED
tests/test_tray_hardware_serial.py::test_clicking_the_row_copies_the_real_serial PASSED
tests/test_tray_hardware_serial.py::test_uncopyable_row_has_no_action PASSED
tests/test_tray_hardware_serial.py::test_clipboard_writer_feeds_the_platform_command PASSED
tests/test_tray_hardware_serial.py::test_clipboard_writer_reports_failure_rather_than_raising PASSED
```

### One test does skip in CI, and it should be seen

`test_hardware_serial.py::test_macos_probe_matches_ioreg` — the `ioreg` cross-check — is `skipif(sys.platform != "darwin")` and **SKIPPED on the Linux runner**. That is a platform gate rather than an environment accident: there is no Mac IOKit registry on ubuntu-latest to compare against. The other 7 tests in that module all run in CI. It does mean the control that proves the macOS probe reads the right registry key is only ever exercised on a Mac — it ran here, and its negative control is documented above, but nobody's CI will re-run it.

## Privacy documentation (changed in this PR, per the design)

This adds a new durable device identifier leaving the machine, in a public repo whose docs enumerate exactly what is sent.

- **`CLAUDE.md`** — new "Device identifiers sent on the heartbeat" subsection under Privacy Model. States what is read per platform, that no permission is required, that an unreadable serial is reported as `null` and not retried, **why** it is collected (joining the fleet to the MDM asset inventory, because name-matching across two systems was the only alternative), and the scope limit: it identifies hardware rather than a person, does not affect tracked or billed time, and must not reach a client-facing surface. Also names `HEARTBEAT_HEALTH_KEYS` as the enforced source of truth for heartbeat egress, so the next person auditing this has one place to look.
- **`src/ui/setup_wizard.py`, consent screen** (Windows/Linux) — new bullet: the computer's serial number identifies the hardware so IT can match it to the company asset list.
- **`src/ui/setup_wizard.py`, macOS Input Monitoring gate** — added to the "WHAT WE COLLECT" column. macOS users never see the consent screen; this gate is their equivalent disclosure boundary, so omitting it would have left macOS entirely undisclosed. Layout has room (the block ends at y≈270, next element at y=318).

- **`CLAUDE.md`, second pass** — documents the tray row as a disclosure surface and asks that it be kept in step with what is actually sent.

### Privacy surface I did NOT edit — needs a human

The tray's "Privacy Policy" menu item opens `https://betterqa.co/privacy-policy-terms-of-service/`, which is outside this repo. I flagged it as needing the hardware serial added; the coordinator checked it and reports that **the page does not describe the agent at all — it covers the Flows browser extension**. That is a human/legal matter, escalated, and out of scope here. It does mean the in-repo disclosures and the new tray row are currently the only accurate description of what the agent collects, which is why the wording in both is kept plain and literal.

## Not done, deliberately

- No server-side work; internal-tool2 is out of scope.
- AFK/billing path untouched.
- Not merged.

## Unverified

- **Windows and Linux probes are untested against real hardware.** Only the macOS path ran on a real machine. The Windows probe's `subprocess.STARTUPINFO` / `CREATE_NO_WINDOW` follow the existing patterns in `aw_manager.py` and `self_updater.py`, and the Linux probe is a plain file read — but "reads correctly on that OS" is inferred from code, not observed. Worth a smoke on one Windows device before the fleet build ships.
- **The `ioreg` control never runs in CI** (platform-gated skip, see above) — it is a Mac-only assertion by nature.
- **The clipboard writer only ran for real on macOS** (`pbcopy`, round-trip verified above). The Windows `clip` and Linux `wl-copy`/`xclip`/`xsel` paths are code-inferred, not observed.
- Version bumped to `1.5.110`, branch based on `main` at `0940355`; the `src/__init__.py` conflict against `main`'s `1.5.109` was resolved to `1.5.110` as instructed. No build was produced or notarized here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
