### PR TITLE
Pin the reconcile-backlog test clock so it stops failing after midnight

### DIFF
--- a/tests/test_sync_engine.py
+++ b/tests/test_sync_engine.py
@@ -384,12 +384,50 @@ class TestSyncEngine:
         """Reconcile builds its OWN fresh _SyncCycleContext (input analysis has
         not run yet), so replayed window events are deterministically classified
         'active' — never inheriting a prior cycle's state. With the per-cycle
-        context now threaded explicitly there is no instance field to leak."""
-        now = datetime.now(timezone.utc)
+        context now threaded explicitly there is no instance field to leak.
+
+        The clock is PINNED (#187). ``_reconcile_backlog`` walks
+        start-of-local-work-day -> now, so a fixture at "real now minus 5
+        minutes" lands in YESTERDAY for the first five minutes after local
+        midnight: no window covers it, nothing is enqueued, and this test failed
+        every night for five minutes with a message pointing at reconcile.
+        Production is right; the fixture was racing the boundary. On a CI runner
+        local midnight is UTC midnight, and ``release: needs: build``, so a tag
+        pushed in that window produced no release artifacts at all.
+
+        Pinning both ends together is the fix, per the house rule that an
+        absolute timestamp is fine when paired with an injected clock. Clamping
+        the event into the window instead would put a second copy of the
+        day_start computation in the test.
+        """
+        # Local midday: far from either boundary, whatever the host timezone.
+        frozen_local = (
+            datetime.now().astimezone().replace(hour=12, minute=0, second=0, microsecond=0)
+        )
+        frozen_utc = frozen_local.astimezone(timezone.utc)
+
+        class _FrozenClock(datetime):
+            """Answers both shapes _reconcile_backlog reads: naive-local, aware-UTC."""
+
+            @classmethod
+            def now(cls, tz=None):
+                if tz is not None:
+                    return frozen_utc.astimezone(tz)
+                return frozen_local.replace(tzinfo=None)
+
         win_event = AWEvent(
-            id=1, timestamp=now - timedelta(minutes=5), duration=120.0,
+            id=1, timestamp=frozen_utc - timedelta(minutes=5), duration=120.0,
             data={"app": "Code", "title": "x"},
         )
+
+        # Fixture precondition: state the geometry this test depends on, so a
+        # future change to the reconcile window fails HERE, naming the cause,
+        # rather than surfacing as "reconcile stopped enqueueing".
+        assert win_event.timestamp.astimezone().date() == frozen_local.date(), (
+            "fixture precondition: the replayed event must fall inside the same "
+            "local work day as the pinned clock, or reconcile cannot reach it"
+        )
+
         # Return the event from the reconcile window that actually covers its
         # timestamp (match on the real time range, not a call counter — the
         # latter is fragile near midnight / as the day-length changes).
@@ -404,7 +442,8 @@ class TestSyncEngine:
         self.queue.enqueue.side_effect = lambda batch: (enqueued.extend(batch), len(batch))[1]
 
         bucket = Mock(id="win-bucket", type=BUCKET_TYPE_WINDOW)
-        self.engine._reconcile_backlog([bucket])
+        with patch("src.sync.sync_engine.datetime", _FrozenClock):
+            self.engine._reconcile_backlog([bucket])
 
         assert enqueued, "reconcile should enqueue the replayed window event"
         assert all(e["activity_state"] == "active" for e in enqueued)


### PR DESCRIPTION
Closes #187.

## The bug

`test_reconcile_backlog_replays_window_events_as_active` placed its fixture at **real now minus 5 minutes**. `_reconcile_backlog` walks *start-of-local-work-day → now*, so for the first five minutes after local midnight that timestamp is **yesterday**, before `day_start`: no window covers it, the `get_events` side effect correctly returns `[]`, nothing is enqueued, and the assertion fails.

Measured on clean `origin/main` @ `2784066`, four minutes apart, **same commit, no code change**:

```
00:01:24 EEST  ->  EXIT 1   assert []   "reconcile should enqueue the replayed window event"
00:05:24 EEST  ->  EXIT 0   1 passed

day_start (local midnight) : 2026-08-13T21:00:00Z
fixture event (now - 5min) : 2026-08-13T20:57:07Z   <- before day_start
```

Production is correct — reconcile is *supposed* to cover only the current work day. The fixture's assumption that "5 minutes ago" is inside that day is what was false.

**Why it is worth more than a flaky-test fix.** On a CI runner local midnight is UTC midnight. The tag `build` job runs the full suite on all four platforms and `release: needs: build`, so a tag pushed between 00:00 and 00:05 UTC produces **no release artifacts at all**, and `releases/latest` silently keeps answering the previous version. Nothing is red where anyone looks. Same shape as #182 (timing raced the wall clock) and #168/#171 (`os.getuid` on Windows) — three releases have now been at risk from tests that pass on a developer machine.

It also misdirects: the failure names `reconcile`, so it reads as a sync-engine defect rather than a stale fixture. `test-fixture-discipline.md` Phantom 6, and note the test's own comment already said a call counter would be *"fragile near midnight"* — the hazard was known and half-fixed, while the fixture's own timestamp was left racing the clock.

## The fix

Pin both ends to local midday, so fixture and boundary move together — the house rule that an absolute timestamp is fine when paired with an injected clock. Clamping the event into the window instead would have put a second copy of the `day_start` computation in the test.

Adds a fixture **precondition** asserting the event shares the pinned clock's local day, so a future change to the reconcile window fails *there*, naming the cause, instead of surfacing as "reconcile stopped enqueueing".

## Verification

**Proof-of-failure handshake**, under a harness that freezes every `src.*` module's clock to 00:01 local:

```
pre-fix  @ 00:01       ->  EXIT 1   1 failed
post-fix @ 00:01       ->  EXIT 0   1 passed
post-fix @ real clock  ->  EXIT 0   1 passed
```

**The harness was controlled before being trusted**, and its first version was wrong in an instructive way. Freezing only `sync_engine` and the test module left every *other* production module on the real clock, so the sweep reported **22 failures** — a blanket spread across unrelated subsystems, which is the signature of a broken instrument rather than a defect cluster. Freezing all of `src.*` dropped it to 8. Fourteen of those "findings" were mine.

**Mutants, each reddening with a distinct message** (anchors asserted unique, `cmp` confirming each applied, tree restored after each; committed before mutating, since `git checkout HEAD -- <path>` silently deletes an uncommitted fix):

| mutant | result @ 00:01 |
|---|---|
| control | exit 0, 1 passed |
| MA unpin the fixture (back to real `now`) | precondition fires **first**, naming the cause |
| MB unpin production (drop the `patch`) | the original `assert []` failure returns |
| MC push the event a day outside the pinned clock | precondition fires, naming the cause |

MA is the one that matters: the precondition reddens *ahead of* the downstream assertion, which is the whole point of adding it.

**Gates.** CI's `test` step replicated locally: **1671 passed, 1 skipped, exit 0**. `ruff` on `tests/test_sync_engine.py` is rule-for-rule identical to `origin/main` (3 findings both sides, diffed via `--stdin-filename`; the E731 lambda is pre-existing and untouched). `verify-tracker-pins.yml` is nightly and network-bound — deliberately not run.

## Not claimed here

The 00:01 sweep leaves **7 other failures** in `test_aw_manager_idle_restart.py`, `test_mic_activity.py` and `test_window_title_capture_telemetry.py`. I am **not** reporting them as defects: `aw_manager.py` mixes `time.time()`/`time.monotonic()` (14 calls) with `datetime`, and the harness freezes only `datetime`, so at least some are the same skew artifact that produced the bogus 22. They are a lead worth a proper look with a harness that freezes `time` too — recorded on #187 rather than guessed at here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
