### PR TITLE
fix(tests): anchor the stale-ongoing call fixture to the real clock

### DIFF
--- a/src/__init__.py
+++ b/src/__init__.py
@@ -1,4 +1,4 @@
 """BetterFlow - ActivityWatch to BetterFlow sync companion app."""
 
-__version__ = "1.5.107"
+__version__ = "1.5.108"
 __author__ = "BetterQA"

--- a/tests/test_call_detector.py
+++ b/tests/test_call_detector.py
@@ -766,9 +766,19 @@ class TestCaptureBoundariesCloseSessions:
 
 class TestStaleOngoingSnapshotsNeverReplay:
     def test_process_queue_drops_ongoing_call_rows(self):
+        from inspect import signature
+
+        from src.sync.queue import OfflineQueue, is_event_storable
+
         harness = TestCallPersistsAcrossSyncCycles()
         engine = harness._build_engine()
-        t0 = datetime(2026, 7, 15, 17, 0, 0, tzinfo=timezone.utc)
+        # RELATIVE anchor, deliberately. _process_queue() evicts anything past
+        # the server's retention window BEFORE batching, so an absolute date
+        # here is a time bomb: it silently ages out of the window and the
+        # 'completed' event is evicted instead of sent, failing this test on a
+        # commit that never changed (it detonated on 2026-07-22, exactly 7d
+        # after the 2026-07-15 literal it used to pin).
+        t0 = datetime.now(timezone.utc) - timedelta(days=1)
         stale_snapshot = {
             "id": "call_Zoom_1784000000",
             "timestamp": t0.isoformat(),
@@ -785,6 +795,23 @@ class TestStaleOngoingSnapshotsNeverReplay:
             "bucket_type": "call",
             "data": {"app": "Zoom", "call_type": "native", "status": "completed"},
         }
+        # Pin the geometry this test depends on: BOTH events must be inside the
+        # retention window, or evict_unstorable() drops them and the assertions
+        # below pass/fail for reasons that have nothing to do with replay.
+        # Read the window from production's own default so it tracks any change.
+        retention_days = (
+            signature(OfflineQueue.evict_unstorable)
+            .parameters["stale_after_days"]
+            .default
+        )
+        stale_cutoff = datetime.now(timezone.utc) - timedelta(days=retention_days)
+        for ev in (stale_snapshot, final_event):
+            assert is_event_storable(ev, stale_cutoff=stale_cutoff), (
+                "test fixture aged out of the queue's retention window "
+                f"({retention_days}d) — anchor the timestamp relative to now, "
+                "never to an absolute date"
+            )
+
         engine.queue.enqueue([stale_snapshot, final_event])
 
         from src.sync.sync_engine import SyncStats


### PR DESCRIPTION
Unblocks CI on `main` for every open PR.

## The mechanism (verified)

`test_process_queue_drops_ongoing_call_rows` pinned its fixture to an absolute
`datetime(2026, 7, 15, 17, 0, 0, tzinfo=timezone.utc)` and enqueued both a stale
`ongoing` snapshot and the final `completed` event at that timestamp.

`SyncEngine._process_queue()` calls `queue.evict_unstorable()` **before** batching,
which drops anything past the server's retention window (`stale_after_days=7`,
`src/sync/queue.py`). Once the calendar passed 2026-07-22 17:00 UTC, *both* events
were evicted, `send_events` was never called, `statuses == []`, and
`assert "completed" in statuses` failed on a commit that had not changed. The
`"ongoing" not in statuses` assertion kept passing vacuously.

Proven by sweeping the fixture age across the horizon rather than assuming:

```
$ PYTHONPATH=. python3 probe_boundary.py
age=   0.0 days  statuses=['completed']    test_would=PASS
age=   1.0 days  statuses=['completed']    test_would=PASS
age=   6.0 days  statuses=['completed']    test_would=PASS
age=   6.9 days  statuses=['completed']    test_would=PASS
age=  6.99 days  statuses=['completed']    test_would=PASS
age=   7.0 days  statuses=[]               test_would=FAIL
age=  7.01 days  statuses=[]               test_would=FAIL
age=   8.0 days  statuses=[]               test_would=FAIL
age=  30.0 days  statuses=[]               test_would=FAIL

hardcoded t0=2026-07-15T17:00Z is 7.09 days old as of now (2026-07-22T19:04:33Z)
```

The boundary lands **exactly** at 7.00 days = `stale_after_days`. This also matches
the CI timeline independently: the same commit passed at 12:59 (fixture age 6.83d)
and failed at 17:24 and 18:46 (age 7.02d / 7.08d). The hypothesis is confirmed, not
assumed.

## The fix

- `t0 = datetime.now(timezone.utc) - timedelta(days=1)` — relative anchor, no clock freezing needed.
- An explicit up-front assertion that **both** events are storable, using production's own
  `is_event_storable()` with the retention window read from `evict_unstorable`'s signature
  default, so it tracks any future change to the window rather than duplicating the `7`.
- All three original assertions (`"ongoing" not in statuses`, `"completed" in statuses`,
  `engine.queue.is_empty()`) are byte-for-byte unchanged. Nothing skipped, xfailed or loosened.

## Test evidence

Proof-of-failure handshake (no `git stash` — worktree-local checkout per `cross-repo-safety.md` Rule 0):

```
# pre-fix
tests/test_call_detector.py:804: in test_process_queue_drops_ongoing_call_rows
    assert "completed" in statuses
E   AssertionError: assert 'completed' in []
1 failed

# post-fix
tests/test_call_detector.py::TestStaleOngoingSnapshotsNeverReplay::test_process_queue_drops_ongoing_call_rows PASSED
```

Durability — the same test run with the process clock advanced 10 years:

```
$ PYTHONPATH=. python3 probe_future.py 3650
simulated now = 2036-07-19T19:05:38Z
PASS with clock advanced 3650 days
```

Negative control for that probe (per `diagnosis-discipline.md` Rule 6): the identical
probe pointed at the **pre-fix** version of the file raises `AssertionError` at
`assert "completed" in statuses`, so it measures something.

Full suite: `PYTHONPATH=. python3 -m pytest` → **1261 passed**, 0 failed. The
previously-failing test is the only delta; nothing else changed colour. `ruff` clean.

## Class sweep

Static: 61 `datetime(20xx,` literals across 23 test files, plus ~100 hardcoded ISO
timestamp strings. Most are inert (idempotency-key hashing, payload shaping, dedup,
ordering) — they never get compared against wall-clock now.

Empirical, because eyeballing 100+ literals is not evidence: I ran the whole suite
under a pytest plugin that advances every `datetime` symbol in `src.*`/`tests.*` by
+365d, then +3650d. Both runs produced the **same 10 failures**, and all 10 are
instrument artifacts, not time bombs — each verified individually:

| Failure | Why it is an artifact |
|---|---|
| `test_daily_time_tracker.py` (8 tests) | test uses `date.today()` (unpatched) while `DailyTimeTracker._today()` uses `datetime.now().date()` (patched) — in reality both read the same clock |
| `test_capture_boundary.py::TestRealSchedulerMisfire::test_near_past_run_date_still_fires_with_none_grace` | APScheduler runs on its own unpatched clock, so the shifted `run_date` sits a year in the future |
| `test_mic_activity.py::...test_snapshot_uploaded_and_session_persists_across_cycles` | function-local `from datetime import datetime` at line 380 re-binds to the real class inside the test body |

So: **no other test in the suite has a wall-clock-date-dependent pass/fail**, at +1y or
+10y, on the `datetime.now()` path. Sweep caveat (stated rather than hidden): the plugin
does not cover `time.time()` or `date.today()` call sites.

Two findings logged, not fixed (out of scope):

1. `tests/test_mic_activity.py:15` — `_ts()` uses the *same* absolute base
   `datetime(2026, 7, 15, 17:00 UTC)` as the bug fixed here. It is currently harmless
   (already 7d+ old and the suite is green, so nothing it feeds is retention-sensitive),
   but it is the identical shape and worth converting opportunistically.
2. `tests/test_queue.py` retention tests are the **correct** pattern and should be the
   model: they pair an absolute timestamp with an explicitly injected
   `now=datetime(2026, 6, 24, ...)`, so the fixture and its clock move together and the
   calendar cannot reach them.

## Recurrence

This is the second time bomb of this class found today — `internal-tool2`'s
`FraudInputSensorMissingTest` was the first (different mechanism: fixture built against
the real clock, then the clock rewound past it). **Proposing, not building here:** a guard
test that fails when an absolute date literal feeds a retention/staleness/checkpoint
fixture without a paired injected `now`. Two instances in one day is a pattern; a third
would make the guard clearly worth its maintenance cost. Happy to open it as a follow-up.

## Version

`__version__` 1.5.107 → 1.5.108. Other open PRs also bump it; conflict at merge time is
expected and yours to resolve.
