### PR TITLE
refactor(privacy): remove the hash_titles control, which did nothing

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -76,9 +76,6 @@ hash titles before egress — there is no client-side title hashing today, and
 implementing it would disable server-side categorization (titles are the
 categorization signal). The settings in `Config.privacy`:
 
-- `hash_titles` (default: **False**) - a per-device preference *forwarded to the
-  server*, NOT a client-side transform. The agent never hashes; the server
-  honours this flag. (Despite the name, raw titles still leave the device.)
 - `domain_only_urls` (default: True) - **enforced client-side** — URLs are
   reduced to their domain before egress. Full URLs require `collect_full_urls`
   (default False, opt-in, sensitive).
@@ -93,8 +90,24 @@ categorization signal). The settings in `Config.privacy`:
   `Config.update_from_server` may only **extend** this list (union with the
   shipped defaults), and only once `DEFER_UNAPPLIED_SERVER_SETTINGS` is lifted —
   a server row can never un-exclude an app.
-- `title_allowlist` - apps allowed to send raw titles even when `hash_titles` is
-  set (forwarded to the server alongside `hash_titles`).
+
+**`hash_titles` and `title_allowlist` no longer exist here (removed 2026-07-23).**
+They were declared on `PrivacySettings`, persisted to `config.json`, populated
+from `/config` and carried in the tray model — and read by nothing. No capture or
+transform path ever consumed them, so the agent's behaviour was identical with
+them on or off. A field named `hash_titles` in a settings surface offered to
+employees, next to controls that *are* enforced, misrepresents how their data is
+handled; since we deliberately keep sending titles raw (they are the server's
+categorisation signal), removal was the fix rather than implementation.
+
+The agent never sent either value to the server — there is no outbound payload or
+PATCH carrying them — so their removal changed nothing server-side. The server
+still emits `privacy.hash_window_titles` / `privacy.title_allowlist` on `/config`;
+`Config.update_from_server` drops both on purpose, with a comment saying why.
+**Title handling is a server-side control** (`AgentDevice::shouldStoreRawTitle` in
+internal-tool2, driven by the `agent_devices` row); the agent has no say in it and
+must not appear to. `tests/test_hash_titles_control_removed.py` fails if either
+symbol returns as live code in `src/`.
 
 The OS keychain holds the auth token (never on disk / in config). If raw titles
 must never leave the device, that requires client-side hashing/redaction, which

--- a/README.md
+++ b/README.md
@@ -81,12 +81,12 @@ Right-click the tray icon for options including pause/resume, private time, proj
 
 BetterFlow is designed with privacy in mind:
 
-- **Window titles** are sent to the BetterFlow server, which applies title handling and
-  categorization. The `hash_titles` preference is forwarded to the server and honoured
-  there - the agent does **not** hash titles on your device. If a title must never leave
-  the machine, exclude its app (below); that is the only client-side title control.
+- **Window titles** are sent to the BetterFlow server **raw**. The agent does **not**
+  hash, redact or transform them on your device, and it has no setting that does -
+  title handling is applied server-side, on the server's own configuration. If a title
+  must never leave the machine, exclude its app (below); that is the **only**
+  client-side title control.
 - **URLs** are stripped to domain-only - no full paths or query parameters
-- **Allowlist** for raw titles - IDEs and terminals can show real titles for project tracking
 - **Exclude apps** - Sensitive apps (1Password, etc.) are never tracked
 - **No keylogging** - We never capture what you type
 - **No screenshots** - We never capture your screen

--- a/src/__init__.py
+++ b/src/__init__.py
@@ -1,4 +1,4 @@
 """BetterFlow - ActivityWatch to BetterFlow sync companion app."""
 
-__version__ = "1.5.112"
+__version__ = "1.5.113"
 __author__ = "BetterQA"

--- a/src/config.py
+++ b/src/config.py
@@ -176,61 +176,13 @@ def get_machine_uuid() -> str:
 class PrivacySettings:
     """Privacy configuration."""
 
-    hash_titles: bool = False  # Send actual window titles for categorization
-    title_allowlist: list[str] = field(
-        default_factory=lambda: [
-            # IDEs and code editors
-            "Visual Studio Code",
-            "Code",
-            "Cursor",
-            "PyCharm",
-            "IntelliJ IDEA",
-            "WebStorm",
-            "PhpStorm",
-            "GoLand",
-            "CLion",
-            "Rider",
-            "RubyMine",
-            "DataGrip",
-            "RustRover",
-            "Fleet",
-            "Android Studio",
-            "Xcode",
-            "Visual Studio",
-            "Sublime Text",
-            "Nova",
-            "BBEdit",
-            "Zed",
-            "Vim",
-            "Neovim",
-            "nvim",
-            "Eclipse",
-            # Terminals
-            "Terminal",
-            "iTerm2",
-            "iTerm",
-            "Windows Terminal",
-            "PowerShell",
-            "Command Prompt",
-            "Warp",
-            "Alacritty",
-            "Kitty",
-            "WezTerm",
-            "Hyper",
-            # API and database tools
-            "Postman",
-            "Insomnia",
-            "DBeaver",
-            "TablePlus",
-            "pgAdmin",
-            "MongoDB Compass",
-            "Redis Insight",
-            # Design tools
-            "Figma",
-            "Sketch",
-            "Adobe XD",
-        ]
-    )
+    # `hash_titles` / `title_allowlist` were REMOVED (2026-07-23). They were declared
+    # here and populated from the server, but no capture or transform code in src/ ever
+    # read them — the agent has never hashed a window title. Keeping a dead field named
+    # "hash_titles" misrepresented how titles are handled, in a settings surface offered
+    # to employees. Title handling is a SERVER-side control (AgentDevice::
+    # shouldStoreRawTitle in internal-tool2, driven by the device row); the agent sends
+    # titles raw and has no say. Do not re-add these without a real client-side consumer.
     domain_only_urls: bool = True  # Strip URLs to domain only
     collect_full_urls: bool = False  # Collect full URLs (sensitive, opt-in)
     collect_page_category: bool = True  # Include coarse page category classification
@@ -466,19 +418,23 @@ def _normalize_hhmm(value) -> str:
 
 
 # Fixing the /config envelope unwrap (bf_client.get_config) means server settings reach
-# the agent for the FIRST TIME EVER — none of them have ever applied. Two of those move
-# real-world behaviour and have nothing to do with working-hours enforcement, so they
-# must land as their own deliberate change rather than as a side effect of a privacy fix:
+# the agent for the FIRST TIME EVER — none of them have ever applied. One of those moves
+# real-world behaviour and has nothing to do with working-hours enforcement, so it must
+# land as its own deliberate change rather than as a side effect of a privacy fix:
 #
 #   tracking.afk_timeout_minutes  — 37 of 44 prod devices are set to 20 while every agent
 #                                   has run the client default of 10. Applying it lengthens
 #                                   the idle grace, i.e. it CHANGES BILLED HOURS.
-#   privacy.hash_window_titles    — 41 of 44 are set to ON. Applying it turns window titles
-#                                   into hashes, so admins lose readable titles.
 #
-# Both are what the DB has always said and what someone intended; they have simply never
-# taken effect. Each needs its own release, with the affected people told first. Flip this
-# to False (one setting at a time) to roll them out.
+# That is what the DB has always said and what someone intended; it has simply never
+# taken effect. It needs its own release, with the affected people told first. Flip this
+# to False to roll it out.
+#
+# An earlier revision of this comment also listed privacy.hash_window_titles here and
+# claimed that applying it would "turn window titles into hashes". That was never true:
+# no client-side title hashing has ever existed in src/, so the setting was inert whether
+# deferred or not. Its local mirror was removed 2026-07-23 — see PrivacySettings and the
+# ignore note in update_from_server.
 #
 # Because the /config envelope fix makes server config reach agents for the FIRST time
 # ever (the whole fleet has run on local defaults), this gate now covers EVERY block that
@@ -853,8 +809,6 @@ class Config:
         """Update local config from server response.
 
         Server returns:
-            privacy.hash_window_titles -> local hash_titles
-            privacy.title_allowlist -> local title_allowlist
             privacy.exclude_apps -> EXTENDS local exclude_apps (union, never replace)
             privacy.track_browser_domains -> local domain_only_urls (inverted)
             sync.sync_interval_seconds -> local interval_seconds
@@ -872,10 +826,14 @@ class Config:
         # are the intended live behaviours.)
         if "privacy" in server_config and not DEFER_UNAPPLIED_SERVER_SETTINGS:
             privacy = server_config["privacy"]
-            if "hash_window_titles" in privacy:
-                self.privacy.hash_titles = self._to_bool(privacy["hash_window_titles"])
-            if "title_allowlist" in privacy:
-                self.privacy.title_allowlist = privacy["title_allowlist"]
+            # DELIBERATELY IGNORED: privacy.hash_window_titles and
+            # privacy.title_allowlist. The server still sends both (they are real
+            # columns on the agent_devices row and AgentConfigController emits
+            # them), but the agent has no client-side title hashing and never had
+            # any — the values were stored in Config and read by nothing. They are
+            # dropped here rather than mirrored, so that no future reader mistakes
+            # a populated field for an enforced control. Title handling is enforced
+            # SERVER-side (AgentDevice::shouldStoreRawTitle). Do not "restore" these.
             if "track_browser_domains" in privacy:
                 # Server tracks domains = we extract domain only
                 self.privacy.domain_only_urls = self._to_bool(privacy["track_browser_domains"])

--- a/src/main.py
+++ b/src/main.py
@@ -2984,8 +2984,6 @@ class BetterFlowApp:
         if key == "sync_interval":
             self.config.sync.interval_seconds = value
             self.coordinator.reschedule(value)
-        elif key == "hash_titles":
-            self.config.privacy.hash_titles = value
         elif key == "domain_only_urls":
             self.config.privacy.domain_only_urls = value
         elif key == "auto_categorize":

--- a/src/ui/tray.py
+++ b/src/ui/tray.py
@@ -158,7 +158,6 @@ class TrayModel:
 
         # Preferences
         self.sync_interval: int = 30
-        self.hash_titles: bool = False
         self.domain_only_urls: bool = False
         self.debug_mode: bool = False
         self.auto_start: bool = False
@@ -603,7 +602,6 @@ class TrayIcon:
                 "on_break": self.model.on_break,
                 "break_minutes_left": self.model.break_minutes_left,
                 "sync_interval": self.model.sync_interval,
-                "hash_titles": self.model.hash_titles,
                 "domain_only_urls": self.model.domain_only_urls,
                 "debug_mode": self.model.debug_mode,
                 "auto_start": self.model.auto_start,
@@ -1211,7 +1209,6 @@ class TrayIcon:
         dashboard_url = f"{parsed.scheme}://{parsed.netloc}/agent/my"
         with self.model.lock:
             self.model.sync_interval = config.sync.interval_seconds
-            self.model.hash_titles = config.privacy.hash_titles
             self.model.domain_only_urls = config.privacy.domain_only_urls
             self.model.auto_categorize = config.privacy.auto_categorize
             self.model.track_display_info = config.privacy.track_display_info

--- a/tests/test_hash_titles_control_removed.py
+++ b/tests/test_hash_titles_control_removed.py
@@ -1,0 +1,205 @@
+"""The `hash_titles` / `title_allowlist` privacy control is GONE, and stays gone.
+
+Why this file exists
+--------------------
+`Config.privacy.hash_titles` was declared, persisted, populated from the server
+and carried in the tray model — and read by no capture or transform code
+anywhere in `src/`. The agent has never hashed a window title; there is no
+`hashlib` call on any title path. It was a switch that did nothing to anyone's
+data, sitting in the product's settings state under a name that says otherwise.
+
+Implementing it was ruled out: titles are the server-side categorisation signal
+and we deliberately keep sending them raw. So the control was REMOVED (2026-07-23)
+rather than wired up. Title handling is enforced server-side
+(`AgentDevice::shouldStoreRawTitle` in internal-tool2, driven by the device row);
+the agent has no say and must not appear to.
+
+The agent never sent either value to the server — `bf_client` has no PATCH and no
+outbound payload carrying them — so removing them changes no server behaviour.
+The server still *sends* them on `/config`; `update_from_server` drops them on
+purpose.
+
+These tests are the guard against a well-meaning "restore the missing privacy
+setting" commit. They are source-level on purpose: `pystray` binds a display
+backend at import and is `None` on a headless CI runner, so anything that needs a
+live `TrayIcon` cannot run in the environment that gates merges — and per
+`test-fixture-discipline.md` a guard that skips where it matters is not a guard.
+"""
+
+from __future__ import annotations
+
+import json
+from dataclasses import fields as dc_fields
+from pathlib import Path
+from unittest.mock import patch
+
+import src.config as config_module
+import src.main as main_module
+import src.ui.tray as tray_module
+from src.config import Config, PrivacySettings
+from src.ui.tray import TrayModel
+
+_DEAD_SYMBOLS = ("hash_titles", "title_allowlist")
+
+_SRC_DIR = Path(config_module.__file__).resolve().parent
+
+
+# --- 1: the field is gone from the config dataclass ------------------------
+
+
+def test_privacy_settings_declares_no_title_hashing_fields():
+    names = {f.name for f in dc_fields(PrivacySettings)}
+    for symbol in _DEAD_SYMBOLS:
+        assert symbol not in names, (
+            f"PrivacySettings re-declared {symbol!r}. It has no client-side "
+            "consumer — the agent does not hash titles. See this module's docstring."
+        )
+    # The real, enforced client-side controls must still be there. If this ever
+    # fails, the removal took a live control with it.
+    assert "exclude_apps" in names
+    assert "domain_only_urls" in names
+
+
+# --- 2: it does not round-trip through config.json -------------------------
+
+
+def test_legacy_config_file_does_not_resurrect_the_setting():
+    """A device upgrading from an older build has these keys on disk already."""
+    config_file = Config.get_config_file()
+    config_file.write_text(json.dumps({
+        "privacy": {
+            "hash_titles": True,
+            "title_allowlist": ["Visual Studio Code"],
+            "domain_only_urls": True,
+        },
+    }))
+
+    config = Config.load()
+
+    for symbol in _DEAD_SYMBOLS:
+        assert not hasattr(config.privacy, symbol), (
+            f"{symbol!r} was restored from an old config.json — Config.load must "
+            "drop unknown keys, not re-attach them."
+        )
+    # ...and saving must not write them back out.
+    config.save()
+    saved = json.loads(config_file.read_text())
+    for symbol in _DEAD_SYMBOLS:
+        assert symbol not in saved.get("privacy", {}), (
+            f"{symbol!r} was persisted back to config.json"
+        )
+
+
+# --- 3: the server can keep sending it; we ignore it -----------------------
+
+
+def test_server_sent_hash_window_titles_is_ignored():
+    """The /config payload still carries these columns. Ungated, they must be
+    dropped — not stored somewhere a future reader mistakes for a live control."""
+    config = Config()
+
+    # Run with the deferral gate OFF, which is the *only* state in which the
+    # privacy block is applied at all. Testing it while deferred would pass for
+    # the wrong reason (nothing in the block executes) — see
+    # test-fixture-discipline.md, Phantom 4.
+    with patch.object(config_module, "DEFER_UNAPPLIED_SERVER_SETTINGS", False):
+        config.update_from_server({
+            "privacy": {
+                "hash_window_titles": True,
+                "title_allowlist": ["SomeApp"],
+                "track_browser_domains": True,
+            },
+        })
+
+    for symbol in _DEAD_SYMBOLS:
+        assert not hasattr(config.privacy, symbol), (
+            f"update_from_server re-created privacy.{symbol} from the server payload"
+        )
+    # Proof the block actually ran, so the assertions above mean something:
+    # track_browser_domains sits in the same `if` and DID apply.
+    assert config.privacy.domain_only_urls is True
+
+
+# --- 4: it is not in the tray ----------------------------------------------
+
+
+def test_tray_model_carries_no_title_hashing_state():
+    model = TrayModel()
+    for symbol in _DEAD_SYMBOLS:
+        assert not hasattr(model, symbol), (
+            f"TrayModel re-declared {symbol!r}; the tray must not carry state for "
+            "a control that does not exist."
+        )
+
+
+def test_tray_source_references_no_title_hashing_control():
+    """Covers the menu items, the model snapshot and `set_config` in one sweep:
+    if the tray mentions the symbol anywhere outside a comment, it is back."""
+    for line_no, line in _code_lines(Path(tray_module.__file__)):
+        for symbol in _DEAD_SYMBOLS:
+            assert symbol not in line, (
+                f"tray.py:{line_no} references {symbol!r}: {line.strip()!r}"
+            )
+
+
+def test_preference_handler_has_no_title_hashing_branch():
+    for line_no, line in _code_lines(Path(main_module.__file__)):
+        for symbol in _DEAD_SYMBOLS:
+            assert symbol not in line, (
+                f"main.py:{line_no} references {symbol!r}: {line.strip()!r}"
+            )
+
+
+# --- 5: the grep guard -----------------------------------------------------
+
+
+def _code_lines(path: Path):
+    """Yield (1-based line number, line) for non-comment lines of a source file.
+
+    Comments are exempt on purpose: the removal left explanatory notes naming
+    these symbols so the next reader does not "restore" them, and a guard that
+    forbade its own explanation would force those notes to be deleted.
+    """
+    for i, line in enumerate(path.read_text(encoding="utf-8").splitlines(), start=1):
+        if line.strip().startswith("#"):
+            continue
+        yield i, line
+
+
+def test_no_consumerless_title_hashing_symbol_anywhere_in_src():
+    """Repo-wide guard. Fails if either symbol reappears as live code in `src/`.
+
+    If you are here because this test failed: a client-side title-hashing control
+    is only legitimate once something in the capture/transform path READS it.
+    Add the consumer first, then relax this test and name the consumer in it.
+    """
+    offenders = []
+    for py_file in sorted(_SRC_DIR.rglob("*.py")):
+        for line_no, line in _code_lines(py_file):
+            for symbol in _DEAD_SYMBOLS:
+                if symbol in line:
+                    rel = py_file.relative_to(_SRC_DIR)
+                    offenders.append(f"src/{rel}:{line_no}: {line.strip()}")
+
+    assert not offenders, (
+        "Consumer-less title-hashing symbol(s) reintroduced:\n  "
+        + "\n  ".join(offenders)
+    )
+
+
+def test_no_client_side_title_hashing_exists():
+    """The claim the removed field made — that titles get hashed on this device —
+    must stay false, or the field should come back and this file should go."""
+    title_hashers = []
+    for py_file in sorted(_SRC_DIR.rglob("*.py")):
+        for line_no, line in _code_lines(py_file):
+            lowered = line.lower()
+            if "hexdigest" in lowered and "title" in lowered:
+                title_hashers.append(f"{py_file.name}:{line_no}")
+
+    assert not title_hashers, (
+        "Client-side title hashing appeared at "
+        + ", ".join(title_hashers)
+        + " — if titles are now hashed on-device, the user-facing control and the "
+        "CLAUDE.md Privacy Model section must be restored to describe it."
+    )

--- a/tests/test_server_config_deferral_and_refetch.py
+++ b/tests/test_server_config_deferral_and_refetch.py
@@ -40,13 +40,16 @@ def test_privacy_egress_settings_do_not_apply_on_upgrade():
     cfg = Config()
     before_full_urls = cfg.privacy.collect_full_urls
     before_domain_only = cfg.privacy.domain_only_urls
-    before_allowlist = list(cfg.privacy.title_allowlist)
 
     cfg.update_from_server({
         "privacy": {
             "collect_full_urls": True,       # would egress FULL urls
             "track_browser_domains": False,  # would flip domain_only_urls off
-            "title_allowlist": ["SomeAppNotInDefaults"],
+            # hash_window_titles / title_allowlist are no longer asserted here:
+            # the agent stopped mirroring them entirely on 2026-07-23 (they had
+            # no client-side consumer), so "deferred" is not the property that
+            # holds any more — "ignored, gate or no gate" is. That is pinned in
+            # tests/test_hash_titles_control_removed.py.
         },
         "collection": {"track_browser_urls": True, "collect_page_category": True},
     })
@@ -55,7 +58,6 @@ def test_privacy_egress_settings_do_not_apply_on_upgrade():
         "server collect_full_urls must be deferred, not applied silently on upgrade"
     )
     assert cfg.privacy.domain_only_urls == before_domain_only
-    assert cfg.privacy.title_allowlist == before_allowlist, "title_allowlist deferred too"
 
 
 def test_capture_and_billing_blocks_do_not_apply_on_upgrade():

--- a/tests/test_server_config_envelope.py
+++ b/tests/test_server_config_envelope.py
@@ -114,12 +114,18 @@ class TestTheWireResponseActuallyConfiguresTheAgent:
 
 
 class TestDeferredSettingsDoNotRideAlong:
-    """The envelope fix makes EVERY server setting apply for the first time ever. Two of
-    them change the real world and have nothing to do with working hours, so they are
-    gated behind DEFER_UNAPPLIED_SERVER_SETTINGS until each is rolled out on purpose:
+    """The envelope fix makes EVERY server setting apply for the first time ever. One of
+    them changes the real world and has nothing to do with working hours, so it is gated
+    behind DEFER_UNAPPLIED_SERVER_SETTINGS until it is rolled out on purpose:
 
       afk_timeout_minutes  37/44 prod devices say 20, agents have run 10 -> moves HOURS
-      hash_window_titles   41/44 say ON -> window titles become hashes, admins lose them
+
+    hash_window_titles used to be listed here as the second one, on the belief that
+    applying it would make the agent hash titles. It never would have: no client-side
+    hashing exists. Its local mirror was removed 2026-07-23 and the payload key is now
+    ignored outright — pinned in tests/test_hash_titles_control_removed.py, which is
+    where that behaviour is asserted. It is still sent in the payload below, because
+    the server still sends it and receiving it must stay harmless.
 
     The privacy release must change exactly one thing: we stop recording out of hours.
     """
@@ -127,7 +133,7 @@ class TestDeferredSettingsDoNotRideAlong:
     def _applied(self):
         client = BetterFlowClient(api_url="https://example.test/api/agent")
         config = Config()
-        before = (config.aw.afk_timeout_minutes, config.privacy.hash_titles)
+        before = (config.aw.afk_timeout_minutes,)
         payload = dict(WIRE_RESPONSE["data"])
         payload["privacy"] = {"hash_window_titles": True, "track_browser_domains": True}
         with patch.object(BetterFlowClient, "_request",
@@ -147,11 +153,15 @@ class TestDeferredSettingsDoNotRideAlong:
             "AFK timeout moved: this silently changes billed hours on 37 devices"
         )
 
-    def test_window_titles_do_not_start_hashing(self):
-        config, before = self._applied()
-        assert config.privacy.hash_titles == before[1], (
-            "hash_window_titles applied: admins would silently lose readable titles"
-        )
+    def test_a_hash_window_titles_payload_is_harmless(self):
+        """The server still puts hash_window_titles on the wire. Receiving it must
+        not resurrect a local field, and must not disturb the rest of the update."""
+        config, _ = self._applied()
+        assert not hasattr(config.privacy, "hash_titles")
+        assert not hasattr(config.privacy, "title_allowlist")
+        # The same payload's schedule still landed, i.e. the ignored key did not
+        # abort the update — this test would otherwise pass on a total no-op.
+        assert config.working_hours.work_start == "07:30"
 
 
 class TestSyncEngineFetchPath:


### PR DESCRIPTION
## Server coupling: the agent never sent it. Safe to remove. (verified)

This was the blocking question, so it leads.

**Outcome: the agent never sends `hash_titles` or `title_allowlist` to the server.** Removing them from the agent changes no server behaviour.

What was checked, on `3bc7609`:

- **No outbound carrier exists.** `grep -rn "hash_titles\|title_allowlist\|hash_window_titles" src/` returns hits in exactly three files — `config.py` (declare + read from `/config`), `main.py` (a settings setter writing the value back into `Config`), `tray.py` (model field, snapshot key, `set_config` copy). None of them is a request payload.
- **`bf_client` has no method that could carry it.** Its complete endpoint list is `POST revoke`, `POST events/batch`, `POST sessions/start`, `POST sessions/end`, `POST heartbeat`, `GET events/status`, `GET events/trends`, `POST logs`, `POST web-login-link`, `GET config`, `GET projects`. There is no PATCH or PUT at all. `HEARTBEAT_HEALTH_KEYS` does not list either symbol, and that tuple is an allowlist — anything absent is dropped at the boundary. The token-exchange/register payload carries only `code`, `device_name`, `platform`, `os_version`, `machine_id`, `hostname`, `agent_version`, `code_verifier`.
- **The server-side writer is the dashboard, not the agent.** `PATCH /agent/devices/{id}` (`AgentAuthController::updateDevice`) does accept `hash_window_titles` and `title_allowlist`, but nothing in the agent calls it. The agent's only relationship to these keys was *receiving* them on `GET /config` (`AgentConfigController`).
- **The server-side reader is untouched and still works.** `AgentDevice::shouldStoreRawTitle()` (internal-tool2, `src/app/Models/AgentDevice.php:372`) reads `$this->hash_window_titles` and `$this->title_allowlist` off the **device row**, and is consumed by `TimelineCardBuilder::sanitizeTitle`. That is fed by the DB column, never by anything the agent sends. **internal-tool2 is not modified by this PR.**

So the data flow was one-way (server → agent) into a field that nothing read — and on top of that it was gated off by `DEFER_UNAPPLIED_SERVER_SETTINGS = True`, so the assignment never even executed on the live fleet.

### Two things I found that differ from the brief (verified)

1. **There is no tray menu item for `hash_titles`, and there is not one for `domain_only_urls` either.** `grep -n "hash_titles" src/ui/tray.py` on `3bc7609` returns three lines — the `TrayModel` field (161), the `_snapshot_model` key (606), and the `set_config` copy (1214). None is a `MenuItem`. The Preferences submenu (`tray.py:770-806`) contains only Launch at Login, Debug Mode, Export Logs, Open Config File, and the update rows. So the control was *settings state carried by the tray*, not a switch a user could currently click. That makes it slightly less bad than "a live toggle that lies", and does not change the conclusion: it was still a named privacy field in the product's settings surface and in `config.json`, which employees can open via **Preferences > Open Config File**.
2. **`src/config.py`'s own comment about it was wrong.** The `DEFER_UNAPPLIED_SERVER_SETTINGS` block claimed applying `privacy.hash_window_titles` would "turn window titles into hashes, so admins lose readable titles." It would not have — there is no client-side hashing to turn on. `hashlib` appears in `src/` only in `aw_manager.py` (tracker binary SHA verification), `auth/pkce.py`, and `bf_client.py` (idempotency key). Corrected in this PR rather than left to mislead the next reader.

## What changed

- `PrivacySettings`: both fields removed, replaced by a note explaining why they must not come back.
- `Config.update_from_server`: stops mirroring `privacy.hash_window_titles` / `privacy.title_allowlist`. The server still sends them; they are now **explicitly ignored with a comment** saying why, per the brief.
- `TrayModel` field, `_snapshot_model` key, `TrayIcon.set_config` copy, and `main.py`'s `_on_preferences` branch: removed.
- `CLAUDE.md` Privacy Model + `README.md` Privacy section: rewritten. The old text described `hash_titles` as "forwarded to the server and honoured there", which was false in the first half and misleading in the second.
- Version 1.5.111 → 1.5.112.

**Not touched:** server-side title hashing (`internal-tool2`), `exclude_apps`, `domain_only_urls`, `collect_full_urls` — the controls that are genuinely enforced client-side. Also stayed out of `sync_engine.py`, `window_source.py` and `input_source.py` per the concurrent-agent note; none was needed.

**Upgrade path:** `Config.load`'s `_safe()` strips unknown keys before constructing the dataclass, so a device carrying `privacy.hash_titles` in its existing `config.json` loads clean and does not re-persist it. Covered by a test.

## Tests

`tests/test_hash_titles_control_removed.py` (8 tests):

| Test | Pins |
|---|---|
| `test_privacy_settings_declares_no_title_hashing_fields` | the dataclass fields are gone — and `exclude_apps`/`domain_only_urls` are still there |
| `test_legacy_config_file_does_not_resurrect_the_setting` | an old `config.json` neither restores the field nor gets it written back |
| `test_server_sent_hash_window_titles_is_ignored` | the `/config` payload is dropped **with the deferral gate patched OFF**, so the privacy block genuinely executes |
| `test_tray_model_carries_no_title_hashing_state` | `TrayModel` has no such attribute |
| `test_tray_source_references_no_title_hashing_control` | tray menu items, snapshot and `set_config` in one sweep |
| `test_preference_handler_has_no_title_hashing_branch` | `main.py`'s setter branch stays gone |
| `test_no_consumerless_title_hashing_symbol_anywhere_in_src` | **the grep guard** — fails if either symbol reappears as live code anywhere in `src/**/*.py` |
| `test_no_client_side_title_hashing_exists` | no `hexdigest` on a title path, i.e. the claim the field made stays false |

Two details worth noting. The gate-off patch in test 3 matters: asserting against the shipped `DEFER_UNAPPLIED_SERVER_SETTINGS = True` would pass because nothing in the block runs — a Phantom 4 (`test-fixture-discipline.md`). And the grep guard **exempts comment lines**, because the removal deliberately leaves notes naming these symbols so nobody restores them; a guard that forbade its own explanation would force those notes out.

### Proof-of-failure handshake

Impl files restored to `HEAD` with `git checkout HEAD -- src/config.py src/main.py src/ui/tray.py` (**not** `git stash` — `refs/stash` is shared across worktrees, `cross-repo-safety.md` Rule 0):

```
7 failed, 1 passed
```

The one that passes pre-removal is `test_no_client_side_title_hashing_exists`, which pins an already-true property rather than describing the defect — the shape `test-fixture-discipline.md` calls the strongest signal. Post-removal: `8 passed`.

### Guard mutation-tested (twice)

```
inject `self.hash_titles: bool = False` into tray.py  -> 3 failed, 5 passed
inject `hash_titles: bool = False` into PrivacySettings -> 4 failed, 4 passed
```

Both mutants reverted; `grep -rn "hash_titles\|title_allowlist" src/` now returns only the three comment lines.

### Existing tests updated (not weakened)

- `test_server_config_deferral_and_refetch.py` — dropped the `title_allowlist` deferral assertion. "Deferred" is no longer the property that holds; "ignored, gate or no gate" is, and that is now pinned in the new file. The `collect_full_urls` / `track_browser_domains` assertions are untouched.
- `test_server_config_envelope.py` — `test_window_titles_do_not_start_hashing` became `test_a_hash_window_titles_payload_is_harmless`. It still sends `hash_window_titles: true` on the wire and now asserts no local field is resurrected **and** that the same payload's working-hours schedule still landed, so it cannot pass on a total no-op.

## Verification

```
PYTHONPATH=. python3 -m pytest -q    -> 1300 passed in 28.47s (exit 0)
ruff, three touched src files        -> 15 findings before, 15 after, 0 new
                                        (repo-wide pre-existing baseline: 146)
```

No skips: `pystray` binds its display backend at import and is `None` on a headless CI runner, so the tray assertions are source-level and model-level rather than requiring a live `TrayIcon` — a guard that skips on CI is not a guard.

**Do not merge** — flagged for human review per the brief.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
