### PR TITLE
docs: agent permission and capture visibility — design + M1 plan

### DIFF
--- a/docs/superpowers/plans/2026-07-27-agent-permission-visibility-m1.md
+++ b/docs/superpowers/plans/2026-07-27-agent-permission-visibility-m1.md
@@ -1,0 +1,978 @@
+# Agent Permission & Capture Visibility — M1 Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make the three agent capture-failure classes visible as deduped, deterministic Slack alerts, without an agent release.
+
+**Architecture:** A new `permissions_degraded` category in the existing `/api/internal/device-health` endpoint emits three reason codes derived server-side. The existing betterqa-bot monitor (10-min cron, `alert_state` cooldown, template-literal formatting, Slack path) consumes them with three new `reasonText()` cases and a per-reason cooldown. Nothing flows through `tracking_degraded`, so no existing consumer changes behaviour.
+
+**Tech Stack:** PHP 8 / Laravel 12 / MySQL / PHPUnit 11 (internal-tool2); TypeScript / vitest / Drizzle+Postgres (betterqa-bot).
+
+**Spec:** `docs/superpowers/specs/2026-07-27-agent-permission-visibility-design.md`
+
+## Global Constraints
+
+Every task's requirements implicitly include this section.
+
+- **internal-tool2 is PR-only. No auto-merge.** 31 commits in 7 days across two authors; the agent-health code in scope changed twice in the three days before this plan (#2170, #2178). Per `rules/cross-repo-safety.md` Rule 1 the auto-merge default is SUSPENDED. Open the PR and stop.
+- **Edit internal-tool2 in a worktree, but run its PHP suite against the MAIN checkout.** The Docker test container mounts the main checkout's `src/`, not worktrees (`rules/cross-repo-safety.md`, internal-tool2 caveat). Coordinate so only one session drives the main checkout, on a clean `main`.
+- **Migrations run BEFORE merge, never after.** Railway auto-deploys `main`, so merging is deploying (`rules/schema-rename-drift.md` §additive columns).
+- **CI does not run. You are the CI.** `ls` each repo's `.github/workflows/` and run every non-deploy workflow's steps locally. Do not look for `ci.yml` by name — betterflow-sync and others have no file by that name.
+- **New columns are nullable with NO default.** `tracking_degraded`, `consecutive_sync_failures`, `idle_tracker_stale_restarts` and `idle_while_active_detections` are all `NOT NULL DEFAULT` columns where never-reported is byte-identical to healthy. Do not add a fifth. Match `window_titles_captured_recently`.
+- **Every new detector excludes never-reported devices by an explicit predicate**, never by relying on a default.
+- **Severity for every `permissions_degraded` reason is `warning`, never `critical`.** `critical` bypasses Slack coalescing and triggers the Telegram fallback. A standing config fault must not page.
+- **The Slack line must be self-sufficient** — person, device, platform, and the exact remedial action. There is deliberately no UI to click through to.
+- **Do NOT flip `ALERT_ON_BLIND_WINDOW_TITLES`.** It stays `false` permanently and is superseded.
+- **Deploy order is server-first and that is safe.** The bot's `reasonText()` `default:` branch names the gap honestly rather than fabricating, so a server ahead of the bot degrades gracefully.
+
+---
+
+## File Structure
+
+**internal-tool2** (worktree off `origin/main`):
+- Create: `src/database/migrations/2026_07_28_000000_add_idle_tracker_blind_to_agent_devices_table.php` — one nullable boolean column.
+- Modify: `src/app/Http/Controllers/Api/Agent/AgentHeartbeatController.php` — accept and persist `idle_tracker_blind`.
+- Modify: `src/app/Http/Controllers/Api/InternalStatsController.php` — extract the two existing detectors to private methods, add a third.
+- Test: `src/tests/Feature/Agent/AgentDeviceHealthEndpointTest.php` — existing file, extend it.
+
+**betterqa-bot** (worktree off `origin/main`):
+- Modify: `src/monitor/betterflow-device-health.ts` — category union, three `reasonText()` cases, `severityFor()` clause, per-reason cooldown.
+- Test: `src/__tests__/betterflow-device-health.test.ts` — existing file, extend it.
+
+`deviceHealth()` is currently 204 lines holding two inline detection blocks. Task 2 extracts each into a private method before Task 3 adds a third, so the method becomes a readable pipeline instead of growing to ~280 lines.
+
+---
+
+### Task 1: Persist `idle_tracker_blind`
+
+The agent has been sending this key since it was added to `HEARTBEAT_HEALTH_KEYS`; the server has nowhere to put it. This is the only migration in M1.
+
+**Files:**
+- Create: `src/database/migrations/2026_07_28_000000_add_idle_tracker_blind_to_agent_devices_table.php`
+- Modify: `src/app/Http/Controllers/Api/Agent/AgentHeartbeatController.php` (`hasHealthTelemetry()` ~`:275-291`, `buildHealthUpdates()` ~`:456-496`)
+- Test: `src/tests/Feature/Agent/AgentDeviceHealthEndpointTest.php`
+
+**Interfaces:**
+- Produces: `agent_devices.idle_tracker_blind` — `boolean NULL`, no default. Read by Task 4.
+
+- [ ] **Step 1: Write the failing test**
+
+Add to `AgentDeviceHealthEndpointTest.php`:
+
+```php
+    #[Test]
+    public function heartbeat_persists_idle_tracker_blind_and_leaves_it_null_when_unreported(): void
+    {
+        $device = $this->makeDevice();
+
+        // A heartbeat that does not mention the key must leave it NULL —
+        // "never told us" must stay distinguishable from "told us false".
+        $this->postJson('/api/agent/heartbeat', [
+            'agent_version' => '1.5.118',
+            'consecutive_sync_failures' => 0,
+        ], $this->agentAuthHeaders($device))->assertOk();
+
+        $this->assertNull(
+            DB::table('agent_devices')->where('id', $device->id)->value('idle_tracker_blind'),
+            'an unreported idle_tracker_blind must stay NULL, not default to false'
+        );
+
+        $this->postJson('/api/agent/heartbeat', [
+            'agent_version' => '1.5.118',
+            'idle_tracker_blind' => true,
+        ], $this->agentAuthHeaders($device))->assertOk();
+
+        $this->assertSame(
+            1,
+            (int) DB::table('agent_devices')->where('id', $device->id)->value('idle_tracker_blind')
+        );
+    }
+```
+
+If `makeDevice()` / `agentAuthHeaders()` do not already exist in this test class, read the file's existing setup helpers and use those instead — do not invent new ones.
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+From the MAIN internal-tool2 checkout on a clean `main`:
+
+```bash
+docker compose exec app php artisan test --filter=heartbeat_persists_idle_tracker_blind
+```
+
+Expected: FAIL — `SQLSTATE... Unknown column 'idle_tracker_blind'`.
+
+- [ ] **Step 3: Write the migration**
+
+```php
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * The agent already reports idle_tracker_blind on every heartbeat; the server
+     * had nowhere to store it, so the one signal that distinguishes "a denied
+     * Input Monitoring grant a restart can't fix" from a transient restart was
+     * being dropped on arrival.
+     *
+     * Nullable with NO default, deliberately. Its neighbours
+     * (tracking_degraded, consecutive_sync_failures, idle_tracker_stale_restarts,
+     * idle_while_active_detections) are NOT NULL DEFAULT, which makes a device
+     * that has never reported byte-identical to a healthy one. Do not copy that.
+     */
+    public function up(): void
+    {
+        Schema::table('agent_devices', function (Blueprint $table) {
+            $table->boolean('idle_tracker_blind')
+                ->nullable()
+                ->after('idle_tracker_stale_restarts');
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::table('agent_devices', function (Blueprint $table) {
+            $table->dropColumn('idle_tracker_blind');
+        });
+    }
+};
+```
+
+- [ ] **Step 4: Accept the key on the heartbeat**
+
+In `hasHealthTelemetry()`, add `'idle_tracker_blind'` to the `hasAny([...])` array.
+
+In `buildHealthUpdates()`, alongside the other reads, add:
+
+```php
+        // Tri-state: only write when the agent actually sent it. A missing key
+        // must leave the stored value untouched (NULL for a device that has
+        // never reported), never coerce to false.
+        if ($request->has('idle_tracker_blind')) {
+            $updates['idle_tracker_blind'] = $request->boolean('idle_tracker_blind');
+        }
+```
+
+Place it next to the existing `window_titles_captured_recently` block, which uses the same `$request->has()` guard — follow that shape exactly.
+
+- [ ] **Step 5: Run the test to verify it passes**
+
+```bash
+docker compose exec app php artisan test --filter=heartbeat_persists_idle_tracker_blind
+```
+
+Expected: PASS.
+
+- [ ] **Step 6: Run the full agent test group for regressions**
+
+```bash
+docker compose exec app php artisan test --testsuite=Feature --filter=Agent
+```
+
+Expected: no new failures. Note any pre-existing failures in the commit body rather than fixing them here.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add src/database/migrations/2026_07_28_000000_add_idle_tracker_blind_to_agent_devices_table.php \
+        src/app/Http/Controllers/Api/Agent/AgentHeartbeatController.php \
+        src/tests/Feature/Agent/AgentDeviceHealthEndpointTest.php
+git commit -m "feat(agent-health): persist idle_tracker_blind, which the agent already sends
+
+The agent has been reporting this on every heartbeat and the server had no
+column for it, so the signal distinguishing a denied Input Monitoring grant
+from a transient tracker restart was dropped on arrival.
+
+Nullable with no default: never-reported must stay distinguishable from
+reported-false. Test asserts both directions."
+```
+
+---
+
+### Task 2: Extract the two existing detectors (no behaviour change)
+
+Pure refactor. `deviceHealth()` is 204 lines with two inline detection blocks; Task 3 adds a third. Extract first so the third lands in a readable method.
+
+**Files:**
+- Modify: `src/app/Http/Controllers/Api/InternalStatsController.php:247-451`
+
+**Interfaces:**
+- Produces: `private function detectTelemetryDegraded(): array` and `private function detectIngestStalled(array $alreadyFlagged): array`, each returning a list of flagged-device arrays in the existing shape. Task 3 adds a sibling.
+
+- [ ] **Step 1: Confirm the existing tests pass before touching anything**
+
+```bash
+docker compose exec app php artisan test --filter=AgentDeviceHealthEndpointTest
+```
+
+Expected: PASS. This is the regression baseline — a refactor with no behaviour change must leave it green. Record the test count.
+
+- [ ] **Step 2: Extract both blocks**
+
+Move lines 259-318 verbatim into `private function detectTelemetryDegraded(): array`, returning `$flagged`. Move lines 348-442 verbatim into `private function detectIngestStalled(array $alreadyFlagged): array`, returning only the rows it appends. Keep every comment — they encode incident history (Anamaria Strezoiu 2026-06-23, Cristian Dragota 2026-06-25) and must not be lost.
+
+`deviceHealth()` becomes:
+
+```php
+    public function deviceHealth(Request $request): JsonResponse
+    {
+        if ($deny = $this->denyIfBadKey($request)) {
+            return $deny;
+        }
+
+        $flagged = $this->detectTelemetryDegraded();
+        $flagged = array_merge($flagged, $this->detectIngestStalled(array_column($flagged, 'device_id')));
+        $flagged = $this->annotateWorkSchedule($flagged);
+
+        return response()->json([
+            'count' => count($flagged),
+            'flagged' => $flagged,
+            'generated_at' => now()->toIso8601String(),
+        ]);
+    }
+```
+
+- [ ] **Step 3: Run the tests to verify nothing changed**
+
+```bash
+docker compose exec app php artisan test --filter=AgentDeviceHealthEndpointTest
+```
+
+Expected: PASS, with the **same test count** as Step 1. A changed count means you altered behaviour.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add src/app/Http/Controllers/Api/InternalStatsController.php
+git commit -m "refactor(device-health): extract the two detectors from deviceHealth
+
+No behaviour change. deviceHealth was 204 lines holding two inline detection
+blocks and is about to gain a third; this makes it a pipeline instead.
+Incident comments moved verbatim."
+```
+
+---
+
+### Task 3: `window_titles_blind` detector
+
+**Files:**
+- Modify: `src/app/Http/Controllers/Api/InternalStatsController.php`
+- Test: `src/tests/Feature/Agent/AgentDeviceHealthEndpointTest.php`
+
+**Interfaces:**
+- Consumes: `detectTelemetryDegraded()` / `detectIngestStalled()` from Task 2.
+- Produces: `private function detectPermissionsDegraded(array $alreadyFlagged): array`, emitting rows with `'category' => 'permissions_degraded'`. Tasks 4 and 5 add reasons to this same method.
+
+- [ ] **Step 1: Write the failing tests**
+
+```php
+    #[Test]
+    public function device_health_flags_a_title_blind_device(): void
+    {
+        $device = $this->makeDevice([
+            'status' => 'active',
+            'window_titles_captured_recently' => false,
+            'health_reported_at' => now(),
+            'last_seen_at' => now(),
+        ]);
+
+        $flagged = $this->getJson('/api/internal/device-health', $this->internalApiHeaders())
+            ->assertOk()->json('flagged');
+
+        $row = collect($flagged)->firstWhere('device_id', $device->id);
+        $this->assertNotNull($row, 'a title-blind device must be flagged');
+        $this->assertSame('permissions_degraded', $row['category']);
+        $this->assertSame('window_titles_blind', $row['reason']);
+        $this->assertFalse($row['tracking_degraded'], 'must not route through tracking_degraded');
+    }
+
+    #[Test]
+    public function device_health_does_not_flag_a_device_that_never_reported_titles(): void
+    {
+        $device = $this->makeDevice([
+            'status' => 'active',
+            'window_titles_captured_recently' => null,
+            'health_reported_at' => null,
+            'last_seen_at' => now(),
+        ]);
+
+        $flagged = $this->getJson('/api/internal/device-health', $this->internalApiHeaders())
+            ->assertOk()->json('flagged');
+
+        $this->assertNull(
+            collect($flagged)->firstWhere('device_id', $device->id),
+            'NULL means never reported, not broken — must not be flagged'
+        );
+    }
+```
+
+Reuse the existing helpers in this test class for device creation and internal-API auth headers; read the file first and match them.
+
+- [ ] **Step 2: Run to verify both fail**
+
+```bash
+docker compose exec app php artisan test --filter=device_health_flags_a_title_blind_device
+docker compose exec app php artisan test --filter=device_health_does_not_flag_a_device_that_never_reported_titles
+```
+
+Expected: the first FAILS (`a title-blind device must be flagged`); the second may already pass vacuously — that is fine and expected, it is a guard, not a proof.
+
+- [ ] **Step 3: Implement the detector**
+
+```php
+    /**
+     * Devices whose OS capture capability is broken, as opposed to devices whose
+     * tracking is degraded. Deliberately emits tracking_degraded => false: routing
+     * this through that flag would change what every existing consumer sees, and a
+     * missing permission is a standing config fault, not "tracking is degraded
+     * right now". This is why ALERT_ON_BLIND_WINDOW_TITLES stays off permanently.
+     *
+     * Each reason excludes never-reported devices with an explicit predicate.
+     * NULL means "the agent has not told us", which is not a fault.
+     */
+    private function detectPermissionsDegraded(array $alreadyFlagged): array
+    {
+        $liveSince = now()->subMinutes(30);
+        $out = [];
+
+        // window_titles_blind — macOS Accessibility missing, Windows tracker
+        // blind, or Linux X11 watcher dead. One symptom, three causes; M2's
+        // explicit grant booleans will disambiguate.
+        $titleRows = DB::table('agent_devices as d')
+            ->leftJoin('users as u', 'u.id', '=', 'd.user_id')
+            ->leftJoin('tenants as t', 't.id', '=', 'd.tenant_id')
+            ->where('d.status', 'active')
+            ->whereNull('d.deleted_at')
+            ->where('d.window_titles_captured_recently', false)
+            ->whereNotNull('d.window_titles_captured_recently')
+            ->where('d.last_seen_at', '>=', $liveSince)
+            ->select(
+                'd.id', 'd.device_name', 'd.platform', 'd.agent_version', 'd.user_id',
+                'd.tenant_id', 'd.timezone', 'd.last_seen_at', 'd.last_sync_at',
+                'd.health_reported_at', 'u.email', 'u.name', 't.name as tenant_name',
+            )
+            ->limit(200)
+            ->get();
+
+        foreach ($titleRows as $r) {
+            if (in_array((int) $r->id, $alreadyFlagged, true)) {
+                continue;
+            }
+            $out[] = $this->permissionsRow($r, 'window_titles_blind');
+        }
+
+        return $out;
+    }
+
+    /** Shape a permissions_degraded row. Keeps the payload identical across reasons. */
+    private function permissionsRow(object $r, string $reason): array
+    {
+        return [
+            'device_id' => (int) $r->id,
+            'device_name' => $r->device_name,
+            'platform' => $r->platform,
+            'agent_version' => $r->agent_version,
+            'user_id' => $r->user_id,
+            'email' => $r->email,
+            'name' => $r->name,
+            'tenant_id' => $r->tenant_id,
+            'tenant_name' => $r->tenant_name,
+            'device_timezone' => $r->timezone,
+            'category' => 'permissions_degraded',
+            'reason' => $reason,
+            'last_seen_at' => $r->last_seen_at,
+            'last_sync_at' => $r->last_sync_at ?? null,
+            'tracking_degraded' => false,
+            'tracking_degraded_since' => null,
+            'idle_tracker_stale_restarts' => 0,
+            'afk_event_age_seconds' => null,
+            'window_event_age_seconds' => null,
+            'consecutive_sync_failures' => 0,
+            'idle_while_active_detections' => 0,
+            'health_reported_at' => $r->health_reported_at ?? null,
+        ];
+    }
+```
+
+Wire it into `deviceHealth()` after the ingest detector:
+
+```php
+        $flagged = array_merge($flagged, $this->detectPermissionsDegraded(array_column($flagged, 'device_id')));
+```
+
+- [ ] **Step 4: Run both tests to verify they pass**
+
+```bash
+docker compose exec app php artisan test --filter=AgentDeviceHealthEndpointTest
+```
+
+Expected: PASS, including the pre-existing tests.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/app/Http/Controllers/Api/InternalStatsController.php src/tests/Feature/Agent/AgentDeviceHealthEndpointTest.php
+git commit -m "feat(device-health): surface title-blind devices as permissions_degraded
+
+Emits tracking_degraded => false so no existing consumer of that flag changes
+behaviour — the reason ALERT_ON_BLIND_WINDOW_TITLES is superseded rather than
+flipped. NULL title capture means never-reported and is explicitly excluded."
+```
+
+---
+
+### Task 4: `idle_tracker_blind` reason
+
+**Files:**
+- Modify: `src/app/Http/Controllers/Api/InternalStatsController.php` (`detectPermissionsDegraded()`)
+- Test: `src/tests/Feature/Agent/AgentDeviceHealthEndpointTest.php`
+
+**Interfaces:**
+- Consumes: `agent_devices.idle_tracker_blind` (Task 1), `permissionsRow()` (Task 3).
+
+- [ ] **Step 1: Write the failing test**
+
+```php
+    #[Test]
+    public function device_health_flags_a_blind_idle_tracker(): void
+    {
+        $device = $this->makeDevice([
+            'status' => 'active',
+            'idle_tracker_blind' => true,
+            'health_reported_at' => now(),
+            'last_seen_at' => now(),
+        ]);
+
+        $row = collect(
+            $this->getJson('/api/internal/device-health', $this->internalApiHeaders())
+                ->assertOk()->json('flagged')
+        )->firstWhere('device_id', $device->id);
+
+        $this->assertNotNull($row);
+        $this->assertSame('idle_tracker_blind', $row['reason']);
+    }
+```
+
+- [ ] **Step 2: Run to verify it fails**
+
+```bash
+docker compose exec app php artisan test --filter=device_health_flags_a_blind_idle_tracker
+```
+
+Expected: FAIL — `Failed asserting that null is not null`.
+
+- [ ] **Step 3: Add the query to `detectPermissionsDegraded()`**
+
+Insert before `return $out;`, and add `$flaggedSoFar = array_merge($alreadyFlagged, array_column($out, 'device_id'));` above it so the reasons do not double-flag one device:
+
+```php
+        // idle_tracker_blind — the AFK tracker stayed stale across repeated
+        // restarts, which the agent reports specifically because a restart
+        // cannot fix it: a denied Input Monitoring grant. NULL = never reported.
+        $flaggedSoFar = array_merge($alreadyFlagged, array_column($out, 'device_id'));
+
+        $blindRows = DB::table('agent_devices as d')
+            ->leftJoin('users as u', 'u.id', '=', 'd.user_id')
+            ->leftJoin('tenants as t', 't.id', '=', 'd.tenant_id')
+            ->where('d.status', 'active')
+            ->whereNull('d.deleted_at')
+            ->where('d.idle_tracker_blind', true)
+            ->whereNotNull('d.idle_tracker_blind')
+            ->where('d.last_seen_at', '>=', $liveSince)
+            ->select(
+                'd.id', 'd.device_name', 'd.platform', 'd.agent_version', 'd.user_id',
+                'd.tenant_id', 'd.timezone', 'd.last_seen_at', 'd.last_sync_at',
+                'd.health_reported_at', 'u.email', 'u.name', 't.name as tenant_name',
+            )
+            ->limit(200)
+            ->get();
+
+        foreach ($blindRows as $r) {
+            if (in_array((int) $r->id, $flaggedSoFar, true)) {
+                continue;
+            }
+            $out[] = $this->permissionsRow($r, 'idle_tracker_blind');
+        }
+```
+
+- [ ] **Step 4: Run to verify it passes**
+
+```bash
+docker compose exec app php artisan test --filter=AgentDeviceHealthEndpointTest
+```
+
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/app/Http/Controllers/Api/InternalStatsController.php src/tests/Feature/Agent/AgentDeviceHealthEndpointTest.php
+git commit -m "feat(device-health): surface a blind idle tracker as permissions_degraded
+
+Consumes the column added one commit earlier. The agent sets this only after
+the tracker has stayed stale across repeated restarts, which is its signal
+that a restart cannot fix it."
+```
+
+---
+
+### Task 5: `input_counters_dead` detector
+
+The derived reason, and the only failure class with no agent-side signal at all. This is what catches the two Windows devices logging 8-9h/day with zero input.
+
+**Files:**
+- Modify: `src/app/Http/Controllers/Api/InternalStatsController.php` (`detectPermissionsDegraded()`)
+- Test: `src/tests/Feature/Agent/AgentDeviceHealthEndpointTest.php`
+
+**Interfaces:**
+- Consumes: `agent_activity_aggregates` (`device_id`, `work_date`, `active_seconds`, `keystrokes_count`, `clicks_count`, `scrolls_count`), `permissionsRow()`.
+
+- [ ] **Step 1: Write the failing tests — including the two adversarial cases**
+
+```php
+    #[Test]
+    public function device_health_flags_a_device_with_dead_input_counters(): void
+    {
+        $device = $this->makeDevice(['status' => 'active', 'last_seen_at' => now()]);
+        $this->seedAggregate($device->id, today(), activeSeconds: 20000, keys: 0, clicks: 0, scrolls: 0);
+
+        $row = collect(
+            $this->getJson('/api/internal/device-health', $this->internalApiHeaders())
+                ->assertOk()->json('flagged')
+        )->firstWhere('device_id', $device->id);
+
+        $this->assertNotNull($row, '5.5h active with zero input of any kind must flag');
+        $this->assertSame('input_counters_dead', $row['reason']);
+    }
+
+    #[Test]
+    public function device_health_does_not_flag_when_scrolls_are_present(): void
+    {
+        // THE adversarial case. Zero keystrokes and zero clicks but real scrolls
+        // is a PARTIAL failure, not a dead tracker, and must not be flagged here.
+        $device = $this->makeDevice(['status' => 'active', 'last_seen_at' => now()]);
+        $this->seedAggregate($device->id, today(), activeSeconds: 20000, keys: 0, clicks: 0, scrolls: 4200);
+
+        $flagged = $this->getJson('/api/internal/device-health', $this->internalApiHeaders())
+            ->assertOk()->json('flagged');
+
+        $this->assertNull(collect($flagged)->firstWhere('device_id', $device->id));
+    }
+
+    #[Test]
+    public function device_health_does_not_flag_a_device_with_no_aggregate_rows(): void
+    {
+        // A read that returned nothing is not proof that there is nothing.
+        $device = $this->makeDevice(['status' => 'active', 'last_seen_at' => now()]);
+
+        $flagged = $this->getJson('/api/internal/device-health', $this->internalApiHeaders())
+            ->assertOk()->json('flagged');
+
+        $this->assertNull(collect($flagged)->firstWhere('device_id', $device->id));
+    }
+
+    #[Test]
+    public function device_health_does_not_flag_below_the_active_floor(): void
+    {
+        $device = $this->makeDevice(['status' => 'active', 'last_seen_at' => now()]);
+        $this->seedAggregate($device->id, today(), activeSeconds: 3600, keys: 0, clicks: 0, scrolls: 0);
+
+        $flagged = $this->getJson('/api/internal/device-health', $this->internalApiHeaders())
+            ->assertOk()->json('flagged');
+
+        $this->assertNull(collect($flagged)->firstWhere('device_id', $device->id), '1h is under the 4h floor');
+    }
+```
+
+Add the seeding helper to the test class:
+
+```php
+    private function seedAggregate(
+        int $deviceId,
+        \Illuminate\Support\Carbon $workDate,
+        int $activeSeconds,
+        int $keys,
+        int $clicks,
+        int $scrolls,
+    ): void {
+        DB::table('agent_activity_aggregates')->insert([
+            'device_id' => $deviceId,
+            'work_date' => $workDate->toDateString(),
+            'app_name' => 'EXCEL.EXE',
+            'active_seconds' => $activeSeconds,
+            'total_seconds' => $activeSeconds,
+            'keystrokes_count' => $keys,
+            'clicks_count' => $clicks,
+            'scrolls_count' => $scrolls,
+            'created_at' => now(),
+            'updated_at' => now(),
+        ]);
+    }
+```
+
+If `agent_activity_aggregates` has NOT NULL columns beyond these, read the migration and add them — do not guess.
+
+- [ ] **Step 2: Run to verify the first fails and the guards pass**
+
+```bash
+docker compose exec app php artisan test --filter=device_health_flags_a_device_with_dead_input_counters
+```
+
+Expected: FAIL. Then run the three guards; they should pass vacuously, which is correct — they exist to stay green after Step 3.
+
+- [ ] **Step 3: Implement the detector**
+
+Append to `detectPermissionsDegraded()`, before `return $out;`:
+
+```php
+        // input_counters_dead — window and AFK capture are healthy but the input
+        // counters are flat zero. No agent-side signal exists for this, so it is
+        // derived. Scrolls are the discriminator: a quiet user still scrolls
+        // constantly (a healthy device logged 58,631 scrolls in Chrome in one
+        // day), so all three counters at zero across 4h+ of active time is a
+        // tracker that is not reporting, not a person working quietly. Summing
+        // all three makes this STRICTLY harder to satisfy than keystrokes+clicks
+        // alone — scrolls-but-no-keystrokes is a different, partial failure and
+        // must not land here.
+        //
+        // HAVING over grouped rows means this fires only when rows EXIST and sum
+        // to zero. "No rows at all" is not "no input" and must never flag.
+        $flaggedSoFar = array_merge($alreadyFlagged, array_column($out, 'device_id'));
+
+        $deadInputDeviceIds = DB::table('agent_activity_aggregates')
+            ->where('work_date', '>=', now()->subDay()->toDateString())
+            ->groupBy('device_id', 'work_date')
+            ->havingRaw('SUM(active_seconds) >= ?', [4 * 3600])
+            ->havingRaw('SUM(keystrokes_count) + SUM(clicks_count) + SUM(scrolls_count) = 0')
+            ->pluck('device_id')
+            ->unique()
+            ->all();
+
+        if ($deadInputDeviceIds !== []) {
+            $inputRows = DB::table('agent_devices as d')
+                ->leftJoin('users as u', 'u.id', '=', 'd.user_id')
+                ->leftJoin('tenants as t', 't.id', '=', 'd.tenant_id')
+                ->where('d.status', 'active')
+                ->whereNull('d.deleted_at')
+                ->whereIn('d.id', $deadInputDeviceIds)
+                ->select(
+                    'd.id', 'd.device_name', 'd.platform', 'd.agent_version', 'd.user_id',
+                    'd.tenant_id', 'd.timezone', 'd.last_seen_at', 'd.last_sync_at',
+                    'd.health_reported_at', 'u.email', 'u.name', 't.name as tenant_name',
+                )
+                ->limit(200)
+                ->get();
+
+            foreach ($inputRows as $r) {
+                if (in_array((int) $r->id, $flaggedSoFar, true)) {
+                    continue;
+                }
+                $out[] = $this->permissionsRow($r, 'input_counters_dead');
+            }
+        }
+```
+
+Note this detector deliberately does NOT gate on `last_seen_at` — a device whose input died and then went offline for the evening is still broken and still worth reporting the next morning.
+
+- [ ] **Step 4: Run the whole test file**
+
+```bash
+docker compose exec app php artisan test --filter=AgentDeviceHealthEndpointTest
+```
+
+Expected: PASS, all four new tests plus every pre-existing one.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/app/Http/Controllers/Api/InternalStatsController.php src/tests/Feature/Agent/AgentDeviceHealthEndpointTest.php
+git commit -m "feat(device-health): derive input_counters_dead, which had no signal at all
+
+Window and AFK capture healthy, input counters flat zero. Found on two Windows
+devices logging 8-9h/day for 10 and 7 consecutive days with zero keystrokes,
+clicks AND scrolls — invisible to every existing signal.
+
+Scrolls are the discriminator and are included in the sum, which makes the
+predicate strictly harder to satisfy: scrolls-without-keystrokes is a partial
+failure and is explicitly tested as a non-flagging case. HAVING over grouped
+rows means no-rows can never masquerade as no-input."
+```
+
+---
+
+### Task 6: Bot — recognise the three reasons
+
+**Files:**
+- Modify: `src/monitor/betterflow-device-health.ts` (category union `:53`, `reasonText()` `:223-282`, `severityFor()` `:285-297`)
+- Test: `src/__tests__/betterflow-device-health.test.ts`
+
+**Interfaces:**
+- Consumes: `category: "permissions_degraded"` and reasons `window_titles_blind` / `idle_tracker_blind` / `input_counters_dead` from Tasks 3-5.
+
+- [ ] **Step 1: Write the failing tests**
+
+```ts
+  it("describes every permissions_degraded reason without falling through to default", () => {
+    for (const reason of ["window_titles_blind", "idle_tracker_blind", "input_counters_dead"]) {
+      const text = reasonText({ ...baseDevice, category: "permissions_degraded", reason } as FlaggedDevice);
+      expect(text).not.toContain("no description for that reason yet");
+      expect(text.length).toBeGreaterThan(40);
+    }
+  });
+
+  it("never escalates a permissions fault to critical, however long it persists", () => {
+    const severity = severityFor({
+      ...baseDevice,
+      category: "permissions_degraded",
+      reason: "window_titles_blind",
+      tracking_degraded_since: new Date(Date.now() - 72 * 3600 * 1000).toISOString(),
+    } as FlaggedDevice);
+    expect(severity).toBe("warning");
+  });
+```
+
+Read the existing test file first: reuse its `baseDevice` fixture and match how it imports the internals. If `reasonText` / `severityFor` are not exported, export them for test only, following whatever pattern the file already uses for the other internals it tests.
+
+- [ ] **Step 2: Run to verify they fail**
+
+```bash
+cd /Users/brad/Code2/betterqa-bot && npx vitest run src/__tests__/betterflow-device-health.test.ts
+```
+
+Expected: FAIL — the first on the default-branch text, the second on `critical`.
+
+- [ ] **Step 3: Widen the category union**
+
+```ts
+  category: "telemetry_degraded" | "heartbeat_stale" | "ingest_stalled" | "permissions_degraded";
+```
+
+- [ ] **Step 4: Add the three `reasonText()` cases**
+
+Insert before `default:`. Each names the exact remedial action, because there is no UI to click through to:
+
+```ts
+    case "window_titles_blind":
+      return `window titles are empty — the agent is recording app names and durations but no titles, so meeting detection and categorisation are degraded. On macOS this is a missing Accessibility grant (System Settings > Privacy & Security > Accessibility > enable BetterFlow); on Windows the bf-window-tracker is blind; on Linux the X11 watcher is dead`;
+    case "idle_tracker_blind":
+      return `idle tracker is blind — it has stayed stale across repeated restarts, which the agent reports specifically because restarting cannot fix it. Almost always a denied Input Monitoring grant (System Settings > Privacy & Security > Input Monitoring > enable BetterFlow). Tracking continues via the OS idle clock meanwhile, so time is not lost`;
+    case "input_counters_dead":
+      return `input counters are dead — window and idle capture are healthy but keystrokes, clicks AND scrolls are all zero across 4h+ of active time. That is a tracker not reporting, not a quiet user. Fraud-detection input is empty for this device. Check AV/endpoint protection blocking bf-idle-tracker, then reinstall the agent`;
+```
+
+- [ ] **Step 5: Pin the severity**
+
+In `severityFor()`, immediately after the existing `window_ingest_stalled` clause:
+
+```ts
+  // A missing permission is a standing config fault that only a human clears —
+  // it will "persist" indefinitely by construction, so the age-based escalation
+  // below is meaningless for it. critical also bypasses Slack coalescing and
+  // fires the Telegram fallback, which is wrong for a config fault.
+  if (d.category === "permissions_degraded") {
+    return "warning";
+  }
+```
+
+- [ ] **Step 6: Run to verify they pass**
+
+```bash
+npx vitest run src/__tests__/betterflow-device-health.test.ts
+```
+
+Expected: PASS.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add src/monitor/betterflow-device-health.ts src/__tests__/betterflow-device-health.test.ts
+git commit -m "feat(device-health): describe the three permissions_degraded reasons
+
+Each line names the exact remedial action because there is deliberately no UI
+to click through to. Severity pinned to warning: a config fault persists by
+construction, so age-based escalation is meaningless, and critical would bypass
+Slack coalescing and fire the Telegram fallback."
+```
+
+---
+
+### Task 7: Bot — per-reason cooldown
+
+`COOLDOWN_SECONDS` is one module-level constant at 6h shared by every reason. A permission fault is cleared only by a human, so 6h means four pings per device per day forever.
+
+**Files:**
+- Modify: `src/monitor/betterflow-device-health.ts:84`, `filterByCooldown()` `:364-392`
+- Test: `src/__tests__/betterflow-device-health.test.ts`
+
+- [ ] **Step 1: Write the failing test**
+
+```ts
+  it("gives permission faults a much longer cooldown than transient faults", () => {
+    expect(cooldownSecondsFor("window_titles_blind")).toBe(72 * 3600);
+    expect(cooldownSecondsFor("input_counters_dead")).toBe(72 * 3600);
+    expect(cooldownSecondsFor("idle_tracker_stale")).toBe(6 * 3600);
+    expect(cooldownSecondsFor("some_reason_invented_later")).toBe(6 * 3600);
+  });
+```
+
+- [ ] **Step 2: Run to verify it fails**
+
+```bash
+npx vitest run src/__tests__/betterflow-device-health.test.ts
+```
+
+Expected: FAIL — `cooldownSecondsFor is not defined`.
+
+- [ ] **Step 3: Implement**
+
+Replace the bare constant with a default plus an override map, keeping the old name as the default so nothing else changes:
+
+```ts
+const COOLDOWN_SECONDS = 6 * 3600; // default: one ping per device+reason per 6h
+// A permission/capture fault is a STANDING condition that only a human clears,
+// so the default 6h would ping four times a day per device indefinitely and
+// train everyone to ignore the channel — the exact failure the server-side
+// ALERT_ON_BLIND_WINDOW_TITLES docblock warns about.
+const PERMISSION_COOLDOWN_SECONDS = 72 * 3600;
+const COOLDOWN_OVERRIDES: Record<string, number> = {
+  window_titles_blind: PERMISSION_COOLDOWN_SECONDS,
+  idle_tracker_blind: PERMISSION_COOLDOWN_SECONDS,
+  input_counters_dead: PERMISSION_COOLDOWN_SECONDS,
+};
+
+/** Cooldown for a reason. Unknown reasons get the default, never zero. */
+export function cooldownSecondsFor(reason: string): number {
+  return COOLDOWN_OVERRIDES[reason] ?? COOLDOWN_SECONDS;
+}
+```
+
+In `filterByCooldown()`, the comparison currently uses the single constant against every row. Change it to evaluate per row via `cooldownSecondsFor(d.reason)`. Read the existing implementation and keep its fail-open behaviour on DB error exactly as-is — that is deliberate.
+
+- [ ] **Step 4: Run to verify it passes**
+
+```bash
+npx vitest run src/__tests__/betterflow-device-health.test.ts
+```
+
+Expected: PASS.
+
+- [ ] **Step 5: Run the full bot suite for regressions**
+
+```bash
+npx vitest run
+```
+
+Expected: no new failures. The cooldown change touches a shared path, so read the summary — do not trust the exit code alone.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/monitor/betterflow-device-health.ts src/__tests__/betterflow-device-health.test.ts
+git commit -m "feat(device-health): per-reason alert cooldown, 72h for permission faults
+
+A single 6h constant was shared by every reason. A permission fault is cleared
+only by a human, so it would ping four times a day per device forever. Unknown
+reasons keep the 6h default."
+```
+
+---
+
+### Task 8: Contract test — server reasons must not outrun the bot
+
+The bot's `default:` branch is honest, but it is the drift point. This is the guard.
+
+**Files:**
+- Test: `src/__tests__/betterflow-device-health.test.ts`
+
+- [ ] **Step 1: Write the test**
+
+```ts
+  // The server invents reasons faster than this file learns them. The default
+  // branch keeps that honest rather than fabricating, but this asserts we
+  // noticed. Update BOTH lists when the server gains a reason.
+  const SERVER_PERMISSION_REASONS = [
+    "window_titles_blind",
+    "idle_tracker_blind",
+    "input_counters_dead",
+  ];
+
+  it("has a description for every permissions reason the server can emit", () => {
+    const undescribed = SERVER_PERMISSION_REASONS.filter((reason) =>
+      reasonText({ ...baseDevice, category: "permissions_degraded", reason } as FlaggedDevice)
+        .includes("no description for that reason yet")
+    );
+    expect(undescribed).toEqual([]);
+  });
+```
+
+- [ ] **Step 2: Verify the guard is witnessed**
+
+Per `rules/test-fixture-discipline.md` Phantom 5, a guard nobody has watched fail does not exist. Temporarily delete the `case "input_counters_dead":` branch, re-run, and confirm the suite goes RED naming that reason. Then restore it and confirm GREEN.
+
+```bash
+npx vitest run src/__tests__/betterflow-device-health.test.ts
+```
+
+Expected: RED with the branch removed, GREEN with it restored. Do not skip this step.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add src/__tests__/betterflow-device-health.test.ts
+git commit -m "test(device-health): guard that every server permissions reason has bot text
+
+Verified by deletion: removing the input_counters_dead case turns the suite red
+naming that reason, then green when restored."
+```
+
+---
+
+### Task 9: Verify against the real fleet before merging
+
+Acceptance is checkable against reality, which is the strongest signal available here.
+
+**Files:** none — verification only.
+
+- [ ] **Step 1: Apply the migration to prod BEFORE merging**
+
+Railway auto-deploys `main`, so merging is deploying. Confirm the column does not exist, apply, confirm it does. Use the DB service's public proxy and the full `psql` path per `rules/coding-standards.md` §7 — never a bare `psql`.
+
+- [ ] **Step 2: Run every non-deploy workflow's steps locally, in both repos**
+
+```bash
+ls /Users/brad/Code2/internal-tool2/.github/workflows/
+ls /Users/brad/Code2/betterqa-bot/.github/workflows/
+```
+
+Do not look for `ci.yml` by name. Read each workflow's step list and run every step, honouring any `working-directory:`. Say explicitly which steps you ran and which you skipped and why.
+
+- [ ] **Step 3: Hit the endpoint against prod data and check the expected output**
+
+The endpoint must return, in the `permissions_degraded` category:
+- exactly **3** `window_titles_blind` rows — devices 17, 6 and 22 (Sergiu Olpretean, Tudor Brad, Timea Eniko Schvartz)
+- exactly **2** `input_counters_dead` rows — devices 24 and 34 (Claudia Malau, Youssef Abdelmeged)
+
+**14 rows, or 0 rows, means the query is wrong — stop and diagnose, do not merge.** Cross-check the title figure independently with `betterflow_agent_devices` using `title_capture="broken"`.
+
+- [ ] **Step 4: Confirm no existing consumer changed**
+
+The `telemetry_degraded` and `ingest_stalled` populations must be identical to before the change. Diff the counts against a pre-change call.
+
+- [ ] **Step 5: Open the PRs and STOP**
+
+internal-tool2 is PR-only, no auto-merge — Martin is active in it. Write the verification evidence from Steps 3 and 4 into the PR description. betterqa-bot follows the ecosystem rules, but ship the server side first: the bot's `default:` branch handles an unknown reason honestly, so server-ahead-of-bot is safe and bot-ahead-of-server is a no-op.
+
+---
+
+## Self-Review
+
+**Spec coverage:** `window_titles_blind` → Task 3. `idle_tracker_blind` → Tasks 1+4. `input_counters_dead` → Task 5. Fail-closed rules → Tasks 3, 5 guards. Reused alert pipeline → Tasks 6, 7. Self-sufficient Slack line → Task 6 Step 4. Per-reason cooldown → Task 7. Contract test → Task 8. Acceptance 3+2 → Task 9. Do-not-flip-the-constant → Global Constraints + Task 3 comment. No grouping, no upgrade nag, no UI → not implemented, by design.
+
+**Not covered here, by design:** M2 (agent grant reporting) is a separate plan. The class-1 backlog reconciliation and the missing ack/snooze are spec open questions, not tasks.
+
+**Type consistency:** `permissionsRow()` shapes every row identically across Tasks 3-5. `cooldownSecondsFor()` is defined in Task 7 and used only there. The category string `permissions_degraded` and the three reason literals are identical in the PHP emitters (Tasks 3-5), the TS union (Task 6), and the contract test (Task 8).

--- a/docs/superpowers/plans/2026-07-27-agent-permission-visibility-m1.md
+++ b/docs/superpowers/plans/2026-07-27-agent-permission-visibility-m1.md
@@ -714,37 +714,86 @@ rows means no-rows can never masquerade as no-input."
 **Interfaces:**
 - Consumes: `category: "permissions_degraded"` and reasons `window_titles_blind` / `idle_tracker_blind` / `input_counters_dead` from Tasks 3-5.
 
-- [ ] **Step 1: Write the failing tests**
+> **Reality check (2026-07-28, read against `origin/main` @ `3a55679`).** This task
+> was drafted without reading the current file and four of its assumptions are
+> wrong. Corrected below; do not restore the originals.
+>
+> 1. **`case "window_titles_blind"` ALREADY EXISTS** (`:292-295`), added with the
+>    server-side `ALERT_ON_BLIND_WINDOW_TITLES` work. Only two cases are new. A
+>    second `case` for the same literal is unreachable code and an ESLint
+>    `no-duplicate-case` error — **replace the existing text, do not add.**
+> 2. **`reasonText` / `severityFor` are not exported and the test file does not
+>    call them.** There is no `baseDevice` fixture; the house fixture is
+>    `degradedDevice(overrides)` and every test drives the public
+>    `checkBetterflowDeviceHealth()` with `mockFetchJson` + a mocked `db`. Follow
+>    the house style — it asserts the CONSUMER (the Slack line that actually
+>    ships) rather than the producer, which is strictly stronger per
+>    `test-fixture-discipline.md` Phantom 7. **Do not export internals to satisfy
+>    the original draft.**
+> 3. **`severityFor` is unreachable for a warning-pin test via the public path
+>    unless the device is live and on-schedule** — see item 4.
+> 4. **A `permissions_degraded` device keeps BOTH liveness gates.**
+>    `isStaleOfflineFalsePositive` (`last_seen_at` older than
+>    `LIVE_RECENT_MINUTES`) and `isOffScheduleFalsePositive` (`off_schedule ===
+>    true`) exempt only `category === "ingest_stalled"`. This is left as-is and is
+>    the correct default: a standing config fault on a laptop nobody is using is
+>    not worth waking anyone for, and the 72h cooldown from Task 7 already makes
+>    it at most one ping per 3 days once the machine IS in use. **Consequence for
+>    Task 9:** the server-side acceptance count (3 title-blind, 2 input-dead) is
+>    an upper bound on what reaches Slack — offline or off-schedule devices are
+>    correctly filtered before alerting. Do not read a smaller Slack count as a
+>    bug without checking `last_seen_at` and `off_schedule` first.
+> 5. **Name collision to avoid.** The existing `case "idle_while_active"`
+>    (`:270-273`) already opens its Slack line with the literal words *"idle
+>    tracker blind"*, and the new reason is spelled `idle_tracker_blind`. Two
+>    different reasons must not produce near-identical prose or triage becomes
+>    guesswork. The new case's text below opens "idle tracker is blind — it has
+>    stayed stale across repeated restarts", which is distinguishable; leave the
+>    `idle_while_active` text alone but do not paraphrase it closer.
+
+- [ ] **Step 1: Write the failing tests** (house style — public entry point)
 
 ```ts
-  it("describes every permissions_degraded reason without falling through to default", () => {
-    for (const reason of ["window_titles_blind", "idle_tracker_blind", "input_counters_dead"]) {
-      const text = reasonText({ ...baseDevice, category: "permissions_degraded", reason } as FlaggedDevice);
-      expect(text).not.toContain("no description for that reason yet");
-      expect(text.length).toBeGreaterThan(40);
+  it("describes both new permissions_degraded reasons instead of falling through", async () => {
+    for (const reason of ["idle_tracker_blind", "input_counters_dead"]) {
+      mockFetchJson({ flagged: [degradedDevice({ category: "permissions_degraded", reason })] });
+      const alerts = await checkBetterflowDeviceHealth();
+      expect(alerts).toHaveLength(1);
+      expect(alerts[0]!.message).not.toContain("no description for that reason yet");
     }
   });
 
-  it("never escalates a permissions fault to critical, however long it persists", () => {
-    const severity = severityFor({
-      ...baseDevice,
+  it("names the remedial action for a title-blind device", async () => {
+    mockFetchJson({ flagged: [degradedDevice({ category: "permissions_degraded", reason: "window_titles_blind" })] });
+    const alerts = await checkBetterflowDeviceHealth();
+    expect(alerts[0]!.message).toContain("Accessibility");
+  });
+
+  it("never escalates a permissions fault to critical, however long it persists", async () => {
+    mockFetchJson({ flagged: [degradedDevice({
       category: "permissions_degraded",
       reason: "window_titles_blind",
       tracking_degraded_since: new Date(Date.now() - 72 * 3600 * 1000).toISOString(),
-    } as FlaggedDevice);
-    expect(severity).toBe("warning");
+    })] });
+    const alerts = await checkBetterflowDeviceHealth();
+    expect(alerts[0]!.severity).toBe("warning");
   });
 ```
 
-Read the existing test file first: reuse its `baseDevice` fixture and match how it imports the internals. If `reasonText` / `severityFor` are not exported, export them for test only, following whatever pattern the file already uses for the other internals it tests.
+`degradedDevice()` already sets a fresh `last_seen_at` and no `off_schedule`, so
+these devices pass both liveness gates. Keep it that way — a stale `last_seen_at`
+here would make the test pass for the wrong reason (Phantom 4).
 
 - [ ] **Step 2: Run to verify they fail**
 
 ```bash
-cd /Users/brad/Code2/betterqa-bot && npx vitest run src/__tests__/betterflow-device-health.test.ts
+cd /Users/brad/Code2/betterqa-bot-permvis && npx vitest run src/__tests__/betterflow-device-health.test.ts
 ```
 
-Expected: FAIL — the first on the default-branch text, the second on `critical`.
+Expected: FAIL — test 1 on the default-branch text for both new reasons, test 2
+on the absent "Accessibility" remedial text, test 3 on `critical`. Test 2 failing
+is what proves the existing `window_titles_blind` case is being *replaced* rather
+than left alone.
 
 - [ ] **Step 3: Widen the category union**
 
@@ -752,11 +801,17 @@ Expected: FAIL — the first on the default-branch text, the second on `critical
   category: "telemetry_degraded" | "heartbeat_stale" | "ingest_stalled" | "permissions_degraded";
 ```
 
-- [ ] **Step 4: Add the three `reasonText()` cases**
+- [ ] **Step 4: Add two cases, replace one**
 
-Insert before `default:`. Each names the exact remedial action, because there is no UI to click through to:
+`case "window_titles_blind"` already exists at `:292-295` — **replace its return
+statement and keep its comment**, then insert the two genuinely new cases before
+`default:`. Each names the exact remedial action, because there is no UI to click
+through to:
 
 ```ts
+    // REPLACES the existing text at :292-295. The old line said only that titles
+    // were blank; it never said what to DO about it, which is the whole point of
+    // the category.
     case "window_titles_blind":
       return `window titles are empty — the agent is recording app names and durations but no titles, so meeting detection and categorisation are degraded. On macOS this is a missing Accessibility grant (System Settings > Privacy & Security > Accessibility > enable BetterFlow); on Windows the bf-window-tracker is blind; on Linux the X11 watcher is dead`;
     case "idle_tracker_blind":
@@ -901,14 +956,22 @@ The bot's `default:` branch is honest, but it is the drift point. This is the gu
     "input_counters_dead",
   ];
 
-  it("has a description for every permissions reason the server can emit", () => {
-    const undescribed = SERVER_PERMISSION_REASONS.filter((reason) =>
-      reasonText({ ...baseDevice, category: "permissions_degraded", reason } as FlaggedDevice)
-        .includes("no description for that reason yet")
-    );
+  it("has a description for every permissions reason the server can emit", async () => {
+    const undescribed: string[] = [];
+    for (const reason of SERVER_PERMISSION_REASONS) {
+      mockFetchJson({ flagged: [degradedDevice({ category: "permissions_degraded", reason })] });
+      const alerts = await checkBetterflowDeviceHealth();
+      if (alerts[0]!.message.includes("no description for that reason yet")) {
+        undescribed.push(reason);
+      }
+    }
     expect(undescribed).toEqual([]);
   });
 ```
+
+Same correction as Task 6: no `reasonText`/`baseDevice` to call. Driving the
+public entry point also makes this guard stronger — it fails if a reason loses
+its text OR if a liveness gate starts silently swallowing the whole category.
 
 - [ ] **Step 2: Verify the guard is witnessed**
 

--- a/docs/superpowers/specs/2026-07-27-agent-permission-visibility-design.md
+++ b/docs/superpowers/specs/2026-07-27-agent-permission-visibility-design.md
@@ -1,0 +1,200 @@
+# Agent permission & capture visibility — design
+
+Status: **specced, not built.** Written 2026-07-27 after a user reported a
+mis-attributed meeting and the investigation could not answer the follow-up
+question — "who else is broken?" — from any existing surface.
+
+## Problem
+
+The agent knows, accurately and continuously, whether it has the OS permissions
+it needs. None of that ever leaves the machine, and nothing tells a human when a
+device stops capturing.
+
+`src/ui/permissions.py` detects macOS Accessibility (`AXIsProcessTrusted`, with
+a real `AXUIElementCopyAttributeValue` probe as the authoritative fallback) and
+Input Monitoring (`IOHIDCheckAccess`). `_check_permissions` re-runs on the 60s
+tick. The window watcher re-checks Accessibility every 30s and logs
+`"Accessibility permission revoked — window titles will be empty"`.
+
+Every one of those readings dies on the device. `HEARTBEAT_HEALTH_KEYS`
+(`src/sync/bf_client.py`) is an allowlist, and no permission grant is in it. The
+tray shows exactly one permission row (Input Monitoring); a Mac with
+Accessibility revoked renders a fully green tray. Server-side there is no
+permissions column, no permissions panel, and no filter — `admin/agents` and
+`admin/agents/fleet` render zero health columns, and the only human surface is a
+degraded badge on the single-device page.
+
+### Three failure classes, not one
+
+The investigation's central finding. These fail independently and need different
+fixes, and today they are not distinguished anywhere:
+
+| # | Failure | Signal that exists | Reaches a human? |
+|---|---|---|---|
+| 1 | Window titles blind — macOS Accessibility missing, Windows tracker blind, Linux X11 watcher dead | `window_titles_captured_recently = false` (stored) | **No** — alert path disabled by a constant |
+| 2 | AFK/idle tracker blind — Input Monitoring denied on the tracker, survives restarts | `idle_tracker_blind` (**on the wire today**) | **No** — server has no column and never reads it |
+| 3 | Input counters dead — keystrokes and clicks zero while window and AFK capture are healthy | **none — no signal exists** | **No** |
+
+Class 3 is the one the investigation actually caught, and it is invisible to
+both other signals. Two Windows devices have logged **zero keystrokes and zero
+clicks across every day recorded** (10 and 7 consecutive days) while reporting
+8-9h/day of active time — and both report `window_titles_captured_recently:
+true` and healthy idle data, so classes 1 and 2 are clean on them. Their
+fraud-detection input stream is empty and nothing anywhere says so.
+
+### Measured state, 2026-07-27 (VERIFIED via `betterflow_agent_devices`)
+
+48 devices: 28 titles OK, **3 titles broken**, 17 unknown. Filtered to devices
+seen in the last 24h, the unknown population collapses to **two**, both on agent
+1.5.95, which predates the field — an upgrade problem, not a permission problem.
+13 of the 17 unknowns have not checked in for 12-139 days.
+
+This supersedes the 38/47 figure quoted in `AgentHeartbeatController`'s
+`ALERT_ON_BLIND_WINDOW_TITLES` docblock. That number came from a log-warning
+sweep on 2026-07-22/23; the column that the flag actually keys on now reads 3
+broken against 28 healthy. Different instruments — the backlog is not provably
+"fixed" — but the page-storm the constant guards against would not happen today.
+
+## Why not simply flip `ALERT_ON_BLIND_WINDOW_TITLES`
+
+Volume is no longer the objection. Coupling is.
+
+Flipping the constant routes class 1 through `tracking_degraded = true`, which
+changes what **every** existing consumer of that flag sees — the
+`telemetry_degraded` population in `/api/internal/device-health`, the bot's
+severity escalation, the admin badge. A missing permission is a standing
+configuration fault, not the "tracking is degraded right now" condition that
+flag was built to mean.
+
+The constant stays `false` permanently and is superseded by a dedicated reason
+code. Its docblock should be updated to say so rather than left implying someone
+should eventually flip it.
+
+## Design
+
+Two milestones. M1 is independently shippable and needs no agent release, so it
+covers devices on old builds that will never report grants.
+
+### M1 — server-derived detection and alerting
+
+**Detection.** A new `permissions_degraded` category in
+`InternalStatsController::deviceHealth()`, modelled on the existing
+`ingest_stalled` block and emitting `tracking_degraded => false` so it never
+contaminates the self-reported population. Three reason codes:
+
+- `window_titles_blind` — active, not soft-deleted, fresh `last_seen_at`,
+  `window_titles_captured_recently = false`.
+- `idle_tracker_blind` — the agent already sends this key; the server has
+  nowhere to put it. Requires the one migration in M1: a nullable boolean column,
+  persistence in the heartbeat, and an entry in `hasHealthTelemetry()`.
+- `input_counters_dead` — fully derived from `agent_activity_aggregates`: rows
+  exist with real `active_seconds`, and `SUM(keystrokes_count + clicks_count) = 0`
+  across two consecutive days.
+
+**Fail-closed rules, non-negotiable in review.** Never-reported devices are
+excluded by an explicit predicate, never by relying on `DEFAULT false` —
+`tracking_degraded`, `consecutive_sync_failures`, `idle_tracker_stale_restarts`
+and `idle_while_active_detections` are all `NOT NULL DEFAULT` columns where a
+device that has never reported is byte-identical to a healthy one, and
+`health_reported_at` is the only column that separates them. `input_counters_dead`
+fires only when aggregate rows **exist** and sum to zero; "no rows" is not "no
+input". The new `idle_tracker_blind` column is nullable with no default, matching
+`window_titles_captured_recently` rather than its neighbours.
+
+**Alerting (betterqa-bot).** The pipeline already exists end-to-end and is
+deterministic — a 10-minute cron, an `alert_state` table keyed on
+`device_id:reason` giving per-reason cooldown for free, pure template-literal
+formatting with no LLM anywhere, and a Slack path with retry, coalescing and an
+audit row. Reuse all of it. The additions are three `reasonText()` cases naming
+the actual fix, a `severityFor()` clause pinning this class to `warning`, and the
+existing seen-on-a-prior-run persistence filter so a blip cannot page.
+
+Severity matters more than it looks: `critical` bypasses Slack coalescing and
+triggers the Telegram fallback. A standing config fault must never reach it.
+
+**The one change to shared code.** `COOLDOWN_SECONDS` is a module-level constant
+at 6h shared by every reason. A permission fault is cleared only by a human, so
+6h means four pings per device per day indefinitely. It becomes per-reason;
+permissions get 72h.
+
+### M2 — agent-authoritative grants
+
+The agent adds `accessibility` and `input_monitoring` booleans to its health
+snapshot and to `HEARTBEAT_HEALTH_KEYS`. It already computes both — this is
+plumbing, not new detection. Two nullable columns server-side.
+
+The alert prefers the explicit grants when non-null and falls back to the derived
+signals when null, so old builds keep working unchanged. Wording upgrades from
+"this tracker is blind" to "grant Input Monitoring", which is the difference
+between an alert someone can act on and one they have to investigate.
+
+## Deliberately not built
+
+- **No grouping or roll-up.** No such primitive exists and the current backlog is
+  3 devices, so it would be 3 messages. Build it when it hurts.
+- **No new "old agent build" nag.** `AGENT_MINIMUM_VERSION` on Railway already
+  pushes the fleet forward: the agent reads `minimum_agent_version` off the
+  heartbeat and fires `on_update_required` when it is below the floor
+  (`src/sync/sync_engine.py:3772-3783`, VERIFIED). A second mechanism for the two
+  1.5.95 machines duplicates a working lever. Confirm those two builds carry that
+  handler before relying on it for them.
+- **No admin UI work in M1.** The chosen model is push, not pull. UI columns
+  remain a real gap (see Open questions) but are not on this path.
+
+## Testing
+
+Per `test-fixture-discipline.md`, each reason needs a test that fails before the
+change. The valuable cases are the adversarial ones, not the happy path:
+
+- A never-reported device is **not** flagged (guards the `DEFAULT false` trap).
+- A device with no aggregate rows at all is **not** flagged as
+  `input_counters_dead` (guards the `fail-closed.md` Rule 4 shape: a read that
+  returned nothing is not proof there is nothing).
+- A device with one zero-input day is **not** flagged; two consecutive are.
+- A soft-deleted or non-active device is never flagged.
+
+Plus a **contract test** that every reason code the server can emit has a
+matching `reasonText()` case in the bot. The bot's `default:` branch is honest
+and names the gap rather than fabricating, but it is the drift point, and this is
+the Phantom-2 shape — assert against the artifact that receives traffic.
+
+**Acceptance is checkable against reality.** Run against today's fleet, M1 must
+produce exactly 3 `window_titles_blind` and 2 `input_counters_dead`, naming those
+specific devices. 14 or 0 means the query is wrong.
+
+## Blast radius
+
+- **Migrations run before merge**, not after. Railway auto-deploys `main`, so
+  merging is deploying.
+- **internal-tool2 is PR-only, no auto-merge.** 31 commits in 7 days across two
+  authors, and the agent-health code in scope changed twice in the three days
+  before this was written (#2170, #2178). Worktree, explicit paths, and per
+  `cross-repo-safety.md` Rule 1 the auto-merge default is suspended.
+- The new category is additive. Existing consumers of `telemetry_degraded` and
+  `ingest_stalled` see no change, which is the point of not flipping the constant.
+
+## Known open questions
+
+- **Is the class-1 backlog genuinely cleared, or did the fleet upgrade past the
+  measurement?** 28 OK against 3 broken is measured on `window_titles_captured_recently`;
+  the 38/47 it supersedes was a log sweep. Worth one deliberate reconciliation
+  before anyone concludes the onboarding problem is solved.
+- **No ack/snooze exists.** `alert_state.suppressed_count` is present but never
+  written by this monitor. Nobody can say "yes, we know about that Mac, stop
+  telling me" without a code change. A 72h cooldown makes this tolerable, not
+  solved.
+- **Admin UI remains blind.** `hardware_serial`, `window_titles_captured_recently`,
+  `consecutive_sync_failures` and the whole never-reported distinction are stored,
+  exposed via MCP, and rendered nowhere. Out of scope here by choice.
+
+## Related
+
+- `docs/superpowers/specs/2026-07-22-window-title-capture-telemetry-design.md` —
+  specced the class-1 signal this builds on.
+- `rules/fail-closed.md` Rule 4 — the read-returned-nothing trap, which classes 1
+  and 3 both sit on.
+- `rules/test-fixture-discipline.md` Phantom 2 — the contract-test pattern for the
+  server/bot reason-code boundary.
+- The macOS background-meeting gap (a Meet detected only while frontmost, mic
+  credit off on macOS by the 2026-07-17 usage-only policy) is **deliberately not
+  in this spec**. It is a product decision, not a bug, and is tracked separately.

--- a/docs/superpowers/specs/2026-07-27-agent-permission-visibility-design.md
+++ b/docs/superpowers/specs/2026-07-27-agent-permission-visibility-design.md
@@ -88,8 +88,20 @@ contaminates the self-reported population. Three reason codes:
   nowhere to put it. Requires the one migration in M1: a nullable boolean column,
   persistence in the heartbeat, and an entry in `hasHealthTelemetry()`.
 - `input_counters_dead` — fully derived from `agent_activity_aggregates`: rows
-  exist with real `active_seconds`, and `SUM(keystrokes_count + clicks_count) = 0`
-  across two consecutive days.
+  exist for the day, `SUM(active_seconds) >= 4h`, and
+  `SUM(keystrokes_count + clicks_count + scrolls_count) = 0`.
+
+**Why all three counters, and why same-day.** Scrolls are the discriminator. A
+quiet user still scrolls constantly — a healthy device logged 58,631 scrolls in
+Chrome in one day. The two broken devices report zero keystrokes, zero clicks
+**and** zero scrolls across every app, including hours in Excel and Slack. That
+is not a person working quietly; it is a tracker that is not reporting, and one
+day of it is already conclusive. Requiring a second consecutive day would add no
+confidence and delay the alert by a day. Including scrolls makes the predicate
+strictly harder to satisfy than keystrokes+clicks alone, which is the safe
+direction: a device with scrolls but no keystrokes is a different, partial
+failure and must NOT be flagged under this reason. The 4h active floor exists so
+a machine left awake and idle cannot trip it.
 
 **Fail-closed rules, non-negotiable in review.** Never-reported devices are
 excluded by an explicit predicate, never by relying on `DEFAULT false` —
@@ -138,8 +150,24 @@ between an alert someone can act on and one they have to investigate.
   (`src/sync/sync_engine.py:3772-3783`, VERIFIED). A second mechanism for the two
   1.5.95 machines duplicates a working lever. Confirm those two builds carry that
   handler before relying on it for them.
-- **No admin UI work in M1.** The chosen model is push, not pull. UI columns
-  remain a real gap (see Open questions) but are not on this path.
+- **No admin UI work in M1.** The chosen model is push, not pull — and the pull
+  surface already exists and is better than what would be built: the
+  `betterflow_agent_devices` MCP tool is tri-state aware (`tracking_degraded_known`,
+  the true/false/null split on title capture) and filterable by
+  `title_capture="broken"`, neither of which the admin screen does.
+
+  This makes one thing mandatory rather than optional: **the Slack line must be
+  self-sufficient.** It names the person, the device, the platform and the exact
+  remedial action, because there is deliberately nowhere to click through to. An
+  alert that says "device 24 is degraded" fails this bar; "Claudia Malau
+  (Windows, device 24): input tracker reporting nothing — 8h active today with
+  zero keystrokes, clicks and scrolls. Reinstall the agent or check AV blocking
+  bf-idle-tracker" meets it.
+
+  Accepted risk: this reasoning holds while the people acting on alerts can reach
+  the MCP. If someone needs to self-serve without it, the UI becomes real work —
+  but nothing in M1 blocks adding it later, and the derived reasons would feed it
+  unchanged.
 
 ## Testing
 
@@ -150,7 +178,11 @@ change. The valuable cases are the adversarial ones, not the happy path:
 - A device with no aggregate rows at all is **not** flagged as
   `input_counters_dead` (guards the `fail-closed.md` Rule 4 shape: a read that
   returned nothing is not proof there is nothing).
-- A device with one zero-input day is **not** flagged; two consecutive are.
+- A device with **zero keystrokes and zero clicks but non-zero scrolls** is
+  **not** flagged. This is the adversarial case — it is the arrangement the
+  author would not naturally pick, and it separates a partial failure from a dead
+  tracker.
+- A device under the 4h active floor is **not** flagged, however quiet.
 - A soft-deleted or non-active device is never flagged.
 
 Plus a **contract test** that every reason code the server can emit has a


### PR DESCRIPTION
Design spec and M1 implementation plan for making the three agent capture-failure classes visible as deduped Slack alerts.

Docs only. No code, no behaviour change.

**The bot half of M1 is already implemented** in betterqa-bot#262 (Tasks 6-8). This branch is what remains: Tasks 1-5 (detection in internal-tool2, one additive migration) and Task 9 (fleet verification), plus M2, which needs an agent release and is deliberately a separate plan that does not exist yet.

Tasks 1-5 were **not** started on purpose. Martin is active in internal-tool2 and `rules/cross-repo-safety.md` Rule 1 suspends the auto-merge default when another session may be on a repo. Whoever picks it up should re-read the plan against current `origin/main` first, because the bot-side tasks had already drifted from reality in three days.

That drift is recorded in `4faca65` rather than silently corrected: five assumptions in the bot tasks were wrong, including a switch case the plan wanted added that already existed, and test helpers the plan assumed were exported when the suite never imported them. Worth reading before trusting Tasks 1-5's line numbers.

The plan carries two constraints that are easy to lose: the migration must be applied **before** merge because Railway auto-deploys main, and internal-tool2's PHP suite only runs against the main checkout, not a worktree.

🤖 Generated with [Claude Code](https://claude.com/claude-code)