### PR TITLE
Pick the update DMG by hardware architecture, not process architecture

### DIFF
--- a/src/machine_arch.py
+++ b/src/machine_arch.py
@@ -1,0 +1,155 @@
+"""Resolve the machine's REAL architecture, seeing through Rosetta 2.
+
+``platform.machine()`` reports the architecture of the **running process**, not
+of the hardware. An x86_64 build running under Rosetta 2 on Apple Silicon
+reports ``x86_64`` — byte-identical to what a genuine Intel Mac reports — so it
+cannot tell "this IS an Intel Mac" from "this is the WRONG BUILD on an Apple
+Silicon Mac". Verified on Apple Silicon:
+
+    native:         platform.machine() = arm64    proc_translated = 0
+    arch -x86_64:   platform.machine() = x86_64   proc_translated = 1
+
+That ambiguity is not academic. The updater picks its download by matching the
+architecture against the release asset names, so an Intel install on an M-series
+Mac re-selected the Intel DMG on every update and could never climb out on its
+own. The only discriminator is the ``sysctl.proc_translated`` flag.
+
+Kept dependency-free and fully injectable (``machine`` / ``translated`` /
+``sysctl_reader`` overrides) so the logic is unit-testable on any host, in the
+same spirit as ``release_version.py``.
+"""
+
+import logging
+import platform
+import subprocess
+import threading
+from typing import Callable, Optional
+
+logger = logging.getLogger(__name__)
+
+ARM64 = "arm64"
+X86_64 = "x86_64"
+
+# `sysctl -n sysctl.proc_translated` answers:
+#   "1"      -> this process is x86_64 running under Rosetta 2 on arm64 hardware
+#   "0"      -> native process
+#   <absent> -> the key does not exist at all on a real Intel Mac, so sysctl
+#               exits non-zero and prints to stderr. Absent and "0" MUST be
+#               treated the same; branching on presence marks every Intel Mac
+#               as translated.
+_PROC_TRANSLATED_KEY = "sysctl.proc_translated"
+
+# Guards the memo below. The tray rebuilds its menu on every stats update, and
+# _create_menu() runs while holding TrayIcon._menu_lock, so an un-memoised probe
+# would fork `sysctl` (timeout=2) under that lock on the sync cycle.
+_lock = threading.Lock()
+_cached_raw: Optional[str] = None
+_probed = False
+
+
+def _read_proc_translated_cached() -> Optional[str]:
+    """``_read_proc_translated`` probed at most once per process.
+
+    The answer cannot change while this process lives, so re-probing is pure
+    waste. Failures are cached too — same rule, same reason, as
+    ``hardware_serial.get_hardware_serial``: on a genuine Intel Mac the key does
+    not exist and never will, so a probe that retried would spawn a subprocess
+    on every menu rebuild forever.
+    """
+    global _cached_raw, _probed
+
+    with _lock:
+        if not _probed:
+            _cached_raw = _read_proc_translated()
+            _probed = True
+        return _cached_raw
+
+
+def reset_cache_for_tests() -> None:
+    """Drop the memo. Tests only — the architecture never changes at runtime."""
+    global _cached_raw, _probed
+    with _lock:
+        _cached_raw = None
+        _probed = False
+
+
+def _read_proc_translated() -> Optional[str]:
+    """Return the raw ``sysctl.proc_translated`` value, or None if unreadable.
+
+    None means "could not determine" — a missing key (real Intel Mac), a sysctl
+    that is not on PATH, a timeout, or a sandbox that blocks the call. Callers
+    must treat None as *not translated*; see ``is_rosetta_translated``.
+    """
+    try:
+        result = subprocess.run(
+            ["sysctl", "-n", _PROC_TRANSLATED_KEY],
+            capture_output=True,
+            text=True,
+            timeout=2,
+        )
+    except (OSError, subprocess.SubprocessError) as exc:
+        logger.debug(f"Could not read {_PROC_TRANSLATED_KEY}: {exc}")
+        return None
+
+    if result.returncode != 0:
+        # Expected on Intel Macs: "second level name 'proc_translated' in
+        # 'sysctl.proc_translated' is invalid". Not an error worth logging loudly.
+        return None
+    return result.stdout.strip()
+
+
+def is_rosetta_translated(
+    system: Optional[str] = None,
+    sysctl_reader: Optional[Callable[[], Optional[str]]] = None,
+) -> bool:
+    """True only when this process is provably running under Rosetta 2.
+
+    Fails toward **False** on every uncertainty, and that direction is
+    deliberate. A false "translated" is actively harmful in a way a false
+    "native" is not: it would make the updater hand an arm64 DMG to a genuine
+    Intel Mac, and there is no reverse Rosetta — that binary simply will not
+    run, turning a working install into a dead one. A false "native" merely
+    preserves today's behaviour.
+
+    Args:
+        system: Override ``platform.system()`` for testing (e.g. "Darwin").
+        sysctl_reader: Override the sysctl probe for testing. Returns the raw
+            string value, or None when unreadable.
+    """
+    system = system or platform.system()
+    if system != "Darwin":
+        # Rosetta 2 is macOS-only. Windows-on-ARM emulation is a separate
+        # mechanism and is not something this agent ships a second build for.
+        return False
+
+    reader = sysctl_reader or _read_proc_translated_cached
+    return reader() == "1"
+
+
+def true_machine_arch(
+    system: Optional[str] = None,
+    machine: Optional[str] = None,
+    translated: Optional[bool] = None,
+    sysctl_reader: Optional[Callable[[], Optional[str]]] = None,
+) -> str:
+    """The architecture of the HARDWARE, not of the running process.
+
+    Returns ``platform.machine()`` unchanged everywhere except the one case it
+    gets wrong: an x86_64 process translated by Rosetta 2, which is really
+    running on arm64 silicon.
+
+    Args:
+        system: Override ``platform.system()`` for testing.
+        machine: Override ``platform.machine()`` for testing.
+        translated: Override the Rosetta determination for testing.
+        sysctl_reader: Override the sysctl probe for testing.
+    """
+    system = system or platform.system()
+    machine = machine or platform.machine()
+
+    if translated is None:
+        translated = is_rosetta_translated(system=system, sysctl_reader=sysctl_reader)
+
+    if translated:
+        return ARM64
+    return machine

--- a/src/main.py
+++ b/src/main.py
@@ -29,6 +29,7 @@ try:
     from .browser_tracker import start_browser_tracker
     from .display_info import start_display_tracker
     from .hardware_serial import get_hardware_serial
+    from .machine_arch import is_rosetta_translated
     from .privacy_notice import (
         acknowledgement_telemetry,
         needs_acknowledgement,
@@ -61,6 +62,7 @@ except ImportError:
     from browser_tracker import start_browser_tracker
     from display_info import start_display_tracker
     from hardware_serial import get_hardware_serial
+    from machine_arch import is_rosetta_translated
     from privacy_notice import (
         acknowledgement_telemetry,
         needs_acknowledgement,
@@ -2913,11 +2915,55 @@ class BetterFlowApp:
         #    Windows/Linux consent screen and would otherwise stay undisclosed.
         self._show_privacy_notice_if_needed()
 
+        # Tell Apple Silicon users running the Intel build that they are, since
+        # nothing else will — Rosetta makes it run fine, just slower.
+        self._warn_if_wrong_arch_build()
+
         logger.info("BetterFlow tray starting")
         try:
             self.tray.run_blocking()
         finally:
             self._shutdown()
+
+    def _warn_if_wrong_arch_build(self) -> None:
+        """Notify when this is the Intel build running on Apple Silicon.
+
+        Rosetta 2 runs the x86_64 build without complaint, so a user who picked
+        the wrong installer gets no symptom, no error and no clue — which is
+        exactly why it goes unnoticed for months. macOS itself uses a
+        notification for this case ("Support Ending for Intel-Based Apps"), so
+        the pattern is one users already recognise.
+
+        Fires once per launch rather than once ever. This is not a notice to be
+        acknowledged and filed away like the privacy text; it reports a live
+        misconfiguration that stays true until somebody reinstalls, and it stops
+        by itself the moment they do. A notification is also safe here where the
+        privacy notice was not — it goes through NSUserNotification/osascript
+        and never touches Tk, so there is no NSApplication contention with
+        pystray (#158).
+
+        Best-effort: a machine with notifications disabled or no sysctl loses
+        the warning and nothing else.
+        """
+        try:
+            if not is_rosetta_translated():
+                return
+            logger.warning(
+                "Running the x86_64 build under Rosetta 2 on Apple Silicon — "
+                "the Apple Silicon build should be installed instead"
+            )
+            # Mirrors Apple's own wording for the same situation ("Support
+            # Ending for Intel-Based Apps ... Learn how to update to an Apple
+            # silicon version") — users have been trained on that phrasing by
+            # macOS itself.
+            send_notification(
+                "Intel version on an Apple Silicon Mac",
+                "BetterFlow is running the Intel build through Rosetta. "
+                "Reinstall the Apple Silicon version for better performance "
+                "and battery life.",
+            )
+        except Exception as exc:
+            logger.warning(f"Architecture check failed, skipping the notice: {exc}")
 
     def _show_privacy_notice_if_needed(self) -> None:
         """Show the one-time data-collection notice, once, and record it.

--- a/src/ui/tray.py
+++ b/src/ui/tray.py
@@ -62,10 +62,16 @@ except ImportError:
 try:
     from ..clipboard import clipboard_available, copy_to_clipboard
     from ..hardware_serial import get_hardware_serial
+    from ..machine_arch import ARM64, is_rosetta_translated, true_machine_arch
     from ..notifications import send_notification
 except ImportError:
     from clipboard import clipboard_available, copy_to_clipboard  # type: ignore[no-redef]
     from hardware_serial import get_hardware_serial  # type: ignore[no-redef]
+    from machine_arch import (  # type: ignore[no-redef]
+        ARM64,
+        is_rosetta_translated,
+        true_machine_arch,
+    )
     from notifications import send_notification  # type: ignore[no-redef]
 
 
@@ -234,6 +240,50 @@ except Exception:
             Item = None
 
 logger = logging.getLogger(__name__)
+
+
+def arch_menu_label(
+    system: Optional[str] = None,
+    machine: Optional[str] = None,
+    translated: Optional[bool] = None,
+) -> str:
+    """Build the label for the tray's architecture row.
+
+    Pure and pystray-free for the same reason as ``serial_menu_row()`` below:
+    the backend binds at import time and is unavailable on a headless CI runner,
+    so a rule reachable only through a live TrayIcon could not be exercised in
+    the environment that gates merges. The UI copy lives here rather than in
+    ``machine_arch`` because that module's job is resolving the architecture,
+    not wording a menu — the same split ``serial_menu_row``/``hardware_serial``
+    already uses.
+
+    The architecture itself comes from ``true_machine_arch()``, never re-derived
+    here: this row and the updater's DMG choice are two halves of one promise,
+    and a second copy of the mapping is how the tray ends up naming one
+    architecture while the updater downloads another.
+
+    The mismatch case names the remedy, not just the state: a user reading
+    "Intel build" has no reason to know that is the wrong one.
+
+    Args:
+        system: Override ``platform.system()`` for testing.
+        machine: Override ``platform.machine()`` for testing.
+        translated: Override the Rosetta determination for testing.
+    """
+    system = system or platform.system()
+    machine = machine or platform.machine()
+    if translated is None:
+        translated = is_rosetta_translated(system=system)
+
+    if system != "Darwin":
+        return f"Architecture: {machine}"
+
+    arch = true_machine_arch(system=system, machine=machine, translated=translated)
+    if translated:
+        return "Architecture: Intel build on Apple Silicon — switch to the Apple Silicon version"
+    if arch == ARM64:
+        return "Architecture: Apple Silicon (native)"
+    return f"Architecture: Intel ({arch})"
 
 
 def serial_menu_row() -> tuple:
@@ -771,6 +821,7 @@ class TrayIcon:
             Item(f"Last sync: {s['last_sync']}", None, enabled=False),
             Item("─" * 20, None, enabled=False),
             self._serial_menu_item(),
+            self._arch_menu_item(),
             Item("Privacy Policy", self._handle_open_privacy),
         ]
         items.append(Item("Diagnostics", pystray.Menu(*diag_items), enabled=logged_in))
@@ -829,6 +880,26 @@ class TrayIcon:
         items.append(Item("Quit", self._handle_quit))
 
         return pystray.Menu(*items)
+
+    def _arch_menu_item(self) -> "Item":
+        """The architecture row: which build of BetterFlow is actually running.
+
+        Sits in Diagnostics because it answers a question users could not
+        otherwise answer about their own machine — an Intel build runs happily
+        on Apple Silicon through Rosetta, so there is no symptom to notice and
+        no way to tell from the app which one was installed. Before this row the
+        only answer was `lipo -archs` on the bundle.
+
+        The label lives in the module-level arch_menu_label() so it can be
+        asserted without a live pystray backend; this method only wraps it in a
+        MenuItem. Do not re-derive the label here — a second copy is how the test
+        and the menu drift apart.
+
+        arch_menu_label() reads the memoised probe in src/machine_arch.py, so
+        rebuilding the menu on every state change costs nothing — the row must
+        never fork sysctl under _menu_lock on the sync cycle.
+        """
+        return Item(arch_menu_label(), None, enabled=False)
 
     def _serial_menu_item(self) -> "Item":
         """The device-serial row: readable value, copyable when we can copy.

--- a/src/update_checker.py
+++ b/src/update_checker.py
@@ -8,9 +8,11 @@ from typing import Callable, Optional
 import requests
 
 try:
+    from .machine_arch import true_machine_arch
     from .sync.http_client import resolve_ca_bundle
     from .url_safety import assert_safe_final_url
 except ImportError:  # PyInstaller bundle (src/ is import root)
+    from machine_arch import true_machine_arch
     from sync.http_client import resolve_ca_bundle
     from url_safety import assert_safe_final_url
 
@@ -72,10 +74,14 @@ def _find_platform_asset(
     Args:
         release: GitHub release dict with "assets" list.
         system: Override platform.system() for testing (e.g. "Darwin", "Windows").
-        arch: Override platform.machine() for testing (e.g. "arm64", "x86_64").
+        arch: Override the detected architecture for testing (e.g. "arm64", "x86_64").
     """
     system = system or platform.system()
-    arch = arch or platform.machine()
+    # NOT platform.machine(): that reports the running PROCESS's architecture,
+    # so an Intel build under Rosetta 2 on Apple Silicon answers "x86_64" and
+    # re-selects the Intel DMG on every update — the wrong build could never
+    # correct itself. true_machine_arch() reports the HARDWARE. See machine_arch.
+    arch = arch or true_machine_arch(system=system)
     pattern = _ASSET_PATTERNS.get(system)
     if not pattern:
         return None

--- a/tests/test_machine_arch.py
+++ b/tests/test_machine_arch.py
@@ -1,0 +1,234 @@
+"""Rosetta-aware architecture detection.
+
+``platform.machine()`` describes the running PROCESS, not the hardware, so an
+x86_64 build translated by Rosetta 2 on Apple Silicon is indistinguishable from
+a genuine Intel Mac by that call alone. These pin the discriminator
+(``sysctl.proc_translated``) and — just as importantly — pin the direction the
+detection fails in, because guessing "translated" wrongly on a real Intel Mac
+would serve it an arm64 build it physically cannot execute.
+"""
+
+import inspect
+import platform
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from src import machine_arch as ma
+from src.machine_arch import (
+    ARM64,
+    X86_64,
+    is_rosetta_translated,
+    true_machine_arch,
+)
+from src.ui import tray as tray_mod
+from src.ui.tray import TrayIcon, arch_menu_label
+
+
+@pytest.fixture(autouse=True)
+def _clear_arch_cache():
+    ma.reset_cache_for_tests()
+    yield
+    ma.reset_cache_for_tests()
+
+
+def _reader(value):
+    """A sysctl probe stub returning a fixed raw value (None = unreadable)."""
+    return lambda: value
+
+
+# --- is_rosetta_translated -------------------------------------------------
+
+
+def test_translated_when_proc_translated_is_one():
+    assert is_rosetta_translated(system="Darwin", sysctl_reader=_reader("1")) is True
+
+
+def test_not_translated_when_proc_translated_is_zero():
+    assert is_rosetta_translated(system="Darwin", sysctl_reader=_reader("0")) is False
+
+
+def test_not_translated_when_key_is_absent():
+    """A real Intel Mac has no sysctl.proc_translated key at all — sysctl exits
+    non-zero and the reader yields None. Absent must read the same as "0";
+    treating absence as translated would mark every Intel Mac as wrong-arch."""
+    assert is_rosetta_translated(system="Darwin", sysctl_reader=_reader(None)) is False
+
+
+def test_never_translated_off_macos():
+    """Rosetta 2 is macOS-only. The probe must not even run elsewhere — a Linux
+    box with some unrelated sysctl must never be called translated."""
+    assert is_rosetta_translated(system="Linux", sysctl_reader=_reader("1")) is False
+    assert is_rosetta_translated(system="Windows", sysctl_reader=_reader("1")) is False
+
+
+def test_unreadable_sysctl_fails_toward_native(monkeypatch):
+    """A sysctl that is missing, sandboxed or times out must degrade to "not
+    translated" rather than raising or claiming translation."""
+    def _boom(*a, **k):
+        raise OSError("sysctl not found")
+
+    monkeypatch.setattr(ma.subprocess, "run", _boom)
+    assert is_rosetta_translated(system="Darwin") is False
+
+
+def test_probe_runs_at_most_once_per_process(monkeypatch):
+    """The tray rebuilds its menu on every stats update, under _menu_lock — the
+    probe must not follow it. Forking sysctl (timeout=2) there blocks every
+    other thread's menu update for as long as the probe takes, and the answer
+    cannot change while the process lives.
+
+    A FAILING probe must be cached too: on a genuine Intel Mac the key does not
+    exist, so a retrying probe spawns a subprocess on every rebuild forever.
+    """
+    calls = []
+
+    def _probe(*a, **k):
+        calls.append(1)
+        raise OSError("sysctl not found")
+
+    monkeypatch.setattr(ma.subprocess, "run", _probe)
+
+    for _ in range(3):
+        assert is_rosetta_translated(system="Darwin") is False
+    assert len(calls) == 1
+
+
+# --- true_machine_arch -----------------------------------------------------
+
+
+def test_translated_x86_process_reports_arm64_hardware():
+    """THE DEFECT. Under Rosetta the process says x86_64; the machine is arm64."""
+    assert (
+        true_machine_arch(system="Darwin", machine=X86_64, translated=True) == ARM64
+    )
+
+
+def test_native_apple_silicon_reports_arm64():
+    assert (
+        true_machine_arch(system="Darwin", machine=ARM64, translated=False) == ARM64
+    )
+
+
+def test_genuine_intel_mac_still_reports_x86_64():
+    """The direction that must never break: an arm64 binary cannot run on Intel
+    at all, so a wrong answer here bricks the install rather than slowing it."""
+    assert (
+        true_machine_arch(system="Darwin", machine=X86_64, translated=False) == X86_64
+    )
+
+
+@pytest.mark.parametrize("system", ["Linux", "Windows"])
+def test_non_macos_arch_passes_through_untouched(system):
+    assert true_machine_arch(system=system, machine=X86_64) == X86_64
+    assert true_machine_arch(system=system, machine="aarch64") == "aarch64"
+
+
+# --- arch_menu_label -------------------------------------------------------
+
+
+def test_label_names_the_remedy_when_translated():
+    """A user reading "Intel build" has no reason to know that is the wrong one,
+    so the mismatch label must say what to do about it."""
+    label = arch_menu_label(system="Darwin", machine=X86_64, translated=True)
+    assert label == (
+        "Architecture: Intel build on Apple Silicon — switch to the Apple Silicon version"
+    )
+
+
+def test_label_for_native_apple_silicon():
+    assert (
+        arch_menu_label(system="Darwin", machine=ARM64, translated=False)
+        == "Architecture: Apple Silicon (native)"
+    )
+
+
+def test_label_for_genuine_intel_mac_is_not_a_warning():
+    """An Intel Mac running the Intel build is correct — it must not be nagged."""
+    label = arch_menu_label(system="Darwin", machine=X86_64, translated=False)
+    assert label == "Architecture: Intel (x86_64)"
+    assert "switch" not in label.lower()
+
+
+def test_label_off_macos_is_plain():
+    assert (
+        arch_menu_label(system="Linux", machine=X86_64, translated=False)
+        == "Architecture: x86_64"
+    )
+
+
+# --- the callsite guard: the production menu really uses it ----------------
+
+
+class _RecordedItem:
+    """Stand-in for pystray.MenuItem that records what production asked for."""
+
+    instances: list = []
+
+    def __init__(self, text, action=None, enabled=True, **kwargs):
+        self.text = text
+        self.action = action
+        self.enabled = enabled
+        _RecordedItem.instances.append(self)
+
+
+def _arch_items() -> list:
+    """Drive the REAL _create_menu() and return the architecture rows it built.
+
+    pystray binds its backend at import time, so on a headless CI runner
+    ``tray.pystray`` is None and TrayIcon() is unconstructable — hence the
+    repo-standard patch. Without this guard, deleting _arch_menu_item() from
+    _create_menu leaves every assertion above green (Phantom 3).
+    """
+    _RecordedItem.instances = []
+    with patch.object(tray_mod, "pystray", MagicMock()):
+        icon = TrayIcon()
+        with patch.object(tray_mod, "Item", _RecordedItem):
+            icon._create_menu()
+    return [i for i in _RecordedItem.instances if "Architecture:" in str(i.text)]
+
+
+def test_production_menu_renders_the_arch_row(monkeypatch):
+    """Fails if the row is dropped from _create_menu, not only if the rule breaks."""
+    monkeypatch.setattr(tray_mod, "arch_menu_label", lambda: "Architecture: probed")
+
+    (item,) = _arch_items()
+    assert str(item.text) == "Architecture: probed"
+    assert not item.enabled, "the row states a fact; it is not clickable"
+
+
+def test_production_menu_label_agrees_with_the_label_builder():
+    """The rendered label matches arch_menu_label()'s output on this host."""
+    (item,) = _arch_items()
+    assert str(item.text) == arch_menu_label()
+
+
+def test_arch_item_delegates_instead_of_re_deriving_the_label():
+    """Callsite guard — the menu must not grow its own copy of the rule.
+
+    Comparing outputs cannot catch this: a parallel builder emitting the same
+    string passes every assertion above. Only reading the consumer's source
+    sees it, which is what one-rule-one-implementation.md prescribes.
+    """
+    source = inspect.getsource(TrayIcon._arch_menu_item)
+    doc = TrayIcon._arch_menu_item.__doc__
+    if doc:
+        source = source.replace(doc, "")
+
+    assert "arch_menu_label()" in source, "the menu stopped calling the shared builder"
+    assert "Architecture:" not in source, "label text re-derived at the callsite"
+    assert "platform.machine" not in source, "arch resolved a second time at the callsite"
+
+
+# --- the real host, as a sanity control ------------------------------------
+
+
+def test_detection_runs_on_this_host_without_error():
+    """No fixture: prove the real probe executes and returns something sane on
+    whatever machine CI or a developer is using. Guards against the module
+    working only under mocks."""
+    arch = true_machine_arch()
+    assert isinstance(arch, str) and arch
+    if platform.system() == "Darwin":
+        # Every Mac is one or the other; a translated x86_64 must resolve to arm64.
+        assert arch in (ARM64, X86_64)

--- a/tests/test_update_checker_arch.py
+++ b/tests/test_update_checker_arch.py
@@ -1,0 +1,118 @@
+"""The updater must pick its DMG by HARDWARE architecture, not by process arch.
+
+An Intel build on an Apple Silicon Mac runs under Rosetta 2, where
+``platform.machine()`` answers ``x86_64``. The updater matched on that, so it
+re-selected the Intel DMG on every single update and a wrong-arch install could
+never correct itself — it stayed on Rosetta indefinitely, one silent update at a
+time.
+
+These drive the REAL detection chain (patching the sysctl probe, not passing
+``arch=``) so they exercise the code path a user actually hits. Passing ``arch=``
+would bypass the fix entirely and pass against the broken version.
+"""
+
+import platform
+
+import pytest
+
+from src import machine_arch as ma
+from src.machine_arch import ARM64, X86_64
+from src.update_checker import _find_platform_asset
+
+ARM_DMG = "BetterFlow-macOS-arm64.dmg"
+INTEL_DMG = "BetterFlow-macOS-x86_64.dmg"
+
+
+@pytest.fixture(autouse=True)
+def _clear_arch_cache():
+    """The probe is memoised for the life of the process (it cannot change), so
+    each simulated host must start from an unprobed module."""
+    ma.reset_cache_for_tests()
+    yield
+    ma.reset_cache_for_tests()
+
+
+def _release(*names):
+    return {
+        "assets": [
+            {"name": n, "browser_download_url": f"https://x/{n}"} for n in names
+        ]
+    }
+
+
+@pytest.fixture
+def mac_release():
+    return _release(ARM_DMG, INTEL_DMG, "BetterFlow-Windows-Setup.exe")
+
+
+def _fake_host(monkeypatch, *, machine, proc_translated):
+    """Simulate a Mac: what the process reports, and what sysctl says.
+
+    ``proc_translated`` is the raw sysctl value — None models a real Intel Mac,
+    where the key does not exist and sysctl exits non-zero.
+    """
+    monkeypatch.setattr(platform, "machine", lambda: machine)
+    monkeypatch.setattr(ma, "_read_proc_translated", lambda: proc_translated)
+
+
+def test_rosetta_install_is_offered_the_apple_silicon_dmg(monkeypatch, mac_release):
+    """THE DEFECT, end to end.
+
+    Process reports x86_64 (Rosetta), hardware is arm64. Pre-fix this returned
+    the Intel DMG, so the machine re-installed the wrong build forever.
+    """
+    _fake_host(monkeypatch, machine=X86_64, proc_translated="1")
+
+    assert _find_platform_asset(mac_release, system="Darwin") == f"https://x/{ARM_DMG}"
+
+
+def test_genuine_intel_mac_still_gets_the_intel_dmg(monkeypatch, mac_release):
+    """The control, and the direction that must never break.
+
+    There is no reverse Rosetta: handing an arm64 DMG to a real Intel Mac ships
+    a binary it cannot execute. This test is what stops the fix overshooting.
+    """
+    _fake_host(monkeypatch, machine=X86_64, proc_translated=None)
+
+    assert _find_platform_asset(mac_release, system="Darwin") == f"https://x/{INTEL_DMG}"
+
+
+def test_native_apple_silicon_gets_the_arm_dmg(monkeypatch, mac_release):
+    _fake_host(monkeypatch, machine=ARM64, proc_translated="0")
+
+    assert _find_platform_asset(mac_release, system="Darwin") == f"https://x/{ARM_DMG}"
+
+
+def test_explicit_arch_override_still_wins(monkeypatch, mac_release):
+    """The existing `arch=` test hook must keep overriding detection, or every
+    test written against it silently starts measuring the host instead."""
+    _fake_host(monkeypatch, machine=X86_64, proc_translated="1")
+
+    assert (
+        _find_platform_asset(mac_release, system="Darwin", arch=X86_64)
+        == f"https://x/{INTEL_DMG}"
+    )
+
+
+def test_rosetta_falls_back_to_generic_dmg_when_no_arm_asset(monkeypatch):
+    """An older release with a single unsuffixed DMG must still update rather
+    than dead-end because no arm64-named asset exists."""
+    _fake_host(monkeypatch, machine=X86_64, proc_translated="1")
+    release = _release("BetterFlow-macOS.dmg")
+
+    assert (
+        _find_platform_asset(release, system="Darwin")
+        == "https://x/BetterFlow-macOS.dmg"
+    )
+
+
+def test_windows_selection_is_unaffected_by_the_arch_change(monkeypatch):
+    """Windows matches on the zip and never on arch; the fix must not disturb
+    it. Pinned because the arch lookup now runs for every platform."""
+    _fake_host(monkeypatch, machine=X86_64, proc_translated=None)
+    release = _release("BetterFlow-Windows-Update.zip", "BetterFlow-Windows-Setup.exe")
+
+    assert (
+        _find_platform_asset(release, system="Windows")
+        == "https://x/BetterFlow-Windows-Update.zip"
+    )


### PR DESCRIPTION
Addresses the Apple Silicon half of #184, reported by Lorenzo Muresan.

## The bug

An Intel build on an Apple Silicon Mac runs under Rosetta 2, where `platform.machine()` answers `x86_64` — byte-identical to what a real Intel Mac answers. `update_checker._find_platform_asset` matched release assets on that value, so a wrong-arch install **re-selected the Intel DMG on every update and could never climb out of Rosetta on its own**. Nothing crashed, so nobody noticed; it just ran slower and drained more battery, indefinitely.

Also fixes the reason nobody could answer Lorenzo's actual question ("are we on the Intel version?"): until now the only way to know was `lipo -archs` on the bundle.

## The fix

New `src/machine_arch.py` resolves the **hardware** architecture via `sysctl.proc_translated`, the only value that separates "is an Intel Mac" from "is the wrong build on an Apple Silicon Mac".

It fails toward *not translated* on every uncertainty (missing key, absent sysctl, timeout, non-Darwin), and that direction is deliberate: **there is no reverse Rosetta.** Wrongly claiming translation would hand a genuine Intel Mac an arm64 DMG it physically cannot execute — turning a slow install into a dead one. A false negative merely preserves today's behaviour. Both directions are pinned by tests.

Surfacing it to users:

- **Tray > Diagnostics** gains an Architecture row. The mismatch case names the remedy, because "Intel build" does not read as "wrong" on its own.
- **A startup notification** when translated, mirroring macOS's own "Support Ending for Intel-Based Apps" wording — a pattern users already recognise. Once per launch, not once ever: this reports a live misconfiguration that stays true until someone reinstalls, and stops by itself when they do. It uses `send_notification` (NSUserNotification/osascript), so unlike the privacy notice there is no Tk/NSApplication contention with pystray (#158).

## Verification

**Proof of failure.** Reverting `src/update_checker.py` alone to its `origin/main` version, with the new module and tests in place, reddens exactly one test:

```
FAILED test_rosetta_install_is_offered_the_apple_silicon_dmg
E   assert 'https://x/BetterFlow-macOS-x86_64.dmg' == 'https://x/BetterFlow-macOS-arm64.dmg'
1 failed, 5 passed
```

The other five pass in **both** versions — including the Intel-Mac control — so the suite isolates the defect rather than describing the new code. Restored, all 25 pass.

**Real hardware, not mocks.** The shipped detection executed under genuine Rosetta on an M1:

```
NATIVE:          process=arm64    translated=False -> true_arch=arm64
UNDER ROSETTA:   process=x86_64   translated=True  -> true_arch=arm64
```

And end-to-end against the live v1.5.122 release payload, natively: selects `BetterFlow-macOS-arm64.dmg`.

*Stated limit:* I could not run `_find_platform_asset` **inside** a translated process end-to-end — system Python lacks the agent's dependency tree and I would not pollute it to get there. Both halves of that composition are separately proven for real (detection above; asset matching against the live release), and the unit tests cover the join with the sysctl probe patched.

**Gates.** Full suite `1660 passed, 1 skipped`, exit 0. `ruff` clean on all new files; `tray.py` and `main.py` carry 7 and 8 pre-existing errors, **rule-for-rule identical** to `origin/main` (diffed, not counted). The pre-commit review hook ran 3 adversarial lenses, found 4 real issues and applied fixes — including memoising the sysctl probe, since the tray rebuilds its menu under `_menu_lock` and forking `sysctl` there would block other threads. That hook noted it verified its own edits *by reading, not execution*, so everything above was re-run from scratch afterwards.

## Not in this PR

Both remain open on #184:

- **Reporting arch on the heartbeat** so the fleet view can answer "who is on Intel?" — needs the internal-tool2 side to store and display it. Shipping the agent half alone would be a write with no reader.
- **A universal2 binary**, which deletes this entire class of bug: no choice to get wrong, no detection to get wrong, no wrong-arch state to recover from. Worth costing before investing further in the detection path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)