### PR TITLE
fix(sync): cross a multi-day backlog gap in one sync cycle

### DIFF
--- a/src/sync/sync_engine.py
+++ b/src/sync/sync_engine.py
@@ -223,6 +223,14 @@ class SyncEngine:
     # ~4 days of history per cycle; the checkpoint persists each skip, so the
     # walk resumes where it left off.
     _BACKLOG_MAX_EMPTY_WINDOWS_PER_CYCLE = 48
+    # Wall-clock budget for that walk, per bucket. The iteration cap alone does
+    # not bound TIME: a degraded-but-answering local AW server can take up to
+    # the client's 10s timeout per probe without raising, and 48 probes x 4
+    # backlogged buckets would blow the 150s sync watchdog deadline (false
+    # "Sync hung" ERROR) and even the 420s wedge ceiling (concurrent cycles).
+    # Healthy probes run ~5ms, so this never triggers in the normal case; when
+    # it does, progress is already persisted and the next cycle resumes.
+    _BACKLOG_WALK_BUDGET_SECONDS = 5.0
 
     def __init__(
         self,
@@ -1864,10 +1872,12 @@ class SyncEngine:
         # loses no progress — the next cycle resumes from the last empty span.
         new_events = [e for e in events if e.timestamp > checkpoint]
         empty_windows_skipped = 0
+        walk_deadline = time.monotonic() + self._BACKLOG_WALK_BUDGET_SECONDS
         while (
             not new_events
             and fetch_end < now
             and empty_windows_skipped < self._BACKLOG_MAX_EMPTY_WINDOWS_PER_CYCLE
+            and time.monotonic() < walk_deadline
         ):
             self.queue.set_checkpoint_forward(bucket_id, fetch_end)
             checkpoint = fetch_end

--- a/src/sync/sync_engine.py
+++ b/src/sync/sync_engine.py
@@ -215,6 +215,14 @@ class SyncEngine:
     # (~300 input/h), so the slice keeps the true oldest events.
     _BACKLOG_WINDOW = timedelta(hours=2)
     _BACKLOG_FETCH_LIMIT = 1000
+    # How many consecutive EMPTY backlog windows one cycle may skip. Each probe
+    # is a cheap local AW query, so a weekend/overnight gap is crossed inside a
+    # single cycle (48 x ~2h ~= 4 days) instead of one window per 60s cycle —
+    # which left the dashboard graph empty for ~30 min every Monday morning
+    # (device 14, 2026-08-03). Bounded so a months-parked device probes at most
+    # ~4 days of history per cycle; the checkpoint persists each skip, so the
+    # walk resumes where it left off.
+    _BACKLOG_MAX_EMPTY_WINDOWS_PER_CYCLE = 48
 
     def __init__(
         self,
@@ -1846,9 +1854,33 @@ class SyncEngine:
         # the checkpoint so an idle gap can't pin the cursor. In steady state
         # (fetch_end == now) the jump never fires, so the lookback's heartbeat-
         # grown re-send is preserved.
+        # Walk ALL consecutive empty windows inside this cycle (bounded), not
+        # one per cycle: a provably-empty span is safe to skip immediately, and
+        # skipping it at one window per 60s cycle left a weekend-sized gap
+        # uncrossed for ~30 minutes after Monday-morning startup while only the
+        # afk heartbeat reached the server (device 14, 2026-08-03). Each skip
+        # persists via set_checkpoint_forward, so an AWClientError mid-walk (it
+        # propagates to _sync_window_buckets' handler) or the per-cycle cap
+        # loses no progress — the next cycle resumes from the last empty span.
         new_events = [e for e in events if e.timestamp > checkpoint]
-        if not new_events and fetch_end < now:
+        empty_windows_skipped = 0
+        while (
+            not new_events
+            and fetch_end < now
+            and empty_windows_skipped < self._BACKLOG_MAX_EMPTY_WINDOWS_PER_CYCLE
+        ):
             self.queue.set_checkpoint_forward(bucket_id, fetch_end)
+            checkpoint = fetch_end
+            lookback_start = checkpoint - timedelta(minutes=2)
+            fetch_end = min(now, lookback_start + self._BACKLOG_WINDOW)
+            events = self.aw.get_events(
+                bucket_id, start=lookback_start, end=fetch_end, limit=self._BACKLOG_FETCH_LIMIT
+            )
+            events.sort(key=lambda e: e.timestamp)
+            new_events = [e for e in events if e.timestamp > checkpoint]
+            empty_windows_skipped += 1
+        if not new_events and fetch_end < now:
+            # Cap reached with the span still empty — resume next cycle.
             return [], lookback_start
 
         if len(events) > self.config.sync.batch_size:

--- a/tests/test_sync_engine_idle_gap_pin.py
+++ b/tests/test_sync_engine_idle_gap_pin.py
@@ -177,3 +177,125 @@ def test_empty_window_walk_is_bounded_per_cycle():
         )
     finally:
         engine.queue.close()
+
+
+def test_walk_stops_at_mid_gap_event_cluster():
+    """The walk must STOP at the first non-empty window, not blind-skip to the
+    newest activity. A Saturday work blip inside a Fri->Mon gap is real billable
+    time; skipping past it persists the checkpoint beyond it (monotonic), and
+    _reconcile_backlog only replays local-midnight->now — the blip would be
+    unrecoverable."""
+    tmp = Path(tempfile.mkdtemp())
+    now = datetime.now(timezone.utc)
+    tail = now - timedelta(hours=49)      # Friday evening
+    blip = now - timedelta(hours=35)      # Saturday afternoon blip
+    resume = now - timedelta(minutes=30)  # Monday morning
+
+    events = [AWEvent(id=1, timestamp=tail, duration=10.0, data={"app": "Terminal"})]
+    events += [
+        AWEvent(id=50 + i, timestamp=blip + timedelta(seconds=30 * i),
+                duration=10.0, data={"app": "Terminal"})
+        for i in range(3)
+    ]
+    events += [
+        AWEvent(id=100 + i, timestamp=resume + timedelta(seconds=30 * i),
+                duration=10.0, data={"app": "Terminal"})
+        for i in range(3)
+    ]
+    aw = _aw_serving(events)
+    engine = _engine(tmp, aw)
+    try:
+        engine.queue.set_checkpoint(BUCKET, tail)
+
+        batch, _lb = engine._fetch_bucket_events(BUCKET, SyncStats())
+
+        got = {e.id for e in batch}
+        assert {50, 51, 52} <= got, (
+            f"mid-gap Saturday events were skipped (batch ids: {sorted(got)})"
+        )
+        assert not {100, 101, 102} & got, (
+            "walk overshot the first non-empty window to Monday's events"
+        )
+        assert engine.queue.get_checkpoint(BUCKET) < blip, (
+            "checkpoint persisted past an unfetched mid-gap cluster"
+        )
+    finally:
+        engine.queue.close()
+
+
+def test_error_mid_walk_keeps_per_skip_progress():
+    """Each skipped window persists BEFORE the next probe, so a probe that
+    errors at window N leaves the checkpoint N windows forward. Persisting only
+    at loop exit would re-walk (and re-fail) the same span every cycle —
+    reincarnating the stall this fix exists to cure."""
+    from src.sync.aw_client import AWClientError
+
+    tmp = Path(tempfile.mkdtemp())
+    now = datetime.now(timezone.utc)
+    tail = now - timedelta(days=30)
+
+    calls = {"n": 0}
+
+    def get_events(bucket_id, start=None, end=None, limit=1000):
+        calls["n"] += 1
+        if calls["n"] >= 4:  # initial probe + 3 loop probes, then the AW dies
+            raise AWClientError("aw went away mid-walk")
+        e = AWEvent(id=1, timestamp=tail, duration=10.0, data={"app": "Terminal"})
+        return [e] if (start is None or e.timestamp >= start) and (end is None or e.timestamp < end) else []
+
+    aw = Mock()
+    aw.get_events.side_effect = get_events
+    engine = _engine(tmp, aw)
+    try:
+        engine.queue.set_checkpoint(BUCKET, tail)
+
+        try:
+            engine._fetch_bucket_events(BUCKET, SyncStats())
+        except AWClientError:
+            pass  # propagates to the per-bucket handler in _sync_window_buckets
+
+        cp = engine.queue.get_checkpoint(BUCKET)
+        # 3 completed skips of ~1h58m each were persisted before the failing probe.
+        assert cp >= tail + timedelta(hours=5), (
+            f"progress before the failing probe was lost (cp={cp.isoformat()})"
+        )
+        assert cp <= tail + timedelta(hours=8), f"overshot past the failure point (cp={cp.isoformat()})"
+    finally:
+        engine.queue.close()
+
+
+def test_walk_wall_clock_budget_bounds_slow_probes():
+    """The iteration cap bounds probes, not time: a degraded local AW server can
+    take seconds per probe without raising. The walk must also stop at
+    _BACKLOG_WALK_BUDGET_SECONDS so one bucket cannot eat the sync watchdog's
+    150s deadline."""
+    from unittest.mock import patch
+
+    tmp = Path(tempfile.mkdtemp())
+    now = datetime.now(timezone.utc)
+    tail = now - timedelta(days=30)
+
+    aw = _aw_serving([AWEvent(id=1, timestamp=tail, duration=10.0, data={"app": "Terminal"})])
+    engine = _engine(tmp, aw)
+    try:
+        engine.queue.set_checkpoint(BUCKET, tail)
+
+        # Each monotonic() read advances 3 "seconds": deadline = t+5, so the
+        # loop's second condition check reads past the deadline after ~2 skips.
+        t = {"v": 1000.0}
+
+        def fake_monotonic():
+            t["v"] += 3.0
+            return t["v"]
+
+        with patch("src.sync.sync_engine.time.monotonic", side_effect=fake_monotonic):
+            batch, _lb = engine._fetch_bucket_events(BUCKET, SyncStats())
+
+        cp = engine.queue.get_checkpoint(BUCKET)
+        assert batch == []
+        assert cp > tail, "walk never ran"
+        assert cp <= tail + timedelta(hours=10), (
+            f"slow-probe walk was not time-bounded (cp={cp.isoformat()})"
+        )
+    finally:
+        engine.queue.close()

--- a/tests/test_sync_engine_idle_gap_pin.py
+++ b/tests/test_sync_engine_idle_gap_pin.py
@@ -111,3 +111,69 @@ def test_post_gap_events_are_eventually_fetched():
         assert engine.queue.get_checkpoint(BUCKET) >= resume
     finally:
         engine.queue.close()
+
+
+def test_multi_day_gap_crossed_in_single_cycle():
+    """A weekend-sized gap must be crossed within ONE _fetch_bucket_events call.
+
+    Incident (PiratesMac / device 14, 2026-08-03): the gap-jump fix above works
+    but advanced only one _BACKLOG_WINDOW (2h) per 60s sync cycle, so a Monday
+    morning after a ~24h weekend gap spent ~30 minutes uploading nothing but the
+    afk heartbeat — empty dashboard graph, "--:--" Arrival, and an
+    active_seconds=0 "Unknown" aggregate until the walker caught up. Consecutive
+    EMPTY windows are provably safe to skip, so they must all be walked inside
+    the same cycle."""
+    tmp = Path(tempfile.mkdtemp())
+    now = datetime.now(timezone.utc)
+    tail = now - timedelta(hours=49)        # Fri evening -> Mon morning gap
+    resume = now - timedelta(minutes=30)    # Monday work has begun
+
+    events = [AWEvent(id=1, timestamp=tail, duration=10.0, data={"app": "Terminal"})]
+    events += [
+        AWEvent(id=100 + i, timestamp=resume + timedelta(seconds=30 * i),
+                duration=10.0, data={"app": "Terminal"})
+        for i in range(3)
+    ]
+    aw = _aw_serving(events)
+    engine = _engine(tmp, aw)
+    try:
+        engine.queue.set_checkpoint(BUCKET, tail)
+
+        batch, _lb = engine._fetch_bucket_events(BUCKET, SyncStats())
+
+        assert [e for e in batch if e.timestamp >= resume], (
+            "one cycle crossed only one empty window — post-gap events would "
+            "wait ~1 min per 2h of gap before first upload"
+        )
+    finally:
+        engine.queue.close()
+
+
+def test_empty_window_walk_is_bounded_per_cycle():
+    """The in-cycle walk must stop at _BACKLOG_MAX_EMPTY_WINDOWS_PER_CYCLE so a
+    months-parked device cannot stall a sync cycle probing its whole history at
+    once. Progress persists via the checkpoint, so the next cycle resumes."""
+    tmp = Path(tempfile.mkdtemp())
+    now = datetime.now(timezone.utc)
+    tail = now - timedelta(days=30)  # long-parked device, nothing since
+
+    aw = _aw_serving([AWEvent(id=1, timestamp=tail, duration=10.0, data={"app": "Terminal"})])
+    engine = _engine(tmp, aw)
+    try:
+        engine.queue.set_checkpoint(BUCKET, tail)
+
+        batch, _lb = engine._fetch_bucket_events(BUCKET, SyncStats())
+        cp = engine.queue.get_checkpoint(BUCKET)
+
+        assert batch == []
+        # Loop ran: the cap's worth of windows was crossed in one cycle
+        # (48 windows x ~1h58m net advance each ~= 94h).
+        assert cp >= tail + timedelta(hours=90), (
+            f"walk did not run inside the cycle (cp={cp.isoformat()})"
+        )
+        # Cap held: the 30-day span was NOT consumed in one cycle.
+        assert cp < now - timedelta(days=20), (
+            f"walk was unbounded within a single cycle (cp={cp.isoformat()})"
+        )
+    finally:
+        engine.queue.close()


### PR DESCRIPTION
## What

After an overnight or weekend gap, the sync engine advanced past the empty span at one 2-hour backlog window per 60-second cycle. A Monday morning start therefore spent about 30 minutes uploading nothing but the afk heartbeat: empty dashboard graph, no Arrival time, and an active_seconds=0 "Unknown" aggregate until the walker caught up. Observed live on device 14 on 2026-08-03 (all 138 window+input events for the morning landed in a single batch at 05:06 UTC, 32 minutes after boot). Same surface as the 2026-06-23 checkpoint-pin incident; that fix made the walk correct but left it slow.

`_fetch_bucket_events` now walks all consecutive provably-empty windows inside the same cycle, bounded two ways:

- `_BACKLOG_MAX_EMPTY_WINDOWS_PER_CYCLE = 48` (about 4 days of gap per cycle) so a months-parked device cannot probe its whole history at once
- `_BACKLOG_WALK_BUDGET_SECONDS = 5.0` wall-clock, because the iteration cap alone does not bound time when the local AW server is degraded-but-answering (up to 10s per probe without raising; 48 probes x 4 buckets would blow the 150s sync watchdog and the 420s wedge ceiling)

Every skip persists through the monotonic `set_checkpoint_forward` before the next probe, so an error mid-walk or either cap loses no progress; the next cycle resumes where the walk stopped.

## Proof of failure

`test_multi_day_gap_crossed_in_single_cycle` and `test_empty_window_walk_is_bounded_per_cycle` both FAILED against the pre-fix engine (one call advanced the checkpoint exactly one window, tail+1h58m, and returned no post-gap events); both pass post-fix. The two pre-existing gap-pin tests pass before and after, pinning the base behaviour.

## Review

Adversarial refutation review ran on the branch diff. No Critical findings. Both Important findings are fixed in the second commit:

1. Wall-clock unbounded walk under a slow local AW server (now bounded by the 5s budget, with a test that mocks `time.monotonic`)
2. Test gap: a blind-skip implementation (skip 48 windows, probe once at the end) passed the original suite while permanently dropping a mid-gap Saturday activity cluster; `test_walk_stops_at_mid_gap_event_cluster` and `test_error_mid_walk_keeps_per_skip_progress` now pin walk-stops-at-first-non-empty-window and persist-before-probe

Optional (logged, not fixed): an event timestamped exactly on a skip boundary is invisible (pre-existing, identical arithmetic pre-fix, needs a microsecond-exact coincidence); the walk performs up to 49 probes while the constant names 48 windows (initial probe uncounted, cosmetic).

## Verification

- Full suite locally (CI is org cost-capped): 1563 passed, 1 skipped, exit 0. Baseline on origin/main was 1558; the delta is exactly the 5 tests this branch adds.
- Mutation matrix, each mechanism reddens a distinct named test, control green: cap=1 -> single-cycle test; cap unbounded -> bounded-walk test; budget removed -> wall-clock test; blind skip -> mid-gap test; late persist -> error-progress test.

## Rollout note

This repo ships to the fleet via tagged releases (agent auto-update). Merging this PR does not deploy anything by itself; the fix reaches devices with the next release tag. Tagging also triggers the installer build workflow, which spends the capped CI budget, so that call is left to a human.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PeNjqeggCMpbkfyFHjdkRF