### PR TITLE
fix(privacy): enforce excluded apps at the egress chokepoint

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -84,7 +84,15 @@ categorization signal). The settings in `Config.privacy`:
   (default False, opt-in, sensitive).
 - `exclude_apps` (default: 1Password, Keychain, System Settings, ...) -
   **enforced client-side** — these apps' events never leave the device. This is
-  the real "never send this app's titles" control.
+  the real "never send this app's titles" control. Enforced at the **egress
+  chokepoint**, `BetterFlowClient.send_events` (via `src/sync/privacy_filter.py`),
+  because that is the one function that puts events on the wire. Do NOT re-add
+  the check to individual producers and do NOT add a new send path that bypasses
+  `send_events`: enforcing per-producer is exactly how the in-process window and
+  input sources shipped able to egress 1Password titles.
+  `Config.update_from_server` may only **extend** this list (union with the
+  shipped defaults), and only once `DEFER_UNAPPLIED_SERVER_SETTINGS` is lifted —
+  a server row can never un-exclude an app.
 - `title_allowlist` - apps allowed to send raw titles even when `hash_titles` is
   set (forwarded to the server alongside `hash_titles`).
 

--- a/src/__init__.py
+++ b/src/__init__.py
@@ -1,4 +1,4 @@
 """BetterFlow - ActivityWatch to BetterFlow sync companion app."""
 
-__version__ = "1.5.111"
+__version__ = "1.5.112"
 __author__ = "BetterQA"

--- a/src/config.py
+++ b/src/config.py
@@ -855,6 +855,7 @@ class Config:
         Server returns:
             privacy.hash_window_titles -> local hash_titles
             privacy.title_allowlist -> local title_allowlist
+            privacy.exclude_apps -> EXTENDS local exclude_apps (union, never replace)
             privacy.track_browser_domains -> local domain_only_urls (inverted)
             sync.sync_interval_seconds -> local interval_seconds
             sync.batch_size -> local batch_size
@@ -880,6 +881,33 @@ class Config:
                 self.privacy.domain_only_urls = self._to_bool(privacy["track_browser_domains"])
             if "collect_full_urls" in privacy:
                 self.privacy.collect_full_urls = self._to_bool(privacy["collect_full_urls"])
+            if "exclude_apps" in privacy:
+                # ADDITIVE ONLY — union with what this build ships, never a
+                # replacement. The Regulament Intern states the excluded-app list
+                # is not limitative and may be extended; this is the mechanism.
+                # Making it a replacement would let one server row REMOVE
+                # 1Password/Keychain from the list, i.e. turn a signed privacy
+                # guarantee off remotely with no release and nobody informed —
+                # exactly the failure mode the deferral gate above exists for.
+                # Union can only ever send LESS data, so the worst a bad payload
+                # can do is stop tracking an app, which is visible and harmless.
+                extra = privacy["exclude_apps"]
+                if isinstance(extra, list):
+                    added = [
+                        a.strip() for a in extra
+                        if isinstance(a, str) and a.strip()
+                        and a.strip() not in self.privacy.exclude_apps
+                    ]
+                    if added:
+                        self.privacy.exclude_apps = self.privacy.exclude_apps + added
+                        logger.info(
+                            "Server config: extended exclude_apps with %s", added
+                        )
+                else:
+                    logger.warning(
+                        "Invalid privacy.exclude_apps from server (expected a "
+                        "list, got %s) — ignoring", type(extra).__name__
+                    )
 
         if "collection" in server_config and not DEFER_UNAPPLIED_SERVER_SETTINGS:
             collection = server_config["collection"]

--- a/src/main.py
+++ b/src/main.py
@@ -1782,6 +1782,10 @@ class BetterFlowApp:
         self.bf = BetterFlowClient(
             api_url=self.config.api_url,
             compress=self.config.sync.compress,
+            # Read LIVE (a lambda, not a snapshot): the exclusion list can change
+            # under us via a config reload, and an app the user just excluded
+            # must stop egressing on the very next send.
+            excluded_apps_provider=lambda: self.config.privacy.exclude_apps,
         )
         self.queue = OfflineQueue()
         self.keychain = KeychainManager()

--- a/src/sync/bf_client.py
+++ b/src/sync/bf_client.py
@@ -5,20 +5,22 @@ import json
 import logging
 import platform
 from dataclasses import dataclass, field
-from typing import Optional
+from typing import Callable, Iterable, Optional
 from urllib.parse import urlparse
 
 import requests
 
 try:
     from .. import __version__
-    from ..config import DEFAULT_API_URL, get_machine_uuid
+    from ..config import DEFAULT_API_URL, PrivacySettings, get_machine_uuid
     from .http_client import BaseApiClient, BetterFlowClientError, BetterFlowAuthError
+    from .privacy_filter import partition_excluded
     from .retry import RetryConfig
 except ImportError:
     from src import __version__
-    from config import DEFAULT_API_URL, get_machine_uuid
+    from config import DEFAULT_API_URL, PrivacySettings, get_machine_uuid
     from sync.http_client import BaseApiClient, BetterFlowClientError, BetterFlowAuthError
+    from sync.privacy_filter import partition_excluded
     from sync.retry import RetryConfig
 
 __all__ = [
@@ -120,6 +122,7 @@ class BetterFlowClient(BaseApiClient):
         compress: bool = True,
         timeout: int = 30,
         retry_config: Optional[RetryConfig] = None,
+        excluded_apps_provider: Optional[Callable[[], Iterable[str]]] = None,
     ):
         """Initialize BetterFlow client.
 
@@ -131,6 +134,12 @@ class BetterFlowClient(BaseApiClient):
             compress: Use gzip compression for event batches
             timeout: Request timeout in seconds
             retry_config: Configuration for retry with exponential backoff
+            excluded_apps_provider: Callable returning the CURRENT excluded-app
+                list, consulted on every send so a live config edit takes effect
+                immediately (a snapshotted list would keep egressing an app the
+                user just excluded). When omitted, the shipped defaults apply:
+                an unwired client still honours the baseline guarantee rather
+                than failing open.
         """
         super().__init__(
             api_url=api_url,
@@ -141,6 +150,27 @@ class BetterFlowClient(BaseApiClient):
             timeout=timeout,
             retry_config=retry_config,
         )
+        self._excluded_apps_provider = excluded_apps_provider
+
+    def _excluded_apps(self) -> Iterable[str]:
+        """Current excluded-app list. Fails CLOSED: if the provider is missing
+        or raises, fall back to the shipped defaults instead of transmitting
+        everything."""
+        provider = self._excluded_apps_provider
+        if provider is None:
+            return PrivacySettings().exclude_apps
+        try:
+            apps = provider()
+        except Exception:
+            logger.warning(
+                "excluded-apps provider failed — falling back to the shipped "
+                "exclusion defaults for this send",
+                exc_info=True,
+            )
+            return PrivacySettings().exclude_apps
+        if apps is None:
+            return PrivacySettings().exclude_apps
+        return apps
 
     # =========================================================================
     # Authentication
@@ -264,6 +294,35 @@ class BetterFlowClient(BaseApiClient):
         if not events:
             return SyncResult(success=True, events_synced=0)
 
+        # THE PRIVACY EGRESS CHOKEPOINT. This is the one function that puts
+        # events on the wire, so it is the one place the excluded-app guarantee
+        # can be enforced for EVERY producer — external AW buckets, the
+        # in-process window/input sources, status spans, the call detector, the
+        # offline-queue drain, and whatever is added next. Enforcing it in the
+        # producers instead is how the in-process sources shipped able to
+        # egress 1Password titles. Do not move this below the request.
+        events, dropped = partition_excluded(events, self._excluded_apps())
+        dropped_ids = [e.get("id") for e in dropped if e.get("id") is not None]
+        if dropped:
+            # Never log the titles/URLs of an excluded app — the app names are
+            # the most that may be recorded, and only locally.
+            logger.info(
+                "Privacy filter: dropped %d event(s) for excluded app(s) %s "
+                "before egress",
+                len(dropped),
+                ", ".join(sorted({a for a in (
+                    e.get("data", {}).get("app") for e in dropped
+                ) if a})),
+            )
+        if not events:
+            # Nothing left to transmit. Report SUCCESS with the dropped ids
+            # reported as accepted: exclusion is a permanent local decision, so
+            # callers must retire these events (drop the queue row, advance the
+            # checkpoint) rather than retry them forever.
+            return SyncResult(
+                success=True, events_synced=0, accepted_ids=dropped_ids
+            )
+
         try:
             # Idempotency key prevents duplicate processing when the same batch
             # is re-sent — either the retry loop after the connection drops once
@@ -341,7 +400,14 @@ class BetterFlowClient(BaseApiClient):
                 success=delivered,
                 events_synced=events_synced,
                 events_queued=queued,
-                accepted_ids=accepted_ids,
+                # Privacy-dropped ids ride along ONLY when the server gave a
+                # per-event verdict. Callers use accepted_ids to decide what not
+                # to re-queue, and a dropped event must never be re-queued; when
+                # there is no verdict (accepted_ids empty) the caller holds the
+                # whole batch and the next attempt re-drops them harmlessly.
+                accepted_ids=(
+                    list(accepted_ids) + dropped_ids if accepted_ids else accepted_ids
+                ),
             )
         except BetterFlowAuthError:
             raise  # Callers must handle token refresh / re-login

--- a/src/sync/privacy_filter.py
+++ b/src/sync/privacy_filter.py
@@ -1,0 +1,66 @@
+"""Egress-boundary privacy filter for excluded applications.
+
+The product guarantee — the one written into the Regulament Intern that every
+employee signs — is that events belonging to an excluded app (password
+managers, Keychain, System Settings, ...) NEVER leave the device.
+
+Historically that guarantee was enforced in ``SyncEngine._transform_event``,
+which only sees events read out of external ActivityWatch buckets. Two later
+event producers (the in-process window source and the in-process input source)
+build BetterFlow-shaped events directly and were appended to the upload list
+without ever passing through it, so enabling either one made the guarantee
+false. Patching each producer would have left the same trap for the third one.
+
+So the filter lives here, as a pure function, and is applied at the single
+place where events are serialised onto the wire
+(``BetterFlowClient.send_events``). Every producer — external buckets,
+in-process sources, status spans, call detector, the offline-queue drain, and
+anything added later — passes through it, because they all end up in that one
+HTTP call.
+
+Matching is deliberately identical to the original ``_transform_event`` check
+(exact, case-sensitive membership on ``data.app``): this closes a bypass, it
+does not change what "excluded" means.
+"""
+
+from typing import Iterable, Optional
+
+
+def event_app(event: dict) -> Optional[str]:
+    """The app an event is attributed to, or None.
+
+    Every producer in this codebase writes the app name to ``data.app``
+    (``SyncEngine._populate_window_data``, ``WindowSource._event``,
+    ``InputSource.drain_input_event``, ``SyncEngine._make_call_bf_event``).
+    Tolerant of a malformed event: anything that isn't a dict-with-a-dict-data
+    simply has no app, and is therefore not excluded.
+    """
+    if not isinstance(event, dict):
+        return None
+    data = event.get("data")
+    if not isinstance(data, dict):
+        return None
+    app = data.get("app")
+    return app if isinstance(app, str) else None
+
+
+def partition_excluded(
+    events: Iterable[dict], exclude_apps: Iterable[str]
+) -> tuple[list[dict], list[dict]]:
+    """Split ``events`` into ``(kept, dropped)`` by the exclusion list.
+
+    ``dropped`` events must never be transmitted, queued for a later attempt,
+    or retried — exclusion is a permanent, local decision, not a delivery
+    failure.
+    """
+    events = list(events)
+    excluded = {a for a in exclude_apps if isinstance(a, str) and a}
+    if not excluded:
+        return events, []
+
+    kept: list[dict] = []
+    dropped: list[dict] = []
+    for event in events:
+        app = event_app(event)
+        (dropped if (app and app in excluded) else kept).append(event)
+    return kept, dropped

--- a/tests/test_excluded_apps_never_egress.py
+++ b/tests/test_excluded_apps_never_egress.py
@@ -1,0 +1,385 @@
+"""The excluded-app privacy guarantee, asserted on the WIRE.
+
+The guarantee ("password managers, Keychain, System Settings never leave your
+device") is written into the Regulament Intern employees sign, so it has to
+hold for every event producer, not just the one that happened to be filtered.
+
+These tests enable each in-process source, let it produce a real event for an
+excluded app, drive the real send path, and inspect the HTTP request body that
+``requests`` would have put on the socket. Asserting on an intermediate dict
+would not distinguish "filtered" from "filtered somewhere that a third producer
+can bypass".
+"""
+
+import gzip
+import json
+from datetime import datetime, timedelta, timezone
+from unittest.mock import Mock
+
+import pytest
+
+from src.config import Config
+from src.sync.activity_analyzer import ActivityAnalyzer
+from src.sync.bf_client import BetterFlowClient
+from src.sync.daily_time_tracker import DailyTimeTracker
+from src.sync.input_source import InputSource
+from src.sync.sync_engine import SyncEngine, SyncStats
+from src.sync.window_source import WindowSource
+
+EXCLUDED_APP = "1Password"
+ALLOWED_APP = "Code"
+SECRET_TITLE = "Personal Vault - brad@betterqa.co"
+
+
+def _now() -> datetime:
+    """Anchor every fixture to the CURRENT instant.
+
+    Deliberately not a hardcoded calendar date: a fixed date drifts out of
+    every freshness / retention window the engine applies and the test starts
+    failing on its own anniversary.
+    """
+    return datetime.now(timezone.utc)
+
+
+class _WireRecorder:
+    """Stands in for ``requests.Session`` and records what was transmitted."""
+
+    def __init__(self):
+        self.bodies: list[dict] = []
+        self.calls = 0
+
+    def request(self, method, url, **kwargs):
+        self.calls += 1
+        if "data" in kwargs and isinstance(kwargs["data"], (bytes, bytearray)):
+            # Event batches are gzipped; decode exactly as the server would.
+            self.bodies.append(json.loads(gzip.decompress(kwargs["data"])))
+        elif "json" in kwargs:
+            self.bodies.append(kwargs["json"])
+        response = Mock()
+        response.status_code = 200
+        response.headers = {}
+        response.content = b"{}"
+        response.json.return_value = {
+            "data": {"processed": 1, "failed": 0, "accepted_ids": []}
+        }
+        return response
+
+    def transmitted_text(self) -> str:
+        return json.dumps(self.bodies)
+
+    def transmitted_events(self) -> list[dict]:
+        out: list[dict] = []
+        for body in self.bodies:
+            out.extend(body.get("events", []))
+        return out
+
+
+def _client(config: Config) -> tuple[BetterFlowClient, _WireRecorder]:
+    recorder = _WireRecorder()
+    kwargs = dict(
+        api_url="https://app.betterflow.eu/api/agent", token="t", device_id="d"
+    )
+    try:
+        client = BetterFlowClient(
+            **kwargs, excluded_apps_provider=lambda: config.privacy.exclude_apps
+        )
+    except TypeError:
+        # The pre-fix client has no such parameter. Degrade instead of erroring
+        # so the proof-of-failure handshake (checkout HEAD~1 -- <impl>, run
+        # these tests) fails on the ACTUAL guarantee — "excluded app reached the
+        # wire" — rather than on a constructor signature, which would prove only
+        # that the API is new. Post-fix behaviour is unchanged: an unwired client
+        # falls back to the shipped exclusion defaults, which contain 1Password.
+        client = BetterFlowClient(**kwargs)
+    client._session = recorder
+    return client, recorder
+
+
+def _engine(config: Config, client: BetterFlowClient) -> SyncEngine:
+    return SyncEngine(
+        aw=Mock(),
+        bf=client,
+        queue=Mock(),
+        config=config,
+        activity_analyzer=Mock(spec=ActivityAnalyzer),
+        time_tracker=Mock(spec=DailyTimeTracker),
+    )
+
+
+class _ScriptedWindowSource(WindowSource):
+    """A WindowSource pre-loaded with samples (probe forced usable)."""
+
+    def __init__(self, samples):
+        super().__init__(hostname="host", foreground_getter=lambda: (ALLOWED_APP, "x"))
+        with self._lock:
+            for sample in samples:
+                self._samples.append(sample)
+
+
+class _ScriptedInputSource(InputSource):
+    """An InputSource with counts already accrued and a scripted frontmost app."""
+
+    def __init__(self, app: str):
+        super().__init__(hostname="host", frontmost_app_getter=lambda: app)
+        self._available = True
+        with self._lock:
+            self._presses = 42
+            self._clicks = 7
+            self._scrolls = 3
+
+    def available(self) -> bool:
+        return True
+
+
+def _assert_clean(recorder: _WireRecorder):
+    """Nothing about the excluded app may appear anywhere in what was sent."""
+    text = recorder.transmitted_text()
+    assert EXCLUDED_APP not in text, f"excluded app reached the wire: {text}"
+    assert SECRET_TITLE not in text, f"excluded app's title reached the wire: {text}"
+    for event in recorder.transmitted_events():
+        assert event.get("data", {}).get("app") != EXCLUDED_APP
+
+
+# ---------------------------------------------------------------------------
+# In-process WINDOW source
+# ---------------------------------------------------------------------------
+
+def test_inproc_window_source_excluded_app_never_reaches_the_wire():
+    cfg = Config()
+    cfg.sync.in_process_window = True
+    client, recorder = _client(cfg)
+    engine = _engine(cfg, client)
+
+    t0 = _now()
+    engine.window_source = _ScriptedWindowSource([
+        (t0, EXCLUDED_APP, SECRET_TITLE),
+        (t0 + timedelta(seconds=30), EXCLUDED_APP, SECRET_TITLE),
+    ])
+    engine._build_inproc_window(t0)  # seeds the checkpoint
+    events, pending = engine._build_inproc_window(t0 + timedelta(seconds=30))
+
+    # The source really did produce an excluded-app event — otherwise this test
+    # would pass for the wrong reason (nothing to filter).
+    assert events and events[0]["data"]["app"] == EXCLUDED_APP
+    assert pending is not None
+
+    engine._send_events(events, SyncStats())
+    _assert_clean(recorder)
+
+
+def test_inproc_window_source_still_sends_non_excluded_apps():
+    """The guard must not be a blanket mute — collection is unchanged."""
+    cfg = Config()
+    cfg.sync.in_process_window = True
+    client, recorder = _client(cfg)
+    engine = _engine(cfg, client)
+
+    t0 = _now()
+    engine.window_source = _ScriptedWindowSource([
+        (t0, ALLOWED_APP, "sync_engine.py"),
+        (t0 + timedelta(seconds=30), ALLOWED_APP, "sync_engine.py"),
+    ])
+    engine._build_inproc_window(t0)
+    events, _ = engine._build_inproc_window(t0 + timedelta(seconds=30))
+    assert events
+
+    engine._send_events(events, SyncStats())
+    sent = recorder.transmitted_events()
+    assert [e["data"]["app"] for e in sent] == [ALLOWED_APP]
+
+
+def test_inproc_window_mixed_batch_drops_only_the_excluded_app():
+    cfg = Config()
+    cfg.sync.in_process_window = True
+    client, recorder = _client(cfg)
+    engine = _engine(cfg, client)
+
+    t0 = _now()
+    engine.window_source = _ScriptedWindowSource([
+        (t0, ALLOWED_APP, "sync_engine.py"),
+        (t0 + timedelta(seconds=20), EXCLUDED_APP, SECRET_TITLE),
+        (t0 + timedelta(seconds=40), ALLOWED_APP, "sync_engine.py"),
+        (t0 + timedelta(seconds=60), ALLOWED_APP, "sync_engine.py"),
+    ])
+    engine._build_inproc_window(t0)
+    events, _ = engine._build_inproc_window(t0 + timedelta(seconds=60))
+    assert any(e["data"]["app"] == EXCLUDED_APP for e in events)
+    assert any(e["data"]["app"] == ALLOWED_APP for e in events)
+
+    engine._send_events(events, SyncStats())
+    _assert_clean(recorder)
+    assert [e["data"]["app"] for e in recorder.transmitted_events()] == [
+        ALLOWED_APP, ALLOWED_APP
+    ]
+
+
+# ---------------------------------------------------------------------------
+# In-process INPUT source
+# ---------------------------------------------------------------------------
+
+def test_inproc_input_source_excluded_app_never_reaches_the_wire():
+    cfg = Config()
+    cfg.sync.in_process_input = True
+    client, recorder = _client(cfg)
+    engine = _engine(cfg, client)
+
+    t0 = _now()
+    engine.input_source = _ScriptedInputSource(EXCLUDED_APP)
+    assert engine._should_use_inproc_input() is True
+    engine._build_inproc_input(t0)  # seeds the checkpoint
+    engine.input_source._presses = 42  # re-accrue after the seed drain
+    event, pending = engine._build_inproc_input(t0 + timedelta(seconds=60))
+
+    assert event is not None and event["data"]["app"] == EXCLUDED_APP
+    assert pending is not None
+
+    engine._send_events([event], SyncStats())
+    _assert_clean(recorder)
+
+
+def test_inproc_input_source_still_sends_non_excluded_apps():
+    cfg = Config()
+    cfg.sync.in_process_input = True
+    client, recorder = _client(cfg)
+    engine = _engine(cfg, client)
+
+    t0 = _now()
+    engine.input_source = _ScriptedInputSource(ALLOWED_APP)
+    engine._build_inproc_input(t0)
+    engine.input_source._presses = 42
+    event, _ = engine._build_inproc_input(t0 + timedelta(seconds=60))
+    assert event is not None
+
+    engine._send_events([event], SyncStats())
+    sent = recorder.transmitted_events()
+    assert len(sent) == 1
+    assert sent[0]["data"]["app"] == ALLOWED_APP
+    assert sent[0]["data"]["presses"] == 42
+
+
+# ---------------------------------------------------------------------------
+# The chokepoint itself: every other producer, and everything added later
+# ---------------------------------------------------------------------------
+
+def test_offline_queue_drain_cannot_egress_an_excluded_app():
+    """A queue row written by a pre-fix build must not egress on drain."""
+    cfg = Config()
+    client, recorder = _client(cfg)
+    legacy_row = {
+        "id": "win-inproc_host_1",
+        "timestamp": _now().isoformat(),
+        "duration": 30.0,
+        "bucket_id": "bf-window-inproc_host",
+        "bucket_type": "currentwindow",
+        "data": {"app": EXCLUDED_APP, "title": SECRET_TITLE},
+    }
+    result = client.send_events([legacy_row])
+
+    assert recorder.calls == 0, "an excluded-app-only batch must not be transmitted"
+    _assert_clean(recorder)
+    # Reported as retired, not as a delivery failure: exclusion is permanent,
+    # so the caller must drop the queue row instead of retrying it forever.
+    assert result.success is True
+    assert result.events_synced == 0
+    assert result.accepted_ids == ["win-inproc_host_1"]
+
+
+def test_client_without_a_wired_provider_still_honours_the_defaults():
+    """Fail closed: an unwired client uses the shipped exclusion list."""
+    recorder = _WireRecorder()
+    client = BetterFlowClient(
+        api_url="https://app.betterflow.eu/api/agent", token="t", device_id="d"
+    )
+    client._session = recorder
+    client.send_events([{
+        "id": "x1",
+        "timestamp": _now().isoformat(),
+        "duration": 10.0,
+        "bucket_id": "b",
+        "bucket_type": "currentwindow",
+        "data": {"app": EXCLUDED_APP, "title": SECRET_TITLE},
+    }])
+    assert recorder.calls == 0
+    _assert_clean(recorder)
+
+
+def test_a_provider_that_raises_falls_back_to_the_defaults():
+    def boom():
+        raise RuntimeError("config unreadable")
+
+    recorder = _WireRecorder()
+    client = BetterFlowClient(
+        api_url="https://app.betterflow.eu/api/agent", token="t", device_id="d",
+        excluded_apps_provider=boom,
+    )
+    client._session = recorder
+    client.send_events([{
+        "id": "x1",
+        "timestamp": _now().isoformat(),
+        "duration": 10.0,
+        "bucket_id": "b",
+        "bucket_type": "currentwindow",
+        "data": {"app": EXCLUDED_APP, "title": SECRET_TITLE},
+    }])
+    assert recorder.calls == 0
+    _assert_clean(recorder)
+
+
+def test_a_newly_excluded_app_stops_egressing_on_the_very_next_send():
+    """The provider is read live, not snapshotted at construction."""
+    cfg = Config()
+    client, recorder = _client(cfg)
+    event = {
+        "id": "x1",
+        "timestamp": _now().isoformat(),
+        "duration": 10.0,
+        "bucket_id": "b",
+        "bucket_type": "currentwindow",
+        "data": {"app": "Bitwarden", "title": "vault"},
+    }
+    client.send_events([event])
+    assert recorder.calls == 1  # not excluded yet
+
+    cfg.privacy.exclude_apps = cfg.privacy.exclude_apps + ["Bitwarden"]
+    client.send_events([dict(event, id="x2")])
+    assert recorder.calls == 1, "a newly excluded app kept egressing"
+
+
+# ---------------------------------------------------------------------------
+# The server-config surface for the exclusion list
+# ---------------------------------------------------------------------------
+
+def test_server_exclude_apps_is_deferred_like_the_rest_of_the_privacy_block():
+    import src.config as config_module
+
+    cfg = Config()
+    baseline = list(cfg.privacy.exclude_apps)
+    assert config_module.DEFER_UNAPPLIED_SERVER_SETTINGS is True
+    cfg.update_from_server({"privacy": {"exclude_apps": ["Bitwarden"]}})
+    assert cfg.privacy.exclude_apps == baseline
+
+
+def test_server_exclude_apps_can_only_extend_never_replace(monkeypatch):
+    import src.config as config_module
+
+    monkeypatch.setattr(config_module, "DEFER_UNAPPLIED_SERVER_SETTINGS", False)
+    cfg = Config()
+    baseline = list(cfg.privacy.exclude_apps)
+    assert EXCLUDED_APP in baseline
+
+    # A payload that omits 1Password must NOT be able to un-exclude it.
+    cfg.update_from_server({"privacy": {"exclude_apps": ["Bitwarden"]}})
+    assert EXCLUDED_APP in cfg.privacy.exclude_apps
+    assert "Bitwarden" in cfg.privacy.exclude_apps
+    assert set(baseline).issubset(set(cfg.privacy.exclude_apps))
+
+
+@pytest.mark.parametrize("payload", ["Bitwarden", {"a": 1}, 5, None])
+def test_server_exclude_apps_ignores_malformed_payloads(monkeypatch, payload):
+    import src.config as config_module
+
+    monkeypatch.setattr(config_module, "DEFER_UNAPPLIED_SERVER_SETTINGS", False)
+    cfg = Config()
+    baseline = list(cfg.privacy.exclude_apps)
+    cfg.update_from_server({"privacy": {"exclude_apps": payload}})
+    assert cfg.privacy.exclude_apps == baseline


### PR DESCRIPTION
Closes two bypasses of the excluded-app privacy guarantee — the one that is about to be written into the Regulament Intern that every employee signs ("excluded apps — password managers, Keychain, System Settings — never leave your device").

**Do not merge yet.** Opened for review per the client-facing-guarantee carve-out.

## The defect

`_transform_event` (`src/sync/sync_engine.py:2290`) drops excluded apps before egress. That is what makes the guarantee true — for events read out of external ActivityWatch buckets. Two later producers build BetterFlow-shaped events directly and are appended to the upload list without ever passing through it:

| Producer | Appended at | Exclusion checks in the file |
|---|---|---|
| `WindowSource` (`sync.in_process_window`) | `sync_engine.py:1266` | `grep -c exclude src/sync/window_source.py` → **0** |
| `InputSource` (`sync.in_process_input`) | `sync_engine.py:1278` | `grep -c exclude src/sync/input_source.py` → **0** |

Both default off (`config.py:325`, `config.py:333`) — but both are set from the **ungated** `sync` server-config block (`config.py:955`, assignments at `config.py:981-990`). The `privacy` block immediately above it (`config.py:872`) *is* gated behind `DEFER_UNAPPLIED_SERVER_SETTINGS`. So a single server toggle made a signed guarantee false, with no release and nobody informed.

## Where the chokepoint went, and why

**`BetterFlowClient.send_events` (`src/sync/bf_client.py`), applied before the batch is serialised**, via a pure helper in the new `src/sync/privacy_filter.py`.

I deliberately did **not** filter at the point events are assembled. `SyncEngine.sync()` assembles `all_events`, but it is not the only thing that sends: there are four distinct call sites for `self.bf.send_events` in `sync_engine.py` alone —

- `sync_engine.py:3301` — `_send_bucket_events`, the regular per-bucket path (reached via `_send_events`)
- `sync_engine.py:3483` — `_process_queue`, the offline-queue drain
- `sync_engine.py:2663` — `_send_status_span` (break / idle / private-time spans)
- `sync_engine.py:729` — `_deliver_final_event`, which the comment explicitly says *"deliberately bypasses `_send_events`"*

Filtering in `_send_events` would have missed three of those, including the queue drain — which is the path that would deliver rows a pre-fix build already wrote to SQLite. Filtering in each producer would have left the identical trap for the third producer, which is precisely how this happened.

`send_events` is the one function that puts events on the wire. Everything above it, and anything added later, converges there.

Design details worth reviewing:

- **Fails closed.** The exclusion list arrives as a provider callable, read live on every send (a snapshot would keep egressing an app the user just excluded). If the provider is missing or raises, it falls back to the shipped `PrivacySettings().exclude_apps` rather than transmitting everything.
- **No double-counting.** `_transform_event`'s check stays: it also populates `stats.window_drop_excluded_apps`, which feeds the user-visible "window data has gone stale — excluded app(s) frontmost" warning at `sync_engine.py:1373`. The new filter touches no counters, and filtering twice is idempotent. *(Verified: `window_seen`/`window_sent` are only incremented in `_extract_and_transform`, which runs on external buckets only, so `_assess_window_filter` was already inert on the in-process path — this change does not alter that either way.)*
- **A privacy drop is not a delivery failure.** An all-excluded batch returns `success=True, events_synced=0` with the dropped ids reported as accepted, so callers retire the queue row instead of retrying it forever. On a partial-verdict response the dropped ids ride along in `accepted_ids` for the same reason.
- **Logs never carry the excluded app's titles or URLs** — only the app names, and only locally.

## Evidence

### 1. Test asserting on the request body

`tests/test_excluded_apps_never_egress.py` (15 tests) replaces `client._session` with a recorder, **gunzips the actual request body** and parses it, so the assertion is on the bytes that would have hit the socket. Each in-process source is enabled, the real builder produces the event, and the real send path runs.

```
$ PYTHONPATH=. python3 -m pytest tests/test_excluded_apps_never_egress.py -q
tests/test_excluded_apps_never_egress.py ...............                 [100%]
15 passed in 0.08s

$ PYTHONPATH=. python3 -m pytest -q
1307 passed in 28.09s
```

No skips; the tests use no absolute dates (every fixture is anchored to `datetime.now(timezone.utc)`).

### 2. Proof-of-failure handshake (no `git stash`)

```
$ git checkout HEAD~1 -- src/sync/bf_client.py src/main.py src/config.py
$ rm -f src/sync/privacy_filter.py
$ PYTHONPATH=. python3 -m pytest tests/test_excluded_apps_never_egress.py -q
8 failed, 7 passed in 0.14s
```

The failures are the guarantee itself, not a missing signature (the harness degrades to the no-provider constructor on `TypeError` specifically so this handshake fails on behaviour):

```
E   AssertionError: excluded app reached the wire: [{"events": [{"id": "win-inproc_host_...",
    "bucket_id": "bf-window-inproc_host", "bucket_type": "currentwindow",
    "data": {"app": "1Password", "title": "Personal Vault - brad@betterqa.co"}}]}]

E   AssertionError: excluded app reached the wire: [{"events": [{"id": "input-inproc_host_...",
    "bucket_id": "bf-input-inproc_host", "bucket_type": "aw-watcher-input",
    "data": {"presses": 42, "clicks": 7, "scrolls": 3, "app": "1Password"}}]}]

E   AssertionError: an excluded-app-only batch must not be transmitted
```

Note the shape: the two `..._still_sends_non_excluded_apps` tests **pass on both sides**. Only the defect-specific cases fail pre-fix, so the suite isolates the bug rather than describing the new code.

```
$ git checkout HEAD -- src/sync/bf_client.py src/main.py src/config.py src/sync/privacy_filter.py
$ PYTHONPATH=. python3 -m pytest tests/test_excluded_apps_never_egress.py -q
15 passed in 0.08s
```

### 3. Mutation test — the guard is witnessed

`partition_excluded` neutered to `return list(events), []`:

```
$ PYTHONPATH=. python3 -m pytest -q
7 failed, 1300 passed in 26.68s
```

Restored → `1307 passed`.

## Answer on `exclude_apps` (this was a real gap)

**Verified: there was no server-config handler.** `grep -rn "exclude_apps" src/` on `3bc7609` returned exactly three hits — the dataclass default (`config.py:240`) and the two read sites (`sync_engine.py:1867`, `2290`). Nothing in `Config.update_from_server` touched it. The list could only be changed by shipping a new agent build.

**I added a handler rather than filing an issue**, because the sentence you are about to sign ("the list is not limitative and may be extended") should be backed by a mechanism, and because leaving it absent invites someone to add it later in the same ungated `sync` block that caused this bug. It is:

- **inside the `privacy` block, behind `DEFER_UNAPPLIED_SERVER_SETTINGS`** — the same gate as `collect_full_urls` and `track_browser_domains`, so it cannot become a third way to change privacy behaviour without a deliberate release;
- **additive only** — a union with the shipped defaults, never a replacement. A server row can add `Bitwarden`; it can never remove `1Password`. This is the load-bearing part: a replacing handler would let one DB row switch a signed guarantee off remotely. Union can only ever cause *less* data to be sent, so the worst a bad payload can do is stop tracking an app, which is visible and harmless;
- **strict about shape** — a non-list payload is logged and ignored (parametrised test covers `str`, `dict`, `int`, `None`).

**The wording caveat you need before signing.** `DEFER_UNAPPLIED_SERVER_SETTINGS` is `True` on `main`, so the handler is inert today and the list is still extended **by shipping an agent update**, not centrally in real time. If the Regulament says the list "can be extended", that is true now. If it implies it can be extended *centrally, without a client update*, that becomes true only when the deferral gate is lifted in a deliberate release. Suggested phrasing: *"the list is not limitative and may be extended"* — no claim about the mechanism or the latency.

## Files

- `src/sync/privacy_filter.py` (new) — pure `partition_excluded(events, exclude_apps) -> (kept, dropped)`
- `src/sync/bf_client.py` — chokepoint in `send_events`; `excluded_apps_provider` with fail-closed default
- `src/main.py` — wires the live provider
- `src/config.py` — gated, additive-only `privacy.exclude_apps` handler
- `tests/test_excluded_apps_never_egress.py` (new) — 15 tests, asserting on the wire
- `CLAUDE.md` — documents the chokepoint and warns against re-adding per-producer checks
- `src/__init__.py` — `1.5.111` → `1.5.112`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
