### PR TITLE
Fail the downloads sync instead of reporting success on missing secrets

### DIFF
--- a/.github/workflows/sync-downloads.yml
+++ b/.github/workflows/sync-downloads.yml
@@ -99,14 +99,26 @@ jobs:
         run: |
           set -euo pipefail
 
-          # Sync is optional automation: the download page also derives its
-          # version/links from the backend's agent.version config fallback.
-          # If the sync secrets are not configured, skip cleanly with a loud
-          # warning rather than failing the release (avoids perpetual red runs
-          # on a feature that needs org-level secrets to be provisioned).
+          # FAIL, do not skip. This step used to emit a ::warning:: and exit 0
+          # when the secrets were absent, on the reasoning that the sync is
+          # "optional automation". The result was a green run that synced
+          # nothing, on every release, for 18 releases: the download page sat
+          # on v1.5.104 while v1.5.122 was live (#183). A green check is a
+          # claim that the page was updated, and nobody re-checks a claim.
+          #
+          # That silence had a second cost. New machines install whatever the
+          # page advertises, so they got v1.5.104 — which predates the Rosetta
+          # preflight added in v1.5.118. An Apple Silicon Mac therefore
+          # recorded zero time with no warning at all, instead of being told to
+          # run softwareupdate --install-rosetta (#188, ~90 minutes lost on
+          # 2026-08-13). The stale page was not cosmetic; it withheld the fix.
+          #
+          # A red run here cannot block a release: this workflow is triggered
+          # by `release: published` and nothing depends on it. Red is exactly
+          # the signal that was missing.
           if [ -z "${BACKEND_URL:-}" ] || [ -z "${RELEASE_SYNC_TOKEN:-}" ]; then
-            echo "::warning::Downloads sync skipped — set the DOWNLOADS_SYNC_BACKEND_URL and DOWNLOADS_SYNC_TOKEN repository secrets (and the backend AGENT_RELEASE_SYNC_TOKEN env) to enable automatic download-page updates."
-            exit 0
+            echo "::error::Downloads sync NOT performed — the download page still advertises the previous version. Set the DOWNLOADS_SYNC_BACKEND_URL and DOWNLOADS_SYNC_TOKEN repository secrets (and the backend AGENT_RELEASE_SYNC_TOKEN env)." >&2
+            exit 1
           fi
 
           curl --fail --show-error --silent \


### PR DESCRIPTION
Refs #183, #188. This does **not** resolve that first issue on its own — see "What this does not fix".

## The bug

The "Sync release metadata to backend" step emitted a `::warning::` and `exit 0` when its secrets were absent, on the reasoning that the sync is *optional automation*. Neither secret has ever been provisioned — `DOWNLOADS_SYNC_BACKEND_URL` and `DOWNLOADS_SYNC_TOKEN` do not appear in `gh secret list` — so the run has reported **success while syncing nothing, on every release, for 18 releases**. The download page sat on v1.5.104 while v1.5.122 was live.

It fired again on the **v1.5.123** publish an hour ago, green:

```
##[warning]Downloads sync skipped — set the DOWNLOADS_SYNC_BACKEND_URL and DOWNLOADS_SYNC_TOKEN repository secrets…
```

A green check is a claim that the page was updated. Nobody re-checks a claim, which is exactly why #183 says *"It looks automated, so nobody checks it."*

## Why this is not cosmetic — it withheld a fix from the person who needed it

New machines install whatever the page advertises. So they got **v1.5.104**, which predates the Rosetta preflight added in **v1.5.118**. Verified against the tags rather than assumed:

```
v1.5.104  2026-07-17  _rosetta_missing refs = 0
v1.5.117  2026-07-23  _rosetta_missing refs = 0
v1.5.118  2026-07-25  _rosetta_missing refs = 8
v1.5.123  2026-08-14  _rosetta_missing refs = 8
```

An Apple Silicon Mac without Rosetta therefore recorded zero time **with no warning at all**, instead of being told to run `softwareupdate --install-rosetta`. That is #188 — ~90 minutes lost on 2026-08-13 — and the mitigation for it had already shipped three weeks earlier. The stale download page is what stopped it arriving.

So #183 is not a cosmetic issue sitting next to #188. It is a contributing cause of #188's second occurrence.

## The change

One guard: `::warning::` + `exit 0` becomes `::error::` + `exit 1`.

A red run here cannot block a release — this workflow is triggered by `release: published` and nothing depends on it. Red is precisely the signal that was missing.

## Verification

The step's shell was extracted from the YAML and executed directly, both versions, same input:

| | secrets absent | secrets present |
|---|---|---|
| pre-fix (`origin/main`) | **exit 0** — `::warning::Downloads sync skipped` | — |
| post-fix | **exit 1** — `::error::Downloads sync NOT performed` | reaches `curl`, i.e. the guard permits |

The "secrets present" column is the control: without it this change could have been a guard that refuses everything, which would be a worse bug than the one being fixed.

YAML re-parsed after the edit (`yaml.safe_load`, 1 job, 3 steps). The patch asserted its anchor matched exactly once before applying.

## What this does not fix

**The secrets still need provisioning** — both repo secrets plus the backend's `AGENT_RELEASE_SYNC_TOKEN`. Until then this makes the next release go red instead of falsely green. That is the intent: the gap becomes visible rather than being mistaken for working automation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

