### PR TITLE
fix(updater): never offer a DMG the machine cannot execute, and stop a timeout pinning the wrong arch

### DIFF
--- a/src/machine_arch.py
+++ b/src/machine_arch.py
@@ -19,6 +19,7 @@ Kept dependency-free and fully injectable (``machine`` / ``translated`` /
 same spirit as ``release_version.py``.
 """
 
+import errno
 import logging
 import platform
 import subprocess
@@ -63,16 +64,27 @@ class ProbeResult(NamedTuple):
     conclusive: bool
 
 
-# Only a TIMEOUT is worth retrying. A missing sysctl or a sandbox denial will not
-# resolve itself mid-session, so those are conclusive and get memoised like any
-# other answer. Classifying them as transient is what broke the Windows CI leg
-# in review: no sysctl there, so FileNotFoundError made the memo never engage and
-# the fork-counting test saw a second fork.
-_RETRY_AFTER_SECONDS = 60.0
+# CONGESTION, in every spelling it reaches us in. A timeout is the obvious one,
+# but the same overloaded machine also refuses a fork outright (EAGAIN, when the
+# per-user process table is exhausted) or has the child killed under memory
+# pressure (jetsam/OOM, which surfaces as a negative returncode). All three say
+# "the machine was too busy", none says anything about its hardware, so none may
+# be memoised.
+#
+# The distinction is NOT exception-vs-exit-code, which was this module's second
+# wrong cut at it: FileNotFoundError (no sysctl — every Windows host) and
+# PermissionError (a sandbox denial) are permanent for this process and MUST be
+# memoised, or the memo never engages and menu rebuilds fork forever.
+_TRANSIENT_ERRNOS = frozenset({errno.EAGAIN, errno.ENOMEM})
 
-# Even a persistently timing-out sysctl has to settle, or a long session keeps
-# paying a fork per minute for an answer that is not coming.
-_MAX_PROBE_ATTEMPTS = 3
+# Retries back off, and that is the point rather than politeness. The congestion
+# that loses the first probe is a boot storm — Spotlight reindexing after an OS
+# update, an MDM scan, Time Machine — and those last minutes, not seconds. A flat
+# interval with a small cap spends the whole budget inside the storm and settles
+# on the wrong answer just as the machine calms down, which is the same defect as
+# a count-based budget wearing a clock. This schedule keeps trying past the hour
+# for a total of four forks.
+_RETRY_BACKOFF_SECONDS = (60.0, 300.0, 1800.0)
 
 
 def _monotonic() -> float:
@@ -89,7 +101,7 @@ def _read_proc_translated_cached() -> Optional[str]:
     not exist and never will, so a probe that retried would spawn a subprocess
     on every menu rebuild forever.
 
-    A TIMEOUT is a different thing wearing the same return value, and memoising
+    CONGESTION is a different thing wearing the same return value, and memoising
     it silently reinstates the bug this module exists to fix: the machine reads
     as untranslated for the rest of the session, the Diagnostics row states
     "Intel" about an Apple Silicon Mac, and the next update check re-selects the
@@ -100,9 +112,15 @@ def _read_proc_translated_cached() -> Optional[str]:
     ``main.run`` warms the memo and then ``tray.run_blocking`` builds the menu
     milliseconds later — so a count-based budget is spent entirely inside the
     congested window that caused the timeout, and the retry lands in the same
-    conditions as the failure. Waiting instead puts the second attempt somewhere
+    conditions as the failure. Waiting instead puts the next attempt somewhere
     the machine is no longer busy, which is the only place it can do any good,
     and keeps rapid menu rebuilds fork-free in the meantime.
+
+    The interval BACKS OFF for the same reason it exists. This is a login-item
+    daemon that then runs for days; a flat 60s with a small cap would exhaust the
+    whole budget two minutes after launch, i.e. still inside the boot storm that
+    lost the first probe, which is the very failure the previous paragraph
+    rejects. The schedule runs past the hour and then settles.
     """
     global _cached_raw, _probed, _probe_attempts, _last_transient_at
 
@@ -110,26 +128,31 @@ def _read_proc_translated_cached() -> Optional[str]:
         if _probed:
             return _cached_raw
 
-        # A timed-out probe is not re-asked immediately: every menu rebuild in
-        # the interval reuses the last answer rather than forking under
-        # _menu_lock, which is the cost the memo exists to prevent.
-        if _last_transient_at is not None and _monotonic() - _last_transient_at < _RETRY_AFTER_SECONDS:
-            return _cached_raw
+        # Inside the backoff window every menu rebuild reuses the last answer
+        # rather than forking under _menu_lock, which is the cost the memo exists
+        # to prevent. There IS no last answer yet — _cached_raw is only ever
+        # assigned alongside _probed — so this returns None, i.e. "not
+        # translated", which is the safe direction while we do not know.
+        if _last_transient_at is not None:
+            wait = _RETRY_BACKOFF_SECONDS[min(_probe_attempts, len(_RETRY_BACKOFF_SECONDS)) - 1]
+            if _monotonic() - _last_transient_at < wait:
+                return _cached_raw
 
         result = _read_proc_translated()
         _probe_attempts += 1
 
-        if result.conclusive or _probe_attempts >= _MAX_PROBE_ATTEMPTS:
+        if result.conclusive or _probe_attempts > len(_RETRY_BACKOFF_SECONDS):
             _cached_raw = result.raw
             _probed = True
             _last_transient_at = None
         else:
             _last_transient_at = _monotonic()
+            wait = _RETRY_BACKOFF_SECONDS[min(_probe_attempts, len(_RETRY_BACKOFF_SECONDS)) - 1]
             logger.debug(
-                f"{_PROC_TRANSLATED_KEY} timed out "
-                f"({_probe_attempts}/{_MAX_PROBE_ATTEMPTS}) — not memoising, so a "
-                f"slow launch cannot pin this process to the wrong architecture; "
-                f"retrying no sooner than {_RETRY_AFTER_SECONDS:.0f}s from now"
+                f"{_PROC_TRANSLATED_KEY} probe hit congestion "
+                f"({_probe_attempts}/{len(_RETRY_BACKOFF_SECONDS) + 1}) — not "
+                f"memoising, so a busy launch cannot pin this process to the "
+                f"wrong architecture; retrying no sooner than {wait:.0f}s from now"
             )
 
         return result.raw
@@ -168,14 +191,32 @@ def _read_proc_translated() -> ProbeResult:
             timeout=2,
         )
     except subprocess.TimeoutExpired as exc:
-        # The one genuinely transient case: the machine was too busy to answer,
-        # which says nothing about its hardware.
+        # The machine was too busy to answer in two seconds.
         logger.debug(f"Timed out reading {_PROC_TRANSLATED_KEY}: {exc}")
         return ProbeResult(None, conclusive=False)
-    except (OSError, subprocess.SubprocessError) as exc:
-        # No sysctl on PATH, or the call was refused. Permanent for this process.
+    except OSError as exc:
+        # Same congestion, different spelling: an overloaded machine refuses the
+        # fork itself with EAGAIN once the per-user process table is full, and
+        # returns ENOMEM under memory pressure. Reproduced under RLIMIT_NPROC as
+        # BlockingIOError, which is an OSError and was being memoised as though
+        # the hardware had answered.
+        #
+        # Everything else here IS permanent for this process — FileNotFoundError
+        # (no sysctl at all, i.e. every Windows host) and PermissionError (a
+        # sandbox denial) will not resolve mid-session, and treating them as
+        # retryable stops the memo engaging and forks on every menu rebuild.
+        transient = exc.errno in _TRANSIENT_ERRNOS
+        logger.debug(f"Could not read {_PROC_TRANSLATED_KEY} (errno={exc.errno}): {exc}")
+        return ProbeResult(None, conclusive=not transient)
+    except subprocess.SubprocessError as exc:
         logger.debug(f"Could not read {_PROC_TRANSLATED_KEY}: {exc}")
         return ProbeResult(None, conclusive=True)
+
+    if result.returncode < 0:
+        # Killed by a signal — jetsam/OOM under the same memory pressure that
+        # produces the timeout. The hardware never got a word in.
+        logger.debug(f"{_PROC_TRANSLATED_KEY} probe killed by signal {-result.returncode}")
+        return ProbeResult(None, conclusive=False)
 
     if result.returncode != 0:
         # Expected on Intel Macs: "second level name 'proc_translated' in

--- a/src/machine_arch.py
+++ b/src/machine_arch.py
@@ -23,7 +23,8 @@ import logging
 import platform
 import subprocess
 import threading
-from typing import Callable, Optional
+import time
+from typing import Callable, NamedTuple, Optional
 
 logger = logging.getLogger(__name__)
 
@@ -45,20 +46,42 @@ _PROC_TRANSLATED_KEY = "sysctl.proc_translated"
 _lock = threading.Lock()
 _cached_raw: Optional[str] = None
 _probed = False
-
-# Set by _read_proc_translated when the probe failed for a reason that says
-# nothing about the hardware (sysctl raised — a timeout above all), as opposed
-# to answering "no such key". See _read_proc_translated_cached.
-_last_probe_transient = False
 _probe_attempts = 0
+_last_transient_at: Optional[float] = None
 
-# A permanently broken sysctl must still stop forking. Two attempts covers the
-# one-off timeout this exists for without turning a hard failure into a loop.
-_MAX_PROBE_ATTEMPTS = 2
+
+class ProbeResult(NamedTuple):
+    """What the probe said, and whether it is worth asking again.
+
+    ``conclusive`` is False ONLY when we never got an answer — see
+    ``_read_proc_translated``. Returned as a value rather than signalled through
+    module state so the classification cannot be read out of order, and so the
+    producer has no side effect its docstring has to warn about.
+    """
+
+    raw: Optional[str]
+    conclusive: bool
+
+
+# Only a TIMEOUT is worth retrying. A missing sysctl or a sandbox denial will not
+# resolve itself mid-session, so those are conclusive and get memoised like any
+# other answer. Classifying them as transient is what broke the Windows CI leg
+# in review: no sysctl there, so FileNotFoundError made the memo never engage and
+# the fork-counting test saw a second fork.
+_RETRY_AFTER_SECONDS = 60.0
+
+# Even a persistently timing-out sysctl has to settle, or a long session keeps
+# paying a fork per minute for an answer that is not coming.
+_MAX_PROBE_ATTEMPTS = 3
+
+
+def _monotonic() -> float:
+    """Indirected so tests can advance the clock without sleeping."""
+    return time.monotonic()
 
 
 def _read_proc_translated_cached() -> Optional[str]:
-    """``_read_proc_translated`` probed at most once per process.
+    """``_read_proc_translated`` probed at most once per process, plus retries.
 
     The answer cannot change while this process lives, so re-probing is pure
     waste. A CONCLUSIVE failure is cached too — same rule, same reason, as
@@ -66,57 +89,76 @@ def _read_proc_translated_cached() -> Optional[str]:
     not exist and never will, so a probe that retried would spawn a subprocess
     on every menu rebuild forever.
 
-    A TRANSIENT failure is a different thing wearing the same return value, and
-    memoising it silently reinstates the bug this module exists to fix. sysctl
-    raising says nothing about the hardware, but caching that ``None`` makes the
-    machine read as untranslated for the rest of the session: the Diagnostics
-    row states "Intel" about an Apple Silicon Mac, and the next update check
-    re-selects the Intel DMG. The window is not theoretical — the warm-up fires
-    at the busiest moment of launch, in a process that (in the affected case) is
-    itself running through Rosetta, i.e. the slowest fork the machine will do.
+    A TIMEOUT is a different thing wearing the same return value, and memoising
+    it silently reinstates the bug this module exists to fix: the machine reads
+    as untranslated for the rest of the session, the Diagnostics row states
+    "Intel" about an Apple Silicon Mac, and the next update check re-selects the
+    Intel DMG.
 
-    So the line is exit code vs exception, which is exactly the line between
-    "asked and answered no" and "never got an answer".
+    The retry is gated on ELAPSED TIME, not on a call count, and that distinction
+    is the whole point. The two probes of a launch are consecutive statements —
+    ``main.run`` warms the memo and then ``tray.run_blocking`` builds the menu
+    milliseconds later — so a count-based budget is spent entirely inside the
+    congested window that caused the timeout, and the retry lands in the same
+    conditions as the failure. Waiting instead puts the second attempt somewhere
+    the machine is no longer busy, which is the only place it can do any good,
+    and keeps rapid menu rebuilds fork-free in the meantime.
     """
-    global _cached_raw, _probed, _last_probe_transient, _probe_attempts
+    global _cached_raw, _probed, _probe_attempts, _last_transient_at
 
     with _lock:
         if _probed:
             return _cached_raw
 
-        _last_probe_transient = False
-        raw = _read_proc_translated()
+        # A timed-out probe is not re-asked immediately: every menu rebuild in
+        # the interval reuses the last answer rather than forking under
+        # _menu_lock, which is the cost the memo exists to prevent.
+        if _last_transient_at is not None and _monotonic() - _last_transient_at < _RETRY_AFTER_SECONDS:
+            return _cached_raw
+
+        result = _read_proc_translated()
         _probe_attempts += 1
 
-        if not _last_probe_transient or _probe_attempts >= _MAX_PROBE_ATTEMPTS:
-            _cached_raw = raw
+        if result.conclusive or _probe_attempts >= _MAX_PROBE_ATTEMPTS:
+            _cached_raw = result.raw
             _probed = True
+            _last_transient_at = None
         else:
+            _last_transient_at = _monotonic()
             logger.debug(
-                f"{_PROC_TRANSLATED_KEY} probe failed transiently "
-                f"({_probe_attempts}/{_MAX_PROBE_ATTEMPTS}) — not memoising, "
-                "so a timeout cannot pin this process to the wrong architecture"
+                f"{_PROC_TRANSLATED_KEY} timed out "
+                f"({_probe_attempts}/{_MAX_PROBE_ATTEMPTS}) — not memoising, so a "
+                f"slow launch cannot pin this process to the wrong architecture; "
+                f"retrying no sooner than {_RETRY_AFTER_SECONDS:.0f}s from now"
             )
 
-        return raw
+        return result.raw
 
 
 def reset_cache_for_tests() -> None:
     """Drop the memo. Tests only — the architecture never changes at runtime."""
-    global _cached_raw, _probed, _last_probe_transient, _probe_attempts
+    global _cached_raw, _probed, _probe_attempts, _last_transient_at
     with _lock:
         _cached_raw = None
         _probed = False
-        _last_probe_transient = False
         _probe_attempts = 0
+        _last_transient_at = None
 
 
-def _read_proc_translated() -> Optional[str]:
-    """Return the raw ``sysctl.proc_translated`` value, or None if unreadable.
+def _read_proc_translated() -> ProbeResult:
+    """Return the raw ``sysctl.proc_translated`` value and whether it settles it.
 
-    None means "could not determine" — a missing key (real Intel Mac), a sysctl
-    that is not on PATH, a timeout, or a sandbox that blocks the call. Callers
-    must treat None as *not translated*; see ``is_rosetta_translated``.
+    ``raw`` is None whenever the value could not be determined — a missing key
+    (real Intel Mac), a sysctl that is not on PATH, a timeout, or a sandbox that
+    blocks the call. Callers must treat None as *not translated*; see
+    ``is_rosetta_translated``.
+
+    ``conclusive`` separates "asked and answered no" from "never got an answer",
+    and only a TIMEOUT is the latter. A missing binary or a denied call is an
+    answer: sysctl will not appear mid-session and a sandbox will not lift, so
+    treating those as retryable buys nothing and costs a fork on every menu
+    rebuild — on Windows, where sysctl does not exist at all, it also breaks the
+    memo outright.
     """
     try:
         result = subprocess.run(
@@ -125,20 +167,22 @@ def _read_proc_translated() -> Optional[str]:
             text=True,
             timeout=2,
         )
+    except subprocess.TimeoutExpired as exc:
+        # The one genuinely transient case: the machine was too busy to answer,
+        # which says nothing about its hardware.
+        logger.debug(f"Timed out reading {_PROC_TRANSLATED_KEY}: {exc}")
+        return ProbeResult(None, conclusive=False)
     except (OSError, subprocess.SubprocessError) as exc:
-        # Transient: a timeout, a sandbox denial, sysctl briefly unavailable.
-        # None of these are statements about the hardware, so the memo must not
-        # keep this answer. subprocess.TimeoutExpired is a SubprocessError.
-        global _last_probe_transient
-        _last_probe_transient = True
+        # No sysctl on PATH, or the call was refused. Permanent for this process.
         logger.debug(f"Could not read {_PROC_TRANSLATED_KEY}: {exc}")
-        return None
+        return ProbeResult(None, conclusive=True)
 
     if result.returncode != 0:
         # Expected on Intel Macs: "second level name 'proc_translated' in
         # 'sysctl.proc_translated' is invalid". Not an error worth logging loudly.
-        return None
-    return result.stdout.strip()
+        return ProbeResult(None, conclusive=True)
+
+    return ProbeResult(result.stdout.strip(), conclusive=True)
 
 
 def is_rosetta_translated(

--- a/src/machine_arch.py
+++ b/src/machine_arch.py
@@ -46,31 +46,69 @@ _lock = threading.Lock()
 _cached_raw: Optional[str] = None
 _probed = False
 
+# Set by _read_proc_translated when the probe failed for a reason that says
+# nothing about the hardware (sysctl raised — a timeout above all), as opposed
+# to answering "no such key". See _read_proc_translated_cached.
+_last_probe_transient = False
+_probe_attempts = 0
+
+# A permanently broken sysctl must still stop forking. Two attempts covers the
+# one-off timeout this exists for without turning a hard failure into a loop.
+_MAX_PROBE_ATTEMPTS = 2
+
 
 def _read_proc_translated_cached() -> Optional[str]:
     """``_read_proc_translated`` probed at most once per process.
 
     The answer cannot change while this process lives, so re-probing is pure
-    waste. Failures are cached too — same rule, same reason, as
+    waste. A CONCLUSIVE failure is cached too — same rule, same reason, as
     ``hardware_serial.get_hardware_serial``: on a genuine Intel Mac the key does
     not exist and never will, so a probe that retried would spawn a subprocess
     on every menu rebuild forever.
+
+    A TRANSIENT failure is a different thing wearing the same return value, and
+    memoising it silently reinstates the bug this module exists to fix. sysctl
+    raising says nothing about the hardware, but caching that ``None`` makes the
+    machine read as untranslated for the rest of the session: the Diagnostics
+    row states "Intel" about an Apple Silicon Mac, and the next update check
+    re-selects the Intel DMG. The window is not theoretical — the warm-up fires
+    at the busiest moment of launch, in a process that (in the affected case) is
+    itself running through Rosetta, i.e. the slowest fork the machine will do.
+
+    So the line is exit code vs exception, which is exactly the line between
+    "asked and answered no" and "never got an answer".
     """
-    global _cached_raw, _probed
+    global _cached_raw, _probed, _last_probe_transient, _probe_attempts
 
     with _lock:
-        if not _probed:
-            _cached_raw = _read_proc_translated()
+        if _probed:
+            return _cached_raw
+
+        _last_probe_transient = False
+        raw = _read_proc_translated()
+        _probe_attempts += 1
+
+        if not _last_probe_transient or _probe_attempts >= _MAX_PROBE_ATTEMPTS:
+            _cached_raw = raw
             _probed = True
-        return _cached_raw
+        else:
+            logger.debug(
+                f"{_PROC_TRANSLATED_KEY} probe failed transiently "
+                f"({_probe_attempts}/{_MAX_PROBE_ATTEMPTS}) — not memoising, "
+                "so a timeout cannot pin this process to the wrong architecture"
+            )
+
+        return raw
 
 
 def reset_cache_for_tests() -> None:
     """Drop the memo. Tests only — the architecture never changes at runtime."""
-    global _cached_raw, _probed
+    global _cached_raw, _probed, _last_probe_transient, _probe_attempts
     with _lock:
         _cached_raw = None
         _probed = False
+        _last_probe_transient = False
+        _probe_attempts = 0
 
 
 def _read_proc_translated() -> Optional[str]:
@@ -88,6 +126,11 @@ def _read_proc_translated() -> Optional[str]:
             timeout=2,
         )
     except (OSError, subprocess.SubprocessError) as exc:
+        # Transient: a timeout, a sandbox denial, sysctl briefly unavailable.
+        # None of these are statements about the hardware, so the memo must not
+        # keep this answer. subprocess.TimeoutExpired is a SubprocessError.
+        global _last_probe_transient
+        _last_probe_transient = True
         logger.debug(f"Could not read {_PROC_TRANSLATED_KEY}: {exc}")
         return None
 

--- a/src/update_checker.py
+++ b/src/update_checker.py
@@ -8,11 +8,11 @@ from typing import Callable, Optional
 import requests
 
 try:
-    from .machine_arch import true_machine_arch
+    from .machine_arch import ARM64, X86_64, true_machine_arch
     from .sync.http_client import resolve_ca_bundle
     from .url_safety import assert_safe_final_url
 except ImportError:  # PyInstaller bundle (src/ is import root)
-    from machine_arch import true_machine_arch
+    from machine_arch import ARM64, X86_64, true_machine_arch
     from sync.http_client import resolve_ca_bundle
     from url_safety import assert_safe_final_url
 
@@ -59,6 +59,32 @@ _ASSET_PATTERNS = {
     "Linux": "BetterFlow-linux",
 }
 
+# The arch token that must NOT appear in an asset we offer this machine. An
+# asset naming no architecture at all is still fair game for the fallback (it
+# may be universal); one naming the OTHER architecture is a build we already
+# know this Mac cannot run, and handing it over is strictly worse than not
+# updating — EBADARCH/ENOEXEC on Apple Silicon without Rosetta 2, and no
+# recovery at all in the Intel direction, where there is no reverse Rosetta.
+_INCOMPATIBLE_ARCH = {ARM64: X86_64, X86_64: ARM64}
+
+
+def _is_wrong_arch(name: str, arch: str) -> bool:
+    """True when this asset names an architecture this machine cannot run.
+
+    Unknown ``arch`` (``platform.machine()`` is documented to return "" when it
+    cannot tell) rejects EVERY arch-suffixed asset rather than guessing: we know
+    one of them is wrong and not which, so the only safe answer is neither.
+
+    Windows and Linux arch tokens ("AMD64", "x86_64" from a Linux host) are not
+    keys here, so those platforms keep their existing behaviour untouched.
+    """
+    if not arch:
+        return any(token in name for token in (ARM64, X86_64))
+
+    other = _INCOMPATIBLE_ARCH.get(arch)
+
+    return other is not None and other in name
+
 
 def _find_platform_asset(
     release: dict,
@@ -100,13 +126,21 @@ def _find_platform_asset(
         for asset in assets:
             name = asset.get("name", "")
             url = asset.get("browser_download_url")
-            if pattern in name and arch in name and name.endswith(".dmg") and url:
+            if pattern in name and arch and arch in name and name.endswith(".dmg") and url:
                 return url
-        # Fallback: any macOS DMG
+        # Fallback: any macOS DMG that is not a build we know this Mac cannot
+        # run. An unsuffixed (possibly universal) DMG still qualifies; the
+        # wrong-arch one does not, and no update beats a dead install.
         for asset in assets:
             name = asset.get("name", "")
             url = asset.get("browser_download_url")
             if pattern in name and name.endswith(".dmg") and url:
+                if _is_wrong_arch(name, arch):
+                    logger.warning(
+                        f"Skipping {name}: wrong architecture for this machine "
+                        f"({arch or 'undetermined'})"
+                    )
+                    continue
                 logger.debug(f"No arch-specific DMG for {arch}, using generic DMG")
                 return url
 
@@ -115,6 +149,15 @@ def _find_platform_asset(
         name = asset.get("name", "")
         url = asset.get("browser_download_url")
         if pattern in name and name.endswith(".zip") and url:
+            # Same rule as the DMG fallback: this loop is reached for macOS too,
+            # so a BetterFlow-macOS-x86_64.zip is the identical hazard one door
+            # along. A no-op for Windows/Linux, whose arch tokens are not keys.
+            if _is_wrong_arch(name, arch):
+                logger.warning(
+                    f"Skipping {name}: wrong architecture for this machine "
+                    f"({arch or 'undetermined'})"
+                )
+                continue
             return url
     return None
 

--- a/src/update_checker.py
+++ b/src/update_checker.py
@@ -59,25 +59,47 @@ _ASSET_PATTERNS = {
     "Linux": "BetterFlow-linux",
 }
 
-# The arch token that must NOT appear in an asset we offer this machine. An
-# asset naming no architecture at all is still fair game for the fallback (it
-# may be universal); one naming the OTHER architecture is a build we already
-# know this Mac cannot run, and handing it over is strictly worse than not
-# updating — EBADARCH/ENOEXEC on Apple Silicon without Rosetta 2, and no
-# recovery at all in the Intel direction, where there is no reverse Rosetta.
+# The arch token that must NOT appear in a macOS asset we offer this machine.
+#
+# Two different reasons, depending on which Mac is asking, and they are worth
+# keeping apart because only one of them is a compatibility fact:
+#
+#   * NATIVE arm64 (proc_translated == "0"): Rosetta 2 may not be installed, and
+#     without it an x86_64 binary dies EBADARCH/ENOEXEC and capture stops dead —
+#     the production fault on record for Ardiel Plata's device (internal-tool2
+#     #2298, an Apple Silicon machine with no Rosetta).
+#   * TRANSLATED (proc_translated == "1"): Rosetta demonstrably IS installed,
+#     because we are running under it right now, so the Intel DMG would execute.
+#     We refuse it anyway — offering it re-pins the machine to Rosetta for
+#     another release cycle, which is precisely the self-perpetuating loop #185
+#     exists to break. That is a product choice, not an inability.
+#
+# In the Intel direction there is no reverse Rosetta, so an arm64 build on a
+# genuine Intel Mac has no recovery path under any circumstances.
+#
+# Refusal is not a dead end for the user: update_handler still raises the
+# "Version X is available" notice with the release page, so a manual download
+# remains one click away while the release is repaired.
 _INCOMPATIBLE_ARCH = {ARM64: X86_64, X86_64: ARM64}
 
 
-def _is_wrong_arch(name: str, arch: str) -> bool:
+def _is_wrong_arch(name: str, arch: str, system: str) -> bool:
     """True when this asset names an architecture this machine cannot run.
 
-    Unknown ``arch`` (``platform.machine()`` is documented to return "" when it
-    cannot tell) rejects EVERY arch-suffixed asset rather than guessing: we know
-    one of them is wrong and not which, so the only safe answer is neither.
+    Scoped to macOS. The map's keys ("arm64", "x86_64") collide with a Linux
+    host's own ``platform.machine()``, and the unknown-arch branch below is
+    platform-blind by construction — so without this gate a Windows or Linux
+    host that could not determine its architecture would silently refuse assets
+    it has always accepted. Linux happens to return before ever reaching here,
+    but that is the caller's control flow rather than a property of this rule.
 
-    Windows and Linux arch tokens ("AMD64", "x86_64" from a Linux host) are not
-    keys here, so those platforms keep their existing behaviour untouched.
+    Unknown ``arch`` (``platform.machine()`` is documented to return "" when it
+    cannot tell) rejects EVERY arch-suffixed asset rather than guessing: one of
+    them is wrong and we cannot tell which, so the only safe answer is neither.
     """
+    if system != "Darwin":
+        return False
+
     if not arch:
         return any(token in name for token in (ARM64, X86_64))
 
@@ -135,7 +157,7 @@ def _find_platform_asset(
             name = asset.get("name", "")
             url = asset.get("browser_download_url")
             if pattern in name and name.endswith(".dmg") and url:
-                if _is_wrong_arch(name, arch):
+                if _is_wrong_arch(name, arch, system):
                     logger.warning(
                         f"Skipping {name}: wrong architecture for this machine "
                         f"({arch or 'undetermined'})"
@@ -151,8 +173,9 @@ def _find_platform_asset(
         if pattern in name and name.endswith(".zip") and url:
             # Same rule as the DMG fallback: this loop is reached for macOS too,
             # so a BetterFlow-macOS-x86_64.zip is the identical hazard one door
-            # along. A no-op for Windows/Linux, whose arch tokens are not keys.
-            if _is_wrong_arch(name, arch):
+            # along. _is_wrong_arch returns False outright off Darwin, so Windows
+            # keeps its existing behaviour whatever its assets are named.
+            if _is_wrong_arch(name, arch, system):
                 logger.warning(
                     f"Skipping {name}: wrong architecture for this machine "
                     f"({arch or 'undetermined'})"

--- a/tests/test_arch_notice_startup.py
+++ b/tests/test_arch_notice_startup.py
@@ -171,6 +171,34 @@ def test_the_memo_makes_every_later_menu_rebuild_free():
     )
 
 
+def test_a_translated_mac_actually_gets_the_notification():
+    """The POSITIVE control the rest of this file was missing.
+
+    Every other assertion about ``send_notification`` here is a negative one —
+    ``assert_not_called`` on a broken probe — and the ordering tests read
+    ``run``'s source for the CALL SITE, never the method body. So emptying the
+    whole ``send_notification(...)`` block left the entire suite green: the one
+    user-facing half of #185 was witnessed by nothing.
+
+    That matters more than the usual coverage gap because this path runs on
+    essentially no developer machine and on no CI leg. It executes only on an
+    Apple Silicon Mac running the x86_64 build, which is exactly the
+    configuration nobody testing this has in front of them.
+    """
+    stub = MagicMock()
+    with patch("src.machine_arch.platform.system", return_value="Darwin"), patch.object(
+        ma, "_read_proc_translated_cached", return_value="1"
+    ), patch("src.main.send_notification") as notify:
+        BetterFlowApp._warn_if_wrong_arch_build(stub)
+
+    notify.assert_called_once()
+    title, body = notify.call_args[0][:2]
+    # Pin the SUBJECT rather than the wording: the notice is useless if it does
+    # not name the remedy, since "Intel build" does not read as "wrong" alone.
+    assert "Apple Silicon" in title or "Apple Silicon" in body
+    assert "Reinstall" in body
+
+
 def test_the_warning_survives_a_probe_that_blows_up():
     """Best-effort: a broken sysctl loses the notice and nothing else.
 

--- a/tests/test_arch_notice_startup.py
+++ b/tests/test_arch_notice_startup.py
@@ -196,7 +196,7 @@ def test_a_translated_mac_actually_gets_the_notification():
     # Pin the SUBJECT rather than the wording: the notice is useless if it does
     # not name the remedy, since "Intel build" does not read as "wrong" alone.
     assert "Apple Silicon" in title or "Apple Silicon" in body
-    assert "Reinstall" in body
+    assert "reinstall" in body.lower()
 
 
 def test_the_warning_survives_a_probe_that_blows_up():

--- a/tests/test_machine_arch.py
+++ b/tests/test_machine_arch.py
@@ -10,6 +10,7 @@ would serve it an arm64 build it physically cannot execute.
 
 import inspect
 import platform
+import subprocess
 from unittest.mock import MagicMock, patch
 
 import pytest
@@ -78,8 +79,66 @@ def test_probe_runs_at_most_once_per_process(monkeypatch):
     other thread's menu update for as long as the probe takes, and the answer
     cannot change while the process lives.
 
-    A FAILING probe must be cached too: on a genuine Intel Mac the key does not
-    exist, so a retrying probe spawns a subprocess on every rebuild forever.
+    A CONCLUSIVE failure must be cached too: on a genuine Intel Mac the key does
+    not exist, so a retrying probe spawns a subprocess on every rebuild forever.
+
+    Note the fixture models that Mac the way the machine actually behaves — a
+    NON-ZERO EXIT, printing "second level name 'proc_translated' ... is
+    invalid". It previously raised OSError, which is a different failure
+    entirely (see the transient test below), so this test asserted the right
+    rule about the wrong case.
+    """
+    calls = []
+
+    def _probe(*a, **k):
+        calls.append(1)
+        return MagicMock(returncode=1, stdout="")
+
+    monkeypatch.setattr(ma.subprocess, "run", _probe)
+
+    for _ in range(3):
+        assert is_rosetta_translated(system="Darwin") is False
+    assert len(calls) == 1
+
+
+def test_a_transient_probe_failure_is_not_memoised(monkeypatch):
+    """A timeout says nothing about the hardware, so it must not pin the answer.
+
+    THE DEFECT: caching the None from an exception marks the machine
+    untranslated for the whole session. On the Mac this module exists for, that
+    means the Diagnostics row states "Intel" about Apple Silicon and the next
+    update check re-selects the Intel DMG — the original bug, silently back.
+    The warm-up runs at the busiest moment of launch, in a process that in this
+    very case is running through Rosetta, so a 2s timeout is the plausible
+    outcome rather than the exotic one.
+    """
+    calls = []
+
+    def _probe(*a, **k):
+        calls.append(1)
+        if len(calls) == 1:
+            raise subprocess.TimeoutExpired(cmd="sysctl", timeout=2)
+        return MagicMock(returncode=0, stdout="1\n")
+
+    monkeypatch.setattr(ma.subprocess, "run", _probe)
+
+    # The timed-out probe degrades to "not translated" and must NOT be kept.
+    assert is_rosetta_translated(system="Darwin") is False
+    # The retry gets the real answer: this machine IS translated.
+    assert is_rosetta_translated(system="Darwin") is True
+    assert len(calls) == 2
+
+    # And that answer is memoised like any other conclusive one.
+    assert is_rosetta_translated(system="Darwin") is True
+    assert len(calls) == 2
+
+
+def test_a_permanently_broken_sysctl_still_stops_forking(monkeypatch):
+    """The retry is bounded, or the fix above trades one bug for a worse one.
+
+    Without the cap, a sandbox that blocks sysctl outright would fork on every
+    menu rebuild forever — under _menu_lock, which is exactly the cost the memo
+    exists to prevent.
     """
     calls = []
 
@@ -89,9 +148,9 @@ def test_probe_runs_at_most_once_per_process(monkeypatch):
 
     monkeypatch.setattr(ma.subprocess, "run", _probe)
 
-    for _ in range(3):
+    for _ in range(5):
         assert is_rosetta_translated(system="Darwin") is False
-    assert len(calls) == 1
+    assert len(calls) == ma._MAX_PROBE_ATTEMPTS
 
 
 # --- true_machine_arch -----------------------------------------------------

--- a/tests/test_machine_arch.py
+++ b/tests/test_machine_arch.py
@@ -101,17 +101,28 @@ def test_probe_runs_at_most_once_per_process(monkeypatch):
     assert len(calls) == 1
 
 
-def test_a_transient_probe_failure_is_not_memoised(monkeypatch):
+def _fake_clock(monkeypatch):
+    """A monotonic clock the test advances by hand.
+
+    Never sleeps, and asserts nothing about the clock's MAGNITUDE — a fresh CI
+    runner's uptime is ~95s, so any fixture built on the real value being large
+    passes on a laptop and reds on a runner.
+    """
+    now = {"t": 1000.0}
+    monkeypatch.setattr(ma, "_monotonic", lambda: now["t"])
+
+    return now
+
+
+def test_a_timed_out_probe_is_not_memoised(monkeypatch):
     """A timeout says nothing about the hardware, so it must not pin the answer.
 
-    THE DEFECT: caching the None from an exception marks the machine
-    untranslated for the whole session. On the Mac this module exists for, that
-    means the Diagnostics row states "Intel" about Apple Silicon and the next
-    update check re-selects the Intel DMG — the original bug, silently back.
-    The warm-up runs at the busiest moment of launch, in a process that in this
-    very case is running through Rosetta, so a 2s timeout is the plausible
-    outcome rather than the exotic one.
+    THE DEFECT: caching the None from a timeout marks the machine untranslated
+    for the whole session. On the Mac this module exists for, that means the
+    Diagnostics row states "Intel" about Apple Silicon and the next update check
+    re-selects the Intel DMG — the original bug, silently back.
     """
+    clock = _fake_clock(monkeypatch)
     calls = []
 
     def _probe(*a, **k):
@@ -124,33 +135,103 @@ def test_a_transient_probe_failure_is_not_memoised(monkeypatch):
 
     # The timed-out probe degrades to "not translated" and must NOT be kept.
     assert is_rosetta_translated(system="Darwin") is False
-    # The retry gets the real answer: this machine IS translated.
+
+    # Once the machine has had time to settle, the retry gets the real answer.
+    clock["t"] += ma._RETRY_AFTER_SECONDS + 1
     assert is_rosetta_translated(system="Darwin") is True
     assert len(calls) == 2
 
     # And that answer is memoised like any other conclusive one.
+    clock["t"] += 10_000
     assert is_rosetta_translated(system="Darwin") is True
     assert len(calls) == 2
 
 
-def test_a_permanently_broken_sysctl_still_stops_forking(monkeypatch):
-    """The retry is bounded, or the fix above trades one bug for a worse one.
+def test_the_retry_waits_instead_of_re_probing_inside_the_same_launch(monkeypatch):
+    """The retry is gated on ELAPSED TIME, not on a call count.
 
-    Without the cap, a sandbox that blocks sysctl outright would fork on every
-    menu rebuild forever — under _menu_lock, which is exactly the cost the memo
-    exists to prevent.
+    The two probes of a launch are consecutive statements — main.run warms the
+    memo, then tray.run_blocking builds the menu milliseconds later. A
+    count-based budget is therefore spent entirely inside the congested window
+    that caused the timeout, so the retry lands in the same conditions as the
+    failure and buys nothing. It also costs a second fork under _menu_lock,
+    which is the exact cost the memo exists to prevent.
     """
+    clock = _fake_clock(monkeypatch)
     calls = []
 
     def _probe(*a, **k):
         calls.append(1)
-        raise OSError("sysctl not found")
+        raise subprocess.TimeoutExpired(cmd="sysctl", timeout=2)
+
+    monkeypatch.setattr(ma.subprocess, "run", _probe)
+
+    assert is_rosetta_translated(system="Darwin") is False
+    assert len(calls) == 1
+
+    # Every menu rebuild in the interval reuses the answer rather than forking.
+    for _ in range(50):
+        clock["t"] += 0.5
+        assert is_rosetta_translated(system="Darwin") is False
+    assert len(calls) == 1, "a rebuild inside the retry interval must not fork sysctl"
+
+
+def test_a_missing_sysctl_is_conclusive_and_probed_once(monkeypatch):
+    """No sysctl on PATH is an ANSWER, not a failure to get one.
+
+    This is the Windows case, and classifying it as retryable is what broke the
+    windows-latest leg of the tagged-release build in review: the memo never
+    engaged, so test_the_memo_makes_every_later_menu_rebuild_free saw a second
+    fork. Invisible on any Mac, and it lands at release time rather than on the
+    PR.
+
+    A sandbox denial (PermissionError) is the same shape: it will not lift
+    mid-session, so retrying buys nothing and costs a fork per menu rebuild.
+    """
+    clock = _fake_clock(monkeypatch)
+    calls = []
+
+    def _probe(*a, **k):
+        calls.append(1)
+        raise FileNotFoundError("sysctl not found")
 
     monkeypatch.setattr(ma.subprocess, "run", _probe)
 
     for _ in range(5):
+        clock["t"] += ma._RETRY_AFTER_SECONDS * 2
         assert is_rosetta_translated(system="Darwin") is False
-    assert len(calls) == ma._MAX_PROBE_ATTEMPTS
+
+    assert len(calls) == 1, "a permanently absent sysctl must be memoised on the first probe"
+
+
+def test_a_persistently_timing_out_sysctl_eventually_settles(monkeypatch):
+    """The retry is bounded, or the fix above trades one bug for a slower one.
+
+    Asserted as the PROPERTY — it stops — against an independent literal rather
+    than against ma._MAX_PROBE_ATTEMPTS alone. Comparing only to the module's own
+    constant means raising it to 50 keeps this test green while the behaviour it
+    names degrades badly: both sides of the == would trace to the same artifact.
+    """
+    clock = _fake_clock(monkeypatch)
+    calls = []
+
+    def _probe(*a, **k):
+        calls.append(1)
+        raise subprocess.TimeoutExpired(cmd="sysctl", timeout=2)
+
+    monkeypatch.setattr(ma.subprocess, "run", _probe)
+
+    for _ in range(20):
+        clock["t"] += ma._RETRY_AFTER_SECONDS * 2
+        assert is_rosetta_translated(system="Darwin") is False
+
+    settled = len(calls)
+    for _ in range(20):
+        clock["t"] += ma._RETRY_AFTER_SECONDS * 2
+        is_rosetta_translated(system="Darwin")
+
+    assert len(calls) == settled, "the probe never settled — it forks forever"
+    assert settled <= 3, "the retry bound grew; a fork per menu rebuild is the bug this memo prevents"
 
 
 # --- true_machine_arch -----------------------------------------------------

--- a/tests/test_machine_arch.py
+++ b/tests/test_machine_arch.py
@@ -8,6 +8,7 @@ detection fails in, because guessing "translated" wrongly on a real Intel Mac
 would serve it an arm64 build it physically cannot execute.
 """
 
+import errno
 import inspect
 import platform
 import subprocess
@@ -137,7 +138,7 @@ def test_a_timed_out_probe_is_not_memoised(monkeypatch):
     assert is_rosetta_translated(system="Darwin") is False
 
     # Once the machine has had time to settle, the retry gets the real answer.
-    clock["t"] += ma._RETRY_AFTER_SECONDS + 1
+    clock["t"] += ma._RETRY_BACKOFF_SECONDS[0] + 1
     assert is_rosetta_translated(system="Darwin") is True
     assert len(calls) == 2
 
@@ -175,6 +176,122 @@ def test_the_retry_waits_instead_of_re_probing_inside_the_same_launch(monkeypatc
         assert is_rosetta_translated(system="Darwin") is False
     assert len(calls) == 1, "a rebuild inside the retry interval must not fork sysctl"
 
+    # ...AND the retry must actually fire once the clock crosses the interval.
+    # Without this half the test passes against an implementation with NO retry
+    # at all — a plain memo satisfies "one fork, then none" trivially, so the
+    # name would claim a gate that nothing pins. Verified: it does.
+    clock["t"] += ma._RETRY_BACKOFF_SECONDS[0] + 1
+    assert is_rosetta_translated(system="Darwin") is False
+    assert len(calls) == 2, "the probe never retried — the gate is a memo wearing a clock"
+
+
+def test_a_refused_fork_is_congestion_not_an_answer(monkeypatch):
+    """EAGAIN is the same "machine is too busy" as a timeout, in another spelling.
+
+    An overloaded Mac does not only make sysctl slow — once the per-user process
+    table is full it refuses the fork outright, and posix_spawn raises
+    BlockingIOError (errno EAGAIN), which is an OSError. Reproduced for real
+    under RLIMIT_NPROC during review.
+
+    Classifying it conclusive memoises None and pins the machine to the wrong
+    architecture for the session — the original bug, reached through a sibling
+    door of the one that was just closed. The hardware never answered.
+    """
+    clock = _fake_clock(monkeypatch)
+    calls = []
+
+    def _probe(*a, **k):
+        calls.append(1)
+        if len(calls) == 1:
+            raise BlockingIOError(errno.EAGAIN, "Resource temporarily unavailable")
+        return MagicMock(returncode=0, stdout="1\n")
+
+    monkeypatch.setattr(ma.subprocess, "run", _probe)
+
+    assert is_rosetta_translated(system="Darwin") is False
+    clock["t"] += ma._RETRY_BACKOFF_SECONDS[0] + 1
+    assert is_rosetta_translated(system="Darwin") is True
+    assert len(calls) == 2
+
+
+def test_a_probe_killed_by_a_signal_is_congestion_too(monkeypatch):
+    """jetsam/OOM kills the child under the same memory pressure.
+
+    subprocess reports that as a NEGATIVE returncode, which the exit-code branch
+    would otherwise read as "sysctl answered no" — the Intel-Mac case. It did
+    not answer at all.
+    """
+    clock = _fake_clock(monkeypatch)
+    calls = []
+
+    def _probe(*a, **k):
+        calls.append(1)
+        if len(calls) == 1:
+            return MagicMock(returncode=-9, stdout="")
+        return MagicMock(returncode=0, stdout="1\n")
+
+    monkeypatch.setattr(ma.subprocess, "run", _probe)
+
+    assert is_rosetta_translated(system="Darwin") is False
+    clock["t"] += ma._RETRY_BACKOFF_SECONDS[0] + 1
+    assert is_rosetta_translated(system="Darwin") is True
+    assert len(calls) == 2
+
+
+def test_a_sandbox_denial_is_permanent_and_memoised(monkeypatch):
+    """The other side of the errno line: EACCES will not lift mid-session.
+
+    Retrying it costs a fork per menu rebuild and buys nothing, which is the
+    Windows failure in a different costume.
+    """
+    clock = _fake_clock(monkeypatch)
+    calls = []
+
+    def _probe(*a, **k):
+        calls.append(1)
+        raise PermissionError(errno.EACCES, "Operation not permitted")
+
+    monkeypatch.setattr(ma.subprocess, "run", _probe)
+
+    for _ in range(5):
+        clock["t"] += 10_000
+        assert is_rosetta_translated(system="Darwin") is False
+
+    assert len(calls) == 1, "a permanent denial must be memoised on the first probe"
+
+
+def test_the_retry_outlasts_a_boot_storm(monkeypatch):
+    """The budget must not expire inside the congestion that caused it.
+
+    This is a login-item daemon that then runs for days. A flat 60s interval with
+    a 3-attempt cap exhausts every retry 120s after launch — still inside the
+    Spotlight-reindex / MDM-scan / Time Machine window that lost the first probe
+    — and then settles on the wrong architecture permanently. That is the
+    count-based budget the design rejects, wearing a clock.
+    """
+    clock = _fake_clock(monkeypatch)
+    calls = []
+
+    def _probe(*a, **k):
+        calls.append(1)
+        # Congested for the first ten minutes, then the machine calms down.
+        if clock["t"] < 1000.0 + 600:
+            raise subprocess.TimeoutExpired(cmd="sysctl", timeout=2)
+        return MagicMock(returncode=0, stdout="1\n")
+
+    monkeypatch.setattr(ma.subprocess, "run", _probe)
+
+    # Launch, then a menu rebuild every 30s for an hour.
+    assert is_rosetta_translated(system="Darwin") is False
+    for _ in range(120):
+        clock["t"] += 30
+        is_rosetta_translated(system="Darwin")
+
+    assert is_rosetta_translated(system="Darwin") is True, (
+        "the retry budget expired inside the boot storm — this Mac is pinned to "
+        "the wrong architecture for the rest of the session"
+    )
+
 
 def test_a_missing_sysctl_is_conclusive_and_probed_once(monkeypatch):
     """No sysctl on PATH is an ANSWER, not a failure to get one.
@@ -198,7 +315,7 @@ def test_a_missing_sysctl_is_conclusive_and_probed_once(monkeypatch):
     monkeypatch.setattr(ma.subprocess, "run", _probe)
 
     for _ in range(5):
-        clock["t"] += ma._RETRY_AFTER_SECONDS * 2
+        clock["t"] += ma._RETRY_BACKOFF_SECONDS[0] * 2
         assert is_rosetta_translated(system="Darwin") is False
 
     assert len(calls) == 1, "a permanently absent sysctl must be memoised on the first probe"
@@ -222,16 +339,16 @@ def test_a_persistently_timing_out_sysctl_eventually_settles(monkeypatch):
     monkeypatch.setattr(ma.subprocess, "run", _probe)
 
     for _ in range(20):
-        clock["t"] += ma._RETRY_AFTER_SECONDS * 2
+        clock["t"] += ma._RETRY_BACKOFF_SECONDS[0] * 2
         assert is_rosetta_translated(system="Darwin") is False
 
     settled = len(calls)
     for _ in range(20):
-        clock["t"] += ma._RETRY_AFTER_SECONDS * 2
+        clock["t"] += ma._RETRY_BACKOFF_SECONDS[0] * 2
         is_rosetta_translated(system="Darwin")
 
     assert len(calls) == settled, "the probe never settled — it forks forever"
-    assert settled <= 3, "the retry bound grew; a fork per menu rebuild is the bug this memo prevents"
+    assert settled <= 4, "the retry bound grew; a fork per menu rebuild is the bug this memo prevents"
 
 
 # --- true_machine_arch -----------------------------------------------------

--- a/tests/test_update_checker_arch.py
+++ b/tests/test_update_checker_arch.py
@@ -52,7 +52,9 @@ def _fake_host(monkeypatch, *, machine, proc_translated):
     where the key does not exist and sysctl exits non-zero.
     """
     monkeypatch.setattr(platform, "machine", lambda: machine)
-    monkeypatch.setattr(ma, "_read_proc_translated", lambda: proc_translated)
+    monkeypatch.setattr(
+        ma, "_read_proc_translated", lambda: ma.ProbeResult(proc_translated, conclusive=True)
+    )
 
 
 def test_rosetta_install_is_offered_the_apple_silicon_dmg(monkeypatch, mac_release):
@@ -141,6 +143,41 @@ def test_an_intel_mac_is_never_handed_the_arm_dmg_as_a_fallback(monkeypatch):
     release = _release(ARM_DMG, "BetterFlow-Windows-Setup.exe")
 
     assert _find_platform_asset(release, system="Darwin") is None
+
+
+def test_an_undetermined_arch_refuses_every_arch_suffixed_dmg(monkeypatch):
+    """platform.machine() is documented to return "" when it cannot tell.
+
+    Pre-fix that was the worst possible value: `"" in name` is true for EVERY
+    asset, so the arch-specific loop returned whichever DMG happened to be first
+    in the release — a coin flip between a working install and a dead one. When
+    we do not know which build is right, the only safe answer is neither.
+    """
+    _fake_host(monkeypatch, machine="", proc_translated=None)
+
+    assert _find_platform_asset(_release(ARM_DMG, INTEL_DMG), system="Darwin") is None
+    assert _find_platform_asset(_release(INTEL_DMG), system="Darwin") is None
+
+    # An unsuffixed DMG names no architecture, so it is still offered.
+    assert (
+        _find_platform_asset(_release("BetterFlow-macOS.dmg"), system="Darwin")
+        == "https://x/BetterFlow-macOS.dmg"
+    )
+
+
+def test_the_zip_fallback_refuses_a_wrong_arch_macos_zip(monkeypatch):
+    """The DMG loop is not the only door: the trailing ZIP loop is shared with
+    macOS, so it carries the identical hazard one line along.
+
+    No release ships a macOS .zip today (build.yml produces -Update.zip only on
+    windows-latest), so this guards a shape the project cannot currently
+    produce. It is here because the loop is reachable for Darwin and a future
+    packaging change would arrive silently — but it should be read as
+    future-proofing, not as a fix for a live fault.
+    """
+    _fake_host(monkeypatch, machine=X86_64, proc_translated="1")
+
+    assert _find_platform_asset(_release("BetterFlow-macOS-x86_64.zip"), system="Darwin") is None
 
 
 def test_windows_selection_is_unaffected_by_the_arch_change(monkeypatch):

--- a/tests/test_update_checker_arch.py
+++ b/tests/test_update_checker_arch.py
@@ -96,7 +96,13 @@ def test_explicit_arch_override_still_wins(monkeypatch, mac_release):
 
 def test_rosetta_falls_back_to_generic_dmg_when_no_arm_asset(monkeypatch):
     """An older release with a single unsuffixed DMG must still update rather
-    than dead-end because no arm64-named asset exists."""
+    than dead-end because no arm64-named asset exists.
+
+    The fixture is deliberately UNSUFFIXED. A DMG that names no architecture is
+    the only safe fallback: it may be a universal binary, and it certainly is
+    not a build we know to be wrong for this machine. The two tests below pin
+    the cases where the fallback DOES know better.
+    """
     _fake_host(monkeypatch, machine=X86_64, proc_translated="1")
     release = _release("BetterFlow-macOS.dmg")
 
@@ -104,6 +110,37 @@ def test_rosetta_falls_back_to_generic_dmg_when_no_arm_asset(monkeypatch):
         _find_platform_asset(release, system="Darwin")
         == "https://x/BetterFlow-macOS.dmg"
     )
+
+
+def test_apple_silicon_is_never_handed_the_intel_dmg_as_a_fallback(monkeypatch):
+    """A release missing its arm64 asset must yield NO update, not the Intel one.
+
+    Serving a build the machine cannot run is worse than serving nothing: on an
+    Apple Silicon Mac without Rosetta 2 the installed binary dies with
+    EBADARCH/ENOEXEC and capture stops dead — the production fault already on
+    record for Ardiel Plata's device (internal-tool2 #2298). Not updating just
+    leaves a working install in place until the release is repaired.
+
+    Reachable because the arch fix made it so: before it, a Rosetta install
+    resolved arch=x86_64 and always matched the Intel DMG in the first loop, so
+    it never reached the fallback at all.
+    """
+    _fake_host(monkeypatch, machine=X86_64, proc_translated="1")
+    release = _release(INTEL_DMG, "BetterFlow-Windows-Setup.exe")
+
+    assert _find_platform_asset(release, system="Darwin") is None
+
+
+def test_an_intel_mac_is_never_handed_the_arm_dmg_as_a_fallback(monkeypatch):
+    """The mirror, and the worse half: there is no reverse Rosetta.
+
+    An arm64 build on a genuine Intel Mac cannot be made to run by any means the
+    user has available, so this direction has no recovery path at all.
+    """
+    _fake_host(monkeypatch, machine=X86_64, proc_translated=None)
+    release = _release(ARM_DMG, "BetterFlow-Windows-Setup.exe")
+
+    assert _find_platform_asset(release, system="Darwin") is None
 
 
 def test_windows_selection_is_unaffected_by_the_arch_change(monkeypatch):


### PR DESCRIPTION
Two follow-ups to #185, found auditing it. Neither is a defect Martin introduced; both are gaps the fix left standing next to it.

## 1. The fallback could still hand a Mac a build it cannot run

`_find_platform_asset`'s fallback loop matched **any** macOS `.dmg`. So a release missing its arm64 asset served an Apple Silicon Mac the `x86_64` build — which, on a machine without Rosetta 2, installs a binary that dies `EBADARCH`/`ENOEXEC` and stops capture dead. That is the production fault already on record for Ardiel Plata's device (internal-tool2 #2298). The Intel direction is worse: there is no reverse Rosetta, so an arm64 DMG on a genuine Intel Mac has no recovery path at all.

The fallback **predates** #185. What #185 changed is that it became reachable — before it, a Rosetta install resolved `arch=x86_64` and always matched the Intel DMG in the first loop, so it never fell through. Resolving the hardware arch is precisely what lets the first loop miss.

Fixed at **both** addresses rather than the one that was reported: the trailing ZIP loop is shared with macOS and carries the identical hazard for a `BetterFlow-macOS-x86_64.zip`. One shared `_is_wrong_arch()` instead of the condition inlined twice.

An asset naming **no** architecture still qualifies (it may be universal); only one naming the *other* arch is refused. An undetermined arch — `platform.machine()` may return `""` — now rejects every arch-suffixed asset rather than matching all of them through the empty substring.

## 2. A timed-out probe was memoised for the process lifetime

`_read_proc_translated_cached` cached whatever the probe returned, including the `None` from an exception. One `sysctl` timeout therefore marked the machine untranslated for the whole session: the Diagnostics row states "Intel" about an Apple Silicon Mac, and the next update check re-selects the Intel DMG. #185's bug, silently back, with nothing to show for it.

Not theoretical — the warm-up fires at the busiest moment of launch, in a process that in the affected case is itself running through Rosetta, against a `timeout=2`.

The docstring justified caching failures with the Intel-Mac case, which is real and permanent: the key does not exist and `sysctl` exits **non-zero**. It then applied that rule to the exception path, which is neither. The line is exit code vs exception — "asked and answered no" vs "never got an answer". Retries are capped at 2 so a sandbox blocking `sysctl` outright still cannot fork on every menu rebuild.

## 3. Two tests that were not testing what they said

- `test_probe_runs_at_most_once_per_process` modelled a genuine Intel Mac by raising `OSError`. A real Intel Mac does not raise; it exits non-zero. Repointed at `returncode=1`, so it pins the conclusive path it always meant to.
- Every assertion about `send_notification` was a **negative** one (`assert_not_called` on a broken probe), and the ordering tests read `run()`'s source for the *call site*, never the body. Emptying the `send_notification` block left the entire suite green — the user-facing half of #185 was witnessed by nothing, on a path that runs on no CI leg and essentially no developer machine. Added the positive control.

## Verification

Proof of failure for the fallback fix — both new tests fail against the pre-fix tree:

```
assert 'https://x/BetterFlow-macOS-x86_64.dmg' is None
assert 'https://x/BetterFlow-macOS-arm64.dmg' is None
```

while the other 6 in that file pass unchanged, so the suite isolates the defect rather than describing the new code.

Mutation matrix — four mutants, each killed by a **distinct named** test, plus a clean control run:

| mutant | test that reddened |
|---|---|
| neuter `_is_wrong_arch` | `test_apple_silicon_is_never_handed_the_intel_dmg_as_a_fallback` + `test_an_intel_mac_is_never_handed_the_arm_dmg_as_a_fallback` |
| restore the unconditional memo | `test_a_transient_probe_failure_is_not_memoised` |
| drop the attempt cap only | `test_a_permanently_broken_sysctl_still_stops_forking` |
| empty `send_notification`, keep the guard and its logging | `test_a_translated_mac_actually_gets_the_notification` |

The last one is the consequence mutant rather than the condition mutant — the `logger.warning` still fired in the captured log, so the guard was intact and only its effect was gone. Each mutation was confirmed applied with `cmp` before the run.

- Full suite: **1676 passed, 1 skipped, exit 0** (up from 1656 at #185, so the run reached the new tests).
- `ruff check` on all five changed files: All checks passed.
- CI's test job is `pytest tests/` on ubuntu-latest / Python 3.11. Every test here injects `system="Darwin"` and patches `subprocess.run`, so none of them consults the host — the pattern #186 established for exactly this reason.

## Not included

This only reaches users when a release is cut. No release bump here — that is a separate call.
