### PR TITLE
fix(watchdog): say how long an overrunning sync cycle actually ran

### DIFF
--- a/docs/superpowers/plans/2026-08-10-watchdog-overrun-duration.md
+++ b/docs/superpowers/plans/2026-08-10-watchdog-overrun-duration.md
@@ -1,0 +1,933 @@
+# Watchdog Overrun Duration and Phase — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make a watchdog overrun say how long the cycle actually ran and which stage it was in, so issue #179's "how many of the 34 are genuinely wedged versus merely over the line" becomes answerable from the daily digest.
+
+**Architecture:** `_do_sync` stamps a start time and a per-cycle phase box. In `finally`, if elapsed reached the deadline, it emits one extra `warning` report whose *fingerprint* encodes a severity band — because the ingest aggregates by fingerprint and by nothing else, so a bucket count is the only measurement that survives. The two existing fire-time reports gain the phase in `context` but keep their fingerprints and levels unchanged.
+
+**Tech Stack:** Python 3, pytest, `unittest.mock`. No new dependencies.
+
+**Spec:** `docs/superpowers/specs/2026-08-10-watchdog-overrun-duration-design.md`
+
+## Global Constraints
+
+- **Do not change `_DO_SYNC_DEADLINE` (150).** This is measurement, not tuning. The issue and the task brief both forbid raising it to silence the alert.
+- **Do not change `_SYNC_WEDGE_CEILING` (420)** or the `sync-wedged` fingerprint/level.
+- **Do not change the two existing fire-time fingerprints or their levels** — `sync-watchdog-timeout` (`error`) and `sync-watchdog-timeout-offline` (`warning`). The existing 34-occurrence group must stay continuous across this change. Adding `context` to them is permitted; changing `message`, `level` or `fingerprint` is not.
+- **All new outcome reports are `level="warning"`.** The fire-time report already paged this cycle at 150s as `error`.
+- **`tags={"component": "sync-watchdog"}`** on every new capture, matching the existing two.
+- Work happens in the worktree `/Users/brad/Code2/betterflow-sync-watchdog` on branch `feat/watchdog-overrun-duration`. Do not touch the primary checkout at `/Users/brad/Code2/betterflow-sync`.
+- Run tests with `PYTHONPATH=. python3 -m pytest` from the worktree root.
+- `tests/test_sync_watchdog_budget.py` and `tests/test_sync_watchdog_outcome_classification.py` must stay green after every task.
+- Python: 4-space indent. Conventional Commits. Never `git add -A` — stage explicit paths only.
+
+---
+
+### Task 1: The pure severity-band function
+
+The bands are expressed as **multiples of the deadline**, not absolute seconds. Two reasons, both concrete: the deadline has already moved once (120s → 150s) and absolute bands would have silently become wrong; and `tests/test_sync_watchdog_outcome_classification.py` shrinks the deadline to 0.3s via an instance override, so absolute bands would collapse every test cycle into the first bucket and the other two would be unreachable without a 300-second sleep.
+
+Keeping it a pure module-level function is what makes the boundaries testable exactly. A timed cycle cannot land on 1.2× reliably; a unit test can.
+
+**Files:**
+- Modify: `src/main.py` (add module-level constants and function above the `SyncCoordinator` class)
+- Test: `tests/test_watchdog_overrun_bands.py` (create)
+
+**Interfaces:**
+- Consumes: nothing from earlier tasks.
+- Produces: `_overrun_fingerprint(elapsed: float, deadline: float) -> str`, returning one of exactly three strings: `"sync-watchdog-overrun-marginal"`, `"sync-watchdog-overrun-moderate"`, `"sync-watchdog-overrun-severe"`. Task 3 calls this.
+
+- [ ] **Step 1: Write the failing test**
+
+Create `tests/test_watchdog_overrun_bands.py`:
+
+```python
+"""Severity bands for a watchdog overrun.
+
+The ingest (betterqa-bot) aggregates error reports by fingerprint and by
+nothing else — `context` is overwritten newest-wins per fingerprint and the
+daily digest reads only `message` + `occurrences`. So the ONLY way an elapsed
+time becomes countable is by riding in the fingerprint. These bands are that
+mechanism.
+
+Bands are multiples of the deadline rather than absolute seconds: the deadline
+has moved once already (120s -> 150s), and the watchdog integration tests
+shrink it to sub-second, which would collapse absolute bands into one bucket.
+
+Boundaries are tested here, exactly, because a timed cycle cannot land on 1.2x
+reliably.
+"""
+
+import pytest
+
+from src.main import _overrun_fingerprint
+
+MARGINAL = "sync-watchdog-overrun-marginal"
+MODERATE = "sync-watchdog-overrun-moderate"
+SEVERE = "sync-watchdog-overrun-severe"
+
+
+@pytest.mark.parametrize(
+    "elapsed,expected",
+    [
+        # At the deadline exactly — the smallest possible overrun.
+        (150.0, MARGINAL),
+        (151.2, MARGINAL),
+        (179.9, MARGINAL),
+        # 1.2x boundary: BELONGS TO moderate, not marginal. Both ends of the
+        # range get a case (diagnosis-discipline.md Rule 3).
+        (180.0, MODERATE),
+        (246.0, MODERATE),
+        (299.9, MODERATE),
+        # 2.0x boundary: belongs to severe.
+        (300.0, SEVERE),
+        (903.4, SEVERE),
+        (5000.0, SEVERE),
+    ],
+)
+def test_bands_at_the_production_deadline(elapsed, expected):
+    assert _overrun_fingerprint(elapsed, 150.0) == expected
+
+
+@pytest.mark.parametrize(
+    "elapsed,expected",
+    [
+        (0.30, MARGINAL),
+        (0.35, MARGINAL),
+        (0.36, MODERATE),
+        (0.45, MODERATE),
+        (0.60, SEVERE),
+        (0.90, SEVERE),
+    ],
+)
+def test_bands_scale_with_a_shrunk_deadline(elapsed, expected):
+    """The property that makes the integration tests possible at all."""
+    assert _overrun_fingerprint(elapsed, 0.3) == expected
+
+
+def test_returns_exactly_three_distinct_fingerprints():
+    """A band that silently aliases another would make two counts one count."""
+    produced = {
+        _overrun_fingerprint(e, 150.0) for e in (150.0, 200.0, 400.0)
+    }
+    assert produced == {MARGINAL, MODERATE, SEVERE}
+
+
+def test_nonpositive_deadline_does_not_divide_by_zero():
+    """Defensive only: a zero deadline is not reachable in production, but a
+    ZeroDivisionError here would escape into _do_sync's finally block and mask
+    whatever real failure the cycle was already reporting."""
+    assert _overrun_fingerprint(10.0, 0.0) == SEVERE
+    assert _overrun_fingerprint(10.0, -1.0) == SEVERE
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `PYTHONPATH=. python3 -m pytest tests/test_watchdog_overrun_bands.py -v`
+
+Expected: FAIL at collection — `ImportError: cannot import name '_overrun_fingerprint' from 'src.main'`.
+
+- [ ] **Step 3: Write minimal implementation**
+
+In `src/main.py`, insert immediately **above** the `class SyncCoordinator` declaration (find it with `grep -n "^class SyncCoordinator" src/main.py`):
+
+```python
+# Watchdog overrun severity bands, as multiples of _DO_SYNC_DEADLINE.
+#
+# Ratios rather than absolute seconds, for two reasons. The deadline has moved
+# once already (120s -> 150s) and absolute bands would have quietly become
+# wrong. And the watchdog tests shrink the deadline to sub-second, where
+# absolute bands would put every test cycle in the first bucket and leave the
+# other two unreachable without a five-minute sleep.
+#
+# The band rides in the FINGERPRINT because that is the only thing the ingest
+# aggregates: betterqa-bot stores `context` but overwrites it newest-wins per
+# fingerprint, and the daily digest selects message + occurrences only. An
+# elapsed time in `context` alone would survive one occurrence and appear in no
+# report; a band in the fingerprint turns the occurrence counter into the
+# distribution.
+_OVERRUN_BANDS = (
+    (1.2, "sync-watchdog-overrun-marginal"),
+    (2.0, "sync-watchdog-overrun-moderate"),
+)
+_OVERRUN_BAND_SEVERE = "sync-watchdog-overrun-severe"
+
+
+def _overrun_fingerprint(elapsed: float, deadline: float) -> str:
+    """Dedup key for a cycle that ran `elapsed` against `deadline`.
+
+    Upper bounds are exclusive, so exactly 1.2x is moderate and exactly 2.0x is
+    severe. Callers must only reach here when elapsed >= deadline.
+    """
+    if deadline <= 0:
+        return _OVERRUN_BAND_SEVERE
+    ratio = elapsed / deadline
+    for limit, fingerprint in _OVERRUN_BANDS:
+        if ratio < limit:
+            return fingerprint
+    return _OVERRUN_BAND_SEVERE
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `PYTHONPATH=. python3 -m pytest tests/test_watchdog_overrun_bands.py -v`
+
+Expected: PASS, 19 passed.
+
+- [ ] **Step 5: Verify the boundary assertions are load-bearing**
+
+Change `ratio < limit` to `ratio <= limit` in `src/main.py`, then run the same command.
+
+Expected: FAIL — specifically `test_bands_at_the_production_deadline[180.0-...moderate]` and `[300.0-...severe]` go red, because 180.0 would become marginal and 300.0 would become moderate.
+
+Then revert that one character back to `<` and re-run. Expected: PASS again.
+
+If the suite stayed green with `<=`, the boundary cases are not witnessing anything — stop and fix the test before continuing.
+
+- [ ] **Step 6: Commit**
+
+```bash
+cd /Users/brad/Code2/betterflow-sync-watchdog
+git add src/main.py tests/test_watchdog_overrun_bands.py
+git commit -m "feat(watchdog): severity bands for a cycle that overran its deadline
+
+Pure function, ratios of the deadline rather than absolute seconds so the
+bands survive the deadline moving (120s -> 150s once already) and so tests
+can shrink it. Boundaries are exclusive upper bounds, witnessed by flipping
+< to <= and watching the 180.0 and 300.0 cases redden.
+
+Not yet wired into _do_sync."
+```
+
+---
+
+### Task 2: Per-cycle phase tracking
+
+**Files:**
+- Modify: `src/main.py:1554-1758` (`_do_sync`), plus a small class above `class SyncCoordinator`
+- Test: `tests/test_watchdog_cycle_phase.py` (create)
+
+**Interfaces:**
+- Consumes: nothing from Task 1.
+- Produces: `_CyclePhase` with a single mutable attribute `.name: str`, initialised to `"startup"`. A local named `phase` inside `_do_sync`, captured by the `_watchdog` closure and readable in `finally`. Task 3 reads `phase.name`.
+
+- [ ] **Step 1: Write the failing test**
+
+Create `tests/test_watchdog_cycle_phase.py`:
+
+```python
+"""Which stage was _do_sync in when the watchdog fired.
+
+Coarse by design: the phase is stamped in _do_sync only, so most real overruns
+will report 'sync' because sync_engine.sync() is where the retry chain and the
+send budget live. That still rules OUT the other four stages, at the cost of
+one file instead of instrumenting the ~1000-line sync_engine.sync() on the
+hottest path in the repo.
+
+The phase lives in a per-cycle box rather than on the coordinator: a cycle
+abandoned by _acquire_sync_slot's takeover keeps running, and an instance
+attribute would let that zombie overwrite its successor's phase.
+"""
+
+import threading
+import time
+from types import SimpleNamespace
+from unittest.mock import Mock
+
+from src.config import Config
+from src.main import SyncCoordinator, _CyclePhase
+from src.reminders import ReminderManager
+from src.sync.sync_engine import SyncEngine
+
+_TEST_DEADLINE = 0.3
+_OVERRUN = 1.2
+
+
+def _ok_stats():
+    return SimpleNamespace(
+        success=True,
+        events_sent=0,
+        events_queued=0,
+        events_filtered=0,
+        gaps_filled=0,
+        errors=[],
+        aw_bucket_fetch_failed=False,
+    )
+
+
+class _Recorder:
+    def __init__(self):
+        self.captures = []
+
+    def capture(self, message, **kwargs):
+        self.captures.append({"message": message, **kwargs})
+
+    def by_fingerprint(self, fingerprint):
+        return [c for c in self.captures if c.get("fingerprint") == fingerprint]
+
+
+class TestCyclePhase:
+    def setup_method(self):
+        self.config = Config()
+        self.aw = Mock()
+        self.aw.is_running.return_value = True
+        self.bf = Mock()
+        self.queue = Mock()
+        self.queue.get_checkpoint.return_value = None
+        self.queue.size.return_value = 0
+        self.queue.is_near_capacity.return_value = False
+        self.sync_engine = Mock(spec=SyncEngine)
+        self.sync_engine.is_paused = False
+        self.sync_engine.is_private = False
+        self.sync_engine.sync.return_value = _ok_stats()
+        self.tray = Mock()
+        self.tray.model = Mock()
+        self.tray.model.lock = threading.RLock()
+        self.aw_manager = Mock()
+        self.aw_manager.is_managing = False
+        self.reminder = Mock(spec=ReminderManager)
+        self.coord = SyncCoordinator(
+            config=self.config,
+            aw=self.aw,
+            bf=self.bf,
+            queue=self.queue,
+            sync_engine=self.sync_engine,
+            tray=self.tray,
+            aw_manager=self.aw_manager,
+            reminder_manager=self.reminder,
+        )
+        self.coord.scheduler = Mock()
+        self.coord.scheduler.running = True
+        self.recorder = _Recorder()
+        self.coord.error_reporter = self.recorder
+        self.coord._fetch_hours_today = Mock(return_value="1:00")
+        self.coord._DO_SYNC_DEADLINE = _TEST_DEADLINE
+
+    def test_a_fresh_box_starts_at_startup(self):
+        assert _CyclePhase().name == "startup"
+
+    def test_overrun_inside_sync_reports_phase_sync(self):
+        def _slow_sync(*_a, **_k):
+            time.sleep(_OVERRUN)
+            return _ok_stats()
+
+        self.sync_engine.sync.side_effect = _slow_sync
+        self.coord._do_sync()
+
+        hung = self.recorder.by_fingerprint("sync-watchdog-timeout")
+        assert len(hung) == 1, self.recorder.captures
+        assert hung[0]["context"]["phase"] == "sync"
+
+    def test_overrun_inside_capture_health_reports_phase_capture_health(self):
+        """The discriminating case: if the stamp were only ever set to 'sync',
+        the test above would pass and this one would not."""
+
+        def _slow_health():
+            time.sleep(_OVERRUN)
+            return True
+
+        self.coord._monitor_capture_health = Mock(side_effect=_slow_health)
+        self.coord._do_sync()
+
+        hung = self.recorder.by_fingerprint("sync-watchdog-timeout")
+        assert len(hung) == 1, self.recorder.captures
+        assert hung[0]["context"]["phase"] == "capture_health"
+
+    def test_existing_fire_time_report_keeps_its_identity(self):
+        """Global constraint: adding context must not move the fingerprint,
+        level or message of the group that already holds 34 occurrences."""
+
+        def _slow_sync(*_a, **_k):
+            time.sleep(_OVERRUN)
+            return _ok_stats()
+
+        self.sync_engine.sync.side_effect = _slow_sync
+        self.coord._do_sync()
+
+        hung = self.recorder.by_fingerprint("sync-watchdog-timeout")
+        assert len(hung) == 1
+        assert hung[0]["level"] == "error"
+        assert "Sync hung" in hung[0]["message"]
+        assert hung[0]["tags"] == {"component": "sync-watchdog"}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `PYTHONPATH=. python3 -m pytest tests/test_watchdog_cycle_phase.py -v`
+
+Expected: FAIL at collection — `ImportError: cannot import name '_CyclePhase' from 'src.main'`.
+
+- [ ] **Step 3: Add the phase box**
+
+In `src/main.py`, directly below the `_overrun_fingerprint` function added in Task 1:
+
+```python
+class _CyclePhase:
+    """The stage _do_sync is currently in, as a per-cycle mutable box.
+
+    Deliberately NOT an attribute on SyncCoordinator. A cycle abandoned by
+    _acquire_sync_slot's takeover keeps running to completion, and an instance
+    attribute would let that zombie overwrite the phase of the cycle that
+    replaced it. Same reasoning the transient-failure counter is captured
+    per-thread rather than re-read from the Timer thread.
+    """
+
+    __slots__ = ("name",)
+
+    def __init__(self) -> None:
+        self.name = "startup"
+```
+
+- [ ] **Step 4: Stamp the phases in `_do_sync`**
+
+All edits are inside `_do_sync` (`src/main.py:1554-1758`).
+
+**4a.** Directly after `cycle_transients = transient_failure_counter()` / `transient_at_cycle_start = cycle_transients.value` (`src/main.py:1583-1584`), add:
+
+```python
+        # Where the cycle is right now, for the watchdog and the cycle-end
+        # outcome report. Per-cycle box, never an instance attribute — see
+        # _CyclePhase.
+        phase = _CyclePhase()
+```
+
+**4b.** In `_watchdog()`, add `context` to the **offline** capture. It currently reads (`src/main.py:1604-1610`):
+
+```python
+                    self.error_reporter.capture(
+                        f"Sync slow — exceeded {self._DO_SYNC_DEADLINE}s while the "
+                        "BetterFlow API was unreachable "
+                        f"({transient_this_cycle} transient "
+                        f"failure{'' if transient_this_cycle == 1 else 's'} this cycle)",
+                        level="warning",
+                        tags={"component": "sync-watchdog"},
+                        fingerprint="sync-watchdog-timeout-offline",
+                    )
+```
+
+Add one line before `fingerprint=`:
+
+```python
+                        context={"phase": phase.name},
+```
+
+**4c.** Same for the **hung** capture (`src/main.py:1616-1622`), adding `context={"phase": phase.name},` before its `fingerprint="sync-watchdog-timeout",` line.
+
+**4d.** Stamp each stage. Set the phase on the line immediately **before** each of these existing lines:
+
+| Existing line | Line to insert before it |
+|---|---|
+| `src/main.py:1662` `self._monitor_capture_health()` (inside the `paused_by_network` branch) | `phase.name = "capture_health"` |
+| `src/main.py:1668` `if not self._monitor_capture_health():` | `phase.name = "capture_health"` |
+| `src/main.py:1671` `stats = self.sync_engine.sync()` | `phase.name = "sync"` |
+| `src/main.py:1724` `hours = self._fetch_hours_today()` | `phase.name = "hours_fetch"` |
+
+Match the surrounding indentation exactly (the `paused_by_network` one is more deeply indented than the others).
+
+**4e.** Directly after `stats = self.sync_engine.sync()` and its blank line, before `if stats.aw_bucket_fetch_failed:`, add:
+
+```python
+            phase.name = "post_sync"
+```
+
+- [ ] **Step 5: Run test to verify it passes**
+
+Run: `PYTHONPATH=. python3 -m pytest tests/test_watchdog_cycle_phase.py -v`
+
+Expected: PASS, 4 passed.
+
+- [ ] **Step 6: Run the two suites that must not regress**
+
+Run:
+```bash
+PYTHONPATH=. python3 -m pytest tests/test_sync_watchdog_budget.py tests/test_sync_watchdog_outcome_classification.py -v
+```
+
+Expected: PASS, all green. If `test_sync_watchdog_outcome_classification.py` reddens, the fire-time captures' fingerprint/level/message were changed rather than merely gaining `context` — revert and redo step 4b/4c.
+
+- [ ] **Step 7: Witness the phase stamp**
+
+Delete the `phase.name = "capture_health"` line at the `if not self._monitor_capture_health():` site only, then run:
+
+```bash
+PYTHONPATH=. python3 -m pytest tests/test_watchdog_cycle_phase.py -v
+```
+
+Expected: FAIL, exactly `test_overrun_inside_capture_health_reports_phase_capture_health`, reporting `'startup' != 'capture_health'`. The other three stay green.
+
+Confirm the deletion actually applied before trusting the result — a no-op edit produces zero failures, which is indistinguishable from an unwitnessed mechanism. Take a copy first and compare:
+
+```bash
+cp src/main.py /tmp/main.before
+# ... delete the one line ...
+cmp -s /tmp/main.before src/main.py && echo "NO-OP — mutant tested nothing"
+```
+
+**Do NOT restore with `git checkout src/main.py`.** Step 4's edits are still uncommitted at this point, so that would discard the whole task and leave the suite green on pre-change code — which reads exactly like success. Restore from the copy instead:
+
+```bash
+cp /tmp/main.before src/main.py
+PYTHONPATH=. python3 -m pytest tests/test_watchdog_cycle_phase.py -v   # green again
+```
+
+- [ ] **Step 8: Commit**
+
+```bash
+cd /Users/brad/Code2/betterflow-sync-watchdog
+git add src/main.py tests/test_watchdog_cycle_phase.py
+git commit -m "feat(watchdog): stamp which stage a sync cycle is in
+
+A per-cycle box, not an instance attribute: a cycle abandoned by the wedge
+takeover keeps running and would otherwise overwrite its successor's phase.
+
+Both existing fire-time reports gain context={'phase': ...}; their
+fingerprints, levels and messages are untouched so the group that already
+holds 34 occurrences stays continuous.
+
+Witnessed by deleting the capture_health stamp and watching exactly that
+test redden."
+```
+
+---
+
+### Task 3: The cycle-end outcome report
+
+This is the deliverable. Everything before it was scaffolding.
+
+**Files:**
+- Modify: `src/main.py:1749-1758` (the `finally` block of `_do_sync`), plus one line near the top of `_do_sync`
+- Test: `tests/test_watchdog_overrun_outcome.py` (create)
+
+**Interfaces:**
+- Consumes: `_overrun_fingerprint(elapsed, deadline)` from Task 1; `_CyclePhase` / the `phase` local from Task 2.
+- Produces: one `error_reporter.capture(...)` per overrunning cycle, `level="warning"`, `tags={"component": "sync-watchdog"}`, `context={"elapsed_seconds": float, "phase": str, "deadline_seconds": float}`, fingerprint from `_overrun_fingerprint`.
+
+- [ ] **Step 1: Write the failing test**
+
+Create `tests/test_watchdog_overrun_outcome.py`:
+
+```python
+"""How long an overrunning cycle actually ran — issue #179.
+
+The watchdog fires AT the deadline, so elapsed measured inside it is always
+~150s no matter what the cycle goes on to do. The real duration is knowable
+only at cycle end, which is where this report is emitted from.
+
+The predicate is `elapsed >= deadline`, deliberately NOT "did the watchdog
+fire": deriving it from elapsed avoids racing the in-flight Timer thread, and
+means these tests never need the timer to fire at all.
+"""
+
+import threading
+import time
+from types import SimpleNamespace
+from unittest.mock import Mock
+
+from src.config import Config
+from src.main import SyncCoordinator
+from src.reminders import ReminderManager
+from src.sync.sync_engine import SyncEngine
+
+_TEST_DEADLINE = 0.3
+
+MARGINAL = "sync-watchdog-overrun-marginal"
+MODERATE = "sync-watchdog-overrun-moderate"
+SEVERE = "sync-watchdog-overrun-severe"
+ALL_BANDS = (MARGINAL, MODERATE, SEVERE)
+
+
+def _ok_stats():
+    return SimpleNamespace(
+        success=True,
+        events_sent=0,
+        events_queued=0,
+        events_filtered=0,
+        gaps_filled=0,
+        errors=[],
+        aw_bucket_fetch_failed=False,
+    )
+
+
+class _Recorder:
+    def __init__(self):
+        self.captures = []
+
+    def capture(self, message, **kwargs):
+        self.captures.append({"message": message, **kwargs})
+
+    def by_fingerprint(self, fingerprint):
+        return [c for c in self.captures if c.get("fingerprint") == fingerprint]
+
+    def outcome_captures(self):
+        return [c for c in self.captures if c.get("fingerprint") in ALL_BANDS]
+
+
+class _Harness:
+    def setup_method(self):
+        self.config = Config()
+        self.aw = Mock()
+        self.aw.is_running.return_value = True
+        self.bf = Mock()
+        self.queue = Mock()
+        self.queue.get_checkpoint.return_value = None
+        self.queue.size.return_value = 0
+        self.queue.is_near_capacity.return_value = False
+        self.sync_engine = Mock(spec=SyncEngine)
+        self.sync_engine.is_paused = False
+        self.sync_engine.is_private = False
+        self.sync_engine.sync.return_value = _ok_stats()
+        self.tray = Mock()
+        self.tray.model = Mock()
+        self.tray.model.lock = threading.RLock()
+        self.aw_manager = Mock()
+        self.aw_manager.is_managing = False
+        self.reminder = Mock(spec=ReminderManager)
+        self.coord = SyncCoordinator(
+            config=self.config,
+            aw=self.aw,
+            bf=self.bf,
+            queue=self.queue,
+            sync_engine=self.sync_engine,
+            tray=self.tray,
+            aw_manager=self.aw_manager,
+            reminder_manager=self.reminder,
+        )
+        self.coord.scheduler = Mock()
+        self.coord.scheduler.running = True
+        self.recorder = _Recorder()
+        self.coord.error_reporter = self.recorder
+        self.coord._fetch_hours_today = Mock(return_value="1:00")
+        self.coord._DO_SYNC_DEADLINE = _TEST_DEADLINE
+
+    def run_cycle_taking(self, seconds):
+        def _slow_sync(*_a, **_k):
+            time.sleep(seconds)
+            return _ok_stats()
+
+        self.sync_engine.sync.side_effect = _slow_sync
+        self.coord._do_sync()
+
+
+class TestOverrunIsMeasured(_Harness):
+    def test_a_marginal_overrun_reports_the_marginal_band(self):
+        self.run_cycle_taking(0.33)  # ~1.1x of 0.3
+
+        got = self.recorder.by_fingerprint(MARGINAL)
+        assert len(got) == 1, self.recorder.captures
+        assert got[0]["level"] == "warning"
+        assert got[0]["tags"] == {"component": "sync-watchdog"}
+
+    def test_a_moderate_overrun_reports_the_moderate_band(self):
+        self.run_cycle_taking(0.45)  # 1.5x
+
+        assert len(self.recorder.by_fingerprint(MODERATE)) == 1, self.recorder.captures
+        assert self.recorder.by_fingerprint(MARGINAL) == []
+
+    def test_a_severe_overrun_reports_the_severe_band(self):
+        self.run_cycle_taking(0.75)  # 2.5x
+
+        assert len(self.recorder.by_fingerprint(SEVERE)) == 1, self.recorder.captures
+        assert self.recorder.by_fingerprint(MODERATE) == []
+
+    def test_the_report_carries_the_elapsed_time_and_the_phase(self):
+        self.run_cycle_taking(0.45)
+
+        got = self.recorder.by_fingerprint(MODERATE)[0]
+        assert got["context"]["phase"] == "sync"
+        assert got["context"]["deadline_seconds"] == _TEST_DEADLINE
+        # A real measurement, not a constant: at least the sleep, and not
+        # absurdly more.
+        assert 0.45 <= got["context"]["elapsed_seconds"] < 5.0
+        assert "0.4" in got["message"] or "0.5" in got["message"]
+
+
+class TestHealthyCyclesStaySilent(_Harness):
+    """THE critical negative. If the predicate is implemented backwards this is
+    the only test that catches it, and the failure mode is an outcome report on
+    every healthy cycle — flooding the ingest this change exists to quieten."""
+
+    def test_a_cycle_inside_the_deadline_emits_no_outcome_report(self):
+        self.run_cycle_taking(0.02)  # far under 0.3
+
+        assert self.recorder.outcome_captures() == [], self.recorder.captures
+
+    def test_the_negative_above_is_not_passing_vacuously(self):
+        """A cycle that never ran would also produce zero outcome captures.
+        Prove the subject was reached: the same harness, overrunning, DOES
+        produce one."""
+        self.run_cycle_taking(0.02)
+        assert self.recorder.outcome_captures() == []
+
+        self.recorder.captures.clear()
+        self.run_cycle_taking(0.45)
+        assert len(self.recorder.outcome_captures()) == 1, self.recorder.captures
+
+
+class TestExistingReportsAreUnchanged(_Harness):
+    def test_an_overrun_still_emits_its_fire_time_error(self):
+        """The outcome report is additive. The group that already holds 34
+        occurrences must keep firing exactly as before."""
+        self.run_cycle_taking(0.45)
+
+        hung = self.recorder.by_fingerprint("sync-watchdog-timeout")
+        assert len(hung) == 1, self.recorder.captures
+        assert hung[0]["level"] == "error"
+
+    def test_the_outcome_report_never_uses_error_level(self):
+        """It measures; the fire-time report pages. A second error would double
+        the alert volume."""
+        self.run_cycle_taking(0.75)
+
+        for capture in self.recorder.outcome_captures():
+            assert capture["level"] == "warning"
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `PYTHONPATH=. python3 -m pytest tests/test_watchdog_overrun_outcome.py -v`
+
+Expected: the three band tests, the payload test, the vacuity test and both `TestExistingReportsAreUnchanged`… precisely: 5 FAIL (every test asserting an outcome capture exists) and 3 PASS (`test_a_cycle_inside_the_deadline_emits_no_outcome_report`, and the two in `TestExistingReportsAreUnchanged` that only check pre-existing behaviour). The negative passing before the feature exists is expected and is exactly why `test_the_negative_above_is_not_passing_vacuously` is there.
+
+- [ ] **Step 3: Stamp the cycle start**
+
+In `_do_sync`, directly after `watchdog_cancelled = threading.Event()` (`src/main.py:1567`), add:
+
+```python
+        # Cycle start, for the cycle-end outcome report. The watchdog fires AT
+        # the deadline, so elapsed measured inside it is always ~150s however
+        # long the cycle really runs — the true duration is only knowable here.
+        cycle_started_at = time.monotonic()
+```
+
+- [ ] **Step 4: Emit the outcome report**
+
+Replace the `finally` block at `src/main.py:1749-1758`:
+
+```python
+        finally:
+            # Clear the wedge stamp only if we're still the current holder — a
+            # taken-over zombie reaching here must not wipe its successor's stamp.
+            with self._sync_takeover_lock:
+                if self._sync_holder is my_lock:
+                    self._sync_started_at = None
+                    self._sync_holder = None
+            watchdog_cancelled.set()
+            watchdog.cancel()
+            my_lock.release()
+```
+
+with:
+
+```python
+        finally:
+            # Clear the wedge stamp only if we're still the current holder — a
+            # taken-over zombie reaching here must not wipe its successor's stamp.
+            with self._sync_takeover_lock:
+                if self._sync_holder is my_lock:
+                    self._sync_started_at = None
+                    self._sync_holder = None
+            watchdog_cancelled.set()
+            watchdog.cancel()
+            my_lock.release()
+            self._report_overrun_outcome(
+                time.monotonic() - cycle_started_at, phase.name
+            )
+```
+
+Then add the method to `SyncCoordinator`, immediately after `_do_sync` ends (i.e. before the `def _set_sync_failure_state` that currently follows it):
+
+```python
+    def _report_overrun_outcome(self, elapsed: float, phase_name: str) -> None:
+        """Record how long a cycle that breached the deadline actually ran.
+
+        Gated on elapsed rather than on "did the watchdog fire" so it cannot
+        race the in-flight Timer thread: a watchdog past its cancelled check but
+        not yet flagged would leave this reading "did not fire" for a cycle that
+        did.
+
+        Level is always warning. The fire-time report already paged this same
+        cycle at the deadline as an error; a second error here would add no
+        paging value and double the volume this change exists to reduce.
+
+        A cycle abandoned by _acquire_sync_slot's takeover reaches here late,
+        with its true elapsed — that is the "is it unbounded?" evidence
+        sync-wedged cannot give, since sync-wedged records only that we gave up
+        at the ceiling.
+        """
+        if elapsed < self._DO_SYNC_DEADLINE or self.error_reporter is None:
+            return
+        self.error_reporter.capture(
+            f"Sync overran the {self._DO_SYNC_DEADLINE}s deadline — "
+            f"finished at {elapsed:.1f}s in phase '{phase_name}'",
+            level="warning",
+            tags={"component": "sync-watchdog"},
+            context={
+                "elapsed_seconds": round(elapsed, 1),
+                "phase": phase_name,
+                "deadline_seconds": self._DO_SYNC_DEADLINE,
+            },
+            fingerprint=_overrun_fingerprint(elapsed, self._DO_SYNC_DEADLINE),
+        )
+```
+
+- [ ] **Step 5: Run test to verify it passes**
+
+Run: `PYTHONPATH=. python3 -m pytest tests/test_watchdog_overrun_outcome.py -v`
+
+Expected: PASS, 8 passed.
+
+- [ ] **Step 6: Run the full watchdog set**
+
+Run:
+```bash
+PYTHONPATH=. python3 -m pytest tests/test_sync_watchdog_budget.py \
+  tests/test_sync_watchdog_outcome_classification.py \
+  tests/test_watchdog_overrun_bands.py \
+  tests/test_watchdog_cycle_phase.py \
+  tests/test_watchdog_overrun_outcome.py -v
+```
+
+Expected: all green.
+
+- [ ] **Step 7: Witness each mechanism separately**
+
+Three mutants, one per mechanism. Each must redden a **distinct named** test. Reverting all three at once proves nothing about any one of them. Before trusting any result, confirm the edit applied — a `sed`/`perl` that matched nothing produces zero failures, which looks identical to an unwitnessed mechanism.
+
+For each: `cp src/main.py /tmp/main.before`, apply the mutant, `cmp -s /tmp/main.before src/main.py && echo "NO-OP — mutant tested nothing"`, run, then restore by reversing the edit by hand.
+
+**Mutant A — invert the predicate.** In `_report_overrun_outcome`, change `if elapsed < self._DO_SYNC_DEADLINE` to `if elapsed > self._DO_SYNC_DEADLINE`.
+Expected red: `test_a_marginal_overrun_reports_the_marginal_band` and the other band tests (they now emit nothing).
+
+**Mutant B — collapse the bands.** Change `fingerprint=_overrun_fingerprint(...)` to `fingerprint="sync-watchdog-overrun-marginal"`.
+Expected red: `test_a_moderate_overrun_reports_the_moderate_band` and `test_a_severe_overrun_reports_the_severe_band`.
+This is the mechanism that carries the entire measurement, so if it survives, the change delivers nothing.
+
+**Mutant C — drop the phase.** Change `"phase": phase_name,` to `"phase": "sync",`.
+Expected red: `test_overrun_inside_capture_health_reports_phase_capture_health` in `tests/test_watchdog_cycle_phase.py`.
+This is the agreement-region trap: every fixture in the *outcome* file overruns inside `sync`, so a hardcoded `"sync"` is indistinguishable there. Only the capture_health fixture separates them.
+
+- [ ] **Step 8: Commit**
+
+```bash
+cd /Users/brad/Code2/betterflow-sync-watchdog
+git add src/main.py tests/test_watchdog_overrun_outcome.py
+git commit -m "feat(watchdog): report how long an overrunning cycle actually ran
+
+Closes the measurement half of #179. The watchdog fires AT the 150s deadline,
+so elapsed observed inside it is always ~150s; the real duration is only
+knowable at cycle end, which is where this emits from.
+
+The band rides in the fingerprint because that is the only thing the ingest
+aggregates — context is overwritten newest-wins per fingerprint and the daily
+digest reads message + occurrences only. Bucketing the fingerprint turns the
+occurrence counter into the distribution, so the digest can finally
+distinguish a 151s cycle from a deadlocked one.
+
+Always warning: the fire-time report already paged this cycle as an error.
+
+Each mechanism witnessed by its own mutant reddening a distinct named test
+(predicate, band selection, phase), with a cmp check that each mutation
+applied."
+```
+
+---
+
+### Task 4: Correct the stale status on the 2026-07-22 spec
+
+Small, but it is the thing that cost this session an hour: the parked spec says it was never built, and it shipped. The next reader deserves better, and a wrong status is worse than no status because it is actively believed.
+
+**Files:**
+- Modify: `docs/superpowers/specs/2026-07-22-watchdog-outcome-classification-design.md:3-5`
+
+**Interfaces:** none.
+
+- [ ] **Step 1: Verify the claim before writing it down**
+
+Run:
+```bash
+cd /Users/brad/Code2/betterflow-sync-watchdog
+grep -n "sync-watchdog-timeout-offline" src/main.py
+ls tests/test_sync_watchdog_outcome_classification.py
+```
+
+Expected: the fingerprint exists in `src/main.py`, and the test file exists. If either is missing, stop — the premise of this task is wrong.
+
+- [ ] **Step 2: Replace the status block**
+
+The file currently opens:
+
+```markdown
+Status: **designed, not scheduled.** Deliberately parked on 2026-07-22 in favour
+of higher-value work (see "Priority" below). Pick this up when the noise or the
+autofix spend justifies it.
+```
+
+Replace those three lines with:
+
+```markdown
+Status: **implemented.** Parked on 2026-07-22, built later; the classification
+described here is live in `SyncCoordinator._watchdog` (`src/main.py`, fingerprints
+`sync-watchdog-timeout` / `sync-watchdog-timeout-offline`) and guarded by
+`tests/test_sync_watchdog_outcome_classification.py`. The "Priority" section
+below is preserved as the record of why it waited, not as current status.
+
+What this design does NOT do is say how long an overrunning cycle ran, which is
+issue #179 — see `2026-08-10-watchdog-overrun-duration-design.md`.
+```
+
+- [ ] **Step 3: Commit**
+
+```bash
+cd /Users/brad/Code2/betterflow-sync-watchdog
+git add docs/superpowers/specs/2026-07-22-watchdog-outcome-classification-design.md
+git commit -m "docs(watchdog): mark the 2026-07-22 classification design as shipped
+
+It has read 'designed, not scheduled' since it landed, which sent a session
+looking for work that was already done. Points forward to the duration design
+for the part that genuinely remains."
+```
+
+---
+
+## Final verification
+
+- [ ] **Full suite**
+
+```bash
+cd /Users/brad/Code2/betterflow-sync-watchdog
+PYTHONPATH=. python3 -m pytest > /tmp/wd-suite.log 2>&1; echo "EXIT: $?"
+tail -15 /tmp/wd-suite.log
+```
+
+Never pipe this — a pipe reports the last element's status and a failed suite would read as success. Expected: EXIT 0, and a test count **higher** than the pre-change baseline. Record the baseline first with `git stash`-free comparison: run the same command on `origin/main` in a separate worktree if the count is in doubt. An identical count means the new files were not collected.
+
+- [ ] **Lint**
+
+```bash
+cd /Users/brad/Code2/betterflow-sync-watchdog && make lint
+```
+
+Expected: clean. `make lint` runs ruff.
+
+- [ ] **CI parity — there is no CI, you are it**
+
+GitHub Actions is cost-capped org-wide, and this repo's workflow skips `test` on tag builds. Read `.github/workflows/build.yml` and run every non-deploy step locally:
+
+```bash
+cd /Users/brad/Code2/betterflow-sync-watchdog
+ls .github/workflows/
+grep -n "run:" .github/workflows/build.yml
+```
+
+Run each `run:` step from the `test` job. Note the Windows job only runs on tag builds, so a Windows-only breakage would first appear as a failed release — this change adds no `os`-specific calls, but confirm no new import is platform-gated.
+
+- [ ] **Git status audit**
+
+```bash
+cd /Users/brad/Code2/betterflow-sync-watchdog
+git status
+git diff origin/main...HEAD --numstat
+```
+
+Every file must be one you intended. Use `--numstat` for the deletion count, never a `^-[^-]` grep — this diff contains markdown list items, whose deleted lines render as `--` and are silently dropped by that pattern.

--- a/docs/superpowers/specs/2026-07-22-watchdog-outcome-classification-design.md
+++ b/docs/superpowers/specs/2026-07-22-watchdog-outcome-classification-design.md
@@ -1,8 +1,13 @@
 # Watchdog outcome classification — design
 
-Status: **designed, not scheduled.** Deliberately parked on 2026-07-22 in favour
-of higher-value work (see "Priority" below). Pick this up when the noise or the
-autofix spend justifies it.
+Status: **implemented.** Parked on 2026-07-22, built later; the classification
+described here is live in `SyncCoordinator._watchdog` (`src/main.py`, fingerprints
+`sync-watchdog-timeout` / `sync-watchdog-timeout-offline`) and guarded by
+`tests/test_sync_watchdog_outcome_classification.py`. The "Priority" section
+below is preserved as the record of why it waited, not as current status.
+
+What this design does NOT do is say how long an overrunning cycle ran, which is
+issue #179 — see `2026-08-10-watchdog-overrun-duration-design.md`.
 
 ## Problem
 

--- a/docs/superpowers/specs/2026-08-10-watchdog-overrun-duration-design.md
+++ b/docs/superpowers/specs/2026-08-10-watchdog-overrun-duration-design.md
@@ -1,0 +1,212 @@
+# Watchdog overrun duration and phase — design
+
+Status: **designed, ready to implement.** Closes the measurement half of
+issue #179.
+
+## Problem
+
+`SyncCoordinator._watchdog()` (`src/main.py:1586`) already classifies an overrun
+into *slow* (API unreachable) versus *hung* (no transient failures) — that is the
+2026-07-22 outcome-classification design, and it shipped. What neither branch can
+say is **how long the cycle actually ran**.
+
+Over a 7-day window issue #179 reports:
+
+```
+Sync hung — exceeded 150s watchdog deadline                     (x34)
+Sync slow — exceeded 150s while the BetterFlow API was unreachable
+  (4 transient failures this cycle)                             (x1)
+```
+
+Every one of the 34 is indistinguishable from every other. A cycle that finished
+at 150.9s and a cycle that deadlocked for twenty minutes produce the identical
+row, and those need opposite fixes: the first is a budget that has grown past its
+envelope, the second is the deadlock path `_acquire_sync_slot` exists to survive.
+
+The in-file comment at `src/main.py:1378-1385` already records one confirmed
+false fire — device 18, 2026-07-22, 150.86s, no log gap, all events delivered on
+the next cycle — which is why the answer here is measurement and not a threshold
+bump.
+
+## Two constraints that determine the whole design
+
+Both were established by reading the ingest, not assumed.
+
+### The watchdog fires *at* the deadline, so it cannot know the duration
+
+`threading.Timer(self._DO_SYNC_DEADLINE, _watchdog)` fires at 150s. Elapsed time
+observed inside `_watchdog()` is therefore always ≈150s, whatever the cycle goes
+on to do. The real duration is knowable only when the cycle ends.
+
+### The backend aggregates by fingerprint and by nothing else
+
+Traced in `betterqa-bot`:
+
+- `context` **is** persisted to a `jsonb` column (`src/db/schema.ts:164-176`), but
+  the row is a per-fingerprint aggregate and the upsert does
+  `context = COALESCE(EXCLUDED.context, error_reports.context)`
+  (`src/webhooks/error-ingest.ts:740`) — newest wins, per-occurrence history is
+  not kept.
+- The daily digest selects `message`, `level`, `occurrences` only
+  (`src/scheduler/error-daily-summary.ts:119-137`) and renders
+  `` `${r.occurrences}×` ${clip(r.message)} `` at `:176`. It never reads
+  `context`. No percentile or numeric aggregation exists against
+  `error_reports` anywhere.
+- Grouping is `(project, fingerprint)` (`src/db/schema.ts:241`), and the agent's
+  explicit `fingerprint` wins outright (`src/monitor/error-fingerprint.ts:66-68`).
+  `message` is the one column overwritten unconditionally
+  (`error-ingest.ts:736`) — newest wins.
+
+So the literal reading of #179 — "record the elapsed time on every deadline
+breach" via the payload's `context` — ships a number that survives exactly one
+occurrence and appears in no report. **The only aggregation available is the
+occurrence counter per fingerprint.** Any measurement that must be countable has
+to ride in the fingerprint.
+
+## Design
+
+### 1. The predicate is elapsed, not "did the watchdog fire"
+
+`_do_sync` stamps `cycle_started_at` at entry. In `finally` it computes
+`elapsed = monotonic() - cycle_started_at` and emits an outcome report iff
+`elapsed >= _DO_SYNC_DEADLINE`.
+
+Deriving it from elapsed rather than from a `watchdog_fired` Event avoids a race
+against the in-flight Timer thread: a watchdog that has passed its cancelled
+check but not yet set a flag would otherwise leave `finally` reading "did not
+fire" for a cycle that did. It also means **no test needs the 150s timer to
+fire** — advancing a fake clock is sufficient.
+
+### 2. Bucketed fingerprints carry the distribution
+
+| elapsed | fingerprint | level |
+|---|---|---|
+| 150s ≤ e < 180s | `sync-watchdog-overrun-150-180` | `warning` |
+| 180s ≤ e < 300s | `sync-watchdog-overrun-180-300` | `warning` |
+| e ≥ 300s | `sync-watchdog-overrun-300plus` | `warning` |
+
+The digest then reads as a distribution without any backend change:
+
+```
+Sync overran the 150s deadline — finished at 151.2s in phase 'sync'   (x31)
+Sync overran the 150s deadline — finished at 246.0s in phase 'sync'   (x2)
+Sync overran the 150s deadline — finished at 903.4s in phase 'sync'   (x1)
+```
+
+Each line's count is trustworthy; each line's *seconds* are a sample, because
+message is overwritten newest-wins. That asymmetry is deliberate and must be
+stated wherever these numbers get quoted — the bucket is the measurement, the
+figure in the text is one arbitrary member of it.
+
+**All three levels are `warning` on purpose.** The fire-time report already
+paged this same cycle at 150s as `error` (`sync-watchdog-timeout`). A second
+`error` at cycle end adds no paging value and doubles the alert volume this
+change is meant to reduce. The outcome report measures; the fire-time report
+pages.
+
+Exact seconds also go in `context` (`elapsed_seconds`, `phase`) for the
+`errors_detail` path, accepting that only the newest survives.
+
+### 3. Phase
+
+A per-cycle mutable holder, captured by the watchdog closure and read in
+`finally`. **Never an instance attribute** — a cycle abandoned by
+`_acquire_sync_slot`'s takeover keeps running, and an attribute would let that
+zombie overwrite its successor's phase. This is the same reasoning the existing
+code gives at `src/main.py:1578-1582` for capturing the transient counter as a
+per-thread object.
+
+Stages stamped in `_do_sync` only:
+
+```
+startup -> capture_health -> sync -> post_sync -> hours_fetch -> done
+```
+
+Honest limitation, stated up front: most overruns will report `sync`, because
+`sync_engine.sync()` is where the retry chain and the send budget live. That is
+still worth having — it positively rules out the other four stages, and it is
+one file instead of instrumenting the ~1000-line `sync_engine.sync()` on the
+hottest path in the repo. If the shipped distribution shows the time really is
+all inside `sync`, deeper instrumentation becomes a follow-up with evidence
+behind it rather than a guess.
+
+Phase rides in both the fire-time reports (as `context`, where "where is it
+stuck right now" is the question and newest-wins is acceptable) and the outcome
+report (in message and context).
+
+### 4. A zombie's late outcome report is a feature
+
+A cycle abandoned at `_SYNC_WEDGE_CEILING` (420s) that eventually returns at,
+say, 1400s reaches `finally` and reports `300plus` with its true elapsed. That
+is precisely the "is it unbounded?" evidence #179 asks for, and `sync-wedged`
+alone cannot supply it — `sync-wedged` records only that we gave up at 420s,
+never what the real duration turned out to be.
+
+## Unchanged by design
+
+Called out so they read as deliberate:
+
+- **`_DO_SYNC_DEADLINE` stays 150.** This is measurement, not tuning. Both the
+  issue and the task brief explicitly forbid raising it to silence the alert.
+- **`_SYNC_WEDGE_CEILING` stays 420**, fingerprint `sync-wedged`, still `error`.
+- **Both fire-time fingerprints and levels keep their identity**
+  (`sync-watchdog-timeout` / `sync-watchdog-timeout-offline`), so the existing
+  34-occurrence group stays continuous and comparable across the change.
+- `bf.reset_session()` / `aw.reset_session()` keep running in both watchdog
+  branches.
+
+## Testing
+
+Against the real `SyncCoordinator._do_sync` with stub clients, asserting on
+captured reports — never on arguments forwarded between functions
+(`rules/test-fixture-discipline.md`).
+
+**Clock:** patch `time.monotonic` at the `main` module level so *every* clock
+read in the cycle moves together. This repo has already shipped a partial-clock
+bomb — #131, where the reader took an injected `now=` but the sibling
+`remove_failed` that wrote the timestamp did not, so the test broke the day wall
+clock passed the fixture date. A whole-module fake has no such seam.
+
+Required cases:
+
+1. Overrun finishing at 151s → exactly one capture at
+   `sync-watchdog-overrun-150-180`, level `warning`.
+2. Overrun finishing at 246s → `sync-watchdog-overrun-180-300`.
+3. Overrun finishing at 903s → `sync-watchdog-overrun-300plus`.
+4. **Boundary: exactly 180.0s lands in `180-300`, not `150-180`.** Both ends of
+   the range get a case (`diagnosis-discipline.md` Rule 3).
+5. **Critical negative: a cycle finishing at 149s emits ZERO outcome captures.**
+   This is the assertion that catches the predicate being implemented backwards,
+   and it must be paired with a positive assertion that the capture list is
+   non-empty in the overrun cases — an empty list satisfies "no outcome capture"
+   for the wrong reason.
+6. Phase attribution: an overrun stalled in `_monitor_capture_health` reports
+   `capture_health`; one stalled in `sync_engine.sync()` reports `sync`.
+
+**Guard witnessing.** Per `test-fixture-discipline.md` Phantom 5, each mechanism
+gets its own mutant and must redden a distinct named test: (a) invert the
+`elapsed >= deadline` comparison, (b) collapse the three buckets to one
+fingerprint, (c) drop the phase stamp. Reverting all three at once proves
+nothing about any one of them. Verify each mutation actually applied (`cmp`
+before/after) before trusting a green run.
+
+`tests/test_sync_watchdog_budget.py` and
+`tests/test_sync_watchdog_outcome_classification.py` must stay green.
+
+## Blast radius
+
+One production file (`src/main.py`), one new test file. No change to
+`sync_engine.py`, no schema change, no server change, no config flag, no new
+dependency.
+
+Failure mode if the elapsed predicate is inverted: an outcome report on every
+healthy cycle, flooding the ingest. Test 5 exists to prevent exactly that.
+
+## Repo hygiene shipped alongside
+
+`docs/superpowers/specs/2026-07-22-watchdog-outcome-classification-design.md`
+still reads `Status: designed, not scheduled` although it shipped — the
+classification it describes is live at `src/main.py:1586-1622` with tests at
+`tests/test_sync_watchdog_outcome_classification.py`. That stale line sent this
+session looking for unimplemented work and will do the same to the next one. Its
+status line gets corrected to point at the implementation.

--- a/docs/superpowers/specs/2026-08-10-watchdog-overrun-duration-design.md
+++ b/docs/superpowers/specs/2026-08-10-watchdog-overrun-duration-design.md
@@ -1,7 +1,12 @@
 # Watchdog overrun duration and phase — design
 
-Status: **designed, ready to implement.** Closes the measurement half of
-issue #179.
+Status: **implemented.** Closes the measurement half of issue #179. The bands
+and the cycle-end outcome report are live in `SyncCoordinator._do_sync` /
+`_report_overrun_outcome` and the module-level `_overrun_fingerprint`
+(`src/main.py`, fingerprints `sync-watchdog-overrun-marginal` /
+`-moderate` / `-severe`), guarded by `tests/test_watchdog_overrun_bands.py`,
+`tests/test_watchdog_cycle_phase.py` and
+`tests/test_watchdog_overrun_outcome.py`.
 
 ## Problem
 
@@ -121,6 +126,20 @@ pages.
 Exact seconds also go in `context` (`elapsed_seconds`, `phase`) for the
 `errors_detail` path, accepting that only the newest survives.
 
+**The outcome report opts out of the client-side dedup** (`dedup_window=0` on
+its `capture` call). `ErrorReporter` suppresses a repeated fingerprint within
+300s, which was uniform while every overrun shared one fingerprint. Split into
+three bands it is not: the marginal band (150–180s) puts the next tick roughly
+180s later and loses about 40% of its reports to that window, while the severe
+band (≥300s) can never be throttled at all. The digest would then overstate
+severe's share by ~1.5–2× — the wrong direction for a question whose known
+failure mode is a *false* "hung" (the 150.86s false fire above). Since the
+counter is the whole measurement, throttling it non-uniformly is not a volume
+control, it is a corrupted statistic. Volume stays bounded by construction: the
+report fires only on an overrun, an overrun is ≥150s, and overlapping ticks are
+skipped by `_acquire_sync_slot` — so ~24/hour/device at worst, all `warning`,
+none of it paging. The fire-time report keeps the default window.
+
 ### 3. Phase
 
 A per-cycle mutable holder, captured by the watchdog closure and read in
@@ -156,6 +175,14 @@ is precisely the "is it unbounded?" evidence #179 asks for, and `sync-wedged`
 alone cannot supply it — `sync-wedged` records only that we gave up at 420s,
 never what the real duration turned out to be.
 
+**But this argument holds only for cycles that eventually RETURN.** A true
+deadlock never reaches `finally`, so it emits no outcome report at all and is
+counted in no band. The severe band therefore sizes the population of *slow but
+finishing* cycles, never the wedged population — which is the half of #179 most
+worth counting. `sync-wedged` remains the only signal for that, and the two have
+to be read together: `severe = 1` means one cycle ran past 300s **and came
+back**, not that one device wedged.
+
 ## Unchanged by design
 
 Called out so they read as deliberate:
@@ -166,6 +193,16 @@ Called out so they read as deliberate:
 - **Both fire-time fingerprints and levels keep their identity**
   (`sync-watchdog-timeout` / `sync-watchdog-timeout-offline`), so the existing
   34-occurrence group stays continuous and comparable across the change.
+
+  Worth saying out loud: once the bands exist, the fire-time report is
+  **strictly redundant** as a measurement — every cycle it fires on also
+  reports a band, with strictly more information. It is kept for continuity
+  (an unbroken 34-occurrence series across the change is what makes
+  before/after comparable) and because it is the report that *pages* while the
+  bands only measure. Once the bands have a few weeks of history and the
+  paging role has been moved onto one of them, the fire-time report can be
+  retired. That is a follow-up with evidence behind it, not something to do in
+  this change.
 - `bf.reset_session()` / `aw.reset_session()` keep running in both watchdog
   branches.
 

--- a/docs/superpowers/specs/2026-08-10-watchdog-overrun-duration-design.md
+++ b/docs/superpowers/specs/2026-08-10-watchdog-overrun-duration-design.md
@@ -74,16 +74,30 @@ to ride in the fingerprint.
 Deriving it from elapsed rather than from a `watchdog_fired` Event avoids a race
 against the in-flight Timer thread: a watchdog that has passed its cancelled
 check but not yet set a flag would otherwise leave `finally` reading "did not
-fire" for a cycle that did. It also means **no test needs the 150s timer to
-fire** — advancing a fake clock is sufficient.
+fire" for a cycle that did. It also means **no test needs the Timer to fire at
+all** — a sub-second sleep past a shrunk deadline is sufficient, so the tests
+never depend on thread scheduling to produce their result.
 
 ### 2. Bucketed fingerprints carry the distribution
 
-| elapsed | fingerprint | level |
-|---|---|---|
-| 150s ≤ e < 180s | `sync-watchdog-overrun-150-180` | `warning` |
-| 180s ≤ e < 300s | `sync-watchdog-overrun-180-300` | `warning` |
-| e ≥ 300s | `sync-watchdog-overrun-300plus` | `warning` |
+Bands are expressed as **multiples of the deadline**, not absolute seconds.
+
+| elapsed | fingerprint | at the 150s deadline | level |
+|---|---|---|---|
+| 1.0× ≤ e < 1.2× | `sync-watchdog-overrun-marginal` | 150–180s | `warning` |
+| 1.2× ≤ e < 2.0× | `sync-watchdog-overrun-moderate` | 180–300s | `warning` |
+| e ≥ 2.0× | `sync-watchdog-overrun-severe` | ≥300s | `warning` |
+
+Ratios rather than absolute seconds for two concrete reasons. The deadline has
+already moved once (120s → 150s), and absolute bands would have quietly become
+wrong rather than failing. And `tests/test_sync_watchdog_outcome_classification.py`
+shrinks the deadline to 0.3s through an instance override, so absolute bands
+would put every test cycle in the first bucket and leave the other two
+unreachable without a five-minute sleep — the measurement would ship untested.
+
+Selection lives in a pure module-level `_overrun_fingerprint(elapsed, deadline)`,
+which is what makes the boundaries testable *exactly*: a timed cycle cannot land
+on 1.2× reliably, a unit test can.
 
 The digest then reads as a distribution without any backend change:
 
@@ -161,27 +175,50 @@ Against the real `SyncCoordinator._do_sync` with stub clients, asserting on
 captured reports — never on arguments forwarded between functions
 (`rules/test-fixture-discipline.md`).
 
-**Clock:** patch `time.monotonic` at the `main` module level so *every* clock
-read in the cycle moves together. This repo has already shipped a partial-clock
-bomb — #131, where the reader took an injected `now=` but the sibling
-`remove_failed` that wrote the timestamp did not, so the test broke the day wall
-clock passed the fixture date. A whole-module fake has no such seam.
+**Clock: no fake clock, and deliberately so.** The obvious move is to patch
+`time.monotonic`, and the repo has already shipped a partial-clock bomb doing
+something adjacent — #131, where the reader took an injected `now=` but the
+sibling `remove_failed` that wrote the timestamp did not, so the test broke the
+day wall clock passed the fixture date. The existing harness avoids the whole
+class instead: it shrinks `_DO_SYNC_DEADLINE` to 0.3s via an *instance* override
+and sleeps for real. Every clock read in the cycle then comes from one real
+clock, so there is no seam to be partially injected. Reuse that pattern; it is
+also why the bands have to be ratios.
 
-Required cases:
+Split by what each level of test can actually prove:
 
-1. Overrun finishing at 151s → exactly one capture at
-   `sync-watchdog-overrun-150-180`, level `warning`.
-2. Overrun finishing at 246s → `sync-watchdog-overrun-180-300`.
-3. Overrun finishing at 903s → `sync-watchdog-overrun-300plus`.
-4. **Boundary: exactly 180.0s lands in `180-300`, not `150-180`.** Both ends of
-   the range get a case (`diagnosis-discipline.md` Rule 3).
-5. **Critical negative: a cycle finishing at 149s emits ZERO outcome captures.**
-   This is the assertion that catches the predicate being implemented backwards,
-   and it must be paired with a positive assertion that the capture list is
-   non-empty in the overrun cases — an empty list satisfies "no outcome capture"
-   for the wrong reason.
-6. Phase attribution: an overrun stalled in `_monitor_capture_health` reports
-   `capture_health`; one stalled in `sync_engine.sync()` reports `sync`.
+**Unit, against the pure band function** — exact boundaries, no timing:
+
+1. 150.0 → marginal; 151.2 → marginal; 179.9 → marginal.
+2. **Exactly 180.0 (1.2×) → moderate, NOT marginal**, and exactly 300.0 (2.0×)
+   → severe. Both ends of every range get a case
+   (`diagnosis-discipline.md` Rule 3). A timed cycle cannot land on 1.2×
+   reliably, which is the whole reason this function is extracted.
+3. The three bands are distinct strings — a band silently aliasing another
+   would turn two counts into one and look like a real distribution.
+
+**Integration, driving the real `_do_sync`** — wiring, not arithmetic:
+
+4. A cycle at ~1.1× emits exactly one capture at the marginal fingerprint,
+   `level="warning"`, `tags={"component": "sync-watchdog"}`; ~1.5× the moderate
+   one; ~2.5× the severe one.
+5. The report carries `elapsed_seconds`, `phase` and `deadline_seconds` in
+   `context`, with elapsed asserted as a *range* around the real sleep rather
+   than an equality — a constant would satisfy an equality against a stub.
+6. **Critical negative: a cycle finishing well inside the deadline emits ZERO
+   outcome captures.** This catches the predicate being implemented backwards,
+   whose failure mode is an outcome report on every healthy cycle — flooding
+   the ingest this change exists to quieten.
+7. **The negative's own vacuity control.** A cycle that never ran also produces
+   zero outcome captures, so the same harness must be shown producing exactly
+   one when it overruns. Without this, test 6 passes for the wrong reason
+   forever.
+8. Phase attribution: an overrun stalled in `_monitor_capture_health` reports
+   `capture_health`; one stalled in `sync_engine.sync()` reports `sync`. The
+   second alone is not enough — every fixture in the outcome tests overruns
+   inside `sync`, so a hardcoded `"sync"` would satisfy all of them.
+9. An overrun still emits its fire-time `sync-watchdog-timeout` error. The
+   outcome report is additive, not a replacement.
 
 **Guard witnessing.** Per `test-fixture-discipline.md` Phantom 5, each mechanism
 gets its own mutant and must redden a distinct named test: (a) invert the

--- a/src/error_reporter.py
+++ b/src/error_reporter.py
@@ -95,6 +95,7 @@ class ErrorReporter:
         context: Optional[dict] = None,
         fingerprint: Optional[str] = None,
         block: bool = False,
+        dedup_window: Optional[float] = None,
     ) -> None:
         """Report a failure. Safe to call from any thread; never raises.
 
@@ -106,13 +107,20 @@ class ErrorReporter:
             context: Freeform diagnostic data (merged with user/device context).
             fingerprint: Stable dedup key; defaults to level + message.
             block: Send synchronously (only for the about-to-exit fatal path).
+            dedup_window: Per-call cooldown override in seconds. ``None`` (the
+                default, and what every caller gets unless it says otherwise)
+                means "use the instance default". ``0`` disables suppression
+                for this call, for reports whose OCCURRENCE COUNT is the
+                measurement — a shared window throttles short-interval
+                fingerprints harder than long-interval ones, which silently
+                skews the very distribution such a report exists to publish.
         """
         if not self.enabled:
             return
 
         try:
             key = fingerprint or f"{level}:{message}"
-            if not self._should_send(key):
+            if not self._should_send(key, dedup_window):
                 logger.debug("Error report suppressed by client-side dedup: %s", key)
                 return
 
@@ -132,8 +140,14 @@ class ErrorReporter:
                 daemon=True,
             ).start()
 
-    def _should_send(self, key: str) -> bool:
-        """True if this fingerprint hasn't been sent within the cooldown window."""
+    def _should_send(self, key: str, dedup_window: Optional[float] = None) -> bool:
+        """True if this fingerprint hasn't been sent within the cooldown window.
+
+        ``dedup_window`` overrides the instance default for this call only;
+        ``None`` means use the default. Pruning always uses the instance
+        default, since it only exists to bound the dict's growth.
+        """
+        window = self._dedup_window if dedup_window is None else dedup_window
         now = time.monotonic()
         with self._lock:
             # Prune stale entries so the dict can't grow without bound.
@@ -142,7 +156,7 @@ class ErrorReporter:
                 del self._recent[k]
 
             last = self._recent.get(key)
-            if last is not None and now - last < self._dedup_window:
+            if last is not None and now - last < window:
                 return False
             self._recent[key] = now
             return True

--- a/src/main.py
+++ b/src/main.py
@@ -1660,6 +1660,12 @@ class SyncCoordinator:
             # Snapshot the phase AT THE MOMENT the deadline was breached —
             # phase.name keeps moving as the cycle finishes up, so this is the
             # only record of what was actually slow. See _CyclePhase.
+            #
+            # Every capture below reads phase.at_deadline, NOT phase.name.
+            # Re-reading phase.name here would let a sync() returning between
+            # this line and the capture give a fire-time report naming a later
+            # stage than the outcome report's — two reports about one cycle,
+            # disagreeing, for no reason a reader could ever reconstruct.
             phase.at_deadline = phase.name
             # Deliberately permissive: ANY transient failure during the cycle
             # downgrades it. A genuine wedge that coincides with one flaky request
@@ -1681,7 +1687,7 @@ class SyncCoordinator:
                         f"failure{'' if transient_this_cycle == 1 else 's'} this cycle)",
                         level="warning",
                         tags={"component": "sync-watchdog"},
-                        context={"phase": phase.name},
+                        context={"phase": phase.at_deadline},
                         fingerprint="sync-watchdog-timeout-offline",
                     )
             else:
@@ -1694,7 +1700,7 @@ class SyncCoordinator:
                         f"Sync hung — exceeded {self._DO_SYNC_DEADLINE}s watchdog deadline",
                         level="error",
                         tags={"component": "sync-watchdog"},
-                        context={"phase": phase.name},
+                        context={"phase": phase.at_deadline},
                         fingerprint="sync-watchdog-timeout",
                     )
             # Unchanged by design: both resets run in BOTH branches. Discarding
@@ -1852,7 +1858,7 @@ class SyncCoordinator:
             self._handle_auth_error(auth_err, source="heartbeat")
 
     def _report_overrun_outcome(
-        self, elapsed: float, phase_at_deadline, phase_at_exit: str
+        self, elapsed: float, phase_at_deadline: Optional[str], phase_at_exit: str
     ) -> None:
         """Record how long a cycle that breached the deadline actually ran.
 
@@ -1904,6 +1910,22 @@ class SyncCoordinator:
                     "deadline_seconds": self._DO_SYNC_DEADLINE,
                 },
                 fingerprint=_overrun_fingerprint(elapsed, self._DO_SYNC_DEADLINE),
+                # The occurrence counter IS the measurement here — the digest
+                # reads message + count and never reads context, so a band's
+                # count is the only thing that publishes the distribution.
+                # The reporter's default 300s window dedups PER FINGERPRINT,
+                # so splitting one fingerprint into three bands made the
+                # throttle non-uniform: a marginal cycle (150-180s) puts the
+                # next tick ~180s later and loses roughly 40% of its reports,
+                # while a severe cycle (>=300s) can never be throttled at all.
+                # That overstates severe's share by ~1.5-2x — the wrong
+                # direction for a question whose known failure mode is a false
+                # "hung" (the confirmed 150.86s false fire above). Volume is
+                # bounded by construction: this fires only on an overrun, an
+                # overrun is >=150s, and overlapping ticks are skipped by
+                # _acquire_sync_slot, so ~24/hour/device at warning level,
+                # none of it paging.
+                dedup_window=0,
             )
         except Exception:
             logger.debug("overrun-outcome report failed", exc_info=True)

--- a/src/main.py
+++ b/src/main.py
@@ -169,6 +169,42 @@ def waiting_auth_message(credentials_unreadable: bool) -> str:
 _VERSION: str = __version__ if isinstance(__version__, str) else __version__.__version__
 
 
+# Watchdog overrun severity bands, as multiples of _DO_SYNC_DEADLINE.
+#
+# Ratios rather than absolute seconds, for two reasons. The deadline has moved
+# once already (120s -> 150s) and absolute bands would have quietly become
+# wrong. And the watchdog tests shrink the deadline to sub-second, where
+# absolute bands would put every test cycle in the first bucket and leave the
+# other two unreachable without a five-minute sleep.
+#
+# The band rides in the FINGERPRINT because that is the only thing the ingest
+# aggregates: betterqa-bot stores `context` but overwrites it newest-wins per
+# fingerprint, and the daily digest selects message + occurrences only. An
+# elapsed time in `context` alone would survive one occurrence and appear in no
+# report; a band in the fingerprint turns the occurrence counter into the
+# distribution.
+_OVERRUN_BANDS = (
+    (1.2, "sync-watchdog-overrun-marginal"),
+    (2.0, "sync-watchdog-overrun-moderate"),
+)
+_OVERRUN_BAND_SEVERE = "sync-watchdog-overrun-severe"
+
+
+def _overrun_fingerprint(elapsed: float, deadline: float) -> str:
+    """Dedup key for a cycle that ran `elapsed` against `deadline`.
+
+    Upper bounds are exclusive, so exactly 1.2x is moderate and exactly 2.0x is
+    severe. Callers must only reach here when elapsed >= deadline.
+    """
+    if deadline <= 0:
+        return _OVERRUN_BAND_SEVERE
+    ratio = elapsed / deadline
+    for limit, fingerprint in _OVERRUN_BANDS:
+        if ratio < limit:
+            return fingerprint
+    return _OVERRUN_BAND_SEVERE
+
+
 class SyncCoordinator:
     """Owns the sync scheduler, sync loop, and hours tracking.
 

--- a/src/main.py
+++ b/src/main.py
@@ -1618,6 +1618,11 @@ class SyncCoordinator:
         # for cases where the sleep notification was missed.
         watchdog_cancelled = threading.Event()
 
+        # Cycle start, for the cycle-end outcome report. The watchdog fires AT
+        # the deadline, so elapsed measured inside it is always ~150s however
+        # long the cycle really runs — the true duration is only knowable here.
+        cycle_started_at = time.monotonic()
+
         # Snapshot the transient-failure counter so the watchdog can tell WHY the
         # cycle ran long. An unreachable API makes a healthy cycle overrun (the
         # retry chain plus the send budget legitimately eat ~150s) — that is slow,
@@ -1820,6 +1825,9 @@ class SyncCoordinator:
             watchdog_cancelled.set()
             watchdog.cancel()
             my_lock.release()
+            self._report_overrun_outcome(
+                time.monotonic() - cycle_started_at, phase.name
+            )
 
         # Heartbeat runs AFTER _sync_lock is released — no need to hold
         # the lock during a blocking HTTP call that can take 30s on timeout.
@@ -1829,6 +1837,38 @@ class SyncCoordinator:
         auth_err = self.sync_engine.send_heartbeat_if_due(stats)
         if auth_err is not None:
             self._handle_auth_error(auth_err, source="heartbeat")
+
+    def _report_overrun_outcome(self, elapsed: float, phase_name: str) -> None:
+        """Record how long a cycle that breached the deadline actually ran.
+
+        Gated on elapsed rather than on "did the watchdog fire" so it cannot
+        race the in-flight Timer thread: a watchdog past its cancelled check but
+        not yet flagged would leave this reading "did not fire" for a cycle that
+        did.
+
+        Level is always warning. The fire-time report already paged this same
+        cycle at the deadline as an error; a second error here would add no
+        paging value and double the volume this change exists to reduce.
+
+        A cycle abandoned by _acquire_sync_slot's takeover reaches here late,
+        with its true elapsed — that is the "is it unbounded?" evidence
+        sync-wedged cannot give, since sync-wedged records only that we gave up
+        at the ceiling.
+        """
+        if elapsed < self._DO_SYNC_DEADLINE or self.error_reporter is None:
+            return
+        self.error_reporter.capture(
+            f"Sync overran the {self._DO_SYNC_DEADLINE}s deadline — "
+            f"finished at {elapsed:.1f}s in phase '{phase_name}'",
+            level="warning",
+            tags={"component": "sync-watchdog"},
+            context={
+                "elapsed_seconds": round(elapsed, 1),
+                "phase": phase_name,
+                "deadline_seconds": self._DO_SYNC_DEADLINE,
+            },
+            fingerprint=_overrun_fingerprint(elapsed, self._DO_SYNC_DEADLINE),
+        )
 
     def _set_sync_failure_state(self, error_message: str) -> None:
         """Pick the right tray state for a failed sync.

--- a/src/main.py
+++ b/src/main.py
@@ -205,6 +205,22 @@ def _overrun_fingerprint(elapsed: float, deadline: float) -> str:
     return _OVERRUN_BAND_SEVERE
 
 
+class _CyclePhase:
+    """The stage _do_sync is currently in, as a per-cycle mutable box.
+
+    Deliberately NOT an attribute on SyncCoordinator. A cycle abandoned by
+    _acquire_sync_slot's takeover keeps running to completion, and an instance
+    attribute would let that zombie overwrite the phase of the cycle that
+    replaced it. Same reasoning the transient-failure counter is captured
+    per-thread rather than re-read from the Timer thread.
+    """
+
+    __slots__ = ("name",)
+
+    def __init__(self) -> None:
+        self.name = "startup"
+
+
 class SyncCoordinator:
     """Owns the sync scheduler, sync loop, and hours tracking.
 
@@ -1619,6 +1635,11 @@ class SyncCoordinator:
         cycle_transients = transient_failure_counter()
         transient_at_cycle_start = cycle_transients.value
 
+        # Where the cycle is right now, for the watchdog and the cycle-end
+        # outcome report. Per-cycle box, never an instance attribute — see
+        # _CyclePhase.
+        phase = _CyclePhase()
+
         def _watchdog():
             if watchdog_cancelled.is_set():
                 return
@@ -1642,6 +1663,7 @@ class SyncCoordinator:
                         f"failure{'' if transient_this_cycle == 1 else 's'} this cycle)",
                         level="warning",
                         tags={"component": "sync-watchdog"},
+                        context={"phase": phase.name},
                         fingerprint="sync-watchdog-timeout-offline",
                     )
             else:
@@ -1654,6 +1676,7 @@ class SyncCoordinator:
                         f"Sync hung — exceeded {self._DO_SYNC_DEADLINE}s watchdog deadline",
                         level="error",
                         tags={"component": "sync-watchdog"},
+                        context={"phase": phase.name},
                         fingerprint="sync-watchdog-timeout",
                     )
             # Unchanged by design: both resets run in BOTH branches. Discarding
@@ -1695,17 +1718,21 @@ class SyncCoordinator:
                 # to prevent. Only the upload sync is skipped (it cannot land
                 # while offline); _monitor_capture_health is local-only, and its
                 # sync-gate return is intentionally ignored on this path.
+                phase.name = "capture_health"
                 self._monitor_capture_health()
                 return
 
             # Health-check + self-heal the local tracker stack. Returns False when
             # the caller should skip the upload sync this cycle (AW unreachable and
             # escalated); True to proceed.
+            phase.name = "capture_health"
             if not self._monitor_capture_health():
                 return
 
+            phase.name = "sync"
             stats = self.sync_engine.sync()
 
+            phase.name = "post_sync"
             if stats.aw_bucket_fetch_failed:
                 # AW answers /info but 503s on /buckets/ — is_running() above
                 # passed, so only this path can recover the hung server.
@@ -1757,6 +1784,7 @@ class SyncCoordinator:
                     stats.errors[0] if stats.errors else "Sync failed"
                 )
 
+            phase.name = "hours_fetch"
             hours = self._fetch_hours_today()
             self.tray.update_stats(
                 hours_today=hours if hours is not None else "---",

--- a/src/main.py
+++ b/src/main.py
@@ -1884,19 +1884,29 @@ class SyncCoordinator:
         if elapsed < self._DO_SYNC_DEADLINE or self.error_reporter is None:
             return
         headline_phase = phase_at_deadline if phase_at_deadline is not None else "unknown"
-        self.error_reporter.capture(
-            f"Sync overran the {self._DO_SYNC_DEADLINE}s deadline — "
-            f"finished at {elapsed:.1f}s in phase '{headline_phase}'",
-            level="warning",
-            tags={"component": "sync-watchdog"},
-            context={
-                "elapsed_seconds": round(elapsed, 1),
-                "phase_at_deadline": headline_phase,
-                "phase_at_exit": phase_at_exit,
-                "deadline_seconds": self._DO_SYNC_DEADLINE,
-            },
-            fingerprint=_overrun_fingerprint(elapsed, self._DO_SYNC_DEADLINE),
-        )
+        # capture() documents "never raises", but its final threading.Thread(...)
+        # .start() is unguarded and can raise RuntimeError on a resource-starved
+        # machine — exactly the machine that overruns its deadline. Unguarded,
+        # that would propagate out of _do_sync's finally block, replace any
+        # in-flight exception, and skip the heartbeat call right after it: a
+        # struggling device would also stop reporting that it is alive. Mirror
+        # _note_tick_failure's guard on the same call.
+        try:
+            self.error_reporter.capture(
+                f"Sync overran the {self._DO_SYNC_DEADLINE}s deadline — "
+                f"finished at {elapsed:.1f}s in phase '{headline_phase}'",
+                level="warning",
+                tags={"component": "sync-watchdog"},
+                context={
+                    "elapsed_seconds": round(elapsed, 1),
+                    "phase_at_deadline": headline_phase,
+                    "phase_at_exit": phase_at_exit,
+                    "deadline_seconds": self._DO_SYNC_DEADLINE,
+                },
+                fingerprint=_overrun_fingerprint(elapsed, self._DO_SYNC_DEADLINE),
+            )
+        except Exception:
+            logger.debug("overrun-outcome report failed", exc_info=True)
 
     def _set_sync_failure_state(self, error_message: str) -> None:
         """Pick the right tray state for a failed sync.

--- a/src/main.py
+++ b/src/main.py
@@ -213,12 +213,21 @@ class _CyclePhase:
     attribute would let that zombie overwrite the phase of the cycle that
     replaced it. Same reasoning the transient-failure counter is captured
     per-thread rather than re-read from the Timer thread.
+
+    `at_deadline` is a second, one-shot snapshot: the phase as it stood the
+    moment the watchdog fired. `name` keeps moving after that (the cycle
+    finishes whatever it was doing), so it answers "what was slow?" where
+    `name` at cycle-end only ever answers "what ran last?". Stays None when
+    the outcome report fires without the Timer having run yet (elapsed can
+    cross the deadline before the Timer thread is scheduled) — that is
+    reported honestly as unknown, never backfilled from `name`.
     """
 
-    __slots__ = ("name",)
+    __slots__ = ("name", "at_deadline")
 
     def __init__(self) -> None:
         self.name = "startup"
+        self.at_deadline = None
 
 
 class SyncCoordinator:
@@ -1648,6 +1657,10 @@ class SyncCoordinator:
         def _watchdog():
             if watchdog_cancelled.is_set():
                 return
+            # Snapshot the phase AT THE MOMENT the deadline was breached —
+            # phase.name keeps moving as the cycle finishes up, so this is the
+            # only record of what was actually slow. See _CyclePhase.
+            phase.at_deadline = phase.name
             # Deliberately permissive: ANY transient failure during the cycle
             # downgrades it. A genuine wedge that coincides with one flaky request
             # is downgraded at the deadline — acceptable, because
@@ -1826,7 +1839,7 @@ class SyncCoordinator:
             watchdog.cancel()
             my_lock.release()
             self._report_overrun_outcome(
-                time.monotonic() - cycle_started_at, phase.name
+                time.monotonic() - cycle_started_at, phase.at_deadline, phase.name
             )
 
         # Heartbeat runs AFTER _sync_lock is released — no need to hold
@@ -1838,7 +1851,9 @@ class SyncCoordinator:
         if auth_err is not None:
             self._handle_auth_error(auth_err, source="heartbeat")
 
-    def _report_overrun_outcome(self, elapsed: float, phase_name: str) -> None:
+    def _report_overrun_outcome(
+        self, elapsed: float, phase_at_deadline, phase_at_exit: str
+    ) -> None:
         """Record how long a cycle that breached the deadline actually ran.
 
         Gated on elapsed rather than on "did the watchdog fire" so it cannot
@@ -1854,17 +1869,30 @@ class SyncCoordinator:
         with its true elapsed — that is the "is it unbounded?" evidence
         sync-wedged cannot give, since sync-wedged records only that we gave up
         at the ceiling.
+
+        phase_at_deadline is the diagnostic value — the stage that was
+        actually slow, snapshotted by the watchdog the instant it fired.
+        phase_at_exit (phase.name at cycle end) is not a substitute: it is
+        whatever stage the cycle finished in, which for a normally-completing
+        cycle is almost always a later, fast stage — "stuck in sync, exited in
+        hours_fetch" is the useful pair, not "hours_fetch" alone. When
+        phase_at_deadline is still None (elapsed crossed the deadline before
+        the Timer thread ran), report that honestly as "unknown" rather than
+        silently falling back to phase_at_exit, which would misattribute the
+        overrun to whichever stage happened to be running last.
         """
         if elapsed < self._DO_SYNC_DEADLINE or self.error_reporter is None:
             return
+        headline_phase = phase_at_deadline if phase_at_deadline is not None else "unknown"
         self.error_reporter.capture(
             f"Sync overran the {self._DO_SYNC_DEADLINE}s deadline — "
-            f"finished at {elapsed:.1f}s in phase '{phase_name}'",
+            f"finished at {elapsed:.1f}s in phase '{headline_phase}'",
             level="warning",
             tags={"component": "sync-watchdog"},
             context={
                 "elapsed_seconds": round(elapsed, 1),
-                "phase": phase_name,
+                "phase_at_deadline": headline_phase,
+                "phase_at_exit": phase_at_exit,
                 "deadline_seconds": self._DO_SYNC_DEADLINE,
             },
             fingerprint=_overrun_fingerprint(elapsed, self._DO_SYNC_DEADLINE),

--- a/tests/_watchdog_harness.py
+++ b/tests/_watchdog_harness.py
@@ -23,6 +23,12 @@ def _ok_stats():
         gaps_filled=0,
         errors=[],
         aw_bucket_fetch_failed=False,
+        # Real SyncStats (sync/sync_engine.py) defaults this False. Missing
+        # here made _select_tray_state raise AttributeError for any test that
+        # runs a cycle to natural completion rather than just past the
+        # watchdog firing — masked previously because nothing read phase.name
+        # past that exception until the cycle-end outcome report did.
+        capture_suppressed=False,
     )
 
 

--- a/tests/_watchdog_harness.py
+++ b/tests/_watchdog_harness.py
@@ -1,0 +1,84 @@
+"""Shared coordinator setup for watchdog phase/duration tests.
+
+Extracted so Task 2's and Task 3's test files don't duplicate the same
+~40-line SyncCoordinator wiring — see task-2-brief.md's amendment.
+"""
+
+import threading
+from types import SimpleNamespace
+from unittest.mock import Mock
+
+from src.config import Config
+from src.main import SyncCoordinator
+from src.reminders import ReminderManager
+from src.sync.sync_engine import SyncEngine
+
+
+def _ok_stats():
+    return SimpleNamespace(
+        success=True,
+        events_sent=0,
+        events_queued=0,
+        events_filtered=0,
+        gaps_filled=0,
+        errors=[],
+        aw_bucket_fetch_failed=False,
+    )
+
+
+class _Recorder:
+    def __init__(self):
+        self.captures = []
+
+    def capture(self, message, **kwargs):
+        self.captures.append({"message": message, **kwargs})
+
+    def by_fingerprint(self, fingerprint):
+        return [c for c in self.captures if c.get("fingerprint") == fingerprint]
+
+
+class CoordinatorHarness:
+    """Base class wiring a SyncCoordinator with mocked collaborators.
+
+    Subclass and use self.coord / self.recorder / self.sync_engine etc.
+    TEST_DEADLINE overrides the watchdog deadline used for the cycle under
+    test; override it on a subclass if a different value is needed.
+    """
+
+    TEST_DEADLINE = 0.3
+
+    def setup_method(self):
+        self.config = Config()
+        self.aw = Mock()
+        self.aw.is_running.return_value = True
+        self.bf = Mock()
+        self.queue = Mock()
+        self.queue.get_checkpoint.return_value = None
+        self.queue.size.return_value = 0
+        self.queue.is_near_capacity.return_value = False
+        self.sync_engine = Mock(spec=SyncEngine)
+        self.sync_engine.is_paused = False
+        self.sync_engine.is_private = False
+        self.sync_engine.sync.return_value = _ok_stats()
+        self.tray = Mock()
+        self.tray.model = Mock()
+        self.tray.model.lock = threading.RLock()
+        self.aw_manager = Mock()
+        self.aw_manager.is_managing = False
+        self.reminder = Mock(spec=ReminderManager)
+        self.coord = SyncCoordinator(
+            config=self.config,
+            aw=self.aw,
+            bf=self.bf,
+            queue=self.queue,
+            sync_engine=self.sync_engine,
+            tray=self.tray,
+            aw_manager=self.aw_manager,
+            reminder_manager=self.reminder,
+        )
+        self.coord.scheduler = Mock()
+        self.coord.scheduler.running = True
+        self.recorder = _Recorder()
+        self.coord.error_reporter = self.recorder
+        self.coord._fetch_hours_today = Mock(return_value="1:00")
+        self.coord._DO_SYNC_DEADLINE = self.TEST_DEADLINE

--- a/tests/test_error_reporter.py
+++ b/tests/test_error_reporter.py
@@ -125,6 +125,52 @@ class TestDedup:
             assert post.call_count == 2
 
 
+class TestDedupWindowOverride:
+    """`capture(dedup_window=...)` exists for reports whose OCCURRENCE COUNT is
+    the measurement. A shared per-fingerprint cooldown throttles a
+    short-interval fingerprint harder than a long-interval one, so once one
+    fingerprint is split into severity bands the suppression stops being
+    uniform and silently skews the distribution the counts are supposed to
+    publish. `None` must remain indistinguishable from omitting it, or every
+    existing caller's behaviour changes with it."""
+
+    def test_a_caller_that_omits_the_window_gets_the_instance_default(self) -> None:
+        r = _reporter(dedup_window=10_000)
+        with patch("src.error_reporter.requests.post") as post:
+            post.return_value = MagicMock(status_code=200, text="ok")
+            r.capture("repeat", fingerprint="same", block=True)
+            r.capture("repeat", fingerprint="same", block=True)
+            assert post.call_count == 1
+
+    def test_passing_none_is_identical_to_omitting_it(self) -> None:
+        r = _reporter(dedup_window=10_000)
+        with patch("src.error_reporter.requests.post") as post:
+            post.return_value = MagicMock(status_code=200, text="ok")
+            r.capture("repeat", fingerprint="same", block=True, dedup_window=None)
+            r.capture("repeat", fingerprint="same", block=True, dedup_window=None)
+            assert post.call_count == 1
+
+    def test_explicit_zero_disables_suppression_for_that_call(self) -> None:
+        r = _reporter(dedup_window=10_000)
+        with patch("src.error_reporter.requests.post") as post:
+            post.return_value = MagicMock(status_code=200, text="ok")
+            r.capture("repeat", fingerprint="same", block=True, dedup_window=0)
+            r.capture("repeat", fingerprint="same", block=True, dedup_window=0)
+            assert post.call_count == 2
+
+    def test_the_override_does_not_leak_to_later_default_calls(self) -> None:
+        """A zero-window call still stamps the fingerprint, so the NEXT caller
+        — one that asked for nothing — is suppressed by the instance default
+        exactly as it was before this parameter existed. The override is
+        per-call, and it fails toward fewer sends, not more."""
+        r = _reporter(dedup_window=10_000)
+        with patch("src.error_reporter.requests.post") as post:
+            post.return_value = MagicMock(status_code=200, text="ok")
+            r.capture("repeat", fingerprint="same", block=True, dedup_window=0)
+            r.capture("repeat", fingerprint="same", block=True)
+            assert post.call_count == 1
+
+
 class TestNeverRaises:
     def test_transport_error_is_swallowed(self) -> None:
         r = _reporter()

--- a/tests/test_watchdog_cycle_phase.py
+++ b/tests/test_watchdog_cycle_phase.py
@@ -1,0 +1,70 @@
+"""Which stage was _do_sync in when the watchdog fired.
+
+Coarse by design: the phase is stamped in _do_sync only, so most real overruns
+will report 'sync' because sync_engine.sync() is where the retry chain and the
+send budget live. That still rules OUT the other four stages, at the cost of
+one file instead of instrumenting the ~1000-line sync_engine.sync() on the
+hottest path in the repo.
+
+The phase lives in a per-cycle box rather than on the coordinator: a cycle
+abandoned by _acquire_sync_slot's takeover keeps running, and an instance
+attribute would let that zombie overwrite its successor's phase.
+"""
+
+import time
+from unittest.mock import Mock
+
+from src.main import _CyclePhase
+
+from ._watchdog_harness import CoordinatorHarness, _ok_stats
+
+_OVERRUN = 1.2
+
+
+class TestCyclePhase(CoordinatorHarness):
+    def test_a_fresh_box_starts_at_startup(self):
+        assert _CyclePhase().name == "startup"
+
+    def test_overrun_inside_sync_reports_phase_sync(self):
+        def _slow_sync(*_a, **_k):
+            time.sleep(_OVERRUN)
+            return _ok_stats()
+
+        self.sync_engine.sync.side_effect = _slow_sync
+        self.coord._do_sync()
+
+        hung = self.recorder.by_fingerprint("sync-watchdog-timeout")
+        assert len(hung) == 1, self.recorder.captures
+        assert hung[0]["context"]["phase"] == "sync"
+
+    def test_overrun_inside_capture_health_reports_phase_capture_health(self):
+        """The discriminating case: if the stamp were only ever set to 'sync',
+        the test above would pass and this one would not."""
+
+        def _slow_health():
+            time.sleep(_OVERRUN)
+            return True
+
+        self.coord._monitor_capture_health = Mock(side_effect=_slow_health)
+        self.coord._do_sync()
+
+        hung = self.recorder.by_fingerprint("sync-watchdog-timeout")
+        assert len(hung) == 1, self.recorder.captures
+        assert hung[0]["context"]["phase"] == "capture_health"
+
+    def test_existing_fire_time_report_keeps_its_identity(self):
+        """Global constraint: adding context must not move the fingerprint,
+        level or message of the group that already holds 34 occurrences."""
+
+        def _slow_sync(*_a, **_k):
+            time.sleep(_OVERRUN)
+            return _ok_stats()
+
+        self.sync_engine.sync.side_effect = _slow_sync
+        self.coord._do_sync()
+
+        hung = self.recorder.by_fingerprint("sync-watchdog-timeout")
+        assert len(hung) == 1
+        assert hung[0]["level"] == "error"
+        assert "Sync hung" in hung[0]["message"]
+        assert hung[0]["tags"] == {"component": "sync-watchdog"}

--- a/tests/test_watchdog_overrun_bands.py
+++ b/tests/test_watchdog_overrun_bands.py
@@ -1,0 +1,77 @@
+"""Severity bands for a watchdog overrun.
+
+The ingest (betterqa-bot) aggregates error reports by fingerprint and by
+nothing else — `context` is overwritten newest-wins per fingerprint and the
+daily digest reads only `message` + `occurrences`. So the ONLY way an elapsed
+time becomes countable is by riding in the fingerprint. These bands are that
+mechanism.
+
+Bands are multiples of the deadline rather than absolute seconds: the deadline
+has moved once already (120s -> 150s), and the watchdog integration tests
+shrink it to sub-second, which would collapse absolute bands into one bucket.
+
+Boundaries are tested here, exactly, because a timed cycle cannot land on 1.2x
+reliably.
+"""
+
+import pytest
+
+from src.main import _overrun_fingerprint
+
+MARGINAL = "sync-watchdog-overrun-marginal"
+MODERATE = "sync-watchdog-overrun-moderate"
+SEVERE = "sync-watchdog-overrun-severe"
+
+
+@pytest.mark.parametrize(
+    "elapsed,expected",
+    [
+        # At the deadline exactly — the smallest possible overrun.
+        (150.0, MARGINAL),
+        (151.2, MARGINAL),
+        (179.9, MARGINAL),
+        # 1.2x boundary: BELONGS TO moderate, not marginal. Both ends of the
+        # range get a case (diagnosis-discipline.md Rule 3).
+        (180.0, MODERATE),
+        (246.0, MODERATE),
+        (299.9, MODERATE),
+        # 2.0x boundary: belongs to severe.
+        (300.0, SEVERE),
+        (903.4, SEVERE),
+        (5000.0, SEVERE),
+    ],
+)
+def test_bands_at_the_production_deadline(elapsed, expected):
+    assert _overrun_fingerprint(elapsed, 150.0) == expected
+
+
+@pytest.mark.parametrize(
+    "elapsed,expected",
+    [
+        (0.30, MARGINAL),
+        (0.35, MARGINAL),
+        (0.36, MODERATE),
+        (0.45, MODERATE),
+        (0.60, SEVERE),
+        (0.90, SEVERE),
+    ],
+)
+def test_bands_scale_with_a_shrunk_deadline(elapsed, expected):
+    """The property that makes the integration tests possible at all."""
+    assert _overrun_fingerprint(elapsed, 0.3) == expected
+
+
+def test_returns_exactly_three_distinct_fingerprints():
+    """A band that silently aliases another would make two counts one count."""
+    produced = {
+        _overrun_fingerprint(e, 150.0) for e in (150.0, 200.0, 400.0)
+    }
+    assert produced == {MARGINAL, MODERATE, SEVERE}
+
+
+def test_nonpositive_deadline_does_not_divide_by_zero():
+    """Defensive only: a zero deadline is not reachable in production, but a
+    ZeroDivisionError here would escape into _do_sync's finally block and mask
+    whatever real failure the cycle was already reporting."""
+    assert _overrun_fingerprint(10.0, 0.0) == SEVERE
+    assert _overrun_fingerprint(10.0, -1.0) == SEVERE

--- a/tests/test_watchdog_overrun_outcome.py
+++ b/tests/test_watchdog_overrun_outcome.py
@@ -1,0 +1,113 @@
+"""How long an overrunning cycle actually ran — issue #179.
+
+The watchdog fires AT the deadline, so elapsed measured inside it is always
+~150s no matter what the cycle goes on to do. The real duration is knowable
+only at cycle end, which is where this report is emitted from.
+
+The predicate is `elapsed >= deadline`, deliberately NOT "did the watchdog
+fire": deriving it from elapsed avoids racing the in-flight Timer thread, and
+means these tests never need the timer to fire at all.
+"""
+
+import time
+
+from tests._watchdog_harness import CoordinatorHarness, _ok_stats
+
+MARGINAL = "sync-watchdog-overrun-marginal"
+MODERATE = "sync-watchdog-overrun-moderate"
+SEVERE = "sync-watchdog-overrun-severe"
+ALL_BANDS = (MARGINAL, MODERATE, SEVERE)
+
+
+def _outcome_captures(recorder):
+    return [c for c in recorder.captures if c.get("fingerprint") in ALL_BANDS]
+
+
+class _Harness(CoordinatorHarness):
+    def run_cycle_taking(self, seconds):
+        def _slow_sync(*_a, **_k):
+            time.sleep(seconds)
+            return _ok_stats()
+
+        self.sync_engine.sync.side_effect = _slow_sync
+        self.coord._do_sync()
+
+
+class TestOverrunIsMeasured(_Harness):
+    def test_a_marginal_overrun_reports_the_marginal_band(self):
+        self.run_cycle_taking(0.33)  # ~1.1x of 0.3
+
+        got = self.recorder.by_fingerprint(MARGINAL)
+        assert len(got) == 1, self.recorder.captures
+        assert got[0]["level"] == "warning"
+        assert got[0]["tags"] == {"component": "sync-watchdog"}
+
+    def test_a_moderate_overrun_reports_the_moderate_band(self):
+        self.run_cycle_taking(0.45)  # 1.5x
+
+        assert len(self.recorder.by_fingerprint(MODERATE)) == 1, self.recorder.captures
+        assert self.recorder.by_fingerprint(MARGINAL) == []
+
+    def test_a_severe_overrun_reports_the_severe_band(self):
+        self.run_cycle_taking(0.75)  # 2.5x
+
+        assert len(self.recorder.by_fingerprint(SEVERE)) == 1, self.recorder.captures
+        assert self.recorder.by_fingerprint(MODERATE) == []
+
+    def test_the_report_carries_the_elapsed_time_and_the_phase(self):
+        self.run_cycle_taking(0.45)
+
+        got = self.recorder.by_fingerprint(MODERATE)[0]
+        # Not "sync": the outcome report reads phase.name in the finally
+        # block, by which point a normally-completing cycle has already
+        # advanced past sync/post_sync to the last stamp before it returns
+        # ("hours_fetch") — even though sync() was the phase that overran.
+        # Verified empirically; see task-3-report.md "Deviations from the
+        # brief" for why this differs from the brief's literal assertion.
+        assert got["context"]["phase"] == "hours_fetch"
+        assert got["context"]["deadline_seconds"] == self.TEST_DEADLINE
+        # A real measurement, not a constant: at least the sleep, and not
+        # absurdly more.
+        assert 0.45 <= got["context"]["elapsed_seconds"] < 5.0
+        assert "0.4" in got["message"] or "0.5" in got["message"]
+
+
+class TestHealthyCyclesStaySilent(_Harness):
+    """THE critical negative. If the predicate is implemented backwards this is
+    the only test that catches it, and the failure mode is an outcome report on
+    every healthy cycle — flooding the ingest this change exists to quieten."""
+
+    def test_a_cycle_inside_the_deadline_emits_no_outcome_report(self):
+        self.run_cycle_taking(0.02)  # far under 0.3
+
+        assert _outcome_captures(self.recorder) == [], self.recorder.captures
+
+    def test_the_negative_above_is_not_passing_vacuously(self):
+        """A cycle that never ran would also produce zero outcome captures.
+        Prove the subject was reached: the same harness, overrunning, DOES
+        produce one."""
+        self.run_cycle_taking(0.02)
+        assert _outcome_captures(self.recorder) == []
+
+        self.recorder.captures.clear()
+        self.run_cycle_taking(0.45)
+        assert len(_outcome_captures(self.recorder)) == 1, self.recorder.captures
+
+
+class TestExistingReportsAreUnchanged(_Harness):
+    def test_an_overrun_still_emits_its_fire_time_error(self):
+        """The outcome report is additive. The group that already holds 34
+        occurrences must keep firing exactly as before."""
+        self.run_cycle_taking(0.45)
+
+        hung = self.recorder.by_fingerprint("sync-watchdog-timeout")
+        assert len(hung) == 1, self.recorder.captures
+        assert hung[0]["level"] == "error"
+
+    def test_the_outcome_report_never_uses_error_level(self):
+        """It measures; the fire-time report pages. A second error would double
+        the alert volume."""
+        self.run_cycle_taking(0.75)
+
+        for capture in _outcome_captures(self.recorder):
+            assert capture["level"] == "warning"

--- a/tests/test_watchdog_overrun_outcome.py
+++ b/tests/test_watchdog_overrun_outcome.py
@@ -58,18 +58,45 @@ class TestOverrunIsMeasured(_Harness):
         self.run_cycle_taking(0.45)
 
         got = self.recorder.by_fingerprint(MODERATE)[0]
-        # Not "sync": the outcome report reads phase.name in the finally
-        # block, by which point a normally-completing cycle has already
-        # advanced past sync/post_sync to the last stamp before it returns
-        # ("hours_fetch") — even though sync() was the phase that overran.
-        # Verified empirically; see task-3-report.md "Deviations from the
-        # brief" for why this differs from the brief's literal assertion.
-        assert got["context"]["phase"] == "hours_fetch"
+        assert got["context"]["phase_at_deadline"] == "sync"
         assert got["context"]["deadline_seconds"] == self.TEST_DEADLINE
         # A real measurement, not a constant: at least the sleep, and not
         # absurdly more.
         assert 0.45 <= got["context"]["elapsed_seconds"] < 5.0
         assert "0.4" in got["message"] or "0.5" in got["message"]
+
+    def test_the_report_also_carries_the_exit_phase_and_the_two_differ(self):
+        """phase_at_deadline and phase_at_exit are genuinely different fields:
+        the watchdog fires mid-sync (deadline snapshot: 'sync'), but the cycle
+        goes on to complete normally, so the LAST stamp before the cycle ends
+        is a later stage. Proving they differ is what stops someone
+        'simplifying' the pair back into one field."""
+        self.run_cycle_taking(0.45)
+
+        got = self.recorder.by_fingerprint(MODERATE)[0]
+        assert got["context"]["phase_at_exit"] == "hours_fetch"
+        assert got["context"]["phase_at_deadline"] != got["context"]["phase_at_exit"]
+
+    def test_a_capture_health_overrun_reports_that_phase_at_deadline(self):
+        """The discriminating fixture. Every other test in this file overruns
+        inside sync(), so phase_at_deadline == 'sync' everywhere else — a
+        mutant that hardcodes 'sync' is invisible to all of them (the
+        agreement-region trap: test-fixture-discipline.md Phantom 12). This is
+        the one fixture where the deadline is breached in a DIFFERENT phase,
+        so only this test can tell a real snapshot from a constant."""
+        def _slow_health():
+            time.sleep(0.45)
+            return True
+
+        self.coord._monitor_capture_health = _slow_health
+        self.coord._do_sync()
+
+        got = self.recorder.by_fingerprint(MODERATE)[0]
+        assert got["context"]["phase_at_deadline"] == "capture_health"
+        # It still completes the cycle normally afterwards (sync() is instant
+        # here), so the exit phase has moved on — same pair shape as the
+        # sync-overrun fixtures above, different deadline phase.
+        assert got["context"]["phase_at_exit"] == "hours_fetch"
 
 
 class TestHealthyCyclesStaySilent(_Harness):

--- a/tests/test_watchdog_overrun_outcome.py
+++ b/tests/test_watchdog_overrun_outcome.py
@@ -9,9 +9,11 @@ fire": deriving it from elapsed avoids racing the in-flight Timer thread, and
 means these tests never need the timer to fire at all.
 """
 
+import threading
 import time
 
 import src.main as main_module
+from src.error_reporter import ErrorReporter
 from tests._watchdog_harness import CoordinatorHarness, _ok_stats
 
 MARGINAL = "sync-watchdog-overrun-marginal"
@@ -36,7 +38,16 @@ class _Harness(CoordinatorHarness):
 
 class TestOverrunIsMeasured(_Harness):
     def test_a_marginal_overrun_reports_the_marginal_band(self):
-        self.run_cycle_taking(0.33)  # ~1.1x of 0.3
+        # 1.05x of 0.3. The marginal/moderate boundary is 1.2x = 0.360s, and
+        # the previous 0.33 sleep measured 0.3404s idle / 0.3573s under load —
+        # 2.7ms from flipping to MODERATE, at which point this reads as a
+        # band-selection defect rather than the timing artifact it is. At
+        # 0.315 the worst of 10 idle runs was 0.3212s (38.8ms of margin), and
+        # the same ~27ms of harness overhead seen under load lands ~0.342s,
+        # still clear. The exact boundaries are pinned by
+        # tests/test_watchdog_overrun_bands.py against the pure function, so
+        # this fixture only has to exercise the wiring.
+        self.run_cycle_taking(0.315)
 
         got = self.recorder.by_fingerprint(MARGINAL)
         assert len(got) == 1, self.recorder.captures
@@ -74,17 +85,31 @@ class TestOverrunIsMeasured(_Harness):
         sleep durations and require elapsed_seconds to track EACH one within
         a tight tolerance; no single constant can satisfy both, and the two
         reported values must move apart by roughly the gap between the
-        sleeps."""
+        sleeps.
+
+        The same demand is made of the MESSAGE, and that half is the one
+        that matters operationally: the daily digest renders `message` and
+        the occurrence count and reads `context` never, so a message frozen
+        to `finished at 0.5s` would publish a fixed number to every operator
+        while every context assertion above stayed green."""
         self.run_cycle_taking(0.45)
-        short = self.recorder.by_fingerprint(MODERATE)[0]["context"]["elapsed_seconds"]
+        short_capture = self.recorder.by_fingerprint(MODERATE)[0]
+        short = short_capture["context"]["elapsed_seconds"]
+        short_message = short_capture["message"]
         assert abs(short - 0.45) < 0.15
 
         self.recorder.captures.clear()
         self.run_cycle_taking(0.75)
-        long = self.recorder.by_fingerprint(SEVERE)[0]["context"]["elapsed_seconds"]
+        long_capture = self.recorder.by_fingerprint(SEVERE)[0]
+        long = long_capture["context"]["elapsed_seconds"]
+        long_message = long_capture["message"]
         assert abs(long - 0.75) < 0.15
 
         assert long - short > 0.2
+        # Two materially different cycles must not produce one string. A
+        # frozen figure in the message satisfies every other assertion in
+        # this file — this is the only one it cannot.
+        assert short_message != long_message, (short_message, long_message)
 
     def test_the_report_also_carries_the_exit_phase_and_the_two_differ(self):
         """phase_at_deadline and phase_at_exit are genuinely different fields:
@@ -118,6 +143,13 @@ class TestOverrunIsMeasured(_Harness):
         # here), so the exit phase has moved on — same pair shape as the
         # sync-overrun fixtures above, different deadline phase.
         assert got["context"]["phase_at_exit"] == "hours_fetch"
+        # And the MESSAGE has to carry it. The digest reads message + count
+        # and never reads context, so the phase reaching an operator depends
+        # entirely on this line — deleting `in phase '...'` from the message
+        # leaves every context assertion in this file green. This is also the
+        # only fixture whose deadline phase is not 'sync', so it is the only
+        # one that can tell a real phase in the message from a constant.
+        assert "capture_health" in got["message"], got["message"]
 
     def test_an_aw_bucket_failure_exits_at_post_sync_not_hours_fetch(self):
         """The discriminating fixture for phase_at_exit. Every other test in
@@ -207,6 +239,79 @@ class TestExistingReportsAreUnchanged(_Harness):
 
         for capture in _outcome_captures(self.recorder):
             assert capture["level"] == "warning"
+
+
+class TestEveryOverrunIsCounted(_Harness):
+    """The design's central claim is that the occurrence counter IS the
+    distribution — the digest reads message + count and never reads context,
+    so a band's count is the only thing that publishes how the population is
+    shaped. That claim is only true if no overrun is ever suppressed.
+
+    This has to drive the REAL ErrorReporter. `_Recorder` (used by every other
+    class in this file) has no dedup at all, so it cannot see the client-side
+    cooldown and would pass whatever the production code did."""
+
+    def setup_method(self):
+        super().setup_method()
+        self.posted = []
+        posted_lock = threading.Lock()
+        outer = self
+
+        class _CapturingReporter(ErrorReporter):
+            def _post(self, payload):  # noqa: N805 - matches the base signature
+                with posted_lock:
+                    outer.posted.append(payload)
+
+        self.coord.error_reporter = _CapturingReporter(
+            endpoint="https://bot.example/notify/error",
+            dsn="dsn-token-1234567890",
+            release="test",
+            # Deliberately huge: with the shipped 300s default this fixture
+            # would be timing-dependent. A window this size means any
+            # suppression at all is a hard failure rather than a race.
+            dedup_window=10_000,
+        )
+
+    def _drain(self):
+        for t in threading.enumerate():
+            if t.name == "error-report":
+                t.join(timeout=5)
+
+    def _overrun_payloads(self):
+        return [p for p in self.posted if p["message"].startswith("Sync overran")]
+
+    def test_two_consecutive_overruns_in_one_band_are_both_reported(self):
+        """Both cycles land in the same band, so they share a fingerprint —
+        the exact case the reporter's per-fingerprint cooldown suppresses.
+        Suppressed, the second overrun is invisible to the counter and the
+        band's count stops being its population.
+
+        The bias this closes is not uniform: the marginal band (150-180s at
+        the real deadline) puts the next tick ~180s later and loses roughly
+        40% of its reports to a 300s window, while the severe band (>=300s)
+        can never be throttled at all — so the digest overstates severe's
+        share, the wrong direction for a question whose known failure mode is
+        a false 'hung'."""
+        self.run_cycle_taking(0.45)
+        self.run_cycle_taking(0.45)
+        self._drain()
+
+        got = self._overrun_payloads()
+        assert len(got) == 2, [p["message"] for p in self.posted]
+        assert all(p["level"] == "warning" for p in got)
+
+    def test_the_fire_time_report_keeps_its_default_dedup(self):
+        """The vacuity control, and a scope check in one. If `dedup_window=0`
+        had been applied to the reporter or to every capture rather than to
+        the outcome report alone, this would post twice — and the fire-time
+        group is the one that pages, whose volume this change exists to leave
+        exactly as it was."""
+        self.run_cycle_taking(0.45)
+        self.run_cycle_taking(0.45)
+        self._drain()
+
+        hung = [p for p in self.posted if p["message"].startswith("Sync hung")]
+        assert len(hung) == 1, [p["message"] for p in self.posted]
 
 
 class TestOutcomeReportFailureIsContained(_Harness):

--- a/tests/test_watchdog_overrun_outcome.py
+++ b/tests/test_watchdog_overrun_outcome.py
@@ -11,6 +11,7 @@ means these tests never need the timer to fire at all.
 
 import time
 
+import src.main as main_module
 from tests._watchdog_harness import CoordinatorHarness, _ok_stats
 
 MARGINAL = "sync-watchdog-overrun-marginal"
@@ -60,10 +61,30 @@ class TestOverrunIsMeasured(_Harness):
         got = self.recorder.by_fingerprint(MODERATE)[0]
         assert got["context"]["phase_at_deadline"] == "sync"
         assert got["context"]["deadline_seconds"] == self.TEST_DEADLINE
-        # A real measurement, not a constant: at least the sleep, and not
-        # absurdly more.
-        assert 0.45 <= got["context"]["elapsed_seconds"] < 5.0
+        # Tight band tied to the configured sleep, not a wide "any plausible
+        # constant" range — see test_the_elapsed_time_tracks_the_actual_sleep
+        # below for the mutant-killing version of this same field.
+        assert abs(got["context"]["elapsed_seconds"] - 0.45) < 0.15
         assert "0.4" in got["message"] or "0.5" in got["message"]
+
+    def test_the_elapsed_time_tracks_the_actual_sleep_not_a_constant(self):
+        """A hardcoded literal (e.g. 0.5) would satisfy a wide band like
+        `0.45 <= x < 5.0` for every fixture in this file — they all sleep
+        somewhere in that range. Run two cycles with distinctly different
+        sleep durations and require elapsed_seconds to track EACH one within
+        a tight tolerance; no single constant can satisfy both, and the two
+        reported values must move apart by roughly the gap between the
+        sleeps."""
+        self.run_cycle_taking(0.45)
+        short = self.recorder.by_fingerprint(MODERATE)[0]["context"]["elapsed_seconds"]
+        assert abs(short - 0.45) < 0.15
+
+        self.recorder.captures.clear()
+        self.run_cycle_taking(0.75)
+        long = self.recorder.by_fingerprint(SEVERE)[0]["context"]["elapsed_seconds"]
+        assert abs(long - 0.75) < 0.15
+
+        assert long - short > 0.2
 
     def test_the_report_also_carries_the_exit_phase_and_the_two_differ(self):
         """phase_at_deadline and phase_at_exit are genuinely different fields:
@@ -97,6 +118,54 @@ class TestOverrunIsMeasured(_Harness):
         # here), so the exit phase has moved on — same pair shape as the
         # sync-overrun fixtures above, different deadline phase.
         assert got["context"]["phase_at_exit"] == "hours_fetch"
+
+    def test_an_aw_bucket_failure_exits_at_post_sync_not_hours_fetch(self):
+        """The discriminating fixture for phase_at_exit. Every other test in
+        this file completes normally and exits at 'hours_fetch' — a mutant
+        hardcoding "phase_at_exit": "hours_fetch" is invisible to all of them
+        (the same agreement-region shape as Mutant C / the capture_health
+        test above, this time on the exit field). aw_bucket_fetch_failed
+        returns _do_sync right after the post_sync stamp, before hours_fetch
+        is ever reached."""
+        def _slow_failed_sync(*_a, **_k):
+            time.sleep(0.45)
+            stats = _ok_stats()
+            stats.aw_bucket_fetch_failed = True
+            return stats
+
+        self.sync_engine.sync.side_effect = _slow_failed_sync
+        self.coord._do_sync()
+
+        got = self.recorder.by_fingerprint(MODERATE)[0]
+        assert got["context"]["phase_at_deadline"] == "sync"
+        assert got["context"]["phase_at_exit"] == "post_sync"
+
+    def test_when_the_timer_never_fires_the_deadline_phase_is_unknown(self, monkeypatch):
+        """The outcome predicate is gated on elapsed, not "did the watchdog
+        fire" — so it can fire in the narrow window where elapsed has crossed
+        the deadline but the Timer thread has not run yet. phase_at_deadline
+        must stay honestly 'unknown' there, never silently fall back to
+        phase_at_exit — that fallback is exactly the pre-fix behaviour this
+        change removed (report whichever stage ran last). Stub
+        threading.Timer to a no-op so _watchdog() genuinely never runs,
+        forcing phase.at_deadline to stay None for the whole cycle."""
+
+        class _NoOpTimer:
+            def __init__(self, *_a, **_k):
+                pass
+
+            def start(self):
+                pass
+
+            def cancel(self):
+                pass
+
+        monkeypatch.setattr(main_module.threading, "Timer", _NoOpTimer)
+        self.run_cycle_taking(0.45)
+
+        got = self.recorder.by_fingerprint(MODERATE)[0]
+        assert got["context"]["phase_at_deadline"] == "unknown"
+        assert got["context"]["phase_at_deadline"] != got["context"]["phase_at_exit"]
 
 
 class TestHealthyCyclesStaySilent(_Harness):
@@ -138,3 +207,32 @@ class TestExistingReportsAreUnchanged(_Harness):
 
         for capture in _outcome_captures(self.recorder):
             assert capture["level"] == "warning"
+
+
+class TestOutcomeReportFailureIsContained(_Harness):
+    def test_a_failed_outcome_report_does_not_skip_the_heartbeat(self):
+        """capture() documents "never raises", but its final
+        threading.Thread(...).start() is unguarded and can raise
+        RuntimeError on a resource-starved machine — exactly the machine
+        that overruns its deadline. Unguarded, that would propagate out of
+        _do_sync's finally block and skip send_heartbeat_if_due right after
+        it: a struggling device would also stop reporting that it is
+        alive.
+
+        Fails only the NEW outcome-report capture, not the pre-existing
+        fire-time capture (fired from the Timer thread, unguarded, out of
+        scope for this fix) — a blanket failing mock would raise there too
+        and turn this into an unrelated background-thread exception instead
+        of a clean assertion on the guard actually being tested."""
+        real_capture = self.recorder.capture
+
+        def _fail_only_the_outcome_report(message, **kwargs):
+            if kwargs.get("fingerprint") in ALL_BANDS:
+                raise RuntimeError("can't start new thread")
+            return real_capture(message, **kwargs)
+
+        self.recorder.capture = _fail_only_the_outcome_report
+
+        self.run_cycle_taking(0.45)  # must not raise
+
+        assert self.sync_engine.send_heartbeat_if_due.called


### PR DESCRIPTION
Closes #179.

## What was wrong

The watchdog fires when a sync cycle passes its 150s deadline, and all 34 weekly occurrences look identical. A cycle that finished at 150.9s and a cycle that deadlocked for twenty minutes produce the same row. Those need opposite fixes: the first is a time budget that has outgrown its envelope, the second is the deadlock path `_acquire_sync_slot` exists to survive.

There is already one confirmed false fire on record (device 18, 150.86s, no log gap, all events delivered next cycle). That is why this measures instead of raising the threshold.

## Two things that shaped the design

**The watchdog fires *at* the deadline, so it cannot know the duration.** Elapsed time observed inside `_watchdog()` is always about 150s regardless of what the cycle goes on to do. The real duration is only knowable once the cycle ends, so the new report comes from `finally`, gated on `elapsed >= deadline` rather than on whether the Timer fired. Useful side effect: no test needs the Timer to fire.

**The ingest aggregates by fingerprint and by nothing else.** Reading betterqa-bot: `context` is stored, but it is overwritten newest-wins per fingerprint, and the daily digest selects only `message` and the occurrence count. Attaching the elapsed time to `context`, which is the obvious reading of the issue, would ship a number that survives one occurrence and shows up in no report. The only aggregation available is the occurrence counter, so anything that needs counting has to ride in the fingerprint.

## What ships

Three severity bands, as multiples of the deadline rather than absolute seconds. The deadline has already moved once, 120s to 150s, and absolute bands would have quietly gone wrong instead of failing.

| elapsed | fingerprint | at 150s |
|---|---|---|
| 1.0x to 1.2x | `sync-watchdog-overrun-marginal` | 150-180s |
| 1.2x to 2.0x | `sync-watchdog-overrun-moderate` | 180-300s |
| 2.0x and up | `sync-watchdog-overrun-severe` | 300s+ |

The digest then reads as a distribution with no backend change. All three are `warning`, because the fire-time report already paged this cycle as an `error` and a second one adds no paging value.

There is also a coarse phase, stamped in `_do_sync` only, recorded at the moment the deadline is breached rather than at cycle exit. Most overruns will say `sync`, which still rules out the other four stages.

## Notes for whoever reads this data

**The count is the measurement. The seconds in the message are one arbitrary sample.** `message` is overwritten newest-wins, so the figure on a digest line belongs to whichever occurrence happened to land last. Please don't quote it as representative.

**The new report opts out of client-side dedup** via `dedup_window=0`, a new optional parameter on `ErrorReporter.capture` that defaults to `None` and leaves every existing caller alone. With a single fingerprint the 300s window throttled uniformly. Across three bands it does not: the marginal band loses roughly 40% of its reports while the severe band is never throttled at all, which would overstate severe by 1.5x to 2x. That is the wrong direction for a question whose known failure mode is a false "hung". Volume stays bounded anyway, since an overrun is 150s+ by construction and overlapping ticks get skipped, so roughly 24/hour/device at worst and none of it paging.

**The severe band sizes slow-but-finishing cycles, not wedged ones.** A true deadlock never reaches `finally`, so it produces no outcome report at all. `sync-wedged` covers that population. Don't read "severe = 1" as the wedge count.

**Context keys differ between the two report families.** The fire-time captures use `context.phase`; the new outcome capture uses `phase_at_deadline` and `phase_at_exit`. Worth knowing before writing a query against either.

Known and deliberately left alone: `_should_send` prunes stale entries using the instance window while comparing against the per-call one, so a future caller passing a window *longer* than the default would be silently truncated. Nothing does that today, since `0` is the only value passed.

The two existing fingerprints, levels and messages are byte-identical to what is live, so the group holding those 34 occurrences stays continuous.

## Verification

Full suite green: 1633 passed, 1 skipped, exit 0. I measured the baseline on `origin/main` separately at 1592 passed, because an identical count would have meant the new tests were never collected. `main` was already green, so nothing here inherits a broken baseline.

CI parity was run locally, since Actions is capped. `build.yml`'s test job is the only non-deploy job and its steps were replicated. Lint is not part of CI; the repo carries 169 pre-existing ruff errors and this branch adds none. The same 8 in `src/main.py` appear on `origin/main` at shifted line numbers, and all four new test files are clean.

Every mechanism is witnessed by its own mutant reddening a distinct named test, with the mutation confirmed applied by `cmp` before the result was trusted. That caught three real gaps during review that reading had missed:

- the phase was originally read at cycle exit, so it named whichever stage ran last rather than the slow one
- the "unknown" fallback was guarded by nothing, and reverting it left all 48 tests green
- the digest message, which is the entire operator-facing output, had no assertion at all and survived being gutted

One thing is deliberately unwitnessed and recorded rather than faked: the fire-time captures now read `phase.at_deadline`, and the divergence that prevents needs a non-deterministic window on the Timer thread. Reverting it reddens nothing, and a contrived fixture would have been worse than saying so.

The end-to-end path, agent to ingest to digest, is verified by reading betterqa-bot's ingest and digest code rather than by a live report. The first real overrun on the fleet confirms it.

## Also here

`docs/superpowers/specs/2026-07-22-watchdog-outcome-classification-design.md` still said "designed, not scheduled" even though it shipped a while back. That line sent this session hunting for work that was already done, so it now points at the implementation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
