### PR TITLE
feat(privacy): one-time data-collection notice for the installed fleet [DO NOT MERGE]

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -141,10 +141,13 @@ weight — a first-run wizard bullet is read once and forgotten. It renders as
 `Device serial: unavailable` when the probe found nothing, never blank and never
 `None`. Keep that row in step with what is actually sent.
 
-- `privacy_notice_ack` (`src/privacy_notice.py`) — `{version, acknowledged_at,
-  device_id}`, the record that this user was shown the data-collection notice
-  before monitoring continued (Romanian Law 190/2018 art. 5 lit. b). Carries no
-  activity data.
+- `disclosure_acknowledgement` (`src/privacy_notice.py`) — `{version,
+  acknowledged_at}`, the record that this user was shown the data-collection
+  notice before monitoring continued (Romanian Law 190/2018 art. 5 lit. b).
+  Carries no activity data and no device id: the server binds the record from
+  the authenticated heartbeat and writes `agent_device_id` itself. The key name
+  and shape are the server's contract (`AgentHeartbeatController` →
+  `agent_disclosure_acknowledgements`), so neither end may be renamed alone.
 
 `src/sync/bf_client.py`'s `HEARTBEAT_HEALTH_KEYS` is the complete, enforced list
 of what the heartbeat forwards — a field missing from it never leaves the

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -141,10 +141,36 @@ weight — a first-run wizard bullet is read once and forgotten. It renders as
 `Device serial: unavailable` when the probe found nothing, never blank and never
 `None`. Keep that row in step with what is actually sent.
 
+- `privacy_notice_ack` (`src/privacy_notice.py`) — `{version, acknowledged_at,
+  device_id}`, the record that this user was shown the data-collection notice
+  before monitoring continued (Romanian Law 190/2018 art. 5 lit. b). Carries no
+  activity data.
+
 `src/sync/bf_client.py`'s `HEARTBEAT_HEALTH_KEYS` is the complete, enforced list
 of what the heartbeat forwards — a field missing from it never leaves the
 machine. Treat that tuple as the source of truth when auditing egress, and
 update this section whenever it changes.
+
+#### The one-time privacy notice
+
+`src/privacy_notice.py` holds the disclosure text, its version, and the
+acknowledgement record; `src/ui/privacy_notice_window.py` is a rendering shell
+with no copy of its own. It shows once per *text version*, on all three
+platforms, from `BetterFlowApp.run` — deliberately NOT from the first-run
+consent screen, which macOS never executes.
+
+Two rules when editing it:
+
+- **Do not hand-edit a version.** `NOTICE_VERSION` is a SHA-256 of the notice
+  text, so changing a single character re-shows the notice to the whole fleet
+  automatically. That is the feature: a new data category must never reach
+  devices that acknowledged the old text.
+- **The three qualifiers in `REQUIRED_QUALIFIERS` are legal, not editorial** —
+  titles leave the machine *as recorded*, input is *counts only*, and the serial
+  *identifies the machine*. Tests fail if any is removed.
+
+The English notice is a rendering of Regulament Intern art. 64^1 alin. (4)-(5).
+If the two disagree, the Romanian prevails — it is the version employees sign.
 
 ### Configuration Storage
 

--- a/build.spec
+++ b/build.spec
@@ -171,6 +171,11 @@ hiddenimports = [
     "ui.tray",
     "ui.permissions",
     "ui.setup_wizard",
+    # Imported lazily inside BetterFlowApp._show_privacy_notice_if_needed, so
+    # the bundle needs it named here — a missing module there is an ImportError
+    # the unit suite (which imports by path) can never see.
+    "ui.privacy_notice_window",
+    "privacy_notice",
     "aw_manager",
     "autostart",
     "windows_tray",  # Windows 11 tray-icon promotion (best-effort, win-only)

--- a/src/__init__.py
+++ b/src/__init__.py
@@ -1,4 +1,1 @@
-"""BetterFlow - ActivityWatch to BetterFlow sync companion app."""
-
-__version__ = "1.5.115"
-__author__ = "BetterQA"
+__version__ = "1.5.116"

--- a/src/config.py
+++ b/src/config.py
@@ -649,6 +649,15 @@ class Config:
     call_detection: CallDetectionSettings = field(default_factory=CallDetectionSettings)
     foreground_activity: ForegroundActivitySettings = field(default_factory=ForegroundActivitySettings)
     setup_complete: bool = False
+    # Record of the one-time privacy notice (src/privacy_notice.py). The version
+    # is a hash of the notice text, so a device holding an OLDER version is
+    # re-shown the notice — that comparison is the whole point, and it is why
+    # this stores the version rather than a bare `privacy_notice_seen: bool`.
+    # Purely local + reported on the heartbeat; the server never writes it back
+    # (update_from_server touches neither field), so a config push cannot forge
+    # an acknowledgement.
+    privacy_notice_ack_version: Optional[str] = None
+    privacy_notice_ack_at: Optional[str] = None  # UTC ISO 8601
     auto_start: bool = False
     check_updates: bool = True
     auto_install_updates: bool = True

--- a/src/disclosure_baseline.py
+++ b/src/disclosure_baseline.py
@@ -466,6 +466,14 @@ UNWATCHED_CONFIG_FIELDS: dict[str, str] = {
     ),
     "engagement": "Thresholds for scoring activity already collected.",
     "fraud_detection": "Thresholds for scoring activity already collected.",
+    "privacy_notice_ack_version": (
+        "Records WHICH disclosure version this user acknowledged. Compliance "
+        "record that the notice was shown, not a collection setting — it "
+        "changes nothing about what the agent gathers."
+    ),
+    "privacy_notice_ack_at": (
+        "When the acknowledgement happened. Compliance state, not collection."
+    ),
     "setup_complete": "First-run wizard state.",
     "auto_start": "Launch at login.",
     "check_updates": "Updater behaviour.",
@@ -499,6 +507,10 @@ HEARTBEAT_HEALTH_KEYS: tuple[str, ...] = (
     "sync_stale_seconds",
     "window_titles_captured_recently",
     "hardware_serial",
+    # The disclosure acknowledgement record (version + timestamp). It
+    # forwards proof the notice was shown; it is compliance evidence, not
+    # a new fact gathered about the machine or the person.
+    "disclosure_acknowledgement",
 )
 
 #: The machine's hostname is read once and embedded in every `bucket_id`, so

--- a/src/main.py
+++ b/src/main.py
@@ -28,6 +28,11 @@ try:
     from .browser_tracker import start_browser_tracker
     from .display_info import start_display_tracker
     from .hardware_serial import get_hardware_serial
+    from .privacy_notice import (
+        acknowledgement_telemetry,
+        needs_acknowledgement,
+        record_acknowledgement,
+    )
     from .reminders import ReminderManager
     from .sync import AWClient, BetterFlowClient, OfflineQueue, SyncEngine
     from .sync.http_client import BetterFlowAuthError, transient_failure_counter
@@ -54,6 +59,11 @@ except ImportError:
     from browser_tracker import start_browser_tracker
     from display_info import start_display_tracker
     from hardware_serial import get_hardware_serial
+    from privacy_notice import (
+        acknowledgement_telemetry,
+        needs_acknowledgement,
+        record_acknowledgement,
+    )
     from reminders import ReminderManager
     from sync import AWClient, BetterFlowClient, OfflineQueue, SyncEngine
     from sync.http_client import BetterFlowAuthError, transient_failure_counter
@@ -1657,6 +1667,18 @@ class SyncCoordinator:
             # a locked-down box, and the server must be able to see it.
             "hardware_serial": get_hardware_serial(),
         }
+        # The privacy-notice acknowledgement: the Law 190/2018 evidence that this
+        # user was informed before monitoring. Re-sent on EVERY heartbeat rather
+        # than once — the server-side reader ships separately and later, so a
+        # send-once design would lose every acknowledgement made before that
+        # deploy. Idempotent upsert; omitted entirely until one exists. Wrapped
+        # because a corrupt record must cost the notice, never the heartbeat.
+        try:
+            ack = acknowledgement_telemetry(self.config)
+            if ack is not None:
+                telemetry["privacy_notice_ack"] = ack
+        except Exception as e:  # noqa: BLE001
+            logger.debug("privacy-notice telemetry unavailable: %s", e)
         # Seconds since the last successful sync round-trip. Lets the server flag
         # "alive but sync stale" (heartbeat fresh, uploads frozen) directly rather
         # than inferring it from upload gaps. Omitted until the first good sync.
@@ -2483,11 +2505,53 @@ class BetterFlowApp:
         # startup — the worker retries until the entry appears.
         self._promote_windows_tray_async()
 
+        # One-time data-collection notice for the INSTALLED BASE.
+        #
+        # Placement is the requirement, not a detail. It sits here because:
+        #  - startup has already begun on its own thread, so tracking, syncing
+        #    and billing run normally while the window is open — the notice
+        #    never gates work;
+        #  - this is the last point the main thread is still ours, and Tk is not
+        #    safe off the main thread on macOS (same sequencing as the first-run
+        #    wizard and the Input Monitoring gate);
+        #  - it is unconditional, so it reaches macOS, which never runs the
+        #    Windows/Linux consent screen and would otherwise stay undisclosed.
+        self._show_privacy_notice_if_needed()
+
         logger.info("BetterFlow tray starting")
         try:
             self.tray.run_blocking()
         finally:
             self._shutdown()
+
+    def _show_privacy_notice_if_needed(self) -> None:
+        """Show the one-time data-collection notice, once, and record it.
+
+        The whole method is best-effort. A machine with no display, a Tk that
+        will not initialise, a read-only config dir — each of those costs the
+        notice and nothing else. Unrecorded means "retry next launch", which is
+        also what a user who closes the window without pressing the button gets:
+        an acknowledgement has to mean somebody dismissed the text deliberately,
+        or it is not evidence of anything.
+
+        The decision and the record both live in ``privacy_notice`` so the
+        version comparison exists exactly once.
+        """
+        try:
+            if not needs_acknowledgement(self.config):
+                return
+            try:
+                from .ui.privacy_notice_window import show_privacy_notice
+            except ImportError:
+                from ui.privacy_notice_window import show_privacy_notice  # type: ignore[no-redef]
+
+            logger.info("Showing the one-time privacy notice")
+            if show_privacy_notice():
+                record_acknowledgement(self.config)
+            else:
+                logger.info("Privacy notice dismissed without acknowledgement")
+        except Exception as e:  # noqa: BLE001 — a notice is never worth a crash
+            logger.warning("Privacy notice could not be shown: %s", e, exc_info=True)
 
     def _promote_windows_tray_async(self) -> None:
         """Best-effort: promote our Windows 11 tray icon onto the taskbar.

--- a/src/main.py
+++ b/src/main.py
@@ -1667,18 +1667,21 @@ class SyncCoordinator:
             # a locked-down box, and the server must be able to see it.
             "hardware_serial": get_hardware_serial(),
         }
-        # The privacy-notice acknowledgement: the Law 190/2018 evidence that this
-        # user was informed before monitoring. Re-sent on EVERY heartbeat rather
-        # than once — the server-side reader ships separately and later, so a
-        # send-once design would lose every acknowledgement made before that
-        # deploy. Idempotent upsert; omitted entirely until one exists. Wrapped
-        # because a corrupt record must cost the notice, never the heartbeat.
+        # The disclosure acknowledgement: the Law 190/2018 evidence that this
+        # user was informed before monitoring. The key name is the server's
+        # (AgentHeartbeatController reads `disclosure_acknowledgement`), not a
+        # local convention — renaming it here alone silently un-wires the
+        # record. Re-sent on EVERY heartbeat rather than once, because the
+        # server-side reader ships separately and later and a send-once design
+        # would lose every acknowledgement made before that deploy. Idempotent
+        # upsert; omitted entirely until one exists. Wrapped because a corrupt
+        # record must cost the notice, never the heartbeat.
         try:
             ack = acknowledgement_telemetry(self.config)
             if ack is not None:
-                telemetry["privacy_notice_ack"] = ack
+                telemetry["disclosure_acknowledgement"] = ack
         except Exception as e:  # noqa: BLE001
-            logger.debug("privacy-notice telemetry unavailable: %s", e)
+            logger.debug("disclosure-acknowledgement telemetry unavailable: %s", e)
         # Seconds since the last successful sync round-trip. Lets the server flag
         # "alive but sync stale" (heartbeat fresh, uploads frozen) directly rather
         # than inferring it from upload gaps. Omitted until the first good sync.

--- a/src/privacy_notice.py
+++ b/src/privacy_notice.py
@@ -1,0 +1,223 @@
+"""The one-time in-app privacy notice — a legal artifact, not a UI nicety.
+
+Romanian Law 190/2018 art. 5 lit. b requires *complete and explicit prior
+information* of employees before workplace electronic monitoring. The agent has
+always carried that disclosure, but only on the first-run path: ``_show_consent``
+(Windows/Linux) and the Input Monitoring gate's ``_draw_disclosure_columns``
+(macOS). Every device already in the fleet onboarded before the current text
+existed, so the installed base has never seen it — and macOS never runs the
+consent screen at all, so the entire Mac fleet has only ever seen the permission
+gate. This module closes that gap and, just as importantly, produces the
+*record* that the condition was met.
+
+Four properties this module exists to guarantee:
+
+1. **The text is data, not markup.** ``NOTICE_SECTIONS`` is the single source;
+   the window renders it and the version hashes it. There is no second copy for
+   the two to drift apart on (``one-rule-one-implementation.md``).
+
+2. **A text change cannot ship without a version change.** ``NOTICE_VERSION``
+   is *derived* from a SHA-256 of the canonical text at import. It is not a
+   constant a developer edits and can forget — forgetting is impossible. That
+   matters because the failure being fixed is exactly "a new data category
+   reached devices that had already acknowledged the old text".
+
+3. **The mandatory qualifiers are asserted, not trusted.** Three phrases do
+   legal work rather than describe a feature, and a future round of "make it
+   fit on one screen" would delete them first. ``REQUIRED_QUALIFIERS`` is
+   enforced by a test.
+
+4. **Nothing here can block work.** Pure functions over a ``Config``; the only
+   side effect is ``config.save()`` in ``record_acknowledgement``. The caller
+   wraps everything — an unshowable notice must never stop tracking, syncing,
+   or billing, on the same principle as the hardware-serial probe.
+
+Authoritative source: Regulament Intern art. 64^1 alin. (4) and (5), in
+Romanian. The agent UI is English, so the notice is English — but if the two
+ever disagree, **the Romanian wins**; it is the version employees sign. That is
+stated inside the notice itself rather than only in this docstring.
+"""
+
+import hashlib
+import logging
+from datetime import datetime, timezone
+from typing import Optional
+
+logger = logging.getLogger(__name__)
+
+# Human-readable half of the version, for ordering records by eye. It carries no
+# correctness weight: the digest below is what actually guarantees a text change
+# is visible, so forgetting to bump this cannot make an edit invisible.
+NOTICE_REVISION = "r1"
+
+NOTICE_TITLE = "What BetterFlow records on this computer"
+
+NOTICE_SUBTITLE = (
+    "BetterFlow is already installed on this computer. This is the full "
+    "description of what it records. Please read it once."
+)
+
+# Each section is (lead paragraph, bullets). Bullets may be empty for a section
+# that is a plain paragraph. This structure IS the notice — the renderer walks
+# it and the version hashes it, so neither can quietly disagree with the other.
+NOTICE_SECTIONS: tuple[tuple[str, tuple[str, ...]], ...] = (
+    (
+        "What BetterFlow records while it is running on your work computer:",
+        (
+            "The name of the application you are using and the title of the "
+            "active window",
+            "Web addresses, reduced to the domain only (for example "
+            "github.com, not the full page address)",
+            # QUALIFIER: without "Counts only ... not which keys you press"
+            # this bullet reads as a keylogger.
+            "Counts of keystrokes, mouse clicks and scrolls. Counts only. The "
+            "application does not record which keys you press",
+            "Whether the computer is active or idle",
+            # QUALIFIER: "identifies the machine" is the entire justification
+            # for collecting a durable hardware identifier.
+            "The computer's hardware serial number, which identifies the "
+            "machine so IT can match it to the company asset list",
+            "Technical details needed to keep the application working: the "
+            "application version and the computer's time zone",
+        ),
+    ),
+    (
+        # QUALIFIER: "as recorded". Dropping it implies titles are anonymised
+        # before they leave the machine. They are not — there is no client-side
+        # title hashing in the agent, and the `hash_titles` setting NAME already
+        # misleads people on exactly this point (it is a preference forwarded to
+        # the server, not a local transform). See CLAUDE.md, Privacy Model.
+        "Window titles are sent to our servers as recorded and are categorised "
+        "there rather than on the computer. A window title can contain the name "
+        "of a document or a web page you have open.",
+        (),
+    ),
+    (
+        "What it does not record:",
+        (
+            "The keys you press or the text you type",
+            "Passwords or message content",
+            "Screenshots",
+            "Anything from excluded applications. Password managers and system "
+            "security prompts — including 1Password, Keychain Access and System "
+            "Settings — are excluded by default",
+            "Full web addresses",
+        ),
+    ),
+    (
+        "Questions or objections: write to dpo@betterqa.co.",
+        (),
+    ),
+    (
+        "This notice reflects Regulamentul Intern, art. 64^1 alin. (4) and (5). "
+        "The Romanian text is the version you signed and is the one that "
+        "prevails if the two ever differ.",
+        (),
+    ),
+)
+
+# Phrases that must survive any future edit. Each is doing legal work; each is
+# the first thing a "make it shorter" pass would delete. Enforced by
+# tests/test_privacy_notice.py, which is the point — a comment warning about a
+# trap does not stop the trap (diagnosis-discipline.md).
+REQUIRED_QUALIFIERS: tuple[str, ...] = (
+    # Titles leave the machine unmodified.
+    "as recorded",
+    # Input is counted, not captured.
+    "Counts only. The application does not record which keys you press",
+    # The serial identifies the machine, not the person.
+    "identifies the machine",
+)
+
+ACK_BUTTON_TEXT = "I have read this"
+
+
+def notice_lines() -> tuple[str, ...]:
+    """Render the notice as display lines, bullets prefixed.
+
+    The single renderer. The Tk window walks this and the version hashes the
+    joined result, so what the user reads and what gets recorded are the same
+    bytes by construction rather than by review.
+    """
+    lines: list[str] = []
+    for lead, bullets in NOTICE_SECTIONS:
+        if lines:
+            lines.append("")
+        lines.append(lead)
+        for bullet in bullets:
+            lines.append(f"•  {bullet}")
+    return tuple(lines)
+
+
+def notice_text() -> str:
+    """The canonical notice as one string — what the version is computed over."""
+    return "\n".join((NOTICE_TITLE, NOTICE_SUBTITLE, *notice_lines()))
+
+
+def _digest(text: str) -> str:
+    return hashlib.sha256(text.encode("utf-8")).hexdigest()[:12]
+
+
+# Derived, never hand-written. Editing a single character of the notice changes
+# this, which re-shows the notice to every device that acknowledged the old text.
+# That is the whole mechanism: a developer CANNOT change the copy and forget the
+# version, because there is no version field to forget.
+NOTICE_VERSION = f"{NOTICE_REVISION}-{_digest(notice_text())}"
+
+
+def needs_acknowledgement(config) -> bool:
+    """Has this device acknowledged the notice text it is about to be shown?
+
+    Compared by VALUE against the current version, never by truthiness: a device
+    holding an older version is exactly the case that must re-show, and a
+    truthiness check ("has some ack") would swallow it — which is the defect
+    this whole feature exists to prevent.
+    """
+    recorded = getattr(config, "privacy_notice_ack_version", None)
+    return recorded != NOTICE_VERSION
+
+
+def record_acknowledgement(config, *, now: Optional[datetime] = None) -> None:
+    """Persist that the user acknowledged the CURRENT text, and when.
+
+    ``now`` is injectable so tests need no wall-clock fixture. Stored UTC ISO
+    8601 — the timestamp is evidence, so it carries an explicit offset rather
+    than a naive local reading nobody can later interpret.
+    """
+    when = now or datetime.now(timezone.utc)
+    if when.tzinfo is None:
+        when = when.replace(tzinfo=timezone.utc)
+    config.privacy_notice_ack_version = NOTICE_VERSION
+    config.privacy_notice_ack_at = when.astimezone(timezone.utc).isoformat()
+    config.save()
+    logger.info(
+        "Privacy notice acknowledged (version=%s at=%s)",
+        config.privacy_notice_ack_version,
+        config.privacy_notice_ack_at,
+    )
+
+
+def acknowledgement_telemetry(config) -> Optional[dict]:
+    """The heartbeat payload for a recorded acknowledgement, or ``None``.
+
+    Reported on EVERY heartbeat for as long as an acknowledgement exists, not
+    once. There is deliberately no delivery state machine here: the server-side
+    reader ships separately and later, so a send-once design would silently lose
+    every acknowledgement made before that deploy — the exact
+    write-with-no-reader failure in one-rule-one-implementation.md, inverted.
+    An idempotent ~80-byte upsert on a 2.5-minute cadence is the cheaper trade.
+
+    ``device_id`` rides along so the record is self-describing; the user is
+    identified by the per-device token the heartbeat is authenticated with.
+    """
+    version = getattr(config, "privacy_notice_ack_version", None)
+    acknowledged_at = getattr(config, "privacy_notice_ack_at", None)
+    # Both halves or nothing: a version with no timestamp is not evidence of
+    # delivery, and reporting it would let a half-written record read as proof.
+    if version is None or acknowledged_at is None:
+        return None
+    payload = {"version": version, "acknowledged_at": acknowledged_at}
+    device_id = getattr(config, "device_id", None)
+    if device_id:
+        payload["device_id"] = device_id
+    return payload

--- a/src/privacy_notice.py
+++ b/src/privacy_notice.py
@@ -36,6 +36,44 @@ Authoritative source: Regulament Intern art. 64^1 alin. (4) and (5), in
 Romanian. The agent UI is English, so the notice is English — but if the two
 ever disagree, **the Romanian wins**; it is the version employees sign. That is
 stated inside the notice itself rather than only in this docstring.
+
+Why the version is computed here and NOT taken from the server
+--------------------------------------------------------------
+
+The heartbeat response carries ``disclosure.version`` — the version the server
+considers in force — and ``disclosure.acknowledged``. This module deliberately
+does not consume either, and that is a decision rather than an omission.
+
+The two ends mean different things by "version". Here it means *the words that
+were displayed*; server-side it means *the policy in force*. Those coincide only
+by luck, because *the server does not deliver the text* — the notice ships
+inside the agent build. So:
+
+- Recording the server's version against a click would produce a record saying
+  the user read text identified by a version the server chose, while they
+  actually read whatever their installed build contained. On a fleet spanning
+  several agent versions, every device reports the same label for different
+  words, and the record stops being falsifiable — which is the exact property
+  that makes it evidence.
+- Re-showing on ``server.version != acknowledged`` would, with today's
+  contract, re-display the SAME words the user already dismissed, because
+  nothing new arrived. It would also not terminate: the agent acknowledges with
+  its text hash, the server compares that against its in-force version, sees a
+  mismatch, and asks again forever.
+
+So the two schemes are not interchangeable. The client hash is tamper-evident
+(copy cannot move without the version moving) and is the only value that
+describes what was on screen. The server's version is centrally controllable,
+which is genuinely valuable — legal should be able to invalidate every prior
+acknowledgement without waiting for an agent release.
+
+Getting both needs a contract change, not an agent change. Either the server
+delivers the notice TEXT (and the agent hashes what it actually rendered — the
+version stays derived, central control is real), or the acknowledgement carries
+BOTH values (``version`` = what was displayed, ``policy_version`` = what the
+server asked for) so the server can close its own loop. Until one of those
+exists, adopting ``disclosure.version`` would trade a property we have for one
+we would not actually get.
 """
 
 import hashlib
@@ -200,15 +238,25 @@ def record_acknowledgement(config, *, now: Optional[datetime] = None) -> None:
 def acknowledgement_telemetry(config) -> Optional[dict]:
     """The heartbeat payload for a recorded acknowledgement, or ``None``.
 
+    Shape is the SERVER's contract, not ours: ``AgentHeartbeatController`` reads
+    ``disclosure_acknowledgement`` as ``{version, acknowledged_at}`` and stores
+    it in ``agent_disclosure_acknowledgements``. Adding a field here does not
+    extend the record, it just sends bytes nothing reads.
+
+    No ``device_id``, deliberately. The server already knows which device is
+    calling — the heartbeat is authenticated by a per-device token and the
+    server writes ``agent_device_id`` itself. A second copy travelling in the
+    body could only ever agree (noise) or disagree (a bug someone then has to
+    adjudicate), and on an evidence record "the two device ids disagree" is a
+    genuinely expensive question. The authenticated context is the stronger
+    binding anyway: a body field is asserted by the client, the token is proven.
+
     Reported on EVERY heartbeat for as long as an acknowledgement exists, not
     once. There is deliberately no delivery state machine here: the server-side
     reader ships separately and later, so a send-once design would silently lose
     every acknowledgement made before that deploy — the exact
     write-with-no-reader failure in one-rule-one-implementation.md, inverted.
-    An idempotent ~80-byte upsert on a 2.5-minute cadence is the cheaper trade.
-
-    ``device_id`` rides along so the record is self-describing; the user is
-    identified by the per-device token the heartbeat is authenticated with.
+    An idempotent ~60-byte upsert on a 2.5-minute cadence is the cheaper trade.
     """
     version = getattr(config, "privacy_notice_ack_version", None)
     acknowledged_at = getattr(config, "privacy_notice_ack_at", None)
@@ -216,8 +264,4 @@ def acknowledgement_telemetry(config) -> Optional[dict]:
     # delivery, and reporting it would let a half-written record read as proof.
     if version is None or acknowledged_at is None:
         return None
-    payload = {"version": version, "acknowledged_at": acknowledged_at}
-    device_id = getattr(config, "device_id", None)
-    if device_id:
-        payload["device_id"] = device_id
-    return payload
+    return {"version": version, "acknowledged_at": acknowledged_at}

--- a/src/sync/bf_client.py
+++ b/src/sync/bf_client.py
@@ -457,11 +457,15 @@ class BetterFlowClient(BaseApiClient):
         # inventory. str | None — see src/hardware_serial.py.
         "hardware_serial",
         # Record that this device was shown, and the user acknowledged, the
-        # current data-collection notice: {version, acknowledged_at, device_id}.
-        # The Law 190/2018 art. 5 lit. b evidence of prior information; the user
-        # is bound by the per-device token this heartbeat authenticates with.
-        # See src/privacy_notice.py.
-        "privacy_notice_ack",
+        # current data-collection notice: {version, acknowledged_at}. The Law
+        # 190/2018 art. 5 lit. b evidence of prior information. The key name and
+        # payload shape are the SERVER's contract — AgentHeartbeatController
+        # reads `disclosure_acknowledgement` and stores it in
+        # agent_disclosure_acknowledgements; do not rename either end alone.
+        # The device is identified by the authenticated heartbeat context, so
+        # the payload deliberately carries no device id. See
+        # src/privacy_notice.py.
+        "disclosure_acknowledgement",
     )
 
     def heartbeat(

--- a/src/sync/bf_client.py
+++ b/src/sync/bf_client.py
@@ -456,6 +456,12 @@ class BetterFlowClient(BaseApiClient):
         # Stable hardware identifier joining this device to the MDM asset
         # inventory. str | None — see src/hardware_serial.py.
         "hardware_serial",
+        # Record that this device was shown, and the user acknowledged, the
+        # current data-collection notice: {version, acknowledged_at, device_id}.
+        # The Law 190/2018 art. 5 lit. b evidence of prior information; the user
+        # is bound by the per-device token this heartbeat authenticates with.
+        # See src/privacy_notice.py.
+        "privacy_notice_ack",
     )
 
     def heartbeat(

--- a/src/ui/privacy_notice_window.py
+++ b/src/ui/privacy_notice_window.py
@@ -1,0 +1,180 @@
+"""The window that shows the one-time privacy notice. A thin shell, on purpose.
+
+Every word it displays comes from ``src/privacy_notice.py`` via ``notice_lines``
+— this module owns layout and nothing else. That split is load-bearing rather
+than tidy: the version recorded against an acknowledgement is a hash of that
+same text, so any copy hard-coded here would be text the user read and the
+record does not describe. ``tests/test_privacy_notice_window.py`` guards it by
+reading this module's source.
+
+Why a ``tk.Text`` and not the canvas the setup wizard draws on: canvas text is
+positioned absolutely and silently clips when it overflows. Clipping a
+decorative subtitle is a cosmetic bug; clipping a disclosure bullet is a
+compliance defect that looks fine in the screenshot the author took. A scrolling
+text widget cannot lose a line.
+
+Threading: called from the main thread only (``BetterFlowApp.run``), before
+pystray takes it over — the same sequencing the first-run wizard and the macOS
+permission gate already use. Tk is not safe off the main thread on macOS.
+"""
+
+import contextlib
+import logging
+import platform
+import tkinter as tk
+
+try:
+    from ..privacy_notice import (
+        ACK_BUTTON_TEXT,
+        NOTICE_SUBTITLE,
+        NOTICE_TITLE,
+        notice_lines,
+    )
+except ImportError:  # PyInstaller bundle
+    from privacy_notice import (  # type: ignore[no-redef]
+        ACK_BUTTON_TEXT,
+        NOTICE_SUBTITLE,
+        NOTICE_TITLE,
+        notice_lines,
+    )
+
+logger = logging.getLogger(__name__)
+
+WINDOW_WIDTH = 720
+WINDOW_HEIGHT = 620
+
+if platform.system() == "Darwin":
+    FONT_FAMILY = "Avenir Next"
+elif platform.system() == "Windows":
+    FONT_FAMILY = "Segoe UI"
+else:
+    FONT_FAMILY = "sans-serif"
+
+# BetterFlow palette, matching the setup wizard.
+BG_COLOR = "#0f0a1a"
+CARD_COLOR = "#1a1028"
+TEXT_COLOR = "#f4f0ff"
+TEXT_MUTED = "#b8a8d6"
+PRIMARY_COLOR = "#7D69B8"
+BTN_TEXT = "#ffffff"
+
+
+def show_privacy_notice(_root_factory=tk.Tk) -> bool:
+    """Show the notice modally. Returns True only if the user acknowledged it.
+
+    Closing the window without pressing the button returns False, which leaves
+    the acknowledgement unrecorded and re-shows the notice next launch. That is
+    the correct legal behaviour: the record has to mean someone dismissed the
+    text deliberately.
+
+    ``_root_factory`` is injected only so tests can drive the callbacks without
+    a display server.
+    """
+    acknowledged = {"value": False}
+    root = _root_factory()
+    root.title("BetterFlow — Privacy Notice")
+    root.geometry(f"{WINDOW_WIDTH}x{WINDOW_HEIGHT}")
+    root.configure(bg=BG_COLOR)
+    root.resizable(False, False)
+
+    def _on_acknowledge() -> None:
+        acknowledged["value"] = True
+        root.destroy()
+
+    def _on_close() -> None:
+        # Not an acknowledgement. Leave the record unwritten and try again next
+        # launch rather than banking a dismissal nobody read.
+        root.destroy()
+
+    root.protocol("WM_DELETE_WINDOW", _on_close)
+
+    tk.Label(
+        root,
+        text=NOTICE_TITLE,
+        font=(FONT_FAMILY, 20, "bold"),
+        bg=BG_COLOR,
+        fg=TEXT_COLOR,
+        wraplength=WINDOW_WIDTH - 80,
+        justify=tk.LEFT,
+    ).pack(anchor="w", padx=40, pady=(32, 8))
+
+    tk.Label(
+        root,
+        text=NOTICE_SUBTITLE,
+        font=(FONT_FAMILY, 12),
+        bg=BG_COLOR,
+        fg=TEXT_MUTED,
+        wraplength=WINDOW_WIDTH - 80,
+        justify=tk.LEFT,
+    ).pack(anchor="w", padx=40, pady=(0, 16))
+
+    body_frame = tk.Frame(root, bg=BG_COLOR)
+    body_frame.pack(fill=tk.BOTH, expand=True, padx=40)
+
+    scrollbar = tk.Scrollbar(body_frame)
+    scrollbar.pack(side=tk.RIGHT, fill=tk.Y)
+
+    body = tk.Text(
+        body_frame,
+        wrap=tk.WORD,
+        font=(FONT_FAMILY, 12),
+        bg=CARD_COLOR,
+        fg=TEXT_COLOR,
+        relief=tk.FLAT,
+        padx=18,
+        pady=16,
+        highlightthickness=0,
+        yscrollcommand=scrollbar.set,
+    )
+    body.pack(side=tk.LEFT, fill=tk.BOTH, expand=True)
+    scrollbar.config(command=body.yview)
+
+    body.insert("1.0", "\n".join(notice_lines()))
+    # Read-only, but still selectable and scrollable — a disabled Text cannot be
+    # copied, and someone should be able to paste this to their own records.
+    body.config(state=tk.DISABLED)
+
+    tk.Button(
+        root,
+        text=ACK_BUTTON_TEXT,
+        command=_on_acknowledge,
+        font=(FONT_FAMILY, 13, "bold"),
+        bg=PRIMARY_COLOR,
+        fg=BTN_TEXT,
+        activebackground=PRIMARY_COLOR,
+        activeforeground=BTN_TEXT,
+        relief=tk.FLAT,
+        highlightthickness=0,
+        borderwidth=0,
+        padx=28,
+        pady=10,
+    ).pack(pady=(20, 28))
+
+    _bring_to_front(root)
+    root.mainloop()
+    return acknowledged["value"]
+
+
+def _bring_to_front(root) -> None:
+    """Raise the window above the tray-only app that has no other UI.
+
+    Best-effort: a window manager that refuses any of this is a cosmetic
+    problem, never a reason to fail the notice.
+    """
+    try:
+        root.update_idletasks()
+        x = (root.winfo_screenwidth() - WINDOW_WIDTH) // 2
+        y = (root.winfo_screenheight() - WINDOW_HEIGHT) // 3
+        root.geometry(f"+{max(x, 0)}+{max(y, 0)}")
+        root.lift()
+        root.attributes("-topmost", True)
+        # Drop topmost straight away so the notice does not sit over everything
+        # the user does afterwards; the raise has already happened.
+        root.after(600, lambda: _drop_topmost(root))
+    except Exception as e:  # noqa: BLE001
+        logger.debug("could not raise the privacy notice window: %s", e)
+
+
+def _drop_topmost(root) -> None:
+    with contextlib.suppress(Exception):
+        root.attributes("-topmost", False)

--- a/src/ui/privacy_notice_window.py
+++ b/src/ui/privacy_notice_window.py
@@ -56,6 +56,7 @@ CARD_COLOR = "#1a1028"
 TEXT_COLOR = "#f4f0ff"
 TEXT_MUTED = "#b8a8d6"
 PRIMARY_COLOR = "#7D69B8"
+PRIMARY_HOVER = "#8f7ccb"  # lighter purple on hover
 BTN_TEXT = "#ffffff"
 
 
@@ -134,21 +135,27 @@ def show_privacy_notice(_root_factory=tk.Tk) -> bool:
     # copied, and someone should be able to paste this to their own records.
     body.config(state=tk.DISABLED)
 
-    tk.Button(
+    # A tk.Button uses the native macOS Aqua style, which IGNORES `bg` — the
+    # purple is silently dropped, leaving white text on the default light button
+    # face (unreadable, caught on a real Mac 2026-07-23). A tk.Label honours
+    # `bg` on every platform, so we render the button as a clickable label and
+    # bind the click ourselves. `hand2` cursor + a hover tint make it read as a
+    # button rather than a caption.
+    ack_button = tk.Label(
         root,
         text=ACK_BUTTON_TEXT,
-        command=_on_acknowledge,
         font=(FONT_FAMILY, 13, "bold"),
         bg=PRIMARY_COLOR,
         fg=BTN_TEXT,
-        activebackground=PRIMARY_COLOR,
-        activeforeground=BTN_TEXT,
-        relief=tk.FLAT,
-        highlightthickness=0,
-        borderwidth=0,
         padx=28,
         pady=10,
-    ).pack(pady=(20, 28))
+        cursor="hand2",
+    )
+    ack_button.pack(pady=(20, 28))
+    ack_button.bind("<Button-1>", lambda _event: _on_acknowledge())
+    ack_button.bind("<Return>", lambda _event: _on_acknowledge())
+    ack_button.bind("<Enter>", lambda _e: ack_button.configure(bg=PRIMARY_HOVER))
+    ack_button.bind("<Leave>", lambda _e: ack_button.configure(bg=PRIMARY_COLOR))
 
     _bring_to_front(root)
     root.mainloop()

--- a/tests/test_privacy_notice.py
+++ b/tests/test_privacy_notice.py
@@ -1,0 +1,203 @@
+"""The notice text, its version, and the acknowledgement record.
+
+The defect being fixed is not "no notice exists" — it is "a new data category
+can reach devices that already acknowledged the old text". So the load-bearing
+assertions here are the ones about the VERSION, not the ones about the copy:
+
+- the version is derived from the text, so editing copy without touching the
+  version is impossible rather than merely discouraged;
+- a device holding an older version re-shows, which is the same comparison as
+  a device holding none.
+
+The qualifier tests exist because three phrases are legal work disguised as
+prose, and a future "make it fit on one screen" pass deletes them first. A
+comment saying so does not stop it (diagnosis-discipline.md); a failing test
+does.
+
+No absolute dates anywhere: every timestamp is injected.
+"""
+
+from datetime import datetime, timedelta, timezone
+
+import pytest
+
+from src import privacy_notice as pn
+from src.config import Config
+
+
+@pytest.fixture
+def config(tmp_path):
+    """A real Config, isolated by conftest's autouse path redirection."""
+    return Config()
+
+
+def _fixed_now(offset_seconds: int = 0) -> datetime:
+    """A deterministic instant derived from the clock, never a literal date.
+
+    A hardcoded datetime in a fixture is a time bomb; two detonated across
+    these repos on 2026-07-22. This stays anchored to whenever the suite runs.
+    """
+    return datetime.now(timezone.utc) + timedelta(seconds=offset_seconds)
+
+
+# ── The text ────────────────────────────────────────────────────────────
+
+def test_every_mandatory_qualifier_survives():
+    """Each of these is doing legal work, not describing a feature."""
+    text = pn.notice_text()
+    for qualifier in pn.REQUIRED_QUALIFIERS:
+        assert qualifier in text, (
+            f"the qualifier {qualifier!r} was removed from the notice — it is "
+            "load-bearing, see the comments in src/privacy_notice.py"
+        )
+
+
+def test_titles_are_not_described_as_anonymised():
+    """"as recorded" is the whole point: nothing hashes titles on the device.
+
+    The `hash_titles` setting NAME already misleads people here, so the notice
+    must not repeat the mistake by implying a local transform.
+    """
+    text = pn.notice_text()
+    assert "sent to our servers as recorded" in text
+    lowered = text.lower()
+    for forbidden in ("anonymis", "anonymiz", "hashed before", "hashed on this"):
+        assert forbidden not in lowered, (
+            f"the notice now claims {forbidden!r}; the agent does no client-side "
+            "title hashing"
+        )
+
+
+def test_input_bullet_cannot_read_as_a_keylogger():
+    text = pn.notice_text()
+    assert "Counts only" in text
+    assert "does not record which keys you press" in text
+
+
+def test_contact_route_is_present():
+    assert "dpo@betterqa.co" in pn.notice_text()
+
+
+def test_romanian_source_prevails_is_stated_in_the_notice():
+    """The English is a rendering; employees signed the Romanian."""
+    text = pn.notice_text()
+    assert "Regulamentul Intern" in text
+    assert "prevails" in text
+
+
+def test_every_bullet_reaches_the_rendered_lines():
+    """The renderer must not drop a section — a lost bullet is a lost disclosure."""
+    lines = pn.notice_lines()
+    for lead, bullets in pn.NOTICE_SECTIONS:
+        assert lead in lines
+        for bullet in bullets:
+            assert f"•  {bullet}" in lines
+
+
+# ── The version ─────────────────────────────────────────────────────────
+
+def test_version_is_derived_from_the_text_not_hand_written(monkeypatch):
+    """Change a character of the notice; the version must change.
+
+    This is requirement 2 in mechanical form. If NOTICE_VERSION were a constant
+    a developer maintains, this test would pass while the guarantee was absent —
+    so it recomputes the version the way production does, against mutated text.
+    """
+    baseline = pn.NOTICE_VERSION
+    assert baseline == f"{pn.NOTICE_REVISION}-{pn._digest(pn.notice_text())}"
+
+    mutated_sections = (
+        ("A newly collected category nobody disclosed before.", ()),
+        *pn.NOTICE_SECTIONS,
+    )
+    monkeypatch.setattr(pn, "NOTICE_SECTIONS", mutated_sections)
+    mutated_version = f"{pn.NOTICE_REVISION}-{pn._digest(pn.notice_text())}"
+
+    assert mutated_version != baseline, (
+        "adding a data category to the notice did not change the version — a "
+        "silent ship to already-acknowledged devices"
+    )
+
+
+def test_version_carries_a_readable_revision_prefix():
+    assert pn.NOTICE_VERSION.startswith(f"{pn.NOTICE_REVISION}-")
+    assert len(pn.NOTICE_VERSION) > len(pn.NOTICE_REVISION) + 1
+
+
+# ── The acknowledgement record ──────────────────────────────────────────
+
+def test_a_fresh_device_needs_the_notice(config):
+    assert pn.needs_acknowledgement(config) is True
+
+
+def test_acknowledging_stops_it_showing_again(config):
+    """The "then stops" half. A notice that reappears every launch gets
+    dismissed reflexively, and the record stops meaning anything."""
+    pn.record_acknowledgement(config, now=_fixed_now())
+    assert pn.needs_acknowledgement(config) is False
+    # And it stays stopped across a reload from disk, not just in memory.
+    assert pn.needs_acknowledgement(Config.load()) is False
+
+
+def test_bumping_the_text_version_reshows_it(config, monkeypatch):
+    pn.record_acknowledgement(config, now=_fixed_now())
+    assert pn.needs_acknowledgement(config) is False
+
+    monkeypatch.setattr(pn, "NOTICE_VERSION", pn.NOTICE_VERSION + "-next")
+    assert pn.needs_acknowledgement(config) is True, (
+        "a new text version did not re-show — the disclosure-gap bug is back"
+    )
+
+
+def test_a_stale_version_is_not_treated_as_acknowledged(config):
+    """Compared by value, never by truthiness. A device holding SOME ack is not
+    a device holding THIS ack."""
+    config.privacy_notice_ack_version = "r0-deadbeefcafe"
+    config.privacy_notice_ack_at = _fixed_now(-86400).isoformat()
+    assert pn.needs_acknowledgement(config) is True
+
+
+def test_the_recorded_time_is_when_it_happened(config):
+    when = _fixed_now(-3600)
+    pn.record_acknowledgement(config, now=when)
+    assert config.privacy_notice_ack_at == when.astimezone(timezone.utc).isoformat()
+    assert config.privacy_notice_ack_version == pn.NOTICE_VERSION
+
+
+def test_a_naive_timestamp_is_recorded_as_utc(config):
+    naive = _fixed_now().replace(tzinfo=None)
+    pn.record_acknowledgement(config, now=naive)
+    assert config.privacy_notice_ack_at.endswith("+00:00")
+
+
+def test_the_record_survives_a_config_round_trip(config):
+    pn.record_acknowledgement(config, now=_fixed_now())
+    reloaded = Config.load()
+    assert reloaded.privacy_notice_ack_version == config.privacy_notice_ack_version
+    assert reloaded.privacy_notice_ack_at == config.privacy_notice_ack_at
+
+
+# ── The heartbeat payload ───────────────────────────────────────────────
+
+def test_no_telemetry_before_an_acknowledgement(config):
+    assert pn.acknowledgement_telemetry(config) is None
+
+
+def test_telemetry_carries_version_time_and_device(config):
+    config.device_id = "sync:abc-123"
+    when = _fixed_now(-120)
+    pn.record_acknowledgement(config, now=when)
+
+    payload = pn.acknowledgement_telemetry(config)
+    assert payload == {
+        "version": pn.NOTICE_VERSION,
+        "acknowledged_at": when.astimezone(timezone.utc).isoformat(),
+        "device_id": "sync:abc-123",
+    }
+
+
+def test_a_half_written_record_is_not_reported(config):
+    """A version with no timestamp is not evidence of delivery."""
+    config.privacy_notice_ack_version = pn.NOTICE_VERSION
+    config.privacy_notice_ack_at = None
+    assert pn.acknowledgement_telemetry(config) is None

--- a/tests/test_privacy_notice.py
+++ b/tests/test_privacy_notice.py
@@ -183,7 +183,16 @@ def test_no_telemetry_before_an_acknowledgement(config):
     assert pn.acknowledgement_telemetry(config) is None
 
 
-def test_telemetry_carries_version_time_and_device(config):
+def test_telemetry_is_exactly_the_server_contract(config):
+    """{version, acknowledged_at} — the shape AgentHeartbeatController reads.
+
+    Asserted as EQUALITY, not as "contains", so an extra field is a failure
+    rather than a passing test and some bytes nobody reads. Note the device id
+    is set on the config and still absent from the payload: the server binds the
+    record to a device from the authenticated heartbeat and writes
+    agent_device_id itself, so a second client-asserted copy could only agree
+    (noise) or disagree (an expensive question on an evidence record).
+    """
     config.device_id = "sync:abc-123"
     when = _fixed_now(-120)
     pn.record_acknowledgement(config, now=when)
@@ -192,7 +201,6 @@ def test_telemetry_carries_version_time_and_device(config):
     assert payload == {
         "version": pn.NOTICE_VERSION,
         "acknowledged_at": when.astimezone(timezone.utc).isoformat(),
-        "device_id": "sync:abc-123",
     }
 
 

--- a/tests/test_privacy_notice_heartbeat.py
+++ b/tests/test_privacy_notice_heartbeat.py
@@ -39,18 +39,14 @@ def _last_body():
 
 def _sample_ack():
     when = datetime.now(timezone.utc) - timedelta(minutes=5)
-    return {
-        "version": pn.NOTICE_VERSION,
-        "acknowledged_at": when.isoformat(),
-        "device_id": "sync:abc-123",
-    }
+    return {"version": pn.NOTICE_VERSION, "acknowledged_at": when.isoformat()}
 
 
 # ── The wire boundary ───────────────────────────────────────────────────
 
 def test_the_key_is_whitelisted_for_the_heartbeat():
     """Membership, not truthiness. Absence here is a silent drop, not an error."""
-    assert "privacy_notice_ack" in BetterFlowClient.HEARTBEAT_HEALTH_KEYS
+    assert "disclosure_acknowledgement" in BetterFlowClient.HEARTBEAT_HEALTH_KEYS
 
 
 @responses.activate
@@ -64,14 +60,14 @@ def test_the_acknowledgement_reaches_the_request_body():
     ack = _sample_ack()
     client = _make_client()
     try:
-        client.heartbeat(health={"privacy_notice_ack": ack})
+        client.heartbeat(health={"disclosure_acknowledgement": ack})
     finally:
         client.close()
 
     body = _last_body()
-    assert body["privacy_notice_ack"] == ack
-    assert body["privacy_notice_ack"]["version"] == pn.NOTICE_VERSION
-    assert body["privacy_notice_ack"]["acknowledged_at"]
+    assert body["disclosure_acknowledgement"] == ack
+    assert body["disclosure_acknowledgement"]["version"] == pn.NOTICE_VERSION
+    assert body["disclosure_acknowledgement"]["acknowledged_at"]
 
 
 @responses.activate
@@ -90,11 +86,11 @@ def test_a_falsy_payload_is_still_forwarded():
     )
     client = _make_client()
     try:
-        client.heartbeat(health={"privacy_notice_ack": {}})
+        client.heartbeat(health={"disclosure_acknowledgement": {}})
     finally:
         client.close()
 
-    assert "privacy_notice_ack" in _last_body()
+    assert "disclosure_acknowledgement" in _last_body()
 
 
 @responses.activate
@@ -111,7 +107,7 @@ def test_a_device_that_never_acknowledged_sends_no_key():
     finally:
         client.close()
 
-    assert "privacy_notice_ack" not in _last_body()
+    assert "disclosure_acknowledgement" not in _last_body()
 
 
 # ── The callsite guard ──────────────────────────────────────────────────
@@ -143,14 +139,14 @@ def test_the_heartbeat_assembler_includes_the_acknowledgement(tmp_path):
     )
 
     telemetry = _telemetry_from_real_app(config)
-    assert "privacy_notice_ack" in telemetry
-    assert telemetry["privacy_notice_ack"]["version"] == pn.NOTICE_VERSION
-    assert telemetry["privacy_notice_ack"]["device_id"] == "sync:abc-123"
+    assert "disclosure_acknowledgement" in telemetry
+    assert telemetry["disclosure_acknowledgement"]["version"] == pn.NOTICE_VERSION
+    assert set(telemetry["disclosure_acknowledgement"]) == {"version", "acknowledged_at"}
 
 
 def test_the_assembler_omits_it_before_any_acknowledgement():
     telemetry = _telemetry_from_real_app(Config())
-    assert "privacy_notice_ack" not in telemetry
+    assert "disclosure_acknowledgement" not in telemetry
 
 
 def test_the_assembler_delegates_instead_of_rebuilding_the_payload():
@@ -180,4 +176,4 @@ def test_reporting_never_raises_into_the_heartbeat(monkeypatch):
     )
     telemetry = _telemetry_from_real_app(Config())
     assert isinstance(telemetry, dict)
-    assert "privacy_notice_ack" not in telemetry
+    assert "disclosure_acknowledgement" not in telemetry

--- a/tests/test_privacy_notice_heartbeat.py
+++ b/tests/test_privacy_notice_heartbeat.py
@@ -1,0 +1,183 @@
+"""The acknowledgement has to reach the WIRE, not just a dict.
+
+``BetterFlowClient.heartbeat`` copies only keys listed in
+``HEARTBEAT_HEALTH_KEYS``. A field absent from that tuple is dropped silently at
+the boundary with no error anywhere — which is how #152 nearly shipped dead. So
+the assertions here read the serialised request body, and the membership check
+is spelled with ``in`` against the tuple rather than "does the telemetry look
+populated".
+
+The last test is the callsite guard: ``_build_health_telemetry`` is the only
+production assembler of that dict, so a perfect payload builder that nothing
+calls would otherwise pass everything above (Phantom 3).
+"""
+
+import inspect
+import json
+from datetime import datetime, timedelta, timezone
+from unittest.mock import MagicMock
+
+import responses
+
+from src import privacy_notice as pn
+from src.config import Config
+from src.main import SyncCoordinator
+from src.sync.bf_client import BetterFlowClient
+
+
+def _make_client():
+    return BetterFlowClient(
+        api_url="https://betterflow.eu/api/agent",
+        token="test-token",
+        device_id="test-device",
+    )
+
+
+def _last_body():
+    return json.loads(responses.calls[-1].request.body)
+
+
+def _sample_ack():
+    when = datetime.now(timezone.utc) - timedelta(minutes=5)
+    return {
+        "version": pn.NOTICE_VERSION,
+        "acknowledged_at": when.isoformat(),
+        "device_id": "sync:abc-123",
+    }
+
+
+# ── The wire boundary ───────────────────────────────────────────────────
+
+def test_the_key_is_whitelisted_for_the_heartbeat():
+    """Membership, not truthiness. Absence here is a silent drop, not an error."""
+    assert "privacy_notice_ack" in BetterFlowClient.HEARTBEAT_HEALTH_KEYS
+
+
+@responses.activate
+def test_the_acknowledgement_reaches_the_request_body():
+    responses.add(
+        responses.POST,
+        "https://betterflow.eu/api/agent/heartbeat",
+        json={"status": "active"},
+        status=200,
+    )
+    ack = _sample_ack()
+    client = _make_client()
+    try:
+        client.heartbeat(health={"privacy_notice_ack": ack})
+    finally:
+        client.close()
+
+    body = _last_body()
+    assert body["privacy_notice_ack"] == ack
+    assert body["privacy_notice_ack"]["version"] == pn.NOTICE_VERSION
+    assert body["privacy_notice_ack"]["acknowledged_at"]
+
+
+@responses.activate
+def test_a_falsy_payload_is_still_forwarded():
+    """Adversarial arrangement: the forwarding must be ``in``, not ``if value``.
+
+    An empty dict is the input that separates the two implementations — a
+    truthiness filter drops it, and the bug only appears for whatever future
+    payload shape happens to be falsy.
+    """
+    responses.add(
+        responses.POST,
+        "https://betterflow.eu/api/agent/heartbeat",
+        json={"status": "active"},
+        status=200,
+    )
+    client = _make_client()
+    try:
+        client.heartbeat(health={"privacy_notice_ack": {}})
+    finally:
+        client.close()
+
+    assert "privacy_notice_ack" in _last_body()
+
+
+@responses.activate
+def test_a_device_that_never_acknowledged_sends_no_key():
+    responses.add(
+        responses.POST,
+        "https://betterflow.eu/api/agent/heartbeat",
+        json={"status": "active"},
+        status=200,
+    )
+    client = _make_client()
+    try:
+        client.heartbeat(health={"consecutive_sync_failures": 0})
+    finally:
+        client.close()
+
+    assert "privacy_notice_ack" not in _last_body()
+
+
+# ── The callsite guard ──────────────────────────────────────────────────
+
+def _telemetry_from_real_app(config) -> dict:
+    """Drive the REAL _build_health_telemetry against a stub coordinator.
+
+    Constructing a SyncCoordinator needs a tray, an engine and a keychain, none
+    of which this path touches — so the production method runs unbound against
+    the handful of attributes it actually reads.
+    """
+    import threading
+
+    stub = MagicMock()
+    stub.config = config
+    stub._idle_tracker_warn_lock = threading.Lock()
+    stub._blind_tracker_window = 0
+    stub._consecutive_sync_failures = 0
+    stub._last_successful_sync = None
+    stub.aw_manager.health_snapshot.return_value = {}
+    return SyncCoordinator._build_health_telemetry(stub)
+
+
+def test_the_heartbeat_assembler_includes_the_acknowledgement(tmp_path):
+    config = Config()
+    config.device_id = "sync:abc-123"
+    pn.record_acknowledgement(
+        config, now=datetime.now(timezone.utc) - timedelta(minutes=5)
+    )
+
+    telemetry = _telemetry_from_real_app(config)
+    assert "privacy_notice_ack" in telemetry
+    assert telemetry["privacy_notice_ack"]["version"] == pn.NOTICE_VERSION
+    assert telemetry["privacy_notice_ack"]["device_id"] == "sync:abc-123"
+
+
+def test_the_assembler_omits_it_before_any_acknowledgement():
+    telemetry = _telemetry_from_real_app(Config())
+    assert "privacy_notice_ack" not in telemetry
+
+
+def test_the_assembler_delegates_instead_of_rebuilding_the_payload():
+    """One rule, one implementation — the shape must not be re-rolled here.
+
+    Comparing outputs cannot catch a parallel builder that happens to agree
+    today; reading the consumer's source can.
+    """
+    source = inspect.getsource(SyncCoordinator._build_health_telemetry)
+    doc = SyncCoordinator._build_health_telemetry.__doc__
+    if doc:
+        source = source.replace(doc, "")
+    assert "acknowledgement_telemetry(" in source, (
+        "the heartbeat stopped calling the shared payload builder"
+    )
+    assert "acknowledged_at" not in source, "payload shape re-derived at the callsite"
+    assert "NOTICE_VERSION" not in source, "version read a second time at the callsite"
+
+
+def test_reporting_never_raises_into_the_heartbeat(monkeypatch):
+    """A broken record must not cost the fleet its heartbeat."""
+    def boom(_config):
+        raise RuntimeError("corrupt acknowledgement record")
+
+    monkeypatch.setattr(
+        "src.main.acknowledgement_telemetry", boom, raising=True
+    )
+    telemetry = _telemetry_from_real_app(Config())
+    assert isinstance(telemetry, dict)
+    assert "privacy_notice_ack" not in telemetry

--- a/tests/test_privacy_notice_startup.py
+++ b/tests/test_privacy_notice_startup.py
@@ -1,0 +1,155 @@
+"""Delivery: the notice actually reaches every platform, once, without gating.
+
+The disclosure gap this fixes is platform-shaped. macOS never runs
+``_show_consent`` — Macs only ever see the Input Monitoring gate — so hanging
+the notice off the consent screen would have re-shipped the same bug to the
+platform that matters most. It therefore lives in ``BetterFlowApp.run``, which
+every platform executes on every launch.
+
+Where in ``run`` is itself a requirement, not a detail. It sits AFTER the
+background startup thread has started (so syncing, tracking and billing are
+already running while the window is open) and BEFORE ``tray.run_blocking``
+(the last point the main thread is still free, since Tk is not safe off it on
+macOS). The ordering test pins that; without it "never blocks work" is prose.
+
+The behavioural tests drive the REAL production method unbound against a stub,
+so nothing here can pass on a helper the app does not call.
+"""
+
+import inspect
+from unittest.mock import MagicMock, patch
+
+from src import privacy_notice as pn
+from src.config import Config
+from src.main import BetterFlowApp
+
+
+def _stub_app(config):
+    stub = MagicMock()
+    stub.config = config
+    return stub
+
+
+def _run_notice(config, *, shows=True, raises=None):
+    """Call the production method with the window replaced."""
+    window = MagicMock(return_value=shows)
+    if raises is not None:
+        window.side_effect = raises
+    with patch(
+        "src.ui.privacy_notice_window.show_privacy_notice", window
+    ):
+        BetterFlowApp._show_privacy_notice_if_needed(_stub_app(config))
+    return window
+
+
+# ── Shown once, then stopped ────────────────────────────────────────────
+
+def test_a_device_that_never_acknowledged_sees_it():
+    config = Config()
+    window = _run_notice(config)
+    window.assert_called_once()
+    assert pn.needs_acknowledgement(config) is False, "the acknowledgement was not recorded"
+
+
+def test_it_does_not_come_back_on_the_next_launch():
+    """The "then stops" half. A notice that reappears every launch is dismissed
+    reflexively and the acknowledgement stops meaning anything."""
+    config = Config()
+    _run_notice(config)
+
+    second = _run_notice(Config.load())
+    second.assert_not_called()
+
+
+def test_a_new_text_version_shows_it_again(monkeypatch):
+    config = Config()
+    _run_notice(config)
+
+    monkeypatch.setattr(pn, "NOTICE_VERSION", pn.NOTICE_VERSION + "-next")
+    again = _run_notice(Config.load())
+    again.assert_called_once()
+
+
+def test_dismissing_without_acknowledging_records_nothing():
+    config = Config()
+    _run_notice(config, shows=False)
+    assert pn.needs_acknowledgement(config) is True, (
+        "closing the window banked an acknowledgement nobody made"
+    )
+
+
+# ── Never blocks work ───────────────────────────────────────────────────
+
+def test_a_broken_window_does_not_stop_the_agent():
+    """No display, a Tk that will not initialise, a hostile WM — all of these
+    must cost the notice, never the tracking."""
+    config = Config()
+    _run_notice(config, raises=RuntimeError("no display name and no $DISPLAY"))
+    # Unrecorded, so it retries next launch — but the app carried on.
+    assert pn.needs_acknowledgement(config) is True
+
+
+def test_a_failed_save_does_not_stop_the_agent(monkeypatch):
+    config = Config()
+    monkeypatch.setattr(
+        Config, "save", lambda self: (_ for _ in ()).throw(OSError("read-only disk"))
+    )
+    _run_notice(config)  # must not raise
+
+
+# ── The callsite guards ─────────────────────────────────────────────────
+
+def test_run_shows_the_notice_on_every_platform():
+    """Fails if the call is dropped from run(), not only if the logic breaks."""
+    source = inspect.getsource(BetterFlowApp.run)
+    assert "_show_privacy_notice_if_needed()" in source
+
+
+def test_the_notice_runs_after_startup_and_before_the_tray():
+    """Ordering IS the "never blocks work" guarantee.
+
+    Before ``_startup_thread.start()`` the notice would gate syncing; after
+    ``tray.run_blocking()`` it would never run at all, and moving it off the
+    main thread is unsafe for Tk on macOS.
+    """
+    source = inspect.getsource(BetterFlowApp.run)
+    startup = source.index("self._startup_thread.start()")
+    notice = source.index("self._show_privacy_notice_if_needed()")
+    tray = source.index("self.tray.run_blocking()")
+    assert startup < notice < tray, (
+        "the notice moved out of the window between background startup and the "
+        "tray loop — it now either gates tracking or never runs"
+    )
+
+
+def test_the_notice_is_not_hidden_behind_the_consent_screen():
+    """macOS never runs _show_consent. Gating on it would re-ship the bug."""
+    source = inspect.getsource(BetterFlowApp.run)
+    notice = source.index("self._show_privacy_notice_if_needed()")
+    # It must not sit inside the `if not self.config.setup_complete:` block.
+    setup_gate = source.index("if not self.config.setup_complete:")
+    tray = source.index("self.tray.run_blocking()")
+    assert setup_gate < notice < tray
+    line = [
+        line for line in source.splitlines()
+        if "self._show_privacy_notice_if_needed()" in line
+    ][0]
+    # Top level of run(): 8 spaces of indentation, not nested in a branch.
+    assert len(line) - len(line.lstrip()) == 8, (
+        "the notice is nested inside a conditional in run() — some platform or "
+        "some state will not see it"
+    )
+
+
+def test_the_handler_delegates_to_the_shared_policy():
+    source = inspect.getsource(BetterFlowApp._show_privacy_notice_if_needed)
+    doc = BetterFlowApp._show_privacy_notice_if_needed.__doc__
+    if doc:
+        source = source.replace(doc, "")
+    assert "needs_acknowledgement(" in source
+    assert "record_acknowledgement(" in source
+    assert "show_privacy_notice(" in source
+    assert "NOTICE_VERSION" not in source, "version comparison re-rolled at the callsite"
+    assert "privacy_notice_ack_version" not in source, (
+        "the handler reads the config field directly instead of asking the policy"
+    )

--- a/tests/test_privacy_notice_window.py
+++ b/tests/test_privacy_notice_window.py
@@ -28,7 +28,13 @@ def _drive(*, press_button: bool = False, close_window: bool = False):
 
     def _mainloop():
         if press_button:
-            tk_mock.Button.call_args.kwargs["command"]()
+            # The ack control is a tk.Label with a "<Button-1>" binding, not a
+            # tk.Button (Aqua ignores a Button's bg — see the window module).
+            # Drive the REAL bound callback, so this exercises the same click
+            # path a user takes rather than a stand-in.
+            binds = tk_mock.Label.return_value.bind.call_args_list
+            click = next(c for c in binds if c.args[0] == "<Button-1>")
+            click.args[1](None)  # the callback takes an event; a dummy is fine
         if close_window:
             root.protocol.call_args.args[1]()
 

--- a/tests/test_privacy_notice_window.py
+++ b/tests/test_privacy_notice_window.py
@@ -1,0 +1,102 @@
+"""The notice window: acknowledgement semantics and text parity.
+
+These must RUN in CI, not skip. A Linux runner has no display, so ``tkinter`` is
+replaced wholesale with a recorder and the window's own callbacks are driven
+directly — the same shape as ``test_tray_state_transitions``' pystray patch. A
+test that skips in the only environment that gates merges is not a guard.
+
+Two things are actually being pinned:
+
+1. **Closing the window is not an acknowledgement.** The record has to mean
+   someone dismissed the text deliberately, or it is not evidence of anything.
+2. **The window renders the versioned text.** The version recorded against an
+   acknowledgement is a hash of ``notice_lines()``; any copy hard-coded in the
+   window would be text the user read and the record does not describe.
+"""
+
+import inspect
+from unittest.mock import MagicMock, patch
+
+from src import privacy_notice as pn
+from src.ui import privacy_notice_window as win
+
+
+def _drive(*, press_button: bool = False, close_window: bool = False):
+    """Run the real show_privacy_notice() against a recorded tkinter."""
+    tk_mock = MagicMock()
+    root = MagicMock()
+
+    def _mainloop():
+        if press_button:
+            tk_mock.Button.call_args.kwargs["command"]()
+        if close_window:
+            root.protocol.call_args.args[1]()
+
+    root.mainloop.side_effect = _mainloop
+
+    with patch.object(win, "tk", tk_mock):
+        result = win.show_privacy_notice(_root_factory=lambda: root)
+    return result, tk_mock, root
+
+
+def test_pressing_the_button_acknowledges():
+    result, _tk, root = _drive(press_button=True)
+    assert result is True
+    root.destroy.assert_called()
+
+
+def test_closing_the_window_is_not_an_acknowledgement():
+    """The half that keeps the record honest — dismissal must be deliberate."""
+    result, _tk, root = _drive(close_window=True)
+    assert result is False
+    root.destroy.assert_called()
+
+
+def test_walking_away_is_not_an_acknowledgement():
+    result, _tk, _root = _drive()
+    assert result is False
+
+
+def test_the_window_renders_the_versioned_text():
+    """Every disclosure line the version hashes must reach the widget."""
+    _result, tk_mock, _root = _drive(press_button=True)
+    inserted = tk_mock.Text.return_value.insert.call_args.args[1]
+    for line in pn.notice_lines():
+        assert line in inserted, f"the window dropped the line {line!r}"
+
+
+def test_the_window_shows_the_notice_title_and_subtitle():
+    _result, tk_mock, _root = _drive(press_button=True)
+    label_texts = [c.kwargs.get("text") for c in tk_mock.Label.call_args_list]
+    assert pn.NOTICE_TITLE in label_texts
+    assert pn.NOTICE_SUBTITLE in label_texts
+
+
+def test_the_body_is_read_only():
+    _result, tk_mock, _root = _drive(press_button=True)
+    tk_mock.Text.return_value.config.assert_any_call(state=tk_mock.DISABLED)
+
+
+# ── The parity guard ────────────────────────────────────────────────────
+
+def test_the_window_does_not_carry_its_own_copy_of_the_notice():
+    """Reading the source is the only thing that catches a second copy.
+
+    A hard-coded duplicate that happens to match today passes every rendering
+    assertion above and drifts the first time only one of them is edited
+    (one-rule-one-implementation.md).
+    """
+    source = inspect.getsource(win)
+    assert "notice_lines()" in source, "the window stopped calling the shared renderer"
+    for fragment in (
+        "dpo@betterqa.co",
+        "hardware serial number",
+        "keystrokes",
+        "as recorded",
+        "Regulamentul Intern",
+    ):
+        assert fragment not in source, (
+            f"the window hard-codes {fragment!r} instead of rendering "
+            "NOTICE_SECTIONS — the recorded version would not describe what "
+            "the user read"
+        )


### PR DESCRIPTION
## DO NOT MERGE

The server-side reader for `privacy_notice_ack` is being built in parallel in **internal-tool2** and is not merged yet. Merging this first ships an acknowledgement that nothing stores — the write-with-no-reader defect in `rules/one-rule-one-implementation.md`. Land the server side, then this.

Also pending: a real-hardware macOS verification (steps at the bottom). The Tk path is exercised headlessly in CI, which is not the same as seeing the window.

---

## Why

The agent's data-collection disclosure has only ever been shown on the first-run path: `_show_consent` in `src/ui/setup_wizard.py` (Windows/Linux) and the Input Monitoring gate's `_draw_disclosure_columns` (macOS). Every device already in the fleet onboarded before the current text existed, so **the installed base has never seen it** — and macOS never runs the consent screen at all, so the entire Mac fleet has only ever seen the permission gate.

Romanian Law 190/2018 art. 5 lit. b requires complete and explicit *prior* information of employees for workplace electronic monitoring. The record of delivery is the evidence that condition was met, which is why this ships a versioned acknowledgement and not just a screen.

## The text version scheme

`NOTICE_VERSION` is **derived**, never hand-written:

```python
NOTICE_VERSION = f"{NOTICE_REVISION}-{sha256(notice_text())[:12]}"   # r1-87b196ffdda1
```

`notice_text()` is built from `NOTICE_SECTIONS`, the single source the window also renders. So:

- Editing one character of the copy changes the version, which re-shows the notice to every device that acknowledged the old text. **There is no version field for a developer to forget** — that was the explicit requirement, and a maintained constant would not have met it.
- `NOTICE_REVISION` (`r1`) is only there so a human can order records by eye. Forgetting to bump it cannot make an edit invisible, because the digest still moves.
- The version is also the description of *exactly which words* a given acknowledgement covers, which is what makes it usable as evidence.

`needs_acknowledgement` compares **by value** against the current version. A device holding an older version is the case that must re-show; a truthiness check ("has some ack") would swallow it, which is the bug being fixed.

## Platform coverage

The notice is called from `BetterFlowApp.run`, unconditionally, on every platform. It is deliberately **not** hung off the consent screen — macOS never executes that, so doing so would have re-shipped the same bug to the platform that matters most here.

Placement inside `run()` is itself a requirement, and `test_the_notice_runs_after_startup_and_before_the_tray` pins it:

```
self._startup_thread.start()          # tracking, syncing, billing already running
self._show_privacy_notice_if_needed() # <- here
self.tray.run_blocking()              # main thread gone after this
```

After the startup thread so the notice never gates work; before `run_blocking` because that is the last point the main thread is free, and Tk is unsafe off the main thread on macOS. Same sequencing the first-run wizard and the Input Monitoring gate already use.

Never blocks work, concretely: the whole handler is wrapped, a failure leaves the record unwritten and retries next launch, and nothing on this path touches tracked or billed time. Two tests cover it (`test_a_broken_window_does_not_stop_the_agent`, `test_a_failed_save_does_not_stop_the_agent`).

## Reporting to the server

**The wire contract is the server's, matched exactly.** The first push of this branch used a key and shape invented independently of `AgentHeartbeatController`; that has been corrected in `42f6ebd`.

`disclosure_acknowledgement` was added to `BetterFlowClient.HEARTBEAT_HEALTH_KEYS`, carrying `{version, acknowledged_at}` — the shape read on line 87 of `AgentHeartbeatController.php` and stored in `agent_disclosure_acknowledgements`. `acknowledged_at` is UTC ISO 8601.

The forwarding loop tests membership with `in`, never truthiness — a field absent from that tuple is dropped silently at the wire boundary with no error anywhere, which is how #152 nearly shipped dead. `test_a_falsy_payload_is_still_forwarded` uses an empty dict as the adversarial input that separates the two implementations.

**No `device_id`.** The server binds the record from the authenticated heartbeat context and writes `agent_device_id` itself, so a client-asserted copy could only agree (noise) or disagree (an expensive question to adjudicate on an evidence record). The token is a *proven* binding; a body field is merely an *asserted* one. `test_telemetry_is_exactly_the_server_contract` asserts payload **equality**, not `contains`, so an extra field fails rather than quietly shipping bytes nothing reads — and it sets `config.device_id` first, so the exclusion is tested against the case where a value is available.

It is re-sent on **every** heartbeat rather than once. Deliberate: the server-side reader ships separately and later, so a send-once design would silently lose every acknowledgement made before that deploy. An idempotent ~60-byte upsert on a 2.5-minute cadence is the cheaper trade, and it needs no delivery state machine.

### Not adopted: the server's `disclosure.version` as the re-show trigger

The downstream `disclosure: {version, acknowledged}` block is deliberately not consumed. This is a decision, not an omission, and the reasoning lives in the `src/privacy_notice.py` module docstring so it is not re-litigated by the next person to read the response shape.

The two ends mean different things by "version". Here it means *the words that were displayed*; server-side it means *the policy in force*. They coincide only by luck, because **the server does not deliver the text** — the notice ships inside the agent build. Consequently:

- **Recording the server's version against a click** would produce a record saying the user read text identified by a version the server chose, while they actually read whatever their installed build contained. On a fleet spanning several agent versions, every device reports the same label for different words. That destroys falsifiability, which is the property that makes the record evidence at all.
- **Re-showing on `server.version != acknowledged`** would, under today's contract, re-display the *same words* the user already dismissed, because nothing new arrived. It also would not terminate: the agent acknowledges with its text hash, the server compares that against its in-force version, sees a mismatch, and asks again forever. The same applies to trusting `acknowledged: false` as a trigger.

So the schemes are not interchangeable, and the trade is real. The client hash is **tamper-evident** — copy cannot move without the version moving — and is the only value that describes what was on screen. The server's version is **centrally controllable**, which is genuinely valuable: legal should be able to invalidate every prior acknowledgement without waiting for an agent release.

Getting both needs a **contract change, not an agent change**. Two options, either of which I'd implement on request:

1. **The server delivers the notice text.** The agent renders what it received and hashes what it actually displayed. The version stays derived and tamper-evident, and central control becomes real rather than nominal. This is the better end state.
2. **The acknowledgement carries both values** — `version` (what was displayed) and `policy_version` (what the server asked for) — so the server can close its own loop without the agent giving up the hash.

Until one of those exists, adopting `disclosure.version` would trade a property we have for one we would not actually get.

## Before / after evidence

**Pre-wiring** — the four new test files against a tree with no config fields, no `HEARTBEAT_HEALTH_KEYS` entry and no `run()` callsite:

```
$ PYTHONPATH=. python3 -m pytest tests/test_privacy_notice*.py -q
...
FAILED tests/test_privacy_notice.py::test_acknowledging_stops_it_showing_again
FAILED tests/test_privacy_notice.py::test_the_record_survives_a_config_round_trip
FAILED tests/test_privacy_notice_heartbeat.py::test_the_key_is_whitelisted_for_the_heartbeat
FAILED tests/test_privacy_notice_heartbeat.py::test_the_acknowledgement_reaches_the_request_body
FAILED tests/test_privacy_notice_heartbeat.py::test_a_falsy_payload_is_still_forwarded
FAILED tests/test_privacy_notice_startup.py::test_a_device_that_never_acknowledged_sees_it
FAILED tests/test_privacy_notice_startup.py::test_it_does_not_come_back_on_the_next_launch
FAILED tests/test_privacy_notice_startup.py::test_a_new_text_version_shows_it_again
FAILED tests/test_privacy_notice_startup.py::test_run_shows_the_notice_on_every_platform
FAILED tests/test_privacy_notice_startup.py::test_the_notice_runs_after_startup_and_before_the_tray
... (19 total)
======================== 19 failed, 24 passed in 1.10s =========================
```

**Post-wiring:**

```
$ PYTHONPATH=. python3 -m pytest tests/test_privacy_notice*.py -q
============================== 43 passed in 0.37s ==============================

$ PYTHONPATH=. python3 -m pytest tests/ -q
============================ 1324 passed in 27.18s =============================

$ python3 -m ruff check src/privacy_notice.py src/ui/privacy_notice_window.py tests/test_privacy_notice*.py
All checks passed!
```

**Negative controls** — the guards bite rather than decorate (`diagnosis-discipline.md` Rule 6: verify the instrument, not just the subject):

All re-run **after** the key rename, since the key name is exactly what changed:

| Sabotage | Result |
|---|---|
| Remove `disclosure_acknowledgement` from `HEARTBEAT_HEALTH_KEYS` | 3 failed, incl. the request-body assertion — `assert 'disclosure_acknowledgement' in {'agent_version': '1.5.111', 'timezone': 'Europe/Bucharest'}` |
| Delete `as recorded` from the titles paragraph | 2 failed (`test_every_mandatory_qualifier_survives`, `test_titles_are_not_described_as_anonymised`) |
| Make the window insert its own hard-coded copy instead of `notice_lines()` | 2 failed (`test_the_window_renders_the_versioned_text`, `test_the_window_does_not_carry_its_own_copy_of_the_notice`) |
| Let `device_id` back into the payload | 2 failed (`test_telemetry_is_exactly_the_server_contract`, `test_the_heartbeat_assembler_includes_the_acknowledgement`) |

The "shown once, then stops" half and the "bumping the version re-shows it" half are both asserted (`test_it_does_not_come_back_on_the_next_launch`, `test_a_new_text_version_shows_it_again`), driving the real production method against a stub rather than a helper.

Tests **run** in CI, none skip: `tkinter` is replaced wholesale with a recorder and the window's own callbacks are driven directly, the same shape as the existing `pystray` patch in `test_tray_state_transitions.py`. Every timestamp in a fixture is derived from `datetime.now()`, never a literal date.

## Phantom-3 guards

Each extracted piece is paired with a test that reads its consumer's source, so a perfect-but-uncalled helper cannot pass:

- `_build_health_telemetry` must call `acknowledgement_telemetry(` and must not re-derive the payload shape or the version.
- `_show_privacy_notice_if_needed` must call `needs_acknowledgement(` / `record_acknowledgement(` / `show_privacy_notice(` and must not touch `privacy_notice_ack_version` or `NOTICE_VERSION` itself.
- `run()` must contain the call, at top-level indentation, between the startup thread and the tray loop.
- The window module must call `notice_lines()` and must not contain any disclosure phrase of its own.

## Disclosure gaps found while verifying the list (NOT added to the notice)

The brief said the list is exhaustive and legally reviewed, and that anything the code collects outside it is a finding rather than something to quietly add. Four, in rough order of exposure. **Nothing here was changed** — they need a legal call, and if any is added the version changes automatically and the whole fleet re-acknowledges.

1. **Hostname, on every single event.** `bucket_id` embeds the machine hostname and is sent verbatim in `_transform_event` (`src/sync/sync_engine.py`). `bf_client.exchange_code` also sends `hostname` at registration. Hostnames on company laptops are frequently personal (`ana-macbook`). Not on the list. *(verified — read the code)*
2. **Microphone in-use flag**, Windows only (`src/sync/mic_activity.py`). Usage-only by policy — whether the default input device is in use, never audio — and it feeds the active/idle determination rather than being reported on its own. Arguably inside "whether the computer is active or idle"; arguably a distinct category an employee would want named. *(verified — read the code; the "arguably" is my judgement, not a legal opinion)*
3. **Monitor and virtual-desktop identity** — `monitor_name`, `monitor_index`, `desktop_id`, `desktop_index` in `_populate_window_data`, gated by `privacy.track_display_info`, **default False**. Not disclosed anywhere. It is server-flippable, so the disclosure would need to exist before it is ever switched on. *(verified — read the code and the default)*
4. **"Full web addresses" is stated unconditionally**, but `privacy.collect_full_urls` (default False) is a server-settable flag that turns full URLs on. The notice is true today for every device; it would become false the moment that flag is flipped for anyone. Worth either a caveat or a rule that the flag is never flipped. *(verified — read the code and the default)*

Not findings, checked and clear: `src/clipboard.py` is a clipboard *writer* for the tray's copy affordance, it reads nothing. `page_category` and `app_category` are coarse labels derived on-device from the title/URL already disclosed. `device_id` is a random per-install UUID, not a hardware or personal identifier.

## Files

| File | |
|---|---|
| `src/privacy_notice.py` | new — text, version, acknowledgement record |
| `src/ui/privacy_notice_window.py` | new — rendering shell, no copy of its own |
| `src/main.py` | `run()` callsite + `_show_privacy_notice_if_needed` + heartbeat payload |
| `src/sync/bf_client.py` | `disclosure_acknowledgement` in `HEARTBEAT_HEALTH_KEYS` |
| `src/config.py` | `privacy_notice_ack_version`, `privacy_notice_ack_at` (device-local state, not wire contract — unchanged by the rename) |
| `build.spec` | hidden imports (the window is imported lazily; a bundle-only `ImportError` is invisible to the unit suite) |
| `CLAUDE.md` | privacy model + heartbeat egress list |
| `src/__init__.py` | 1.5.110 -> **1.5.111** |

## Triggering it on a real Mac

The state that suppresses the notice is one field in `~/Library/Application Support/BetterFlow/config.json`. Quit BetterFlow first (the tray writes that file on exit paths).

```bash
# 1. Quit BetterFlow from the tray menu.

# 2. See what this device currently holds (nothing, before this PR ships):
python3 -c "import json,os;p=os.path.expanduser('~/Library/Application Support/BetterFlow/config.json');d=json.load(open(p));print({k:v for k,v in d.items() if k.startswith('privacy_notice')})"

# 3. Clear the acknowledgement (this is the whole reset):
python3 - <<'PY'
import json, os
p = os.path.expanduser('~/Library/Application Support/BetterFlow/config.json')
d = json.load(open(p))
d['privacy_notice_ack_version'] = None
d['privacy_notice_ack_at'] = None
json.dump(d, open(p, 'w'), indent=2)
print('cleared')
PY

# 4. Launch BetterFlow. The notice appears once, centred, after the tray starts up.
```

What to check while it is open:

- The tray icon still comes up and **syncing keeps running** while the window sits there — that is the "never blocks work" claim, and it is the one thing CI cannot show you.
- Every bullet is readable and nothing is clipped; the body scrolls if your display is short.
- Press **I have read this**, then confirm the record landed:

```bash
python3 -c "import json,os;p=os.path.expanduser('~/Library/Application Support/BetterFlow/config.json');d=json.load(open(p));print(d['privacy_notice_ack_version'], d['privacy_notice_ack_at'])"
# expect: r1-87b196ffdda1 2026-...+00:00
```

- Relaunch — the notice must **not** come back. That half matters as much as the first.
- Then re-clear, relaunch, and this time **close the window with the red button instead of pressing the button**. The record must stay empty and the notice must return on the next launch.

Running from source instead of an installed build: `make run` uses the same config file and the same code path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
