### PR TITLE
test(diagnostics): pin the logs_requested upload failure to warning level

### DIFF
--- a/src/sync/http_client.py
+++ b/src/sync/http_client.py
@@ -284,9 +284,10 @@ class BaseApiClient:
 
     # In-cycle network budget. A single retrying request runs at most
     # (max_retries + 1) attempts * timeout + backoff. With max_retries=3 and a
-    # 30s timeout that is ~129s — past the 120s sync watchdog (SyncCoordinator
-    # ._DO_SYNC_DEADLINE), so a hung/slow server (e.g. the 2026-06-30 Redis/502
-    # outage) false-trips "Sync hung". max_retries=2 bounds the worst-case chain
+    # 30s timeout that is ~129s — past the sync watchdog (SyncCoordinator
+    # ._DO_SYNC_DEADLINE, 120s when this was written, 150s now), so a hung/slow
+    # server (e.g. the 2026-06-30 Redis/502 outage) false-trips "Sync hung".
+    # max_retries=2 bounds the worst-case chain
     # to ~94s, comfortably inside the watchdog; the OfflineQueue is the durable
     # cross-cycle retry, so a failed batch is re-sent next cycle regardless — the
     # 4th in-cycle attempt only amplified the stall. Guarded by

--- a/tests/test_log_upload_failure_severity.py
+++ b/tests/test_log_upload_failure_severity.py
@@ -1,0 +1,155 @@
+"""Severity guard for the logs_requested upload failure report.
+
+Origin: 2026-07-27, BUG-003541 — "Agent log upload failed: upload POST failed:
+Cannot connect to BetterFlow API", one occurrence, auto-filed from live runtime
+telemetry. The condition is a device that could not reach the BetterFlow API
+while an admin had asked for its log tail.
+
+Nothing is lost when this happens: ``_upload_requested_logs`` clears nothing
+client-side, and the server clears its ``logs_requested`` flag only on a
+successful upload, so the next heartbeat retries. A single handled, self-healing
+transient must therefore report as ``warning`` — reporting it as ``error`` pages
+humans and draws the autofix drafter onto a non-problem, which is the same noise
+failure ``_do_sync``'s watchdog classification fixed for the sibling report
+(#151, tests/test_sync_watchdog_outcome_classification.py).
+
+The level was already correct when this guard was written; what was missing was
+anything WATCHING it. ``test_failed_upload_post_reports_to_ops`` in
+tests/test_sync_engine.py pins the message text and the call count but never the
+severity, so a change from warning to error passed the suite. Per
+``rules/test-fixture-discipline.md`` Phantom 5, a guard is only real once it has
+been watched failing — this one was, by flipping the production level to "error"
+and confirming these tests go red.
+
+Drives the REAL ``_send_heartbeat`` -> ``_upload_requested_logs`` path with a
+stubbed transport and asserts on what the error reporter actually captured,
+never on arguments forwarded between functions.
+"""
+
+from unittest.mock import Mock, patch
+
+from src.config import Config
+from src.sync.http_client import BetterFlowAuthError, BetterFlowClientError
+from src.sync.sync_engine import SyncEngine
+
+# The exact transport failure BUG-003541 was filed from.
+_OFFLINE = "Cannot connect to BetterFlow API"
+
+# Dedup fingerprint the report is grouped under. Pinned so a rename has to be
+# deliberate: the reporter's dedup window is what stops a persistent outage
+# flooding ops on every heartbeat.
+_FINGERPRINT = "log-upload-failed"
+
+
+class _Recorder:
+    """Records what was actually captured, instead of asserting on a Mock's args."""
+
+    def __init__(self):
+        self.captures = []
+
+    def capture(self, message, **kwargs):
+        self.captures.append({"message": message, **kwargs})
+
+    def by_level(self, level):
+        return [c for c in self.captures if c.get("level") == level]
+
+    def by_fingerprint(self, fingerprint):
+        return [c for c in self.captures if c.get("fingerprint") == fingerprint]
+
+
+class TestLogUploadFailureSeverity:
+    def setup_method(self):
+        self.aw = Mock()
+        self.bf = Mock()
+        self.queue = Mock()
+        self.queue.get_checkpoint.return_value = None
+        self.queue.evict_unstorable.return_value = {
+            "count": 0, "bucket_ids": [], "oldest": None, "newest": None,
+            "real_loss_count": 0, "unstorable_count": 0,
+        }
+        self.config = Config()
+        self.config.working_hours.known = True
+
+        self.engine = SyncEngine(
+            aw=self.aw,
+            bf=self.bf,
+            queue=self.queue,
+            config=self.config,
+            activity_analyzer=Mock(),
+            time_tracker=Mock(),
+        )
+        self.recorder = _Recorder()
+        self.engine.error_reporter = self.recorder
+
+        # An admin has requested this device's logs.
+        self.bf.heartbeat.return_value = {
+            "success": True, "data": {"logs_requested": True},
+        }
+
+    def _run_heartbeat(self):
+        with patch.object(SyncEngine, "_read_log_tail", return_value=b"log-bytes"):
+            return self.engine._send_heartbeat()
+
+    def test_unreachable_api_reports_the_upload_failure_as_warning(self):
+        """The BUG-003541 condition itself: an offline device reports at
+        warning, never error."""
+        self.bf.upload_logs.side_effect = BetterFlowClientError(_OFFLINE)
+
+        self._run_heartbeat()
+
+        reports = self.recorder.by_fingerprint(_FINGERPRINT)
+        assert len(reports) == 1, self.recorder.captures
+        assert reports[0]["level"] == "warning"
+        assert _OFFLINE in reports[0]["message"]
+
+    def test_unreachable_api_emits_no_error_level_report_at_all(self):
+        """The noise property stated end-to-end: a handled transient must not
+        put ANY error-level event on the ops ingest, whatever its fingerprint."""
+        self.bf.upload_logs.side_effect = BetterFlowClientError(_OFFLINE)
+
+        self._run_heartbeat()
+
+        assert self.recorder.by_level("error") == [], self.recorder.captures
+
+    def test_a_5xx_upload_failure_is_also_warning(self):
+        """Not special-cased to connection errors — any retryable POST failure
+        is the same self-healing condition."""
+        self.bf.upload_logs.side_effect = BetterFlowClientError("500")
+
+        self._run_heartbeat()
+
+        reports = self.recorder.by_fingerprint(_FINGERPRINT)
+        assert len(reports) == 1, self.recorder.captures
+        assert reports[0]["level"] == "warning"
+
+    def test_upload_failure_does_not_break_the_heartbeat_cycle(self):
+        """No data loss / no wedge: the failure is swallowed at the heartbeat
+        boundary, so the cycle completes and the next one retries. A returned
+        exception here means the caller would fire a re-login instead."""
+        self.bf.upload_logs.side_effect = BetterFlowClientError(_OFFLINE)
+
+        assert self._run_heartbeat() is None
+        # Nothing was consumed or cleared client-side by the failed attempt.
+        self.queue.clear.assert_not_called()
+
+    def test_auth_failure_still_surfaces_for_relogin(self):
+        """The downgrade must not swallow the one upload failure that is NOT
+        self-healing. An expired session needs re-login, so _send_heartbeat
+        returns the auth error to its caller rather than reporting and moving
+        on."""
+        self.bf.upload_logs.side_effect = BetterFlowAuthError("expired")
+
+        result = self._run_heartbeat()
+
+        assert isinstance(result, BetterFlowAuthError)
+        assert self.recorder.by_fingerprint(_FINGERPRINT) == []
+
+    def test_successful_upload_reports_nothing(self):
+        """Negative control: the happy path must produce no capture at all, so
+        the assertions above are responding to the failure and not to the
+        harness always capturing something."""
+        self.bf.upload_logs.side_effect = None
+
+        self._run_heartbeat()
+
+        assert self.recorder.captures == []


### PR DESCRIPTION
Investigation of two auto-filed runtime bugs, BUG-003541 and BUG-003529 (1 occurrence each, last 2026-07-27). **Both conditions turned out to be handled correctly already, and both already report at `warning`.** No production behaviour changes here.

## What the two bugs actually are

| Bug | Emit site | Level today |
|---|---|---|
| BUG-003541 "Agent log upload failed: upload POST failed: Cannot connect to BetterFlow API" | `SyncEngine._report_upload_failure` (`src/sync/sync_engine.py`) | `warning` |
| BUG-003529 "Sync slow — exceeded 150s while the BetterFlow API was unreachable (1 transient failure this cycle)" | `SyncCoordinator._do_sync._watchdog` (`src/main.py`) | `warning` |

Neither loses data:

- **Log upload** — `_upload_requested_logs` clears nothing client-side. The server clears its `logs_requested` flag only on a successful upload, so a failed attempt simply retries on the next heartbeat.
- **Watchdog** — the overrun path resets pooled sessions and returns; events stay in the durable `OfflineQueue` and go out next cycle. A genuine wedge is still escalated to `error` by `_SYNC_WEDGE_CEILING` (420s).

BUG-003529's own wording is the proof its fix is already live: "Sync slow … 1 transient failure this cycle" is the post-#151 message. The pre-#151 text was "Sync hung — exceeded 150s watchdog deadline" at `level=error`. #151 shipped in v1.5.116, and the reporting device was running it.

## So what was actually wrong

Nothing was **watching** the log-upload severity. The pre-existing `test_failed_upload_post_reports_to_ops` pins the message text and the call count but never the level, so flipping `level="warning"` to `"error"` in `_report_upload_failure` left **all 115 tests in `tests/test_sync_engine.py` green**. Correct by accident, guarded by nothing.

The watchdog side is already properly guarded (`tests/test_sync_watchdog_outcome_classification.py`) — verified by mutation, see below.

## Changes

- **`tests/test_log_upload_failure_severity.py` (new)** — 6 tests driving the real `_send_heartbeat` -> `_upload_requested_logs` path with a stubbed transport, asserting on what the error reporter actually captured rather than on forwarded mock args.
- **`src/sync/http_client.py`** — comment-only. It described `_DO_SYNC_DEADLINE` as 120s in the present tense; it has been 150s since #151. The budget guards in `tests/test_sync_watchdog_budget.py` read the constant dynamically and were unaffected.

## Evidence

**Guard watched failing** (`test-fixture-discipline.md` Phantom 5), against the committed tree so restore is index-safe:

```
# mutant: _report_upload_failure level warning -> error
tests/test_log_upload_failure_severity.py ... 3 failed, 3 passed
  FAILED test_unreachable_api_reports_the_upload_failure_as_warning
  FAILED test_unreachable_api_emits_no_error_level_report_at_all
  FAILED test_a_5xx_upload_failure_is_also_warning
E   AssertionError: [{'fingerprint': 'log-upload-failed', 'level': 'error',
     'message': 'Agent log upload failed: upload POST failed: Cannot connect to BetterFlow API'}]

# same mutant, pre-existing suite — proves the gap was real
tests/test_sync_engine.py ... 115 passed
```

The 3 orthogonal cases (auth passthrough, cycle-not-broken, happy-path negative control) correctly stay green under the mutant — only the defect-specific assertions move.

**The watchdog's existing guard is also witnessed** — mutating its `warning` to `error` reddens `test_overrun_with_transient_failures_reports_warning`.

**CI run locally** (Actions is cost-capped off org-wide; a PR with zero checks still reports green):

- `build.yml` **test** job, verbatim `pytest tests/ -v --tb=short` -> **1558 passed, 1 skipped**, exit 0. Baseline on `origin/main` was 1552 + 1 skipped; +6 matches the 6 tests added.
- `build.yml` **build** job — gated to `refs/tags/v*` / `workflow_dispatch`, so not triggered by this PR. **No release triggered.**
- `verify-tracker-pins.yml` — `push` trigger is paths-filtered to `aw_manager.py` / `test_aw_manager_asset_integrity.py` / `verify_tracker_pins.py`; this diff touches none, and it has no `pull_request` trigger.
- `sync-downloads.yml` — `release: published` only; the deploy workflow, not applicable.
- `ruff` (not in CI): new test file clean. `http_client.py` reports 8 findings that are byte-identical on `origin/main` — pre-existing, left alone.

Caveat: run on macOS arm64 / Python 3.11.15; CI runs ubuntu / 3.11.

## On the 150s threshold

Leaving it at 150s. The worst-case *legitimate* cycle is `_CYCLE_NETWORK_BUDGET_SECONDS` (50s) + one retry chain (3 attempts x 30s timeout + up to 3.75s jitter, ~94s) = **~144s**, so the margin is only ~6s — which is exactly why the observed incident was 150.86s, 0.86s over. That margin is deliberate (`sync_engine.py:3360` documents capping the cycle at one surviving chain), and the consequence of crossing it is already the correct one: a `warning`, not a page, with `_SYNC_WEDGE_CEILING` (420s) still catching a real wedge. Raising the deadline would delay the post-sleep pooled-connection reset that is the watchdog's original purpose, to suppress an event that is already correctly classified.

## Recommendation

**Close both bugs as working-as-intended.** They are warning-level telemetry describing handled, self-healing conditions. The remaining noise is that warning-level events are being auto-filed as bugs at all — that is a filing-threshold question for the monitoring bot, not a defect in this repo.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
