### PR TITLE
fix(updater): fail loud on managed (root-owned) install instead of silent 30-min loop

### DIFF
--- a/src/self_updater.py
+++ b/src/self_updater.py
@@ -92,6 +92,41 @@ def _get_app_bundle_path() -> Optional[Path]:
     return None
 
 
+def app_bundle_replaceable() -> bool:
+    """True if the current user can replace the running app in place.
+
+    The self-update applies by renaming the bundle within its parent
+    (``BetterFlow.app`` -> ``BetterFlow.old.app``) then moving the new one in. A
+    bundle installed by the MDM ``.pkg`` lands in ``/Applications`` owned by
+    **root**, so a user-context updater gets ``[Errno 13] Permission denied`` on
+    that rename — every 30-min cycle, silently, forever (Tudor/Fabian, 2026-07).
+    The updater cannot fix that itself; the caller must fail loud (tell the user
+    to reinstall / route updates via MDM) rather than loop on a doomed attempt.
+
+    macOS only: the root-owned ``.pkg`` case is macOS-specific, and the Windows /
+    Linux paths differ (exe-dir swap / AppImage replace), so this returns True
+    there. Returns True when the layout is unknown (dev/source run) so it never
+    blocks a normal install; a genuine permission failure is still caught in the
+    apply path.
+    """
+    if sys.platform != "darwin":
+        return True
+    app_path = _get_app_bundle_path()
+    if app_path is None:
+        return True
+    try:
+        bundle_uid = app_path.stat().st_uid
+    except OSError:
+        return True
+    my_uid = os.getuid()
+    if my_uid == 0:
+        return True
+    # Ownership is the reliable signal: a bundle we don't own can't be renamed by
+    # us (the observed EPERM). /Applications is group-writable for admins, so an
+    # os.access() on the parent would miss the root-owned case.
+    return bundle_uid == my_uid
+
+
 # Set once per process so the "install properly" nag isn't repeated on every
 # stage / staged-apply attempt within a single run.
 _downloads_warning_sent = False

--- a/src/update_handler.py
+++ b/src/update_handler.py
@@ -43,6 +43,10 @@ class UpdateHandler:
         # Version we last toasted the user about, so the 30-min re-checks notify
         # once per version instead of on every check.
         self._notified_version: Optional[str] = None
+        # Same once-per-version latch for the "this managed install can't
+        # self-update" warning, so a root-owned (.pkg) machine gets told once,
+        # not every 30-min check.
+        self._managed_warned_version: Optional[str] = None
         self._staged_lock = threading.Lock()
         self._update_jobs_started = False
         self._update_jobs_lock = threading.Lock()
@@ -133,6 +137,35 @@ class UpdateHandler:
         # No-op if nothing valid is staged.
         self._apply_staged_update()
 
+    def _managed_install_ok(self) -> bool:
+        """False when the running bundle can't be replaced by this user (a
+        root-owned / MDM .pkg install). Never raises — on any doubt it returns
+        True so a normal install is never blocked (the apply path still guards)."""
+        try:
+            try:
+                from .self_updater import app_bundle_replaceable
+            except ImportError:
+                from self_updater import app_bundle_replaceable
+            return app_bundle_replaceable()
+        except Exception:
+            logger.debug("app_bundle_replaceable check failed; assuming replaceable", exc_info=True)
+            return True
+
+    def _report_managed_blocked(self, version: str) -> None:
+        """Report once that a managed install is stuck (so ops can push via MDM)."""
+        reporter = getattr(self.coordinator, "error_reporter", None)
+        if reporter is None:
+            return
+        try:
+            reporter.capture(
+                f"Self-update blocked: managed/root-owned install can't self-update to {version}",
+                level="warning",
+                tags={"component": "update-handler"},
+                fingerprint="update-managed-install-blocked",
+            )
+        except Exception:
+            logger.warning("managed-install-blocked report failed", exc_info=True)
+
     def _on_update_available(
         self, version: str, url: str, asset_url: Optional[str] = None, apply_now: bool = False
     ) -> None:
@@ -140,6 +173,25 @@ class UpdateHandler:
         stage it (and maybe apply)."""
         logger.info(f"Update available: v{version} | {url} (asset: {asset_url})")
         self.tray.set_update_available(version, url, asset_url)
+
+        # A managed (.pkg / root-owned) install can't replace itself — the
+        # self-update rename EPERMs every cycle (see
+        # self_updater.app_bundle_replaceable). Detect it up front: tell the user
+        # once how to fix it, report to ops once, and do NOT loop on a doomed
+        # download+apply. Gate before the normal notify/stage so we don't offer an
+        # "Install & Restart" that can only fail.
+        if asset_url and not self._managed_install_ok():
+            if version != self._managed_warned_version:
+                self._managed_warned_version = version
+                send_notification(
+                    "BetterFlow update needs a manual step",
+                    f"Version {version} is available, but this managed install "
+                    "can't update itself. Reinstall from github.com/"
+                    "Better-Quality-Assurance/betterflow-sync/releases/latest, "
+                    "or contact IT.",
+                )
+                self._report_managed_blocked(version)
+            return
 
         # Notify ONCE per version, at detection — so the user always learns an
         # update is available, including on the otherwise-silent auto-apply path,

--- a/tests/test_self_updater_replaceable.py
+++ b/tests/test_self_updater_replaceable.py
@@ -1,0 +1,77 @@
+"""app_bundle_replaceable() gates the self-update against a bundle the current
+user can't replace — the root-owned MDM .pkg install that EPERMs on the rename
+every cycle (Tudor/Fabian, 2026-07). See self_updater.app_bundle_replaceable.
+"""
+
+import os
+import sys
+from pathlib import Path
+from types import SimpleNamespace
+from unittest.mock import patch
+
+import pytest
+
+import src.self_updater as su
+
+
+class _FakeApp:
+    def __init__(self, uid: int) -> None:
+        self._uid = uid
+
+    def stat(self) -> SimpleNamespace:
+        return SimpleNamespace(st_uid=self._uid)
+
+
+def test_non_darwin_is_always_replaceable():
+    with patch.object(su.sys, "platform", "win32"):
+        assert su.app_bundle_replaceable() is True
+
+
+def test_unknown_layout_is_replaceable():
+    with patch.object(su.sys, "platform", "darwin"), \
+         patch.object(su, "_get_app_bundle_path", return_value=None):
+        assert su.app_bundle_replaceable() is True
+
+
+def test_user_owned_bundle_is_replaceable():
+    with patch.object(su.sys, "platform", "darwin"), \
+         patch.object(su, "_get_app_bundle_path", return_value=_FakeApp(os.getuid())), \
+         patch.object(su.os, "getuid", return_value=os.getuid()):
+        assert su.app_bundle_replaceable() is True
+
+
+def test_root_owned_bundle_is_not_replaceable():
+    # The reported failure: bundle owned by root (uid 0), we are a normal user.
+    with patch.object(su.sys, "platform", "darwin"), \
+         patch.object(su, "_get_app_bundle_path", return_value=_FakeApp(0)), \
+         patch.object(su.os, "getuid", return_value=501):
+        assert su.app_bundle_replaceable() is False
+
+
+def test_running_as_root_can_replace_anything():
+    with patch.object(su.sys, "platform", "darwin"), \
+         patch.object(su, "_get_app_bundle_path", return_value=_FakeApp(0)), \
+         patch.object(su.os, "getuid", return_value=0):
+        assert su.app_bundle_replaceable() is True
+
+
+# ---- real-environment checks against the actual machine state ----
+
+@pytest.mark.skipif(sys.platform != "darwin", reason="macOS ownership semantics")
+def test_real_root_owned_backup_is_not_replaceable():
+    p = Path("/Applications/BetterFlow-old-1.5.106.app")
+    if not p.exists():
+        pytest.skip("no root-owned backup bundle present on this machine")
+    if p.stat().st_uid == os.getuid():
+        pytest.skip("backup bundle is not root-owned here")
+    with patch.object(su, "_get_app_bundle_path", return_value=p):
+        assert su.app_bundle_replaceable() is False
+
+
+@pytest.mark.skipif(sys.platform != "darwin", reason="macOS ownership semantics")
+def test_real_user_owned_app_matches_ownership():
+    p = Path("/Applications/BetterFlow.app")
+    if not p.exists():
+        pytest.skip("no installed app present on this machine")
+    with patch.object(su, "_get_app_bundle_path", return_value=p):
+        assert su.app_bundle_replaceable() is (p.stat().st_uid == os.getuid())

--- a/tests/test_update_handler_managed_install.py
+++ b/tests/test_update_handler_managed_install.py
@@ -1,0 +1,52 @@
+"""A managed (root-owned) install must be told ONCE that it can't self-update,
+and must NOT loop on a doomed download+apply. See UpdateHandler._on_update_available.
+"""
+
+import threading
+from unittest.mock import MagicMock, patch
+
+import src.update_handler as uh
+from src.update_handler import UpdateHandler
+
+
+def _handler() -> UpdateHandler:
+    h = UpdateHandler.__new__(UpdateHandler)
+    h.tray = MagicMock()
+    h.config = MagicMock()
+    h.config.auto_install_updates = True
+    h.coordinator = MagicMock()
+    h._version = "1.5.106"
+    h._notified_version = None
+    h._managed_warned_version = None
+    h._staged_version = None
+    h._staged_lock = threading.Lock()
+    return h
+
+
+def test_managed_install_warns_once_and_never_stages():
+    h = _handler()
+    with patch.object(h, "_managed_install_ok", return_value=False), \
+         patch.object(uh, "send_notification") as notify, \
+         patch.object(h, "_stage_and_maybe_apply") as stage, \
+         patch.object(h, "_report_managed_blocked") as report:
+        # Two checks of the same version (the 30-min re-check).
+        h._on_update_available("1.5.118", "http://x", asset_url="http://x/a.dmg", apply_now=True)
+        h._on_update_available("1.5.118", "http://x", asset_url="http://x/a.dmg", apply_now=True)
+
+    stage.assert_not_called()          # never attempt the doomed apply
+    assert notify.call_count == 1      # told once, not every check
+    report.assert_called_once()        # ops told once
+    # The toast is the manual-step one, not the normal "available" one.
+    title, body = notify.call_args[0][0], notify.call_args[0][1]
+    assert "manual step" in title.lower()
+    assert "reinstall" in body.lower()
+
+
+def test_replaceable_install_proceeds_to_stage():
+    h = _handler()
+    with patch.object(h, "_managed_install_ok", return_value=True), \
+         patch.object(uh, "send_notification"), \
+         patch.object(h, "_stage_and_maybe_apply") as stage:
+        h._on_update_available("1.5.118", "http://x", asset_url="http://x/a.dmg", apply_now=True)
+
+    stage.assert_called_once()          # normal path unaffected


### PR DESCRIPTION
**Point 2 hygiene fix** for the self-update failure diagnosed today. An MDM `.pkg` installs the app **root-owned** in `/Applications`; the user-context updater then EPERMs renaming the bundle every 30-min check, silently, forever (Tudor's machine + a stuck cluster).

## Change
- `self_updater.app_bundle_replaceable()` — macOS ownership pre-check; `False` for a root-owned bundle (the `.pkg` case), `True` on non-darwin / unknown layout / running-as-root so a normal install is never blocked.
- `update_handler._on_update_available` — if an update is available but the bundle isn't replaceable: notify the user **once per version** (reinstall link) + report to ops **once**, and **skip** the doomed download+apply. Normal user-owned path is untouched.

## Scope / honesty
This does **not** unstick already-stuck machines — they can't self-update to receive it. Those need an MDM push or a manual reinstall (link already circulated). This stops the *silent-failure class* going forward.

## Verification
- 9 new tests pass; full suite **1486 pass** (only 4 pre-existing env failures: missing optional `pyobjc-framework-ApplicationServices`).
- Includes a **real-environment** test: `app_bundle_replaceable()` returns `False` against the actual root-owned `/Applications/BetterFlow-old-1.5.106.app` on the build machine, `True` for a user-owned bundle — i.e. verified against the exact failure condition, not just mocks.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DdHDzscNnH7unQUF3662op