### PR TITLE
Pin the arch-probe warm-up, and finish the architecture row off macOS

### DIFF
--- a/src/ui/tray.py
+++ b/src/ui/tray.py
@@ -242,6 +242,19 @@ except Exception:
 logger = logging.getLogger(__name__)
 
 
+# Windows reports "AMD64", Linux "x86_64"/"aarch64", and Windows-on-ARM
+# "ARM64" — three spellings of two families. Lower-cased keys, because the
+# spelling is the platform's choice and not something a user should have to
+# decode. Anything absent renders as its raw token: an unknown architecture is
+# better shown verbatim than guessed at.
+_NON_DARWIN_ARCH_FAMILIES = {
+    "amd64": "64-bit x86",
+    "x86_64": "64-bit x86",
+    "arm64": "64-bit ARM",
+    "aarch64": "64-bit ARM",
+}
+
+
 def arch_menu_label(
     system: Optional[str] = None,
     machine: Optional[str] = None,
@@ -265,6 +278,13 @@ def arch_menu_label(
     The mismatch case names the remedy, not just the state: a user reading
     "Intel build" has no reason to know that is the wrong one.
 
+    Off macOS the row reads "<family> (<raw>)" to match the macOS rows, which
+    are prose rather than a bare token. It deliberately does NOT say "Intel"
+    there: on macOS every x86_64 machine really is Intel, but ``AMD64`` on
+    Windows is the x86-64 *instruction set* and says nothing about the vendor,
+    so naming Intel would be a plain factual error on an AMD CPU. An
+    unrecognised value falls back to the raw token rather than guessing.
+
     Args:
         system: Override ``platform.system()`` for testing.
         machine: Override ``platform.machine()`` for testing.
@@ -276,7 +296,10 @@ def arch_menu_label(
         translated = is_rosetta_translated(system=system)
 
     if system != "Darwin":
-        return f"Architecture: {machine}"
+        family = _NON_DARWIN_ARCH_FAMILIES.get(machine.lower())
+        if not family:
+            return f"Architecture: {machine}"
+        return f"Architecture: {family} ({machine})"
 
     arch = true_machine_arch(system=system, machine=machine, translated=translated)
     if translated:

--- a/src/ui/tray.py
+++ b/src/ui/tray.py
@@ -242,12 +242,12 @@ except Exception:
 logger = logging.getLogger(__name__)
 
 
-# Windows reports "AMD64", Linux "x86_64"/"aarch64", and Windows-on-ARM
-# "ARM64" — three spellings of two families. Lower-cased keys, because the
+# Windows reports "AMD64", Linux "x86_64"/"aarch64", Windows-on-ARM "ARM64" —
+# four spellings of two instruction sets. Lower-cased keys, because the
 # spelling is the platform's choice and not something a user should have to
 # decode. Anything absent renders as its raw token: an unknown architecture is
 # better shown verbatim than guessed at.
-_NON_DARWIN_ARCH_FAMILIES = {
+_NON_DARWIN_ARCH_ISAS = {
     "amd64": "64-bit x86",
     "x86_64": "64-bit x86",
     "arm64": "64-bit ARM",
@@ -278,12 +278,22 @@ def arch_menu_label(
     The mismatch case names the remedy, not just the state: a user reading
     "Intel build" has no reason to know that is the wrong one.
 
-    Off macOS the row reads "<family> (<raw>)" to match the macOS rows, which
-    are prose rather than a bare token. It deliberately does NOT say "Intel"
-    there: on macOS every x86_64 machine really is Intel, but ``AMD64`` on
-    Windows is the x86-64 *instruction set* and says nothing about the vendor,
-    so naming Intel would be a plain factual error on an AMD CPU. An
-    unrecognised value falls back to the raw token rather than guessing.
+    Off macOS the row reads "<instruction set> (<raw>)" to match the macOS
+    rows, which are prose rather than a bare token. Two things it deliberately
+    does NOT claim there, because only the Darwin branch resolves hardware:
+
+    - **No CPU vendor.** Every x86_64 Mac really is an Intel Mac, so the Darwin
+      row can say "Intel". ``AMD64`` on Windows names the x86-64 instruction
+      set and says nothing about who made the chip, so copying that wording
+      would be a plain factual error on a Ryzen.
+    - **No hardware family.** These names describe the ISA this PROCESS
+      executes, which is all ``platform.machine()`` reports. An x64 build under
+      Windows-on-ARM emulation genuinely is executing x86-64, so "64-bit x86"
+      stays true where "this is an x86 machine" would not. Seeing through that
+      emulation needs a Windows equivalent of ``proc_translated``, which
+      ``machine_arch`` deliberately does not model.
+
+    An unrecognised value falls back to the raw token rather than guessing.
 
     Args:
         system: Override ``platform.system()`` for testing.
@@ -296,10 +306,10 @@ def arch_menu_label(
         translated = is_rosetta_translated(system=system)
 
     if system != "Darwin":
-        family = _NON_DARWIN_ARCH_FAMILIES.get(machine.lower())
-        if not family:
+        isa = _NON_DARWIN_ARCH_ISAS.get(machine.lower())
+        if not isa:
             return f"Architecture: {machine}"
-        return f"Architecture: {family} ({machine})"
+        return f"Architecture: {isa} ({machine})"
 
     arch = true_machine_arch(system=system, machine=machine, translated=translated)
     if translated:

--- a/tests/test_arch_notice_startup.py
+++ b/tests/test_arch_notice_startup.py
@@ -9,28 +9,39 @@ It is ALSO the first caller of ``machine_arch``'s memoised ``sysctl`` probe —
 but read the next paragraph before pricing that, because the obvious reading is
 wrong and was in this file's first draft.
 
-The tray rebuilds its menu on every stats update and ``_create_menu()`` runs
-under ``_menu_lock`` (``tray.py:1665``/``:1679``), so an UN-MEMOISED probe would
-fork ``sysctl`` (``timeout=2``) under that lock for the life of the process.
-That is real, and the memo is what prevents it. The warm-up ordering is not:
-``_update_menu`` returns early while ``self._icon`` is ``None``, and the first
-``_create_menu()`` in production is a constructor argument inside
-``run_blocking()`` (``tray.py:1785``), evaluated before ``_icon`` is assigned
-and while no menu lock is held. So dropping the warm-up costs exactly one
-lock-free fork on the main thread at startup — not an ongoing cost, and not a
-cost under the lock.
+The tray rebuilds its menu on every stats update, and ``_create_menu()`` runs
+under ``_menu_lock`` (built at ``tray.py:1675`` and ``:1689``, under the locks
+taken at ``:1666`` and ``:1685``). The menu is built EAGERLY — ``_arch_menu_item``
+calls ``arch_menu_label()`` and hands the finished string to ``Item`` — so an
+UN-MEMOISED probe really would fork ``sysctl`` (``timeout=2``) under that lock
+for the life of the process. The memo is what prevents it.
+
+The warm-up ordering is NOT what prevents it, though that was this file's first
+draft: ``_update_menu`` returns early while ``self._icon`` is ``None``, and the
+first ``_create_menu()`` in production is a constructor argument
+(``tray.py:1795``) inside ``run_blocking()``, evaluated before ``_icon`` is
+assigned at ``:1791`` and holding no menu lock. So dropping the warm-up costs
+exactly one lock-free fork on the main thread at startup — not an ongoing cost,
+and not a cost under the lock.
 
 Hence two independent guards, failing for different reasons: the ordering tests
 catch the call moving or being deleted, and the fork-counting pair catches the
 MEMO being removed. Do not merge their rationales; they are not the same claim.
 
-Every test here injects ``system="Darwin"`` rather than reading the host's.
-Both short-circuit before the probe off macOS (``machine_arch.py:120``,
-``tray.py:298``), so a host-dependent version of these tests counts zero forks
-and fails on the ubuntu runner that gates every PR — and on three of the four
-platforms of the tag build, which produces no release when any leg is red. A
-``skipif`` would be worse than useless: only tag builds run a macOS job, so the
-guard would then execute in no PR-gating job at all.
+Every test here injects ``system="Darwin"`` rather than reading the host's. The
+short-circuit is in ``machine_arch.py:120`` — ``is_rosetta_translated`` returns
+``False`` for a non-Darwin system without ever consulting the reader. Note that
+``arch_menu_label`` does NOT itself short-circuit first: it calls
+``is_rosetta_translated`` unconditionally (``tray.py:306``) and only then takes
+its non-Darwin branch (``:308``). The net effect is the same — no fork off
+macOS — but the mechanism lives in one place, not two, and this file exists to
+stop the next reader inheriting a mechanism that is not there.
+
+Either way a host-dependent version of these tests counts zero forks and fails
+on the ubuntu runner that gates every PR — and on three of the four platforms
+of the tag build, which produces no release when any leg is red. A ``skipif``
+would be worse than useless: only tag builds run a macOS job, so the guard
+would then execute in no PR-gating job at all.
 """
 
 import inspect

--- a/tests/test_arch_notice_startup.py
+++ b/tests/test_arch_notice_startup.py
@@ -1,0 +1,157 @@
+"""The wrong-arch notice, and the ordering that keeps ``sysctl`` off the tray lock.
+
+``_warn_if_wrong_arch_build`` looks like a pure user-facing courtesy, so the
+obvious refactor is to move it, defer it, or drop it onto a worker. It has a
+second job that nothing in its own body advertises: it is the FIRST caller of
+``machine_arch``'s memoised probe, and it runs on the main thread while the
+tray is still idle.
+
+That matters because the architecture row is rebuilt with every menu rebuild,
+and ``TrayIcon._create_menu()`` runs while holding ``_menu_lock`` on the sync
+cycle. With a cold memo the row forks ``sysctl`` (``timeout=2``) under that
+lock. Today it is always warm by then — but only because of where the warning
+sits in ``run()``, and nothing pinned that until this file. The comments in
+``machine_arch`` and ``TrayIcon._arch_menu_item`` both assert the property as
+though it were structural; it is positional.
+
+So there are two tests here, and they fail for different reasons. The ordering
+test catches the call moving or being deleted. The behavioural test pins the
+REASON the ordering matters, by counting real subprocess forks — it would still
+fail if the memo were removed while the ordering stayed correct.
+"""
+
+import inspect
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from src import machine_arch as ma
+from src.main import BetterFlowApp
+from src.ui.tray import arch_menu_label
+
+
+@pytest.fixture(autouse=True)
+def _clear_arch_cache():
+    ma.reset_cache_for_tests()
+    yield
+    ma.reset_cache_for_tests()
+
+
+# --- the callsite guards ---------------------------------------------------
+
+
+def test_run_warns_about_a_wrong_arch_build():
+    """Fails if the call is dropped from run(), not only if the logic breaks."""
+    source = inspect.getsource(BetterFlowApp.run)
+    assert "_warn_if_wrong_arch_build()" in source
+
+
+def test_the_warning_runs_before_the_tray_loop():
+    """Ordering is load-bearing twice over.
+
+    After ``tray.run_blocking()`` the call would never execute at all — that
+    method blocks for the life of the process. And the probe would then first
+    run from a menu rebuild, i.e. under ``_menu_lock``, which is the thing the
+    memo exists to prevent (see this module's docstring).
+    """
+    source = inspect.getsource(BetterFlowApp.run)
+    warn = source.index("self._warn_if_wrong_arch_build()")
+    tray = source.index("self.tray.run_blocking()")
+    assert warn < tray, (
+        "the arch warning moved after the tray loop — it now never fires, and "
+        "the first sysctl probe lands under _menu_lock on the sync cycle"
+    )
+
+
+def test_the_warning_is_not_nested_behind_a_platform_branch():
+    """It must reach every launch; is_rosetta_translated() does the filtering.
+
+    Gating the call on a platform check in run() would put the same rule in two
+    places, and the copy in run() is the one that would drift.
+    """
+    source = inspect.getsource(BetterFlowApp.run)
+    line = [
+        line
+        for line in source.splitlines()
+        if "self._warn_if_wrong_arch_build()" in line
+    ][0]
+    # Top level of run(): 8 spaces of indentation, not inside a conditional.
+    assert len(line) - len(line.lstrip()) == 8, (
+        "the arch warning is nested inside a branch in run() — some platform "
+        "or some state will not warm the probe"
+    )
+
+
+# --- the reason the ordering matters ---------------------------------------
+
+
+def _counting_probe():
+    """The real probe, wrapped so we can count actual subprocess forks."""
+    calls = []
+    real = ma._read_proc_translated
+
+    def counting():
+        calls.append(1)
+        return real()
+
+    return calls, counting
+
+
+def test_a_cold_probe_really_does_fork_from_the_menu_row():
+    """The positive control, and it is not optional.
+
+    The test below asserts an ABSENCE of forks. An absence is also what a
+    broken counter, an unreachable row, or a label that stopped consulting
+    machine_arch would produce. This proves the row can reach the probe at all,
+    so the zero next door means something.
+    """
+    calls, counting = _counting_probe()
+    with patch.object(ma, "_read_proc_translated", counting):
+        ma.reset_cache_for_tests()
+        arch_menu_label()
+
+    assert len(calls) == 1, (
+        "the architecture row no longer reaches the sysctl probe — the test "
+        "below is now asserting nothing"
+    )
+
+
+def test_warming_the_probe_first_makes_every_menu_rebuild_free():
+    """What run() buys the tray: no fork under _menu_lock, ever.
+
+    50 rebuilds stands in for a long-lived session — the tray rebuilds its menu
+    on every stats update, so an un-memoised probe would fork sysctl on the
+    sync cycle for the life of the process.
+    """
+    calls, counting = _counting_probe()
+    with patch.object(ma, "_read_proc_translated", counting):
+        ma.reset_cache_for_tests()
+
+        # Exactly what _warn_if_wrong_arch_build does first.
+        ma.is_rosetta_translated()
+        warmup_forks = len(calls)
+        calls.clear()
+
+        for _ in range(50):
+            arch_menu_label()
+
+    assert warmup_forks == 1, "the warm-up did not probe; nothing was cached"
+    assert calls == [], (
+        f"the architecture row forked sysctl {len(calls)} times after the "
+        "warm-up — the memo in machine_arch is gone, and menu rebuilds now "
+        "block _menu_lock on the sync cycle"
+    )
+
+
+def test_the_warning_survives_a_probe_that_blows_up():
+    """Best-effort: a broken sysctl loses the notice and nothing else.
+
+    Startup must not die because a diagnostic could not be computed.
+    """
+    stub = MagicMock()
+    with patch.object(
+        ma, "_read_proc_translated_cached", side_effect=OSError("no sysctl")
+    ):
+        BetterFlowApp._warn_if_wrong_arch_build(stub)  # must not raise
+
+    stub.tray.assert_not_called()

--- a/tests/test_arch_notice_startup.py
+++ b/tests/test_arch_notice_startup.py
@@ -1,23 +1,36 @@
-"""The wrong-arch notice, and the ordering that keeps ``sysctl`` off the tray lock.
+"""The wrong-arch notice: that it fires at all, and that the probe stays memoised.
 
-``_warn_if_wrong_arch_build`` looks like a pure user-facing courtesy, so the
-obvious refactor is to move it, defer it, or drop it onto a worker. It has a
-second job that nothing in its own body advertises: it is the FIRST caller of
-``machine_arch``'s memoised probe, and it runs on the main thread while the
-tray is still idle.
+``_warn_if_wrong_arch_build`` sits in ``BetterFlowApp.run()`` just before
+``self.tray.run_blocking()``. That position is load-bearing for one plain
+reason: ``run_blocking()`` blocks for the life of the process, so a call moved
+below it never executes. Nothing pinned the position until this file.
 
-That matters because the architecture row is rebuilt with every menu rebuild,
-and ``TrayIcon._create_menu()`` runs while holding ``_menu_lock`` on the sync
-cycle. With a cold memo the row forks ``sysctl`` (``timeout=2``) under that
-lock. Today it is always warm by then — but only because of where the warning
-sits in ``run()``, and nothing pinned that until this file. The comments in
-``machine_arch`` and ``TrayIcon._arch_menu_item`` both assert the property as
-though it were structural; it is positional.
+It is ALSO the first caller of ``machine_arch``'s memoised ``sysctl`` probe —
+but read the next paragraph before pricing that, because the obvious reading is
+wrong and was in this file's first draft.
 
-So there are two tests here, and they fail for different reasons. The ordering
-test catches the call moving or being deleted. The behavioural test pins the
-REASON the ordering matters, by counting real subprocess forks — it would still
-fail if the memo were removed while the ordering stayed correct.
+The tray rebuilds its menu on every stats update and ``_create_menu()`` runs
+under ``_menu_lock`` (``tray.py:1665``/``:1679``), so an UN-MEMOISED probe would
+fork ``sysctl`` (``timeout=2``) under that lock for the life of the process.
+That is real, and the memo is what prevents it. The warm-up ordering is not:
+``_update_menu`` returns early while ``self._icon`` is ``None``, and the first
+``_create_menu()`` in production is a constructor argument inside
+``run_blocking()`` (``tray.py:1785``), evaluated before ``_icon`` is assigned
+and while no menu lock is held. So dropping the warm-up costs exactly one
+lock-free fork on the main thread at startup — not an ongoing cost, and not a
+cost under the lock.
+
+Hence two independent guards, failing for different reasons: the ordering tests
+catch the call moving or being deleted, and the fork-counting pair catches the
+MEMO being removed. Do not merge their rationales; they are not the same claim.
+
+Every test here injects ``system="Darwin"`` rather than reading the host's.
+Both short-circuit before the probe off macOS (``machine_arch.py:120``,
+``tray.py:298``), so a host-dependent version of these tests counts zero forks
+and fails on the ubuntu runner that gates every PR — and on three of the four
+platforms of the tag build, which produces no release when any leg is red. A
+``skipif`` would be worse than useless: only tag builds run a macOS job, so the
+guard would then execute in no PR-gating job at all.
 """
 
 import inspect
@@ -26,6 +39,7 @@ from unittest.mock import MagicMock, patch
 import pytest
 
 from src import machine_arch as ma
+from src.machine_arch import X86_64
 from src.main import BetterFlowApp
 from src.ui.tray import arch_menu_label
 
@@ -47,19 +61,17 @@ def test_run_warns_about_a_wrong_arch_build():
 
 
 def test_the_warning_runs_before_the_tray_loop():
-    """Ordering is load-bearing twice over.
+    """``run_blocking()`` blocks for the life of the process.
 
-    After ``tray.run_blocking()`` the call would never execute at all — that
-    method blocks for the life of the process. And the probe would then first
-    run from a menu rebuild, i.e. under ``_menu_lock``, which is the thing the
-    memo exists to prevent (see this module's docstring).
+    A call moved below it does not run late — it never runs at all, on any
+    machine, forever, with nothing to show for it.
     """
     source = inspect.getsource(BetterFlowApp.run)
     warn = source.index("self._warn_if_wrong_arch_build()")
     tray = source.index("self.tray.run_blocking()")
     assert warn < tray, (
-        "the arch warning moved after the tray loop — it now never fires, and "
-        "the first sysctl probe lands under _menu_lock on the sync cycle"
+        "the arch warning moved below the tray loop — run_blocking() never "
+        "returns, so the notice can no longer fire on any machine"
     )
 
 
@@ -78,15 +90,20 @@ def test_the_warning_is_not_nested_behind_a_platform_branch():
     # Top level of run(): 8 spaces of indentation, not inside a conditional.
     assert len(line) - len(line.lstrip()) == 8, (
         "the arch warning is nested inside a branch in run() — some platform "
-        "or some state will not warm the probe"
+        "or some state will not see it"
     )
 
 
-# --- the reason the ordering matters ---------------------------------------
+# --- the memo, which is what keeps sysctl off _menu_lock -------------------
 
 
 def _counting_probe():
-    """The real probe, wrapped so we can count actual subprocess forks."""
+    """The real probe, wrapped so we can count actual subprocess forks.
+
+    The counter increments BEFORE delegating, so a host with no ``sysctl`` (any
+    CI runner that is not a Mac) still records the attempt. That is what lets
+    these assertions mean the same thing on every platform.
+    """
     calls = []
     real = ma._read_proc_translated
 
@@ -102,13 +119,14 @@ def test_a_cold_probe_really_does_fork_from_the_menu_row():
 
     The test below asserts an ABSENCE of forks. An absence is also what a
     broken counter, an unreachable row, or a label that stopped consulting
-    machine_arch would produce. This proves the row can reach the probe at all,
-    so the zero next door means something.
+    machine_arch would produce — and it is exactly what the whole non-Darwin
+    branch produces. This proves the row can reach the probe at all, so the
+    zero next door means something.
     """
     calls, counting = _counting_probe()
     with patch.object(ma, "_read_proc_translated", counting):
         ma.reset_cache_for_tests()
-        arch_menu_label()
+        arch_menu_label(system="Darwin", machine=X86_64)
 
     assert len(calls) == 1, (
         "the architecture row no longer reaches the sysctl probe — the test "
@@ -116,42 +134,48 @@ def test_a_cold_probe_really_does_fork_from_the_menu_row():
     )
 
 
-def test_warming_the_probe_first_makes_every_menu_rebuild_free():
-    """What run() buys the tray: no fork under _menu_lock, ever.
+def test_the_memo_makes_every_later_menu_rebuild_free():
+    """Menu rebuilds run under ``_menu_lock``; a fork there blocks the tray.
 
-    50 rebuilds stands in for a long-lived session — the tray rebuilds its menu
-    on every stats update, so an un-memoised probe would fork sysctl on the
-    sync cycle for the life of the process.
+    50 rebuilds stands in for a long-lived session — the tray rebuilds on every
+    stats update, so without the memo this is a 2s-worst-case fork under the
+    lock on the sync cycle, for the life of the process.
     """
     calls, counting = _counting_probe()
     with patch.object(ma, "_read_proc_translated", counting):
         ma.reset_cache_for_tests()
 
-        # Exactly what _warn_if_wrong_arch_build does first.
-        ma.is_rosetta_translated()
+        ma.is_rosetta_translated(system="Darwin")
         warmup_forks = len(calls)
         calls.clear()
 
         for _ in range(50):
-            arch_menu_label()
+            arch_menu_label(system="Darwin", machine=X86_64)
 
-    assert warmup_forks == 1, "the warm-up did not probe; nothing was cached"
+    assert warmup_forks == 1, "the first probe did not fork; nothing was cached"
     assert calls == [], (
         f"the architecture row forked sysctl {len(calls)} times after the "
-        "warm-up — the memo in machine_arch is gone, and menu rebuilds now "
-        "block _menu_lock on the sync cycle"
+        "first probe — the memo in machine_arch is gone, and menu rebuilds "
+        "now block _menu_lock on the sync cycle"
     )
 
 
 def test_the_warning_survives_a_probe_that_blows_up():
     """Best-effort: a broken sysctl loses the notice and nothing else.
 
-    Startup must not die because a diagnostic could not be computed.
+    Two halves, and the second is the one worth writing. Startup must not die
+    because a diagnostic could not be computed — AND the failure must stay
+    silent, because a notice fired on an unknown architecture would tell a
+    genuine Intel Mac it is running the wrong build.
+
+    ``platform.system`` is forced because on a Linux runner
+    ``is_rosetta_translated`` returns before consulting the probe at all, so
+    the OSError would never be raised and this would pass vacuously.
     """
     stub = MagicMock()
-    with patch.object(
+    with patch("src.machine_arch.platform.system", return_value="Darwin"), patch.object(
         ma, "_read_proc_translated_cached", side_effect=OSError("no sysctl")
-    ):
+    ), patch("src.main.send_notification") as notify:
         BetterFlowApp._warn_if_wrong_arch_build(stub)  # must not raise
 
-    stub.tray.assert_not_called()
+    notify.assert_not_called()

--- a/tests/test_machine_arch.py
+++ b/tests/test_machine_arch.py
@@ -150,10 +150,46 @@ def test_label_for_genuine_intel_mac_is_not_a_warning():
     assert "switch" not in label.lower()
 
 
-def test_label_off_macos_is_plain():
+@pytest.mark.parametrize(
+    "system,machine,expected",
+    [
+        ("Linux", X86_64, "Architecture: 64-bit x86 (x86_64)"),
+        ("Linux", "aarch64", "Architecture: 64-bit ARM (aarch64)"),
+        ("Windows", "AMD64", "Architecture: 64-bit x86 (AMD64)"),
+        ("Windows", "ARM64", "Architecture: 64-bit ARM (ARM64)"),
+    ],
+)
+def test_label_off_macos_reads_like_the_macos_rows(system, machine, expected):
+    """The row is prose on macOS; a bare "AMD64" beside it looked unfinished.
+
+    The raw token stays in parentheses because it is the value a support
+    conversation actually needs.
+    """
+    assert arch_menu_label(system=system, machine=machine, translated=False) == expected
+
+
+def test_label_off_macos_never_claims_a_cpu_vendor():
+    """"Intel" is right on macOS and wrong everywhere else.
+
+    Every x86_64 Mac is an Intel Mac, so the Darwin row can say so. ``AMD64``
+    is the name of the *instruction set*; on Windows it is just as likely to be
+    a Ryzen. Naming a vendor there would be a plain factual error, and the
+    macOS wording is the tempting thing to copy.
+    """
+    for system, machine in [("Windows", "AMD64"), ("Linux", X86_64)]:
+        label = arch_menu_label(system=system, machine=machine, translated=False)
+        assert "intel" not in label.lower(), label
+        assert "apple" not in label.lower(), label
+
+
+def test_label_falls_back_to_the_raw_token_for_an_unknown_arch():
+    """An architecture we have no name for is shown verbatim, not guessed at.
+
+    Without the fallback the lookup would render "Architecture: None (riscv64)".
+    """
     assert (
-        arch_menu_label(system="Linux", machine=X86_64, translated=False)
-        == "Architecture: x86_64"
+        arch_menu_label(system="Linux", machine="riscv64", translated=False)
+        == "Architecture: riscv64"
     )
 
 


### PR DESCRIPTION
Two follow-ups to #185, both found while auditing it. No behaviour change on macOS — the Darwin branch and the DMG selection are untouched.

**Scaffolding-to-fix ratio, stated rather than discovered in review:** 4 lines of behaviour change against ~180 lines of test. The label edit is small; most of this PR pins an invariant in `BetterFlowApp.run()` that already existed on `main` and was unguarded. That is a second, unrelated change riding along in a copy-polish PR, and worth vetoing if you would rather it were split.

## 1. The architecture row was a bare token off macOS

`Architecture: AMD64` sat next to `Architecture: Apple Silicon (native)`. Now `Architecture: 64-bit x86 (AMD64)`, raw token kept in parentheses because that is the value a support conversation needs.

Two things it deliberately does **not** claim off macOS, since only the Darwin branch resolves hardware:

- **No CPU vendor.** Every x86_64 Mac is an Intel Mac, so the Darwin row can say "Intel". `AMD64` on Windows names the instruction set and could be a Ryzen.
- **No hardware family.** The names describe the ISA the *process* executes. An x64 build under Windows-on-ARM emulation genuinely is executing x86-64, so "64-bit x86" stays true where "this is an x86 machine" would not.

Unrecognised values fall back to the raw token rather than rendering `Architecture: None (riscv64)`.

## 2. The ordering in `run()` was unguarded

`_warn_if_wrong_arch_build()` sits just before `self.tray.run_blocking()`. `run_blocking()` never returns, so a call moved below it does not fire late — it never fires again on any machine. Nothing pinned that.

**Correction to this PR's first draft, and to how the ordering was priced.** The original claim was that losing the warm-up puts a `sysctl` fork under `_menu_lock` on the sync cycle. It does not: `_update_menu` returns early while `_icon` is `None`, and the first `_create_menu()` in production is a constructor argument inside `run_blocking()` (`tray.py:1785`), evaluated before `_icon` is assigned and holding no menu lock. Dropping the warm-up costs exactly **one lock-free fork at startup**.

The **memo** is what keeps forks off the lock — rebuilds at `tray.py:1665`/`:1679` do hold it, so Martin's existing comment in `machine_arch` is correct and stands. Only the attribution to the *ordering* was wrong. The two guards are therefore kept separate and fail for different reasons.

## Verification

**CI is green on the real runner:** `test pass 1m34s` ([run](https://github.com/Better-Quality-Assurance/betterflow-sync/actions/runs/31741731372)). Worth saying plainly: the first push of this branch was **red**, because both fork-counting tests only passed on macOS — `arch_menu_label()` and `is_rosetta_translated()` short-circuit before the probe off Darwin, so the fork count was 0 where 1 was asserted. Local green on a Mac is not the gate. On a `v*` tag the same suite runs on all four platforms and `release` needs `build`, so this would have failed 3 of 4 legs and produced **no release at all** — the v1.5.119 `os.getuid` class (#168/#171) again.

Fixed by injecting `system="Darwin"` rather than `skipif`: only tag builds run a macOS job, so a skip would leave the guard executing in no PR-gating job at all (Phantom 5).

**Every guard witnessed failing, under a simulated non-Darwin runner** — anchors asserted unique before mutating, `cmp` confirming each applied, tree restored after each:

| mutant | reddens |
|---|---|
| control | exit 0, 30 passed |
| M1 delete the warn call | presence + ordering + nesting |
| M2 nest behind a platform branch | nesting only |
| M3 remove the memo | memo guard (+ existing probe-once test) |
| M4 move after the tray loop | ordering only |
| M5 say "Intel" off macOS | vendor guard + the `AMD64` case |
| M6 drop the unknown-arch fallback | fallback guard only |
| M7 row stops reaching the probe | positive control only |
| M8 notify despite a failed probe | the blow-up test |

M8 matters because that test previously asserted **nothing**: `stub.tray.assert_not_called()` checks whether `self.tray` was invoked as a callable, and `_warn_if_wrong_arch_build` never references `self.tray` on any path, so it held for every input including one where the notice fired. It now patches `src.main.send_notification` and forces `platform.system` to Darwin — without which the `OSError` is never raised and it passes vacuously on the exact runner that gates merges.

**The simulation harness was itself controlled.** It reddens the *previous* version of the test file with exactly the two failures CI reported, while that same previous version passes on macOS. One unrelated test (`test_hardware_serial.py::test_macos_probe_matches_ioreg`) fails under the harness on `origin/main` too — it gates on `sys.platform`, which the harness does not patch, so it skips correctly on a real Linux runner.

**Gates.** Full suite on macOS: 1671 passed, 1 skipped, exit 0 (up from 1660, +11, reconciling exactly with the tests added). `ruff` clean on both test files; `src/ui/tray.py` carries 7 findings (ruff's own error count; my earlier "9" was `wc -l` on concise output, which includes the fixable-hint lines) rule-for-rule identical to `origin/main` (diffed via `--stdin-filename`, not counted). `verify-tracker-pins.yml` is nightly-scheduled and network-bound — deliberately not run.

**Audit gate:** two reviewer lenses in parallel. Both independently found the platform Critical; the correctness lens additionally found the wrong lock rationale and the vacuous assertion. The design lens swept for a duplicate architecture→name mapping and found none — this is the only one in the tree — and confirmed the `tray.py`/`machine_arch.py` layering split is respected.

*Stated limit:* the three ordering tests read `inspect.getsource(BetterFlowApp.run)` rather than driving `run()`, which starts threads and blocks for the process lifetime. That is the existing house pattern for this exact invariant (`tests/test_privacy_notice_startup.py:117-159`). The fork-counting pair drives the real label builder and the real memo, so the behaviour is tested rather than read.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

