### PR TITLE
fix(sync): cross a multi-day empty backlog gap in one cycle, not one 2h window per cycle

### DIFF
--- a/src/sync/sync_engine.py
+++ b/src/sync/sync_engine.py
@@ -215,6 +215,14 @@ class SyncEngine:
     # (~300 input/h), so the slice keeps the true oldest events.
     _BACKLOG_WINDOW = timedelta(hours=2)
     _BACKLOG_FETCH_LIMIT = 1000
+    # An EMPTY span (weekend, leave) is walked window-by-window INSIDE one
+    # cycle, not one window per cycle — at one 2h step per 60s cycle a 62h
+    # weekend takes ~31 min, during which the morning's window/input events sit
+    # captured-but-unsent and the server's 15-min window-ingest-stall alert
+    # fires (device 14, 2026-08-03). Each empty step is one cheap local AW
+    # query; the cap bounds a cycle when the checkpoint is ancient (64 × 2h =
+    # ~5.3 days per cycle, so any realistic gap clears in 1-2 cycles).
+    _EMPTY_GAP_MAX_WINDOWS_PER_CYCLE = 64
 
     def __init__(
         self,
@@ -1847,8 +1855,30 @@ class SyncEngine:
         # (fetch_end == now) the jump never fires, so the lookback's heartbeat-
         # grown re-send is preserved.
         new_events = [e for e in events if e.timestamp > checkpoint]
-        if not new_events and fetch_end < now:
+        # Walk consecutive empty windows within THIS cycle (each is one local AW
+        # query) so a multi-day empty span is crossed in seconds, not one window
+        # per 60s cycle. The checkpoint advances per step, so an interrupted walk
+        # resumes where it left off; the per-cycle cap keeps an ancient
+        # checkpoint from turning one cycle into thousands of fetches.
+        empty_steps = 0
+        while (
+            not new_events
+            and fetch_end < now
+            and empty_steps < self._EMPTY_GAP_MAX_WINDOWS_PER_CYCLE
+        ):
+            empty_steps += 1
             self.queue.set_checkpoint_forward(bucket_id, fetch_end)
+            checkpoint = fetch_end
+            lookback_start = fetch_end
+            fetch_end = min(now, lookback_start + self._BACKLOG_WINDOW)
+            events = self.aw.get_events(
+                bucket_id, start=lookback_start, end=fetch_end, limit=self._BACKLOG_FETCH_LIMIT
+            )
+            events.sort(key=lambda e: e.timestamp)
+            new_events = [e for e in events if e.timestamp > checkpoint]
+        if not new_events and fetch_end < now:
+            # Cap reached mid-gap — the next cycle resumes from the advanced
+            # checkpoint.
             return [], lookback_start
 
         if len(events) > self.config.sync.batch_size:

--- a/tests/test_sync_engine_idle_gap_pin.py
+++ b/tests/test_sync_engine_idle_gap_pin.py
@@ -111,3 +111,73 @@ def test_post_gap_events_are_eventually_fetched():
         assert engine.queue.get_checkpoint(BUCKET) >= resume
     finally:
         engine.queue.close()
+
+
+def test_multi_day_gap_crossed_in_single_cycle():
+    """A weekend-sized EMPTY gap must be crossed inside ONE fetch call.
+
+    Advancing one _BACKLOG_WINDOW (2h) per 60s sync cycle crosses a 62h weekend
+    in ~31 cycles = ~31 minutes, during which the morning's window/input events
+    sit captured-but-unsent and the server's 15-min window-ingest-stall alert
+    fires (device 14, 2026-08-03 — every Monday, every device with a weekend
+    gap). The empty-window walk must happen inside the cycle, not across cycles.
+    """
+    tmp = Path(tempfile.mkdtemp())
+    now = datetime.now(timezone.utc)
+    tail = now - timedelta(hours=62)        # Friday-evening pre-weekend tail
+    resume = now - timedelta(minutes=10)    # Monday-morning work
+
+    events = [AWEvent(id=1, timestamp=tail, duration=10.0, data={"app": "Terminal"})]
+    events += [
+        AWEvent(id=100 + i, timestamp=resume + timedelta(seconds=30 * i),
+                duration=10.0, data={"app": "Terminal"})
+        for i in range(3)
+    ]
+    aw = _aw_serving(events)
+    engine = _engine(tmp, aw)
+    try:
+        engine.queue.set_checkpoint(BUCKET, tail)
+
+        batch, _lb = engine._fetch_bucket_events(BUCKET, SyncStats())
+
+        post_gap = [e for e in batch if e.timestamp >= resume]
+        assert post_gap, (
+            "one fetch cycle returned no post-gap events — the empty weekend "
+            "span is being crossed one 2h window per cycle, stalling upload "
+            "~31 min and tripping the server's window-ingest-stall alert"
+        )
+    finally:
+        engine.queue.close()
+
+
+def test_empty_gap_walk_is_bounded_per_cycle():
+    """The in-cycle walk must terminate after a bounded number of empty windows
+    (each is a local HTTP call), resuming from the advanced checkpoint next
+    cycle — an ancient checkpoint must not turn one cycle into thousands of
+    fetches."""
+    tmp = Path(tempfile.mkdtemp())
+    now = datetime.now(timezone.utc)
+    tail = now - timedelta(days=400)
+
+    aw = _aw_serving([])  # nothing to find, ever
+    engine = _engine(tmp, aw)
+    try:
+        engine.queue.set_checkpoint(BUCKET, tail)
+
+        batch, _lb = engine._fetch_bucket_events(BUCKET, SyncStats())
+
+        assert batch == []
+        cp = engine.queue.get_checkpoint(BUCKET)
+        max_walk = (
+            engine._EMPTY_GAP_MAX_WINDOWS_PER_CYCLE * engine._BACKLOG_WINDOW
+            + engine._BACKLOG_WINDOW  # the pre-loop first window
+        )
+        assert cp > tail, "cursor did not advance at all"
+        assert cp <= tail + max_walk, (
+            f"cursor advanced {(cp - tail)} in one cycle — the per-cycle bound "
+            "on empty-window fetches is not being enforced"
+        )
+        # And the number of AW round-trips this cycle is the bound, not the gap size.
+        assert aw.get_events.call_count <= engine._EMPTY_GAP_MAX_WINDOWS_PER_CYCLE + 1
+    finally:
+        engine.queue.close()


### PR DESCRIPTION
## The bug

After a weekend, the window/input bucket checkpoints sit ~62h behind. The empty-window gap-jump in `_fetch_bucket_events` advanced only ONE `_BACKLOG_WINDOW` (2h) per 60s sync cycle, so crossing the weekend took ~31 cycles = **~31 minutes** during which the morning's window/input events were captured locally but never uploaded. The AFK checkpoint isn't pinned, so billing kept flowing — but the server (correctly) fired the `window_ingest_stalled` / app-attribution-gap alert. This hits **every device with a weekend gap, every Monday**.

## Live evidence (device 14, 2026-08-03)

- Agent log: `1 sent` (the AFK event) every cycle 07:36–08:05 EAT, then a **139-event flush at 08:06:44** — exactly 30 min after start.
- Prod `agent_events`: the morning's window rows all have `created_at` 05:06:39–05:08:39 UTC while their `event_timestamp` starts at 04:34 UTC.
- First upload of the day carried a Jul-31 14:40 tail — the pinned checkpoint.

## The fix

Walk consecutive empty windows **inside** one `_fetch_bucket_events` call (each step is one local AW query; the checkpoint advances per step so an interrupted walk resumes), capped at `_EMPTY_GAP_MAX_WINDOWS_PER_CYCLE = 64` (~5.3 days/cycle) so an ancient checkpoint can't turn one cycle into thousands of fetches.

## Proof-of-failure handshake

- `test_multi_day_gap_crossed_in_single_cycle`: **failed pre-fix** (`batch` was `[]` — the single jump advanced only 2h into a 62h gap), passes post-fix.
- `test_empty_gap_walk_is_bounded_per_cycle`: **failed pre-fix** (cap didn't exist), passes post-fix; also asserts AW round-trips per cycle ≤ cap+1.
- The two pre-existing idle-gap-pin tests pass before and after (they pin correct behaviour, not this defect).
- Full suite: **1560 passed, 1 skipped** (CI runs pytest only; ruff findings on these files are pre-existing on main, verified via stash baseline).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PutE4XEaZQu7YMBF9bUdnF