### PR TITLE
fix(build): make a clean macOS build work without tribal knowledge

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -137,6 +137,27 @@ make dmg
 # 3. Install: drag from DMG to /Applications
 ```
 
+### macOS build environment
+
+`make build-mac` handles the three environment traps that used to fail a first
+build (missing CA bundle, wrong-architecture `pyinstaller` off PATH, stale
+`dist/`). See `docs/SIGNING.md` § "Build environment traps on macOS". Short
+version:
+
+- The tracker download resolves certifi's CA bundle itself — do **not** export
+  `SSL_CERT_FILE` by hand.
+- PyInstaller is resolved by `scripts/resolve-pyinstaller.sh`, which verifies the
+  interpreter's architecture and fails loudly rather than producing a silently
+  x86_64 app. Building from a **git worktree** has no venv, so pass
+  `PYINSTALLER_PYTHON=/path/to/betterflow-sync/venv/bin/python3`.
+- `make clean-dist` (a dependency of `build-mac`) removes only
+  `dist/BetterFlow.app` and `dist/BetterFlow`.
+
+Never capture a build's exit code through a pipeline
+(`( make ... ; echo "EXIT: $?" )` reports success for a failed build — the echo
+succeeded). Write the status to its own file and verify the artifact:
+`lipo -archs dist/BetterFlow.app/Contents/MacOS/BetterFlow`.
+
 ## CI/CD
 
 GitHub Actions workflow (`.github/workflows/build.yml`) builds for macOS and Windows on push to `main`. Tagged releases (`v*`) create draft GitHub releases with ZIP artifacts.

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 # BetterFlow - Build Makefile
 
-.PHONY: install install-dev install-mac test lint format clean build build-mac build-windows build-linux appimage run download-aw clean-aw sign-mac notarize-mac staple-mac dmg _dmg-only pkg _pkg-only ship ship-arm64 ship-x86_64 dev icons
+.PHONY: install install-dev install-mac test lint format clean clean-dist build build-mac build-windows build-linux appimage run download-aw clean-aw sign-mac notarize-mac staple-mac dmg _dmg-only pkg _pkg-only ship ship-arm64 ship-x86_64 dev icons
 
 # Install production dependencies
 install:
@@ -28,6 +28,15 @@ clean:
 	find . -type d -name __pycache__ -exec rm -rf {} +
 	find . -type f -name "*.pyc" -delete
 
+# Remove ONLY the PyInstaller output paths under dist/. PyInstaller aborts with
+# "the output directory ... is not empty" if a previous partial or failed run
+# left them behind, which is the normal state after any interrupted build.
+# Deliberately scoped: DMGs, PKGs and the arch-renamed .app copies in dist/
+# are left alone, and nothing outside dist/ is touched.
+clean-dist:
+	@rm -rf dist/BetterFlow.app dist/BetterFlow
+	@echo "[clean-dist] removed dist/BetterFlow.app and dist/BetterFlow (if present)"
+
 # Download ActivityWatch binaries for current platform
 download-aw:
 	python scripts/download_aw.py
@@ -40,9 +49,17 @@ clean-aw:
 build: download-aw
 	pyinstaller build.spec --clean
 
-# Build for macOS
-build-mac: download-aw
-	pyinstaller build.spec --clean
+# Build for macOS.
+#
+# Does NOT call `pyinstaller` off PATH: on a post-Rosetta-migration machine that
+# resolves to the stale Intel Homebrew prefix (/usr/local/bin/pyinstaller), which
+# builds a silently x86_64 .app on an arm64 host — indistinguishable from a
+# correct build by filename. scripts/resolve-pyinstaller.sh picks an interpreter
+# whose PyInstaller runs as $(TARGET_ARCH) and fails loudly if there is none.
+# Override with PYINSTALLER_PYTHON=/path/to/venv/bin/python3.
+build-mac: download-aw clean-dist
+	@py=$$(./scripts/resolve-pyinstaller.sh $(TARGET_ARCH)) || exit 1; \
+	"$$py" -m PyInstaller build.spec --clean
 	@$(MAKE) sign-mac
 	@echo "Built: dist/BetterFlow.app"
 

--- a/docs/SIGNING.md
+++ b/docs/SIGNING.md
@@ -79,6 +79,93 @@ file .venv-arm64/bin/python3    # should say "arm64"
 file .venv-x86_64/bin/python3   # should say "x86_64"
 ```
 
+## Build environment traps on macOS (read this before your first build)
+
+Three environment problems used to make a first build from a clean checkout or a
+worktree fail three times in a row, each error masking the next. All three are
+now handled by the build itself; this section records what they were, so an
+unfamiliar error message is recognisable.
+
+### 1. TLS: `CERTIFICATE_VERIFY_FAILED` from `make download-aw`
+
+Some macOS Pythons (notably the python.org framework builds under
+`/usr/local/bin`) point `openssl_cafile` at an `etc/openssl/cert.pem` that was
+never installed, so *every* HTTPS request fails with "unable to get local issuer
+certificate". The error names TLS and says nothing about the missing bundle.
+
+`scripts/download_aw.py` now resolves a usable CA bundle itself, in order:
+`SSL_CERT_FILE` / `REQUESTS_CA_BUNDLE` if the caller set one that exists, then
+certifi's bundle, then the interpreter default. It prints which one it used. If
+verification still fails it exits 1 with a message naming the real cause and the
+three ways to fix it — no more exporting `SSL_CERT_FILE` by hand.
+
+### 2. Toolchain: `pyinstaller` off PATH can be the wrong architecture
+
+On a machine that has been through a Rosetta migration, `which pyinstaller` can
+resolve to `/usr/local/bin/pyinstaller` — the **Intel** Homebrew prefix. That
+either dies with a "bad interpreter" error or builds a silently **x86_64** .app
+on an arm64 host. A wrong-arch bundle shipped to an Apple Silicon fleet runs
+under Rosetta and nothing in the artifact name says so.
+
+`make build-mac` therefore never calls `pyinstaller` off PATH. It calls
+`scripts/resolve-pyinstaller.sh`, which picks the first interpreter that both
+imports PyInstaller **and** reports the wanted architecture, announcing every
+candidate it rejects and why:
+
+```
+$ ./scripts/resolve-pyinstaller.sh
+[resolve-pyinstaller] using /path/venv/bin/python3 (PyInstaller 6.19.0, arm64)
+/path/venv/bin/python3
+```
+
+Search order: `$PYINSTALLER_PYTHON`, `$VIRTUAL_ENV`, `.venv-<arch>`, `venv`,
+`.venv`, then `python3` from PATH. If nothing matches it exits 1 and prints the
+full rejection list plus the venv-creation command — it never falls back to
+"whatever builds".
+
+Two consequences worth knowing:
+
+- **Worktrees have no venv.** `git worktree` checkouts do not contain
+  `.venv-arm64/` or `venv/`, so the resolver falls through to PATH `python3` and
+  the build usually fails on a mismatched wheel (e.g. an x86_64-only `psutil`).
+  Point it at the primary checkout's venv:
+  `PYINSTALLER_PYTHON=/path/to/betterflow-sync/venv/bin/python3 make build-mac`.
+- **The name is `venv/`, not `.venv/`.** Both may exist on an older machine and
+  only one has PyInstaller. The resolver checks, so you do not have to.
+
+### 3. Stale `dist/` blocks PyInstaller
+
+PyInstaller refuses to write into a non-empty output directory:
+
+```
+ERROR: The output directory ".../dist/BetterFlow.app" is not empty.
+```
+
+which is the normal state after any interrupted build. `make build-mac` now
+depends on `clean-dist`, which removes exactly `dist/BetterFlow.app` and
+`dist/BetterFlow` — DMGs, PKGs and the arch-renamed `.app` copies in `dist/` are
+left alone, and nothing outside `dist/` is touched.
+
+### 4. Do not capture a build's exit code through a pipeline
+
+```bash
+# WRONG — reports 0 for a failed build, because `echo` succeeded
+( make build-mac > build.log 2>&1 ; echo "EXIT: $?" >> build.log )
+
+# RIGHT — status goes to its own file, read separately
+make build-mac > /tmp/build.log 2>&1; echo "MAKE_EXIT=$?" > /tmp/build.status
+```
+
+Then verify the **artifact**, not the command:
+
+```bash
+lipo -archs dist/BetterFlow.app/Contents/MacOS/BetterFlow   # expect: arm64
+codesign -dv --verbose=4 dist/BetterFlow.app 2>&1 | grep TeamIdentifier
+spctl -a -vv -t install dist/BetterFlow-macOS-*.pkg         # if packaging
+```
+
+A fresh timestamp and the right arch are facts. A green command is a claim.
+
 ## Releasing
 
 Once setup is done, the release pipeline is:

--- a/scripts/download_aw.py
+++ b/scripts/download_aw.py
@@ -3,10 +3,12 @@
 import os
 import platform
 import shutil
+import ssl
 import stat
 import subprocess
 import sys
 import tempfile
+import urllib.error
 import urllib.request
 import zipfile
 
@@ -83,14 +85,70 @@ def resolve_binary_path(output_dir: str, name: str, plat: str) -> str | None:
     return None
 
 
+def build_ssl_context() -> ssl.SSLContext:
+    """Build a TLS context with a CA bundle that actually exists.
+
+    Several Pythons on macOS (notably the python.org framework builds) ship
+    with `openssl_cafile` pointing at an `etc/openssl/cert.pem` that was never
+    installed, so *every* HTTPS request fails with
+    CERTIFICATE_VERIFY_FAILED / "unable to get local issuer certificate".
+    The error names TLS and says nothing about the missing bundle, which is
+    why this used to be worked around by exporting SSL_CERT_FILE by hand.
+
+    Resolution order:
+      1. SSL_CERT_FILE / REQUESTS_CA_BUNDLE, if the caller set one that exists.
+      2. certifi's bundle, if certifi is importable.
+      3. The interpreter's own default (may or may not work).
+    """
+    for env_var in ("SSL_CERT_FILE", "REQUESTS_CA_BUNDLE"):
+        path = os.environ.get(env_var)
+        if path and os.path.isfile(path):
+            print(f"  TLS: using {env_var}={path}")
+            return ssl.create_default_context(cafile=path)
+
+    try:
+        import certifi
+
+        cafile = certifi.where()
+        if os.path.isfile(cafile):
+            print(f"  TLS: using certifi bundle {cafile}")
+            return ssl.create_default_context(cafile=cafile)
+        print(f"  TLS: certifi reported a missing bundle at {cafile}")
+    except ImportError:
+        print("  TLS: certifi not installed, falling back to system defaults")
+
+    return ssl.create_default_context()
+
+
 def download_release(plat: str) -> str:
     """Download release zip to a temp file. Returns path to zip."""
     asset = RELEASE_ASSETS[plat]
     url = f"{RELEASE_BASE}/{asset}"
     print(f"Downloading {url} ...")
 
+    context = build_ssl_context()
     tmp = tempfile.mktemp(suffix=".zip")
-    urllib.request.urlretrieve(url, tmp)
+    try:
+        with urllib.request.urlopen(url, context=context) as response, open(
+            tmp, "wb"
+        ) as out:
+            shutil.copyfileobj(response, out)
+    except urllib.error.URLError as exc:
+        if isinstance(exc.reason, ssl.SSLCertVerificationError):
+            print()
+            print("ERROR: TLS certificate verification failed.")
+            print(f"  interpreter: {sys.executable}")
+            print(f"  default CA file: {ssl.get_default_verify_paths().openssl_cafile}")
+            print()
+            print("  This is a missing CA bundle on this machine, not a network or")
+            print("  GitHub problem. Fix it with ONE of:")
+            print(f"    {sys.executable} -m pip install --upgrade certifi")
+            print("    /Applications/Python 3.x/Install Certificates.command")
+            print("    SSL_CERT_FILE=/path/to/cacert.pem make download-aw")
+            print()
+            print(f"  Underlying error: {exc.reason}")
+            sys.exit(1)
+        raise
 
     size_mb = os.path.getsize(tmp) / (1024 * 1024)
     print(f"Downloaded {size_mb:.1f} MB")

--- a/scripts/resolve-pyinstaller.sh
+++ b/scripts/resolve-pyinstaller.sh
@@ -1,0 +1,92 @@
+#!/usr/bin/env bash
+#
+# Resolve a Python interpreter that (a) has PyInstaller installed and (b) runs
+# on the architecture we intend to build for. Prints the interpreter path on
+# stdout; every diagnostic goes to stderr so callers can do:
+#
+#     PY=$(./scripts/resolve-pyinstaller.sh) && "$PY" -m PyInstaller build.spec
+#
+# Why this exists: `which pyinstaller` on a machine that has been through a
+# Rosetta migration can resolve to /usr/local/bin/pyinstaller — the *Intel*
+# Homebrew prefix — which either dies with "bad interpreter" or, worse, builds
+# a silently x86_64 .app on an arm64 host. A wrong-arch bundle ships to an
+# Apple Silicon fleet and runs under Rosetta with nothing in the artifact name
+# to say so. So: never trust PATH, and always verify the arch.
+#
+# Search order (first candidate that satisfies BOTH checks wins):
+#   1. $PYINSTALLER_PYTHON  (explicit override; must still pass both checks)
+#   2. $VIRTUAL_ENV/bin/python3
+#   3. .venv-<arch>/bin/python3
+#   4. venv/bin/python3
+#   5. .venv/bin/python3
+#   6. python3 from PATH
+#
+# Desired arch: $1, else $TARGET_ARCH, else `uname -m` (aarch64 -> arm64).
+
+set -euo pipefail
+
+PROJECT_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+
+host_arch="$(uname -m | sed 's/aarch64/arm64/')"
+want_arch="${1:-${TARGET_ARCH:-$host_arch}}"
+
+say() { printf '[resolve-pyinstaller] %s\n' "$*" >&2; }
+
+# Prints "<version> <machine>" if the interpreter has PyInstaller, else nothing.
+probe() {
+    "$1" -c 'import PyInstaller, platform; print(PyInstaller.__version__, platform.machine())' 2>/dev/null
+}
+
+candidates=()
+[ -n "${PYINSTALLER_PYTHON:-}" ] && candidates+=("$PYINSTALLER_PYTHON")
+[ -n "${VIRTUAL_ENV:-}" ] && candidates+=("$VIRTUAL_ENV/bin/python3")
+candidates+=(
+    "$PROJECT_ROOT/.venv-$want_arch/bin/python3"
+    "$PROJECT_ROOT/venv/bin/python3"
+    "$PROJECT_ROOT/.venv/bin/python3"
+)
+path_python="$(command -v python3 || true)"
+[ -n "$path_python" ] && candidates+=("$path_python")
+
+rejected=()
+reject() {
+    rejected+=("$1")
+    # Announce every rejection as it happens: a candidate skipped silently is
+    # exactly how the wrong toolchain gets used without anyone noticing.
+    say "rejected $1"
+}
+
+for py in "${candidates[@]}"; do
+    if [ ! -x "$py" ]; then
+        reject "$py — not executable / does not exist"
+        continue
+    fi
+    info="$(probe "$py" || true)"
+    if [ -z "$info" ]; then
+        reject "$py — PyInstaller not importable"
+        continue
+    fi
+    version="${info%% *}"
+    machine="${info##* }"
+    if [ "$machine" != "$want_arch" ]; then
+        reject "$py — PyInstaller $version but runs as $machine, wanted $want_arch"
+        continue
+    fi
+    say "using $py (PyInstaller $version, $machine)"
+    printf '%s\n' "$py"
+    exit 0
+done
+
+say "ERROR: no Python with PyInstaller running as $want_arch was found."
+say "Rejected candidates, in search order:"
+for r in "${rejected[@]}"; do say "  - $r"; done
+say ""
+say "This guard exists because PATH's pyinstaller on this machine can be the"
+say "stale Intel Homebrew one (/usr/local/bin/pyinstaller), which builds an"
+say "x86_64 app on an arm64 host without saying so."
+say ""
+say "Fix: create/refresh the arch-matched venv, e.g."
+say "  python3 -m venv .venv-$want_arch && .venv-$want_arch/bin/pip install -r requirements.txt pyinstaller"
+say "or point the build at an existing one:"
+say "  PYINSTALLER_PYTHON=/path/to/venv/bin/python3 make build-mac"
+exit 1

--- a/src/__init__.py
+++ b/src/__init__.py
@@ -1,4 +1,4 @@
 """BetterFlow - ActivityWatch to BetterFlow sync companion app."""
 
-__version__ = "1.5.108"
+__version__ = "1.5.109"
 __author__ = "BetterQA"


### PR DESCRIPTION
A clean `make build-mac` / `make pkg` from a fresh worktree failed three times in a row on 2026-07-22. Three separate environment causes, each masking the next, none named by its own error message. This makes the build handle all three itself.

Nothing about the produced artifact changes: same spec, same signing, same notarisation path. `TARGET_ARCH` is passed to the new resolver only, never newly injected into `build.spec`'s environment, so PyInstaller's `target_arch` stays exactly as it was.

---

## Trap 1 — `download-aw` dies on TLS

**Cause.** `scripts/download_aw.py` used `urllib.request.urlretrieve` with no CA bundle. `/usr/local/bin/python3` on this machine points `openssl_cafile` at `/Library/Frameworks/Python.framework/Versions/3.11/etc/openssl/cert.pem` — a directory that exists and is **empty**. Every HTTPS request fails, and the error says "SSL" and nothing about a missing bundle.

**Fix.** `build_ssl_context()` resolves, in order: `SSL_CERT_FILE` / `REQUESTS_CA_BUNDLE` if the caller set one that exists, then certifi's bundle, then the interpreter default. It prints which it used. If verification still fails, the script exits 1 with a message naming the real cause.

**Evidence — pre-fix path fails in this shell** (the exact call the old code made):

```
$ python3 -c "urllib.request.urlretrieve('https://github.com/.../activitywatch-v0.13.2-macos-x86_64.zip','/dev/null')"
PRE-FIX PATH FAILED: URLError <urlopen error [SSL: CERTIFICATE_VERIFY_FAILED]
  certificate verify failed: unable to get local issuer certificate (_ssl.c:1006)>
```

**Post-fix, same shell, no `SSL_CERT_FILE` exported** — status captured to its own file, not through a pipeline:

```
$ make download-aw > /tmp/dl.log 2>&1; echo "MAKE_EXIT=$?" > /tmp/dl.status
$ cat /tmp/dl.status
MAKE_EXIT=0
$ cat /tmp/dl.log
Downloading https://github.com/ActivityWatch/.../activitywatch-v0.13.2-macos-x86_64.zip ...
  TLS: using certifi bundle /Library/Frameworks/.../certifi/cacert.pem
Downloaded 168.6 MB
Extracting binaries...
  Extracting runtime aw-watcher-window -> bf-window-tracker/
  Extracting runtime aw-watcher-afk -> bf-idle-tracker/
  Extracting runtime aw-server-rust -> bf-data-service/
Done! All binaries downloaded successfully.
```

Artifact, not command: the three tracker runtimes are on disk under `resources/trackers/darwin/`.

**The failure branch fires too** (negative control — pointed at a self-signed CA that cannot verify GitHub):

```
$ SSL_CERT_FILE=/tmp/wrongca.pem python3 -c "import download_aw; download_aw.download_release('darwin')"
  TLS: using SSL_CERT_FILE=/tmp/wrongca.pem

ERROR: TLS certificate verification failed.
  interpreter: /usr/local/bin/python3
  default CA file: /Library/Frameworks/Python.framework/Versions/3.11/etc/openssl/cert.pem

  This is a missing CA bundle on this machine, not a network or
  GitHub problem. Fix it with ONE of:
    /usr/local/bin/python3 -m pip install --upgrade certifi
    /Applications/Python 3.x/Install Certificates.command
    SSL_CERT_FILE=/path/to/cacert.pem make download-aw
EXIT=1
```

---

## Trap 2 — wrong `pyinstaller`, silently wrong architecture

**Approach taken: resolve the interpreter explicitly *and* verify its architecture, failing loudly when nothing matches.** Both, not either — "use the venv" alone breaks the moment the venv is missing (a worktree) or was built for the wrong arch, and then silently falls back to PATH. The arch check is the part that cannot be fooled: it asks the candidate interpreter what it actually is, rather than trusting its path.

`make build-mac` no longer calls `pyinstaller`. It calls `scripts/resolve-pyinstaller.sh`, which walks `$PYINSTALLER_PYTHON` → `$VIRTUAL_ENV` → `.venv-<arch>` → `venv` → `.venv` → PATH `python3`, takes the first that both imports PyInstaller and reports the wanted arch, announces every rejection, and exits 1 with the venv-creation command if none qualifies. Only the resolved path goes to stdout, so `py=$(...)` stays clean.

**Evidence — the guard discriminates.** Negative control: a real interpreter with PyInstaller 6.19.0 that runs as x86_64 on this arm64 host (`exec arch -x86_64 /usr/local/bin/python3 "$@"`), offered as the preferred candidate.

```
$ PYINSTALLER_PYTHON=/tmp/fake-intel-python3 ./scripts/resolve-pyinstaller.sh arm64
[resolve-pyinstaller] rejected /tmp/fake-intel-python3 — PyInstaller 6.19.0 but runs as x86_64, wanted arm64
[resolve-pyinstaller] rejected .../.venv-arm64/bin/python3 — not executable / does not exist
[resolve-pyinstaller] using /usr/local/bin/python3 (PyInstaller 6.19.0, arm64)
/usr/local/bin/python3
```

And the inverse — an arm64 PyInstaller asked for an x86_64 build is refused outright, exit 1:

```
$ PYINSTALLER_PYTHON=.../venv/bin/python3 ./scripts/resolve-pyinstaller.sh x86_64
[resolve-pyinstaller] ERROR: no Python with PyInstaller running as x86_64 was found.
[resolve-pyinstaller]   - .../venv/bin/python3 — PyInstaller 6.19.0 but runs as arm64, wanted x86_64
[resolve-pyinstaller]   - /usr/local/bin/python3 — PyInstaller 6.19.0 but runs as arm64, wanted x86_64
EXIT=1
```

**Note on today's state of `/usr/local/bin/pyinstaller`** — it no longer silently builds x86_64; its shebang points at a deleted Intel interpreter, so it dies outright:

```
$ /usr/local/bin/pyinstaller --version
bad interpreter: /usr/local/opt/python@3.11/bin/python3.11: no such file or directory
```

So the *silent* wrong-arch build was not reproducible on this machine today; the guard is verified against a synthesised x86_64 candidate instead, which exercises the same check. Inferred, not verified: that the historical `/usr/local/bin/pyinstaller` produced an x86_64 app silently.

---

## Trap 3 — stale `dist/`

**Fix.** New `clean-dist` target, a dependency of `build-mac`, removing exactly `dist/BetterFlow.app` and `dist/BetterFlow`. DMGs, PKGs, the arch-renamed `.app` copies `ship-*` leaves in `dist/`, and everything outside `dist/` are untouched.

**Evidence — real end-to-end build over a stale, non-empty `dist/BetterFlow.app`** (the recipe's `clean-dist` + resolver + PyInstaller steps; `sign-mac` deliberately not run in this agent shell):

```
before:  dist/BetterFlow.app/Contents/stale.txt     (plus dist/BetterFlow/ from an earlier failed run)

[clean-dist] removed dist/BetterFlow.app and dist/BetterFlow (if present)
[resolve-pyinstaller] using /Users/brad/Code2/betterflow-sync/venv/bin/python3 (PyInstaller 6.19.0, arm64)
...
23582 INFO: Build complete! The results are available in: .../dist

$ cat /tmp/build2.status
PYINSTALLER_EXIT=0
```

Artifact verified, not the command:

```
$ lipo -archs dist/BetterFlow.app/Contents/MacOS/BetterFlow
arm64
$ file dist/BetterFlow.app/Contents/MacOS/BetterFlow
Mach-O 64-bit executable arm64
```

`stale.txt` is gone; the bundle is a fresh, correct-arch build.

---

## Reporting trap (also fixed in docs)

`( make pkg > log 2>&1 ; echo "EXIT: $?" )` reports success for a failed build — the `echo` succeeded. `docs/SIGNING.md` and `CLAUDE.md` now carry the wrong/right pair, and every command in this PR captured its status to its own file.

## What I did not verify

- **No full `make pkg` / `make dmg` / notarisation run.** Signing, DMG creation and the notary round trip were not exercised — none of their code changed, but "the whole chain still reaches a notarised artifact" is unverified by me.
- **`make pkg` does not exist on `main`** (nor on this branch); it is only described in `docs/superpowers/specs/2026-07-22-mdm-pkg-deployment-design.md`, so it presumably lives on another unmerged branch. Whatever `pkg` target lands should depend on `build-mac`, which is where all three fixes sit.
- **`ship-arm64` / `ship-x86_64` untouched.** They already call `.venv-arm64` / `.venv-x86_64` explicitly, so they were never exposed to the PATH trap, and they already do their own `rm -rf`. They do not get the arch guard.
- **`make build` (generic), `build-windows`, `build-linux` untouched** — still bare `pyinstaller`. Only the macOS path is guarded, so `make build` on a Mac can still pick the wrong toolchain.
- **CI unaffected** — `.github/workflows/build.yml` calls `pyinstaller build.spec --clean` directly, not `make build-mac`.
- **Pre-existing red, unrelated to this PR:** `tests/test_call_detector.py::TestStaleOngoingSnapshotsNeverReplay::test_process_queue_drops_ongoing_call_rows` fails (1 failed, 1260 passed). Confirmed pre-existing by reverting the version bump and re-running — still fails. `make lint` is also red with import-sort findings across `src/`; `scripts/` is not linted at all, and the two ruff findings in `download_aw.py` sit on lines I did not touch.

Version bumped to **1.5.108**. Conflicts with other open version bumps are expected and yours to resolve.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
