### PR TITLE
fix(tests): stop the self-updater tests breaking the Windows build

### DIFF
--- a/tests/test_self_updater_replaceable.py
+++ b/tests/test_self_updater_replaceable.py
@@ -33,25 +33,39 @@ def test_unknown_layout_is_replaceable():
         assert su.app_bundle_replaceable() is True
 
 
+# These three force the darwin branch via the platform patch, so they exercise
+# macOS logic on EVERY runner — including Windows, where `os.getuid` does not
+# exist at all. Two consequences, both load-bearing:
+#   * use a literal uid, never `os.getuid()`, or the test file raises
+#     AttributeError on Windows before any assertion runs;
+#   * patch `su.os.getuid` with `create=True`, because patch.object refuses by
+#     default to patch an attribute the target module does not have.
+# Dropping either one turns the whole Windows build red — and since the release
+# job needs every platform green, that blocks the release rather than just
+# failing a test (v1.5.119's first tag build, 2026-07-29).
+_A_NORMAL_UID = 501
+_ROOT_UID = 0
+
+
 def test_user_owned_bundle_is_replaceable():
     with patch.object(su.sys, "platform", "darwin"), \
-         patch.object(su, "_get_app_bundle_path", return_value=_FakeApp(os.getuid())), \
-         patch.object(su.os, "getuid", return_value=os.getuid()):
+         patch.object(su, "_get_app_bundle_path", return_value=_FakeApp(_A_NORMAL_UID)), \
+         patch.object(su.os, "getuid", create=True, return_value=_A_NORMAL_UID):
         assert su.app_bundle_replaceable() is True
 
 
 def test_root_owned_bundle_is_not_replaceable():
     # The reported failure: bundle owned by root (uid 0), we are a normal user.
     with patch.object(su.sys, "platform", "darwin"), \
-         patch.object(su, "_get_app_bundle_path", return_value=_FakeApp(0)), \
-         patch.object(su.os, "getuid", return_value=501):
+         patch.object(su, "_get_app_bundle_path", return_value=_FakeApp(_ROOT_UID)), \
+         patch.object(su.os, "getuid", create=True, return_value=_A_NORMAL_UID):
         assert su.app_bundle_replaceable() is False
 
 
 def test_running_as_root_can_replace_anything():
     with patch.object(su.sys, "platform", "darwin"), \
-         patch.object(su, "_get_app_bundle_path", return_value=_FakeApp(0)), \
-         patch.object(su.os, "getuid", return_value=0):
+         patch.object(su, "_get_app_bundle_path", return_value=_FakeApp(_ROOT_UID)), \
+         patch.object(su.os, "getuid", create=True, return_value=_ROOT_UID):
         assert su.app_bundle_replaceable() is True
 
 


### PR DESCRIPTION
v1.5.119's first tag build produced **no artifacts**. Windows went red, and because the release job requires every platform green, it was skipped entirely.

Not a product defect — macOS (both arches) and Linux were green throughout, and notarization worked. It was three tests.

## Mechanism

The `app_bundle_replaceable` unit tests force the darwin branch with a platform patch, so they execute macOS logic on **every** runner including Windows, where `os.getuid` does not exist. Two separate calls hit that:

- `os.getuid()` used to build the fixture uid — raises before any assertion runs
- `patch.object(su.os, "getuid", ...)` — patch.object refuses by default to patch an attribute the target module lacks

Result on Windows: `3 failed, 1489 passed`.

The two *real-environment* tests in the same file were correctly guarded with `skipif(sys.platform != "darwin")`. These three were not, because they look platform-independent — the platform is patched, after all. That is the trap.

## Fix

Portable rather than skipped, so the tests keep running everywhere and still cover the macOS logic they were written for: literal uids instead of `os.getuid()`, and `create=True` on the getuid patches.

## Verification

Simulated the Windows condition locally with `del os.getuid`:

- old form → `AttributeError: <module 'os' (frozen)> does not have the attribute 'getuid'` — the identical string CI reported
- new form → all three pass

Full suite 1513 passed on macOS.

This is why #168 shipped clean: the Windows job only runs on a tag build, so a Windows-only breakage cannot be seen at PR time.