### PR TITLE
fix: two audit findings on the tracking-blindspot beta (outage self-heal + exec latch)

### DIFF
--- a/src/aw_manager.py
+++ b/src/aw_manager.py
@@ -861,12 +861,23 @@ class AWManager:
 
         binaries_dir = self._get_binaries_dir()
 
-        if binaries_dir:
+        if binaries_dir and not (self._exec_failed_components - self._disabled_components):
             # Clear the latch on EVERY route that resolves usable binaries, not
             # just a fresh download — the frozen-bundle path installs trackers
             # without downloading, so a device that recovered via an app update
             # would otherwise keep reporting tracker_download_failed forever and
             # train the ops ingest to ignore the signal.
+            #
+            # But NOT while a component is still known-unrunnable. "binaries_dir
+            # resolved" proves they DOWNLOADED; it has never proved they EXECUTE,
+            # and tracker_download_failed now also means "cannot execute" (see the
+            # EBADARCH/ENOEXEC handler in _start_component). Clearing here on an
+            # exec-broken device — before the watcher loop below re-latches it, or
+            # when BF_SERVER/_wait_for_server bails first and the loop never runs —
+            # reports the device healthy while it captures nothing. The successful
+            # _start_component below is the only proof of execution and clears the
+            # flags itself under this exact same guard; that is where the clear
+            # belongs. _lifecycle_lock (RLock) is held by our caller.
             self.tracker_download_failed = False
             self._managed_components_unavailable = False
 

--- a/src/main.py
+++ b/src/main.py
@@ -1425,6 +1425,80 @@ class SyncCoordinator:
             return TrayState.PAUSED, "Idle"
         return TrayState.SYNCING, None
 
+    def _monitor_capture_health(self) -> bool:
+        """Self-heal the local tracker stack and escalate a real AW outage.
+
+        Local-only: it restarts/rebuilds trackers and updates the reachability
+        clock, but never uploads. That is exactly why it is factored out of the
+        inline sync path and shared with the paused_by_network branch: capture
+        continues during a network outage, but that branch used to ``return``
+        before any of this ran, so a tracker that died (or never started)
+        mid-outage was never restarted until the network came back.
+
+        Returns True if the caller should proceed to ``sync_engine.sync()``,
+        False if it should skip the upload this cycle (AW unreachable, escalated).
+        """
+        if self.aw_manager.is_managing:
+            self.aw_manager.restart_if_needed()
+            # Escalate a non-converging restart loop: repeated forced restarts
+            # mean the restart isn't fixing it (orphan tracker / missing Input
+            # Monitoring permission). Capture so it surfaces instead of looping
+            # silently; error_reporter dedup throttles.
+            try:
+                restarts = self.aw_manager.stale_restart_count()
+                if (
+                    restarts >= self._RESTART_LOOP_ALERT_THRESHOLD
+                    and not self._restart_loop_escalated
+                    and self.error_reporter is not None
+                ):
+                    self.error_reporter.capture(
+                        f"Idle-tracker restart loop not converging ({restarts} restarts this session)",
+                        level="warning",
+                        tags={"component": "idle-tracker"},
+                        context={"stale_restarts": restarts},
+                        fingerprint="idle-tracker-restart-loop",
+                    )
+                    # Once per session — the restart count is monotonic, so
+                    # without this latch the capture would re-fire every cycle
+                    # (only the reporter's dedup window kept it from flooding).
+                    self._restart_loop_escalated = True
+            except Exception:
+                # WARNING, not debug: if the reporter itself is broken (bad DSN,
+                # etc.) the escalation we built to surface this loop must not fail
+                # silently every cycle.
+                logger.warning("restart-loop escalation check failed", exc_info=True)
+
+        # Outside working hours the trackers are stopped ON PURPOSE, so
+        # aw.is_running() is False and escalating it would (a) flip the tray to
+        # "ActivityWatch not responding" every night and (b) rebuild a stack that
+        # is meant to be down. Hold the unreachable clock instead. The online
+        # caller still falls through to sync() on this path — that is where the
+        # offline queue drains, the heartbeat is sent, AND fetch_server_config()
+        # retries (a device whose first config fetch failed has known=False, so
+        # capture is suppressed, so the tracker is down; only reaching sync()
+        # re-fetches it). The offline caller returns regardless.
+        capture_suppressed = not self.config.working_hours.allows(
+            datetime.now(timezone.utc)
+        )
+
+        if capture_suppressed:
+            # Deliberately down. Hold the unreachable clock where it is rather
+            # than clearing it: suppression is not evidence that ActivityWatch
+            # recovered, and clearing here is what made the escalation unreachable
+            # in practice (see _note_aw_unreachable).
+            self._note_aw_capture_suppressed()
+        elif not self.aw.is_running():
+            # is_running() already reset+retried the HTTP session, so this is a
+            # real stall, not a stale-socket blip. Grace period before escalating:
+            # a single missed cycle usually self-heals.
+            if self._note_aw_unreachable():
+                self._escalate_aw_unreachable()
+            return False
+        else:
+            # AW actually answered — the only thing that counts as recovery.
+            self._note_aw_reachable()
+        return True
+
     def _do_sync(self) -> None:
         """Perform a sync cycle."""
         my_lock = self._acquire_sync_slot()
@@ -1523,69 +1597,24 @@ class SyncCoordinator:
             if self.paused_by_network:
                 self.tray.set_state(TrayState.QUEUED, "Offline")
                 self.tray.update_stats(queue_size=self.queue.size())
+                # A network outage suspends UPLOAD, not capture: suspend_upload()
+                # keeps the trackers recording and queueing locally, often for
+                # hours. So the capture stack must still be health-checked and
+                # self-healed here — every restart/rebuild path lives below this
+                # gate and used to be skipped for the ENTIRE outage, so a tracker
+                # that crashed (or never started) recorded nothing until the
+                # network returned: the exact blind capture this release exists
+                # to prevent. Only the upload sync is skipped (it cannot land
+                # while offline); _monitor_capture_health is local-only, and its
+                # sync-gate return is intentionally ignored on this path.
+                self._monitor_capture_health()
                 return
 
-            if self.aw_manager.is_managing:
-                self.aw_manager.restart_if_needed()
-                # Escalate a non-converging restart loop: repeated forced
-                # restarts mean the restart isn't fixing it (orphan tracker /
-                # missing Input Monitoring permission). Capture so it surfaces
-                # instead of looping silently; error_reporter dedup throttles.
-                try:
-                    restarts = self.aw_manager.stale_restart_count()
-                    if (
-                        restarts >= self._RESTART_LOOP_ALERT_THRESHOLD
-                        and not self._restart_loop_escalated
-                        and self.error_reporter is not None
-                    ):
-                        self.error_reporter.capture(
-                            f"Idle-tracker restart loop not converging ({restarts} restarts this session)",
-                            level="warning",
-                            tags={"component": "idle-tracker"},
-                            context={"stale_restarts": restarts},
-                            fingerprint="idle-tracker-restart-loop",
-                        )
-                        # Once per session — the restart count is monotonic, so
-                        # without this latch the capture would re-fire every cycle
-                        # (only the reporter's dedup window kept it from flooding).
-                        self._restart_loop_escalated = True
-                except Exception:
-                    # WARNING, not debug: if the reporter itself is broken (bad
-                    # DSN, etc.) the escalation we built to surface this loop must
-                    # not fail silently every cycle.
-                    logger.warning("restart-loop escalation check failed", exc_info=True)
-
-            # Outside working hours the trackers are stopped ON PURPOSE, so
-            # aw.is_running() is False and the branch below would (a) escalate a
-            # deliberate silence to "ActivityWatch not responding" in the tray every
-            # single night, and (b) `return` before sync_engine.sync() — which is
-            # where the offline queue gets drained, the heartbeat is sent, AND
-            # fetch_server_config() retries. That last one is a trap: a device whose
-            # first config fetch failed has known=False, so capture is suppressed, so
-            # the tracker is down, so sync() is never reached, so the config is never
-            # re-fetched — suppressed forever, zero tracking, until someone restarts
-            # the app AND the network happens to be up. Fall through instead: sync()
-            # has its own suppressed path that skips the AW reads.
-            capture_suppressed = not self.config.working_hours.allows(
-                datetime.now(timezone.utc)
-            )
-
-            if capture_suppressed:
-                # Deliberately down. Hold the unreachable clock where it is
-                # rather than clearing it: suppression is not evidence that
-                # ActivityWatch recovered, and clearing here is what made the
-                # escalation unreachable in practice (see _note_aw_unreachable).
-                self._note_aw_capture_suppressed()
-            elif not self.aw.is_running():
-                # is_running() already reset+retried the HTTP session, so this
-                # is a real stall, not a stale-socket blip. Grace period before
-                # escalating: a single missed cycle usually self-heals.
-                if self._note_aw_unreachable():
-                    self._escalate_aw_unreachable()
+            # Health-check + self-heal the local tracker stack. Returns False when
+            # the caller should skip the upload sync this cycle (AW unreachable and
+            # escalated); True to proceed.
+            if not self._monitor_capture_health():
                 return
-            else:
-                # AW actually answered — the only thing that counts as recovery.
-                self._note_aw_reachable()
 
             stats = self.sync_engine.sync()
 

--- a/tests/test_outage_still_heals_capture.py
+++ b/tests/test_outage_still_heals_capture.py
@@ -1,0 +1,128 @@
+"""A network outage suspends UPLOAD, not capture — so the local tracker stack
+must still be health-checked and self-healed during one.
+
+Before this fix `_do_sync` returned the instant `paused_by_network` was True,
+BEFORE the restart/rebuild path. `suspend_upload()` keeps the trackers recording
+and queueing for the whole outage (often hours), so a tracker that crashed — or,
+like Fabian's device, never started at all — recorded nothing until the network
+came back. That is the exact "device silently records nothing" failure mode the
+1.5.118 tracking-blindspot work exists to close, reintroduced by the one path
+nobody re-checked: an outage.
+
+The escalation tests drive `_note_aw_unreachable` / `_escalate_aw_unreachable`
+directly and never through `_do_sync`, so this branch had zero coverage.
+"""
+
+import threading
+from unittest.mock import MagicMock, PropertyMock, patch
+
+import src.main as main_mod
+from src.main import SyncCoordinator
+
+
+def _coord() -> SyncCoordinator:
+    c = SyncCoordinator.__new__(SyncCoordinator)
+    c._DO_SYNC_DEADLINE = 150
+    c._RESTART_LOOP_ALERT_THRESHOLD = 999
+    c._restart_loop_escalated = False
+    c._aw_unreachable_streak = 0
+    c._aw_unreachable_since = None
+    c._AW_UNREACHABLE_ESCALATE_SECONDS = 180.0
+    c._sync_takeover_lock = threading.Lock()
+    c._sync_holder = None
+    c._sync_started_at = None
+    c.error_reporter = None
+    c.aw = MagicMock()
+    c.aw_manager = MagicMock()
+    c.aw_manager.is_managing = False
+    c.tray = MagicMock()
+    c.queue = MagicMock()
+    c.sync_engine = MagicMock()
+    c.sync_engine.is_private = False
+    c.break_mgr = MagicMock()
+    c.break_mgr.is_on_break = False
+    c.config = MagicMock()
+    c.config.working_hours.allows.return_value = True
+    return c
+
+
+def _drive_do_sync(c: SyncCoordinator):
+    lock = MagicMock()
+    with patch.object(SyncCoordinator, "paused_by_network", new_callable=PropertyMock, return_value=True), \
+         patch.object(SyncCoordinator, "idle_paused", new_callable=PropertyMock, return_value=False), \
+         patch.object(main_mod.threading, "Timer", return_value=MagicMock()), \
+         patch.object(c, "_acquire_sync_slot", return_value=lock):
+        c._do_sync()
+    return lock
+
+
+# ---- the outage branch of _do_sync must run capture health ----
+
+def test_outage_branch_invokes_capture_health_and_skips_upload():
+    c = _coord()
+    lock = MagicMock()
+    with patch.object(SyncCoordinator, "paused_by_network", new_callable=PropertyMock, return_value=True), \
+         patch.object(SyncCoordinator, "idle_paused", new_callable=PropertyMock, return_value=False), \
+         patch.object(main_mod.threading, "Timer", return_value=MagicMock()), \
+         patch.object(c, "_acquire_sync_slot", return_value=lock), \
+         patch.object(c, "_monitor_capture_health") as health:
+        c._do_sync()
+
+    health.assert_called_once()
+    # Upload cannot land offline — sync() is still skipped.
+    c.sync_engine.sync.assert_not_called()
+    lock.release.assert_called_once()
+
+
+def test_a_dead_tracker_during_an_outage_is_rebuilt():
+    # Fabian's exact shape: nothing ever started (is_managing False), AW dead,
+    # inside working hours, unreachable past the grace window. Pre-fix the outage
+    # branch returned before any of this, so the rebuild never fired.
+    c = _coord()
+    c.aw.is_running.return_value = False
+    c._aw_unreachable_since = 0.001  # already well past the 180s grace window
+
+    _drive_do_sync(c)
+
+    c.aw_manager.force_restart.assert_called_once()
+
+
+# ---- _monitor_capture_health itself (the extracted, shared helper) ----
+
+def test_monitor_returns_true_and_notes_recovery_when_aw_answers():
+    c = _coord()
+    c.aw.is_running.return_value = True
+
+    assert c._monitor_capture_health() is True
+    assert c._aw_unreachable_since is None  # recovery recorded
+
+
+def test_monitor_skips_sync_and_escalates_a_real_outage():
+    c = _coord()
+    c.aw.is_running.return_value = False
+    c._aw_unreachable_since = 0.001
+
+    assert c._monitor_capture_health() is False
+    c.aw_manager.force_restart.assert_called_once()
+
+
+def test_monitor_does_not_escalate_or_rebuild_out_of_hours():
+    # Out of hours the trackers are down on purpose; escalating would rebuild a
+    # stack meant to be off and flip the tray to an error every night.
+    c = _coord()
+    c.config.working_hours.allows.return_value = False
+    c.aw.is_running.return_value = False
+
+    assert c._monitor_capture_health() is True  # falls through to sync() online
+    c.aw_manager.force_restart.assert_not_called()
+
+
+def test_monitor_restarts_managed_trackers():
+    c = _coord()
+    c.aw_manager.is_managing = True
+    c.aw_manager.stale_restart_count.return_value = 0
+    c.aw.is_running.return_value = True
+
+    c._monitor_capture_health()
+
+    c.aw_manager.restart_if_needed.assert_called_once()

--- a/tests/test_start_locked_preserves_exec_latch.py
+++ b/tests/test_start_locked_preserves_exec_latch.py
@@ -1,0 +1,93 @@
+"""The capture-dead latch must survive a _start_locked() tick that resolves
+binaries but bails before the watcher loop re-latches the broken component.
+
+`_start_component`'s EBADARCH handler latches `_exec_failed_components` +
+`tracker_download_failed` for a binary that cannot execute (Fabian's device,
+2026-07-23: recorded zero seconds for two days while the heartbeat reported
+healthy). But `_start_locked` unconditionally cleared both flags the moment
+`_get_binaries_dir()` resolved — and "binaries on disk" only ever proved they
+DOWNLOADED, never that they RUN. So on the next tick the latch was wiped before
+anything re-verified execution; if BF_SERVER (or _wait_for_server) then failed
+for any reason, the watcher loop that would have re-latched the still-broken
+component never ran, and the device reported itself healthy while blind.
+
+The fix gates the clear on the same condition the successful-start path uses:
+don't clear while a component is still known-unrunnable.
+"""
+
+from unittest.mock import patch
+
+from src.aw_manager import AWManager, BF_SERVER
+
+
+def _mgr() -> AWManager:
+    mgr = AWManager(aw_port=5600)
+    mgr._capture_suppressed = False
+    return mgr
+
+
+def test_exec_latch_survives_a_server_start_failure_before_the_watcher_loop():
+    mgr = _mgr()
+    # A watcher is permanently unrunnable (latched on a prior tick), so the
+    # device is capturing nothing and the flags say so.
+    mgr._exec_failed_components = {"bf-window-tracker"}
+    mgr.tracker_download_failed = True
+    mgr._managed_components_unavailable = True
+
+    # This tick: binaries resolve, but the server fails to start, so _start_locked
+    # returns before the watcher loop that would re-latch the broken watcher.
+    with patch.object(mgr, "_rosetta_missing", return_value=False), \
+         patch.object(mgr, "_port_in_use", return_value=False), \
+         patch.object(mgr, "_get_binaries_dir", return_value="/fake/trackers"), \
+         patch.object(mgr, "_start_component", return_value=False) as start_component:
+        result = mgr._start_locked()
+
+    assert result is False
+    # BF_SERVER was the thing we failed on; the watcher loop was never reached.
+    start_component.assert_called_once_with(BF_SERVER, "/fake/trackers")
+    assert mgr.tracker_download_failed is True, (
+        "a still-exec-broken device must not report healthy just because its "
+        "binaries are on disk — that is the two-day silent blackout this latch "
+        "exists to end"
+    )
+    assert mgr._managed_components_unavailable is True
+    assert "bf-window-tracker" in mgr._exec_failed_components
+
+
+def test_a_clean_device_still_clears_the_download_latch_on_resolve():
+    # The frozen-bundle recovery path must keep working: no exec failures
+    # outstanding => "binaries resolved" clears a stale download latch even
+    # though nothing was downloaded this run. Server start fails here too, so we
+    # isolate exactly the clear-on-resolve behaviour (no watcher loop).
+    mgr = _mgr()
+    mgr._exec_failed_components = set()
+    mgr.tracker_download_failed = True
+    mgr._managed_components_unavailable = True
+
+    with patch.object(mgr, "_rosetta_missing", return_value=False), \
+         patch.object(mgr, "_port_in_use", return_value=False), \
+         patch.object(mgr, "_get_binaries_dir", return_value="/fake/trackers"), \
+         patch.object(mgr, "_start_component", return_value=False):
+        mgr._start_locked()
+
+    assert mgr.tracker_download_failed is False
+    assert mgr._managed_components_unavailable is False
+
+
+def test_a_disabled_broken_component_does_not_hold_the_latch():
+    # A component that is DISABLED is never started, so it must not keep the
+    # device pinned to "capturing nothing" — the guard subtracts disabled ones.
+    mgr = _mgr()
+    mgr._exec_failed_components = {"bf-window-tracker"}
+    mgr._disabled_components = {"bf-window-tracker"}
+    mgr.tracker_download_failed = True
+    mgr._managed_components_unavailable = True
+
+    with patch.object(mgr, "_rosetta_missing", return_value=False), \
+         patch.object(mgr, "_port_in_use", return_value=False), \
+         patch.object(mgr, "_get_binaries_dir", return_value="/fake/trackers"), \
+         patch.object(mgr, "_start_component", return_value=False):
+        mgr._start_locked()
+
+    assert mgr.tracker_download_failed is False
+    assert mgr._managed_components_unavailable is False


### PR DESCRIPTION
Two verified correctness findings from an adversarial audit of #164 (`v1.5.118-beta.2`). Both stack onto that branch. Each ships with a proof-of-failure test (fails against the beta, passes here).

## 1. Keep self-healing the tracker stack during a network outage
`_do_sync` returned the instant `paused_by_network` was true — **before** `restart_if_needed()` and the AW-unreachable rebuild. That was correct when an outage still called `pause()`, but this beta makes an outage `suspend_upload()` instead: the trackers keep recording for the whole outage. So a tracker that crashed — or never started (Fabian's device: `_processes` empty) — recorded nothing until the network returned. This is the exact blind-capture the beta exists to prevent, on the one path the new escalation was never reachable from.

Fix: extract the health/escalation block into `_monitor_capture_health()` (local-only, no upload) and call it from **both** the normal path and the outage branch. Online path is behaviour-identical; the outage branch now self-heals capture then still skips the upload sync. Working-hours suppression still suppresses.

Proof: `test_a_dead_tracker_during_an_outage_is_rebuilt` — `force_restart` called 0× on the beta, once here. Also closes the coverage gap where the escalation tests never drove `_do_sync`'s outage branch.

## 2. Don't clear the capture-dead latch while a component can't execute
`_start_locked` cleared `tracker_download_failed` / `_managed_components_unavailable` the moment `_get_binaries_dir()` resolved. That flag now also means "binary cannot execute", but "binaries on disk" only ever proved they *downloaded*. So a tick that resolved binaries wiped the exec-failed latch before re-verifying; if `BF_SERVER`/`_wait_for_server` then bailed, the watcher loop that re-latches never ran and the device reported healthy while blind.

Fix: gate the clear on the same condition the successful-start path uses — `not (_exec_failed_components - _disabled_components)`. Frozen-bundle recovery still clears on a clean device; a still-blind one stays latched.

Proof: `test_exec_latch_survives_a_server_start_failure_before_the_watcher_loop` — flag cleared to `False` on the beta, stays `True` here.

## Verification
Full suite: **1477 passed**, the only 4 failures are a missing optional `pyobjc-framework-ApplicationServices` in the local venv (identical on the beta, not a regression). Both new proof tests verified failing against `v1.5.118-beta.2` via `git checkout HEAD~1`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DdHDzscNnH7unQUF3662op