### PR TITLE
feat(privacy): guard that fails when collection config diverges from the disclosure

### DIFF
--- a/src/__init__.py
+++ b/src/__init__.py
@@ -1,4 +1,4 @@
 """BetterFlow - ActivityWatch to BetterFlow sync companion app."""
 
-__version__ = "1.5.113"
+__version__ = "1.5.114"
 __author__ = "BetterQA"

--- a/src/disclosure_baseline.py
+++ b/src/disclosure_baseline.py
@@ -1,0 +1,509 @@
+"""The declared baseline of what this agent collects — the code side of the
+monitoring disclosure employees sign.
+
+===========================================================================
+LEGAL COUNTERPART: BetterQA Regulament Intern, art. 68^1 alin. (6)
+                   ("Monitorizarea activitatii la statia de lucru")
+CHANGES HERE REQUIRE A DISCLOSURE REVIEW: dpo@betterqa.co
+===========================================================================
+
+Read this first if you are here because a test failed.
+
+Several collection behaviours in this agent are **server-flippable at
+runtime**. Nothing about that is visible in a release: a row changes in the
+backend, the next `/config` poll applies it, and the document every employee
+signed becomes false without a build, a changelog entry, or anybody being
+re-informed. That is not hypothetical — it is how `privacy.exclude_apps`
+came to have no server handler at all while `sync.in_process_window`, which
+bypassed the exclusion list entirely, could be switched on from a database
+row with no deferral gate (see PR #159).
+
+`tests/test_disclosure_baseline.py` compares the agent's *effective*
+collection configuration against what is declared below and fails on any
+divergence. It is deliberately a **baseline comparison, not a denylist of
+forbidden settings**. A denylist only catches the flags somebody already
+thought of; it goes stale the day a new field is added, which is exactly the
+failure this guard exists to prevent. Comparing against a declared baseline
+catches anything new *by construction* — including a field added next year by
+someone who has never read this file.
+
+Three kinds of divergence fail:
+
+1. **A watched value changed.** `track_display_info` flipped to True, an app
+   dropped out of `exclude_apps`, and so on.
+2. **A watched setting became reachable from the server, or its gate
+   changed.** A field moving from the deferred `privacy` block into the
+   ungated `sync` block changes nothing about the shipped default and
+   everything about who can change it, silently, tomorrow.
+3. **A new setting appeared that nobody has classified.** This is the one
+   that makes the guard outlive its author. Every field of every watched
+   settings group must be classified DISCLOSED or INTERNAL here. A field in
+   neither is a failure, and the fix is one line plus a decision about
+   whether employees need to be told.
+
+Classifying a field INTERNAL is a legitimate, cheap act for a knob that is
+genuinely about billing or transport — it keeps the guard from crying wolf,
+which is how guards get deleted. Reclassifying a DISCLOSED field as INTERNAL
+to silence a failure is not; it is the same act as deleting the test, and it
+is reviewable precisely because it happens in this file.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any
+
+# --------------------------------------------------------------------------
+# Where the legal text lives, and who owns it. The failure message quotes
+# these, so a developer who trips the guard is told what to update and whom
+# to tell without having to find this file first.
+# --------------------------------------------------------------------------
+
+REGULAMENT_ARTICLE = "Regulament Intern, art. 68^1 alin. (6)"
+REGULAMENT_TITLE = "Monitorizarea activitatii la statia de lucru"
+DISCLOSURE_CONTACT = "dpo@betterqa.co"
+
+# --------------------------------------------------------------------------
+# Classification of a settings field.
+# --------------------------------------------------------------------------
+
+#: The field governs WHAT is collected or WHETHER it leaves the device. It is
+#: described, directly or in substance, in the Regulament article above. Its
+#: value and its server reachability are both pinned.
+DISCLOSED = "disclosed"
+
+#: The field does not change what is collected — it tunes billing, transport,
+#: or presentation. Not pinned, but it must still be listed, so that a NEW
+#: field cannot slip in unclassified.
+INTERNAL = "internal"
+
+# --------------------------------------------------------------------------
+# Server reachability, as computed from `Config.update_from_server`.
+#
+# These are not declarations of intent; they are what a parse of the real
+# function reports. Declaring one wrongly fails the guard.
+# --------------------------------------------------------------------------
+
+#: Not assignable from a server `/config` payload at all. Changing it requires
+#: shipping a build — which means a release, and a chance to notice.
+SERVER_NONE: tuple[str, ...] = ()
+
+#: Assignable only inside a `not DEFER_UNAPPLIED_SERVER_SETTINGS` branch. The
+#: gate is True on main, so these are inert today and cannot change behaviour
+#: until the gate is lifted in a deliberate release.
+GATED = "gated"
+
+#: Assignable with NO deferral gate. A backend row changes it on the next
+#: poll, on the whole fleet, with no release. This is the highest-risk
+#: classification and every DISCLOSED field carrying it needs the Regulament
+#: to be honest about the fact that it can change without notice.
+LIVE = "live"
+
+#: Assignable only in the deferral-EXEMPT branch, which accepts the disabling
+#: direction only (currently `call_detection.mic_signal=false`). A remote
+#: off-switch for a probe is a privacy improvement and is allowed to bypass
+#: the staged rollout; it can never turn collection ON.
+KILL_ONLY = "kill-only"
+
+
+_UNSET = object()
+
+
+@dataclass(frozen=True)
+class Declared:
+    """One field of one watched settings group, as declared to employees."""
+
+    kind: str
+    #: For DISCLOSED: what the employee was told, in the terms they were told
+    #: it. For INTERNAL: why this field does not change what is collected.
+    why: str
+    #: DISCLOSED only — the shipped default, pinned exactly.
+    value: Any = _UNSET
+    #: DISCLOSED only — the sorted reachability tuple the AST probe must
+    #: report for this field. `SERVER_NONE` means "not remotely settable".
+    server: tuple[str, ...] = SERVER_NONE
+
+    def __post_init__(self) -> None:
+        if self.kind not in (DISCLOSED, INTERNAL):
+            raise ValueError(f"unknown classification {self.kind!r}")
+        if self.kind == DISCLOSED and self.value is _UNSET:
+            raise ValueError("a DISCLOSED field must pin its value")
+        if not self.why:
+            raise ValueError("every field must carry a reason")
+
+
+def is_pinned(d: Declared) -> bool:
+    """True when this declaration pins a value (i.e. it is DISCLOSED)."""
+    return d.kind == DISCLOSED and d.value is not _UNSET
+
+
+# ==========================================================================
+# THE BASELINE
+#
+# Keyed by the attribute name on `Config`. Every field of every group listed
+# here must appear; the guard fails on a field that is present in the
+# dataclass and missing here, and on one present here and missing from the
+# dataclass.
+# ==========================================================================
+
+BASELINE: dict[str, dict[str, Declared]] = {
+    # ----------------------------------------------------------------------
+    # PrivacySettings — the group that exists to decide what leaves the
+    # device. Every field here is collection-relevant unless it is dead code.
+    # ----------------------------------------------------------------------
+    "privacy": {
+        "domain_only_urls": Declared(
+            DISCLOSED,
+            value=True,
+            server=(GATED,),
+            why=(
+                "Employees are told browsing is recorded as the SITE, not the "
+                "page: URLs are cut to their domain on the device before "
+                "anything is sent. Flipping this to False sends full URLs, "
+                "including query strings, which routinely carry document "
+                "names, search terms and record identifiers."
+            ),
+        ),
+        "collect_full_urls": Declared(
+            DISCLOSED,
+            value=False,
+            server=(GATED,),
+            why=(
+                "The opt-in that overrides domain-only stripping. It is the "
+                "same disclosure as domain_only_urls approached from the "
+                "other side, and it must stay off for the sentence about "
+                "domains to remain true."
+            ),
+        ),
+        "exclude_apps": Declared(
+            DISCLOSED,
+            value=[
+                "1Password",
+                "Keychain Access",
+                "System Preferences",
+                "System Settings",
+                # macOS system agents
+                "SecurityAgent",
+                "UserNotificationCenter",
+                "loginwindow",
+                "ScreenSaverEngine",
+                "CoreServicesUIAgent",
+                "AirPlayUIAgent",
+                "SystemUIServer",
+                # Auto-updaters
+                "Microsoft AutoUpdate",
+                "Software Update",
+            ],
+            server=(GATED,),
+            why=(
+                "The named promise: activity in these applications never "
+                "leaves the device. Password managers and the OS credential "
+                "and security prompts are the whole point. REMOVING an entry "
+                "narrows a guarantee that was made by name — that is a "
+                "disclosure change even though nothing about the mechanism "
+                "moved. Adding one only ever sends less."
+            ),
+        ),
+        "track_display_info": Declared(
+            DISCLOSED,
+            value=False,
+            server=(GATED,),
+            why=(
+                "Records which monitor and which virtual desktop the active "
+                "window was on. That is workstation-layout information about "
+                "the person, it is disclosed nowhere today, and it is off. "
+                "Turning it on requires a Regulament change first."
+            ),
+        ),
+        "track_browser_urls": Declared(
+            DISCLOSED,
+            value=False,
+            server=(GATED,),
+            why=(
+                "Reads the active browser tab's address without an extension "
+                "(AppleScript on macOS, UI Automation on Windows). It is a "
+                "second, independent route to browsing data that does not go "
+                "through the browser at all, and it is off."
+            ),
+        ),
+        "collect_page_category": Declared(
+            DISCLOSED,
+            value=True,
+            server=(GATED,),
+            why=(
+                "Attaches a coarse category to browsing activity. Employees "
+                "are told activity is categorised; this is the browsing half "
+                "of that sentence."
+            ),
+        ),
+        "auto_categorize": Declared(
+            DISCLOSED,
+            value=True,
+            server=(GATED,),
+            why=(
+                "Attaches an app category from server-side mappings. The "
+                "application half of the same sentence."
+            ),
+        ),
+        "default_categories": Declared(
+            INTERNAL,
+            why=(
+                "A local app-name to category lookup used for labelling. It "
+                "changes how already-collected activity is described, never "
+                "what is collected or sent."
+            ),
+        ),
+    },
+    # ----------------------------------------------------------------------
+    # SyncSettings — mostly transport, but it carries the flags that decide
+    # WHICH SOURCE produces activity data. Those are collection decisions
+    # wearing a transport group's name, and they are the ungated ones.
+    # ----------------------------------------------------------------------
+    "sync": {
+        "in_process_window": Declared(
+            DISCLOSED,
+            value=False,
+            server=(LIVE,),
+            why=(
+                "Captures the active window (application and title) inside "
+                "the agent itself rather than via the external ActivityWatch "
+                "watcher. It is a distinct capture mechanism, it is remotely "
+                "switchable with NO deferral gate, and until PR #159 lands "
+                "its output did not pass the excluded-apps filter at all. "
+                "Any change to its default or its gate is a disclosure event."
+            ),
+        ),
+        "in_process_input": Declared(
+            DISCLOSED,
+            value=False,
+            server=(LIVE,),
+            why=(
+                "Counts keystrokes, clicks and scrolls using OS-level input "
+                "hooks in this process. It records counts, never characters, "
+                "but employees are told about keyboard and mouse ACTIVITY "
+                "measurement and this is the mechanism. Remotely switchable "
+                "with no deferral gate."
+            ),
+        ),
+        "in_process_afk": Declared(
+            DISCLOSED,
+            value=True,
+            server=SERVER_NONE,
+            why=(
+                "Derives the away-from-keyboard stream in-process from the OS "
+                "idle clock. This is what decides whether a period counts as "
+                "worked, which is the part of the disclosure employees care "
+                "about most."
+            ),
+        ),
+        "stop_external_afk_tracker": Declared(
+            DISCLOSED,
+            value=False,
+            server=SERVER_NONE,
+            why=(
+                "Selects which process produces the AFK stream. It does not "
+                "change what is measured, but it changes which component is "
+                "running on the machine, and the disclosure names the "
+                "bundled ActivityWatch trackers."
+            ),
+        ),
+        "min_window_event_seconds": Declared(
+            DISCLOSED,
+            value=5.0,
+            server=(LIVE,),
+            why=(
+                "The granularity floor: window and browsing events shorter "
+                "than this are discarded on the device and never sent. "
+                "Lowering it to 0 turns a coarse record of what someone "
+                "worked on into a near-keystroke-resolution log of every "
+                "window they glanced at. Remotely settable with no deferral "
+                "gate, which is why it is pinned here."
+            ),
+        ),
+        "interval_seconds": Declared(
+            INTERNAL,
+            why="How often already-collected events are uploaded. Transport cadence.",
+        ),
+        "batch_size": Declared(
+            INTERNAL,
+            why="How many events go in one upload request. Transport shape.",
+        ),
+        "compress": Declared(
+            INTERNAL,
+            why="gzip on the upload body. Encoding, not content.",
+        ),
+        "idle_pause_minutes": Declared(
+            INTERNAL,
+            why=(
+                "Pauses the SYNC LOOP after this long AFK. It stops uploads "
+                "of an idle machine; it does not change what the trackers "
+                "record while it is paused."
+            ),
+        ),
+    },
+    # ----------------------------------------------------------------------
+    # CallDetectionSettings — the microphone probe. The only sensor-shaped
+    # thing in the agent, and the one with the sharpest disclosure edge.
+    # ----------------------------------------------------------------------
+    "call_detection": {
+        "enabled": Declared(
+            DISCLOSED,
+            value=True,
+            server=(GATED,),
+            why=(
+                "Master switch for meeting detection. Employees are told that "
+                "time in calls is recognised as work; this is what does it."
+            ),
+        ),
+        "mic_signal": Declared(
+            DISCLOSED,
+            value=True,
+            server=(GATED, KILL_ONLY),
+            why=(
+                "Whether the agent asks the OS if the MICROPHONE IS IN USE. "
+                "It reads a boolean device state and never audio, but 'the "
+                "employer's software checks my microphone' is exactly the "
+                "sentence that must appear in the disclosure and be true. The "
+                "kill-only reachability is deliberate and must be preserved: "
+                "the probe can be switched OFF fleet-wide without waiting for "
+                "a release, and can never be switched ON that way."
+            ),
+        ),
+        "min_call_duration": Declared(
+            INTERNAL,
+            why=(
+                "Discards call sessions shorter than this so an accidental "
+                "app launch is not billed. Billing threshold on data already "
+                "observed."
+            ),
+        ),
+        "max_credit_minutes": Declared(
+            INTERNAL,
+            why=(
+                "Caps how much active time a single detected call may credit. "
+                "Purely a billing bound."
+            ),
+        ),
+    },
+    # ----------------------------------------------------------------------
+    # ForegroundActivitySettings — infers activity from CPU use of the
+    # frontmost app when there is no input. Default off for billing-safety
+    # reasons, but it is also an inference about the person.
+    # ----------------------------------------------------------------------
+    "foreground_activity": {
+        "enabled": Declared(
+            DISCLOSED,
+            value=False,
+            server=(GATED,),
+            why=(
+                "Credits activity from the frontmost application's CPU use "
+                "when no keyboard or mouse input is present — i.e. it infers "
+                "'working' without any input evidence. Off, and the "
+                "disclosure does not claim this inference is made."
+            ),
+        ),
+        "cpu_threshold_percent": Declared(
+            INTERNAL,
+            why="Sensitivity of an inference that is switched off. Tuning.",
+        ),
+        "max_credit_minutes": Declared(
+            INTERNAL,
+            why="Billing bound on the same switched-off inference.",
+        ),
+        "min_session_seconds": Declared(
+            INTERNAL,
+            why="Blip filter on the same switched-off inference.",
+        ),
+    },
+    # ----------------------------------------------------------------------
+    # AWSettings — the local ActivityWatch endpoint plus the idle threshold.
+    # ----------------------------------------------------------------------
+    "aw": {
+        "afk_timeout_minutes": Declared(
+            DISCLOSED,
+            value=10,
+            server=(GATED,),
+            why=(
+                "How long without input before the employee is recorded as "
+                "away. This is the definition of 'idle' in the document and "
+                "in every timesheet that follows from it."
+            ),
+        ),
+        "host": Declared(
+            INTERNAL,
+            why="Loopback address of the local ActivityWatch server. Transport.",
+        ),
+        "port": Declared(
+            INTERNAL,
+            why="Local ActivityWatch port. Transport.",
+        ),
+    },
+}
+
+
+# ==========================================================================
+# Settings groups that exist on `Config`.
+#
+# The groups above are watched field-by-field. This is the outer inventory:
+# it fails when a NEW settings group appears on `Config` — the case where
+# somebody adds `screenshots: ScreenshotSettings` and no per-field check
+# would ever have looked at it, because the group itself is new.
+# ==========================================================================
+
+#: Config attributes that are watched field-by-field above.
+WATCHED_GROUPS: frozenset[str] = frozenset(BASELINE)
+
+#: Config attributes deliberately NOT watched, each with a reason. Anything
+#: on Config that is in neither set fails the inventory check.
+UNWATCHED_CONFIG_FIELDS: dict[str, str] = {
+    "api_url": "Where events are sent, not what is collected.",
+    "device_id": "Locally generated install identifier, disclosed separately.",
+    "reminders": "Break and private-time prompts shown TO the user.",
+    "working_hours": (
+        "Restricts collection to a schedule — it can only ever cause LESS "
+        "to be recorded, and it is a per-employee contractual matter handled "
+        "outside the agent."
+    ),
+    "engagement": "Thresholds for scoring activity already collected.",
+    "fraud_detection": "Thresholds for scoring activity already collected.",
+    "setup_complete": "First-run wizard state.",
+    "auto_start": "Launch at login.",
+    "check_updates": "Updater behaviour.",
+    "auto_install_updates": "Updater behaviour.",
+    "update_channel": "Updater behaviour.",
+    "debug_mode": "Local log verbosity.",
+}
+
+
+# ==========================================================================
+# Collection facts that are not settings.
+#
+# Some of what we disclose is not a flag anyone can flip; it is simply what
+# the code does. Those facts still go stale, and a signed document does not
+# distinguish 'we changed a setting' from 'we changed the code'.
+# ==========================================================================
+
+#: The complete list of health/telemetry keys the heartbeat is allowed to
+#: forward. `BetterFlowClient.heartbeat` filters against this tuple, so a key
+#: absent from it never leaves the machine — which makes it the enforced
+#: egress allowlist, and therefore a disclosure surface. A new entry here is
+#: a new thing reported about the employee's machine.
+HEARTBEAT_HEALTH_KEYS: tuple[str, ...] = (
+    "idle_tracker_stale_restarts",
+    "idle_tracker_blind",
+    "inproc_afk",
+    "afk_event_age_seconds",
+    "window_event_age_seconds",
+    "consecutive_sync_failures",
+    "idle_while_active_detections",
+    "sync_stale_seconds",
+    "window_titles_captured_recently",
+    "hardware_serial",
+)
+
+#: The machine's hostname is read once and embedded in every `bucket_id`, so
+#: it rides along on every event whether or not anyone considered it an
+#: identifier. On personal-name-configured Macs ("Ana's MacBook Pro") it is
+#: an identifier for the person, not the device. Pinned as a fact so that
+#: changing it — in either direction — is a visible act.
+HOSTNAME_IS_EMBEDDED_IN_BUCKET_IDS = True

--- a/tests/test_disclosure_baseline.py
+++ b/tests/test_disclosure_baseline.py
@@ -1,0 +1,450 @@
+"""The agent's effective collection configuration must match what employees
+were told it collects.
+
+This is the enforcement half of `src/disclosure_baseline.py`. Read that file
+first — it explains why this is a baseline comparison and not a denylist, and
+it is where the fix for any failure below goes.
+
+Four things are compared, in the order a reader should think about them:
+
+* `test_no_unclassified_settings_group` — a NEW settings group on `Config`.
+* `test_no_unclassified_setting` — a NEW field in a watched group.
+* `test_declared_values_still_hold` — a watched default changed.
+* `test_declared_server_reachability_still_holds` — a watched field became
+  remotely flippable, or its deferral gate changed.
+
+Plus two non-setting collection facts: the heartbeat's egress allowlist and
+the hostname embedded in every bucket id.
+
+Nothing here constructs a tray, a client or a sync engine. It reads dataclass
+fields and parses source, so it runs identically on a headless CI runner and
+cannot be quietly skipped.
+"""
+
+from __future__ import annotations
+
+import ast
+import dataclasses
+import inspect
+from pathlib import Path
+
+import pytest
+
+from src import config as config_module
+from src.config import Config
+from src.disclosure_baseline import (
+    BASELINE,
+    DISCLOSED,
+    DISCLOSURE_CONTACT,
+    GATED,
+    HEARTBEAT_HEALTH_KEYS,
+    HOSTNAME_IS_EMBEDDED_IN_BUCKET_IDS,
+    KILL_ONLY,
+    LIVE,
+    REGULAMENT_ARTICLE,
+    REGULAMENT_TITLE,
+    UNWATCHED_CONFIG_FIELDS,
+    WATCHED_GROUPS,
+    is_pinned,
+)
+
+_SRC = Path(__file__).resolve().parents[1] / "src"
+
+_DEFERRAL_GATE = "DEFER_UNAPPLIED_SERVER_SETTINGS"
+
+
+# ---------------------------------------------------------------------------
+# Failure message
+#
+# A guard that says "AssertionError: False is not True" teaches people to
+# delete it. Every failure below names the document that just became wrong,
+# the person to tell, and the specific edit that resolves it.
+# ---------------------------------------------------------------------------
+
+
+def _fail(headline: str, detail: str, fix: str) -> str:
+    return (
+        f"\n\n  {headline}\n\n"
+        f"{detail}\n"
+        f"  This changes what BetterQA told employees it collects, in the\n"
+        f"  monitoring disclosure they each signed:\n\n"
+        f"      {REGULAMENT_ARTICLE}\n"
+        f"      \"{REGULAMENT_TITLE}\"\n\n"
+        f"  Tell {DISCLOSURE_CONTACT} BEFORE merging. The Regulament article\n"
+        f"  is a signed document; if the agent's behaviour moves and the text\n"
+        f"  does not, the signature covers something that is no longer true.\n\n"
+        f"  To resolve:\n{fix}\n"
+        f"  The declarations live in src/disclosure_baseline.py.\n"
+    )
+
+
+# ---------------------------------------------------------------------------
+# Server-reachability probe
+#
+# Parses `Config.update_from_server` and reports, for every `self.<group>.<field>`
+# assignment, the deferral gate of the branch it sits in. This is a measurement
+# of the real function, not a restatement of intent: it is what caught that
+# `sync.in_process_window` is remotely flippable with no gate while every
+# `privacy.*` field is deferred.
+# ---------------------------------------------------------------------------
+
+
+def _gate_of(tests: list[ast.expr]) -> str:
+    """Classify the deferral gate implied by a stack of enclosing `if` tests."""
+    negated = False
+    plain = False
+    for test in tests:
+        for node in ast.walk(test):
+            if (
+                isinstance(node, ast.UnaryOp)
+                and isinstance(node.op, ast.Not)
+                and any(
+                    isinstance(n, ast.Name) and n.id == _DEFERRAL_GATE
+                    for n in ast.walk(node.operand)
+                )
+            ):
+                negated = True
+            if isinstance(node, ast.Name) and node.id == _DEFERRAL_GATE:
+                plain = True
+    if negated:
+        return GATED
+    if plain:
+        return KILL_ONLY
+    return LIVE
+
+
+def _collect(node: ast.AST, tests: list[ast.expr], out: dict) -> None:
+    if isinstance(node, ast.If):
+        for stmt in node.body:
+            _collect(stmt, tests + [node.test], out)
+        for stmt in node.orelse:
+            _collect(stmt, tests, out)
+        return
+
+    if isinstance(node, (ast.Assign, ast.AugAssign)):
+        targets = node.targets if isinstance(node, ast.Assign) else [node.target]
+        for target in targets:
+            if (
+                isinstance(target, ast.Attribute)
+                and isinstance(target.value, ast.Attribute)
+                and isinstance(target.value.value, ast.Name)
+                and target.value.value.id == "self"
+                and target.value.attr in WATCHED_GROUPS
+            ):
+                key = (target.value.attr, target.attr)
+                out.setdefault(key, set()).add(_gate_of(tests))
+
+    for child in ast.iter_child_nodes(node):
+        _collect(child, tests, out)
+
+
+def _server_reachability() -> dict[tuple[str, str], tuple[str, ...]]:
+    """Map (group, field) -> sorted gates it can be assigned under."""
+    tree = ast.parse(inspect.getsource(config_module))
+    fn = next(
+        node
+        for node in ast.walk(tree)
+        if isinstance(node, ast.FunctionDef) and node.name == "update_from_server"
+    )
+    out: dict[tuple[str, str], set[str]] = {}
+    for stmt in fn.body:
+        _collect(stmt, [], out)
+    return {key: tuple(sorted(gates)) for key, gates in out.items()}
+
+
+def _normalise(value):
+    """Compare lists of strings as unordered — a reorder of `exclude_apps` is
+    not a change in what is collected, and a guard that fires on it gets
+    deleted for crying wolf."""
+    if isinstance(value, list) and all(isinstance(v, str) for v in value):
+        return sorted(value)
+    return value
+
+
+# ---------------------------------------------------------------------------
+# Sanity: the probe itself must work.
+#
+# A broken probe does not raise, it returns a plausible finding. If this test
+# ever fails, every reachability result below is void — do not "fix" the
+# baseline to match it.
+# ---------------------------------------------------------------------------
+
+
+def test_the_reachability_probe_actually_measures_something():
+    reach = _server_reachability()
+    assert reach, "the probe found no server-assignable settings at all"
+    # Negative control: a gate classification the probe must be able to tell
+    # apart. If everything came back identical the probe measures nothing.
+    gates = {g for gates in reach.values() for g in gates}
+    assert GATED in gates, "probe never reports a deferred assignment"
+    assert LIVE in gates, "probe never reports an ungated assignment"
+    assert len(gates) > 1, "probe returns one verdict for everything"
+
+
+# ---------------------------------------------------------------------------
+# 1. A new settings GROUP nobody classified.
+# ---------------------------------------------------------------------------
+
+
+def test_no_unclassified_settings_group():
+    on_config = {f.name for f in dataclasses.fields(Config)}
+    classified = set(WATCHED_GROUPS) | set(UNWATCHED_CONFIG_FIELDS)
+
+    unclassified = sorted(on_config - classified)
+    assert not unclassified, _fail(
+        f"UNCLASSIFIED SETTINGS GROUP ON Config: {', '.join(unclassified)}",
+        (
+            "  A new group of settings exists on Config and nothing has decided\n"
+            "  whether it affects what this agent collects.\n\n"
+        ),
+        (
+            "    * If it changes what is collected: add it to BASELINE and\n"
+            "      classify each of its fields.\n"
+            "    * If it does not: add it to UNWATCHED_CONFIG_FIELDS with the\n"
+            "      reason it is out of scope.\n"
+        ),
+    )
+
+    vanished = sorted(classified - on_config)
+    assert not vanished, _fail(
+        f"BASELINE DESCRIBES SETTINGS GROUPS THAT NO LONGER EXIST: {', '.join(vanished)}",
+        (
+            "  The baseline is describing an agent that is not the one in this\n"
+            "  tree, so it has stopped guarding whatever replaced these.\n\n"
+        ),
+        "    * Remove the stale entries from src/disclosure_baseline.py.\n",
+    )
+
+
+# ---------------------------------------------------------------------------
+# 2. A new FIELD nobody classified.
+#
+# This is the property that makes the guard outlive its author: a setting
+# added next year by someone who has never read the baseline still fails,
+# because it is absent from a declaration rather than present in a denylist.
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("group", sorted(BASELINE))
+def test_no_unclassified_setting(group: str):
+    declared = BASELINE[group]
+    actual = {f.name for f in dataclasses.fields(getattr(Config(), group))}
+
+    unclassified = sorted(actual - set(declared))
+    assert not unclassified, _fail(
+        f"UNCLASSIFIED SETTING(S) IN Config.{group}: {', '.join(unclassified)}",
+        (
+            f"  New field(s) appeared in Config.{group} and nothing has decided\n"
+            "  whether they affect what this agent collects. That decision is\n"
+            "  the point of this guard: the last disclosure list went stale\n"
+            "  exactly this way, by a field being added and nobody noticing.\n\n"
+        ),
+        (
+            "    * If it changes WHAT is collected, WHETHER it leaves the\n"
+            "      device, or WHO can change that at runtime: declare it\n"
+            "      DISCLOSED with its value and server reachability, and get\n"
+            "      the Regulament article updated.\n"
+            "    * If it is billing, transport or presentation tuning:\n"
+            "      declare it INTERNAL with the reason. Cheap, and it keeps\n"
+            "      this guard from crying wolf.\n"
+        ),
+    )
+
+    vanished = sorted(set(declared) - actual)
+    assert not vanished, _fail(
+        f"BASELINE DESCRIBES SETTINGS THAT NO LONGER EXIST IN Config.{group}: "
+        f"{', '.join(vanished)}",
+        (
+            "  A declared setting has been removed from the code. If it was\n"
+            "  DISCLOSED, the Regulament may now describe a behaviour the\n"
+            "  agent no longer has.\n\n"
+        ),
+        "    * Remove the stale entries from src/disclosure_baseline.py.\n",
+    )
+
+
+# ---------------------------------------------------------------------------
+# 3. A declared value changed.
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    ("group", "name"),
+    [
+        (g, n)
+        for g, fields in sorted(BASELINE.items())
+        for n, d in sorted(fields.items())
+        if is_pinned(d)
+    ],
+)
+def test_declared_values_still_hold(group: str, name: str):
+    declared = BASELINE[group][name]
+    effective = getattr(getattr(Config(), group), name)
+
+    assert _normalise(effective) == _normalise(declared.value), _fail(
+        f"COLLECTION SETTING CHANGED: {group}.{name}",
+        (
+            f"    declared to employees : {declared.value!r}\n"
+            f"    shipping in this build: {effective!r}\n\n"
+            f"  What this setting governs:\n"
+            f"    {declared.why}\n\n"
+        ),
+        (
+            "    * If the new value is intended, update BASELINE and get the\n"
+            "      Regulament article amended to match, in that order.\n"
+            "    * If it is not intended, this guard just caught a silent\n"
+            "      change to what BetterQA collects from its employees.\n"
+        ),
+    )
+
+
+# ---------------------------------------------------------------------------
+# 4. A declared field's server reachability changed.
+#
+# The subtlest and most important of the four. A field can keep its default
+# forever and still turn a signed document into a lie, if somebody moves its
+# handler out of the deferred block and into an ungated one. Nothing about
+# the shipped build changes; everything about who can change it does.
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    ("group", "name"),
+    [
+        (g, n)
+        for g, fields in sorted(BASELINE.items())
+        for n, d in sorted(fields.items())
+        if d.kind == DISCLOSED
+    ],
+)
+def test_declared_server_reachability_still_holds(group: str, name: str):
+    declared = BASELINE[group][name]
+    effective = _server_reachability().get((group, name), ())
+
+    explain = {
+        (): "not settable from the server at all (requires shipping a build)",
+        (GATED,): (
+            f"settable from the server, but only behind {_DEFERRAL_GATE} "
+            "(inert until a deliberate release lifts the gate)"
+        ),
+        (LIVE,): (
+            "settable from the server RIGHT NOW, with no deferral gate — a "
+            "backend row changes it fleet-wide on the next poll, with no "
+            "release and nobody informed"
+        ),
+        (KILL_ONLY,): "settable from the server in the DISABLING direction only",
+        (GATED, KILL_ONLY): (
+            f"deferred behind {_DEFERRAL_GATE} for enabling, with a "
+            "deferral-exempt path for disabling only"
+        ),
+    }
+
+    def describe(value: tuple[str, ...]) -> str:
+        return explain.get(tuple(sorted(value)), f"gates {sorted(value)!r}")
+
+    assert tuple(sorted(effective)) == tuple(sorted(declared.server)), _fail(
+        f"WHO CAN CHANGE {group}.{name} AT RUNTIME HAS CHANGED",
+        (
+            f"    declared : {describe(declared.server)}\n"
+            f"    actual   : {describe(effective)}\n\n"
+            f"  What this setting governs:\n"
+            f"    {declared.why}\n\n"
+            "  The shipped default may be unchanged. That is not the point:\n"
+            "  a collection behaviour that can be switched remotely is one the\n"
+            "  disclosure must describe as switchable, or must not permit.\n\n"
+        ),
+        (
+            "    * Moving a collection setting into an UNGATED server block\n"
+            f"      needs {DISCLOSURE_CONTACT} to sign off first — that is a\n"
+            "      change to what can happen without telling anyone.\n"
+            "    * Moving one behind the deferral gate, or removing its\n"
+            "      handler, is a tightening: update BASELINE and say so.\n"
+        ),
+    )
+
+
+# ---------------------------------------------------------------------------
+# 5. Collection facts that are not settings.
+# ---------------------------------------------------------------------------
+
+
+def test_heartbeat_egress_allowlist_still_holds():
+    from src.sync.bf_client import BetterFlowClient
+
+    effective = tuple(BetterFlowClient.HEARTBEAT_HEALTH_KEYS)
+    added = sorted(set(effective) - set(HEARTBEAT_HEALTH_KEYS))
+    removed = sorted(set(HEARTBEAT_HEALTH_KEYS) - set(effective))
+
+    assert not added and not removed, _fail(
+        "THE HEARTBEAT NOW REPORTS SOMETHING DIFFERENT ABOUT THE MACHINE",
+        (
+            f"    newly reported : {added or 'none'}\n"
+            f"    no longer sent : {removed or 'none'}\n\n"
+            "  HEARTBEAT_HEALTH_KEYS is the enforced egress allowlist for the\n"
+            "  heartbeat — a key absent from it never leaves the device, so a\n"
+            "  key added to it is a new fact reported about the employee's\n"
+            "  machine, independent of any privacy setting. One of these keys\n"
+            "  is already the hardware serial number.\n\n"
+        ),
+        (
+            "    * Update HEARTBEAT_HEALTH_KEYS in src/disclosure_baseline.py\n"
+            "      and check the new key against the Regulament's list of what\n"
+            "      is reported. CLAUDE.md's device-identifier section is the\n"
+            "      other place that must stay in step.\n"
+        ),
+    )
+
+
+def test_hostname_is_still_embedded_in_every_bucket_id():
+    source = (_SRC / "sync" / "sync_engine.py").read_text()
+
+    reads_hostname = "self._hostname = socket.gethostname()" in source
+    in_bucket_ids = 'bucket_id": f"' in source and "{self._hostname}" in source
+    effective = reads_hostname and in_bucket_ids
+
+    assert effective == HOSTNAME_IS_EMBEDDED_IN_BUCKET_IDS, _fail(
+        "THE MACHINE HOSTNAME IS NO LONGER TRAVELLING ON EVERY EVENT "
+        "(or has started to)",
+        (
+            f"    declared : hostname embedded in bucket ids = "
+            f"{HOSTNAME_IS_EMBEDDED_IN_BUCKET_IDS}\n"
+            f"    actual   : {effective} "
+            f"(reads hostname={reads_hostname}, in bucket_id={in_bucket_ids})\n\n"
+            "  The hostname is read once at startup and interpolated into every\n"
+            "  bucket id, so it accompanies every event whether or not anyone\n"
+            "  treated it as an identifier. On a Mac named by its owner it\n"
+            "  identifies the person, not the machine.\n\n"
+        ),
+        (
+            "    * If this stopped being true, that is a privacy improvement\n"
+            "      and the disclosure should stop claiming it. Update\n"
+            "      HOSTNAME_IS_EMBEDDED_IN_BUCKET_IDS either way.\n"
+        ),
+    )
+
+
+# ---------------------------------------------------------------------------
+# 6. The baseline itself must stay honest.
+# ---------------------------------------------------------------------------
+
+
+def test_every_declaration_carries_a_reason():
+    """A baseline entry with no stated reason is a value nobody can review."""
+    for group, fields in BASELINE.items():
+        for name, declared in fields.items():
+            assert declared.why.strip(), f"{group}.{name} declares no reason"
+            if declared.kind == DISCLOSED:
+                assert len(declared.why) > 40, (
+                    f"{group}.{name} is DISCLOSED but its reason is too thin to "
+                    "review against the Regulament"
+                )
+
+
+def test_the_baseline_points_at_the_regulament():
+    """Greppable from both ends: someone reading the Regulament must be able to
+    find the code, and someone reading the code must be able to find the
+    Regulament."""
+    text = (_SRC / "disclosure_baseline.py").read_text()
+    assert REGULAMENT_ARTICLE in text
+    assert DISCLOSURE_CONTACT in text
+    assert "art. 68^1" in REGULAMENT_ARTICLE


### PR DESCRIPTION
## What

A declared baseline of every collection-relevant setting (`src/disclosure_baseline.py`) plus a test that fails on any divergence from it. It is the code-side counterpart of the monitoring article every employee signs — **Regulament Intern art. 68^1 alin. 6** — and it exists to keep "we disclosed everything" true after the signatures dry.

## Why a baseline, not a denylist

A denylist of forbidden flags rots the day someone adds a field nobody listed — which is precisely the failure that started this audit. A baseline catches anything new **by construction**: every field of every watched group must be classified `DISCLOSED` (value + server-reachability pinned) or `INTERNAL` (billing/transport, with a stated reason). A field in neither fails.

## Four divergences fail, each naming the article + dpo@betterqa.co

1. a watched default changed
2. a field became remotely flippable or changed deferral gate — this is the subtle one: `in_process_window`/`input` were set from the **ungated `sync`** block, not the deferred `privacy` block, so a backend row flips them fleet-wide with no release
3. a **new unclassified setting** appeared (the property that outlives the author)
4. non-setting facts moved: the heartbeat egress allowlist, and the hostname embedded in every bucket id

Server-reachability is **measured by parsing `Config.update_from_server`'s AST**, not by restating intent — and carries a negative control that voids the result if the probe stops telling gates apart.

## Proof it bites (mutation-tested, reverted)

- flip `track_display_info` False→True → 1 failed
- add an unclassified privacy field → 1 failed
- neuter the guard's own comparison → does not stay falsely green

## Provenance

The base agent hit a spend limit mid-build; the finished module + suite were complete and passing, and I rebased onto #159 + #160, at which point **the guard caught both merges** (`exclude_apps` gained a gated handler; `hash_titles`/`title_allowlist` were removed). Updating the baseline to match is the guard working as designed, not a fixup. Full suite 1358 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)