### PR TITLE
Ask the user to grant Accessibility instead of logging at them

### DIFF
--- a/src/sync/macos_window_watcher.py
+++ b/src/sync/macos_window_watcher.py
@@ -77,6 +77,11 @@ class MacOSWindowWatcher:
         # emit a one-shot log on each transition.
         self._last_accessibility: Optional[bool] = None
         self._last_accessibility_check_ts: float = 0.0
+        # Whether the user has been TOLD, this launch, that Accessibility is
+        # denied. Distinct from the log warning above, which fires every 60s
+        # and reaches nobody. Cleared on a grant so a later revocation warns
+        # again — see _notify_accessibility_required_once.
+        self._accessibility_notified: bool = False
         # One-shot flag: the AX messaging-timeout symbol is either present for
         # the whole process lifetime or never, so warn about it only once.
         self._ax_timeout_warned = False
@@ -112,6 +117,8 @@ class MacOSWindowWatcher:
             trusted = AXIsProcessTrusted()
             if not trusted:
                 logger.warning("Process does NOT have Accessibility permission — window titles will be empty")
+                # A log line is not a channel to a user who cannot see the log.
+                self._notify_accessibility_required_once()
         except ImportError:
             logger.error("Cannot start MacOSWindowWatcher: pyobjc-framework-ApplicationServices not installed")
             return False
@@ -375,11 +382,55 @@ class MacOSWindowWatcher:
             logger.info(
                 "Accessibility permission now granted — window titles will be tracked"
             )
+            # Re-arm: if the grant is ever taken away again the user must be
+            # told again. A latch that only ever sets would make the SECOND
+            # revocation as silent as the first one was.
+            self._accessibility_notified = False
         elif not trusted and self._last_accessibility:
             logger.warning(
                 "Accessibility permission revoked — window titles will be empty"
             )
+            self._notify_accessibility_required_once()
         self._last_accessibility = trusted
+
+    def _notify_accessibility_required_once(self) -> None:
+        """Ask the user to grant Accessibility. Once per launch, not once per check.
+
+        The warning this accompanies has been logged once a MINUTE, for nine
+        days on one device and ~15 on two others, and changed nothing: the log
+        is on the user's disk and nobody reads it (#194). The grant can only be
+        given by the person sitting at the machine, so they are the one who has
+        to be asked.
+
+        Once per launch rather than once ever, and the reasoning is the same as
+        ``aw_manager._notify_rosetta_required_once``: this reports a live
+        misconfiguration that stays true until someone acts, and it stops by
+        itself when they do. Repeating it every 60s alongside the log line would
+        train them to dismiss it, which is how a notice becomes as useless as
+        the log.
+
+        Best-effort. A machine with notifications disabled loses the prompt and
+        nothing else — capture is unaffected either way, since app names and
+        durations do not need this grant.
+        """
+        if self._accessibility_notified:
+            return
+        self._accessibility_notified = True
+        try:
+            try:
+                from ..notifications import send_notification
+            except ImportError:
+                from notifications import send_notification  # type: ignore[no-redef]
+
+            send_notification(
+                "BetterFlow can't read window titles",
+                "Grant Accessibility to BetterFlow in System Settings > "
+                "Privacy & Security > Accessibility. App names and time are "
+                "still being tracked.",
+            )
+        except Exception as e:
+            # Never let a failed notification stop the watcher starting.
+            logger.debug("Accessibility notification failed: %s", e)
 
     def _note_emit(self) -> None:
         """A window heartbeat was posted — clear any no-emit streak (and log a

--- a/tests/test_accessibility_prompt.py
+++ b/tests/test_accessibility_prompt.py
@@ -1,0 +1,183 @@
+"""The user gets ASKED when Accessibility is denied, not just logged at.
+
+Five macOS devices have been recording empty window titles for 9-15 days while
+the watcher logged "Process does NOT have Accessibility permission" once a
+minute. The log is on the user's own disk; the grant can only be given by the
+person sitting at the machine; nobody ever connected the two (#194).
+
+These tests are deliberately NOT gated on Darwin. `tests/test_macos_window_watcher.py`
+carries `importorskip("AppKit")` + `skipif(system() != "Darwin")`, which is right
+for tests that drive the real AX API — but the PR gate runs on ubuntu-latest, so
+a guard living only there executes in no merge-gating job at all. The notify
+latch is pure Python and the watcher class imports without pyobjc (AppKit and
+ApplicationServices are imported inside methods, not at module level), so this
+runs on every runner. The one test that needs the AX symbol injects a fake
+module rather than requiring the real one.
+"""
+
+import sys
+import types
+from unittest.mock import MagicMock, patch
+
+from src.sync.macos_window_watcher import MacOSWindowWatcher
+
+NOTIFY = "src.notifications.send_notification"
+
+
+def _watcher():
+    return MacOSWindowWatcher(MagicMock(), poll_interval=0.1)
+
+
+def _fake_ax(trusted):
+    """A stand-in ApplicationServices.
+
+    Carries ``AXUIElementCreateApplication`` as well as ``AXIsProcessTrusted``
+    because ``start()`` imports BOTH in one statement — omit either and the
+    whole import raises, sending start() down its "pyobjc not installed" branch
+    and returning False before the permission check is ever reached. That
+    failure looks like the feature not working; it is the fixture not reaching
+    the subject.
+    """
+    mod = types.ModuleType("ApplicationServices")
+    mod.AXIsProcessTrusted = lambda: trusted
+    mod.AXUIElementCreateApplication = lambda pid: None
+    return mod
+
+
+def test_the_user_is_notified_when_accessibility_is_denied():
+    w = _watcher()
+    with patch(NOTIFY) as notify:
+        w._notify_accessibility_required_once()
+
+    notify.assert_called_once()
+    title, body = notify.call_args[0][0], notify.call_args[0][1]
+    # The prompt has to name the remedy: "can't read window titles" alone gives
+    # the user nothing to do, which is the state this fix exists to end.
+    assert "Accessibility" in body
+    assert "System Settings" in body
+    assert title
+
+
+def test_the_prompt_says_tracking_still_works():
+    """Do not imply the day is not being recorded — it is.
+
+    Accessibility gates the window TITLE only; app names, durations and
+    categorisation all survive without it. A prompt that reads like "tracking is
+    broken" would send the user to support over an attribution-detail fault.
+    """
+    w = _watcher()
+    with patch(NOTIFY) as notify:
+        w._notify_accessibility_required_once()
+
+    body = notify.call_args[0][1].lower()
+    assert "still" in body and ("tracked" in body or "tracking" in body)
+
+
+def test_it_fires_once_per_launch_not_once_per_check():
+    """start() re-runs every 60s under the capture policy.
+
+    That is exactly why the log line was useless — 60 warnings an hour that
+    nobody reads. A notification at that rate trains the user to dismiss it,
+    which would reproduce the same uselessness with more annoyance.
+    """
+    w = _watcher()
+    with patch(NOTIFY) as notify:
+        for _ in range(50):
+            w._notify_accessibility_required_once()
+
+    assert notify.call_count == 1
+
+
+def test_a_second_revocation_notifies_again():
+    """The latch re-arms on a grant.
+
+    A latch that only ever sets would make the SECOND revocation exactly as
+    silent as the first one was — the bug, reintroduced one level down.
+    """
+    w = _watcher()
+    w._last_accessibility = False
+
+    with patch(NOTIFY) as notify:
+        w._notify_accessibility_required_once()  # first denial
+        assert notify.call_count == 1
+
+        # The user grants it: the transition handler must re-arm.
+        w._last_accessibility_check_ts = 0.0
+        with patch.dict(sys.modules, {"ApplicationServices": _fake_ax(True)}):
+            w._maybe_log_accessibility_transition()
+        assert w._accessibility_notified is False, "grant did not re-arm the latch"
+
+        # ...and takes it away again.
+        w._notify_accessibility_required_once()
+        assert notify.call_count == 2
+
+
+def test_a_revocation_while_running_prompts():
+    """Not only the start-up path. A grant can be withdrawn mid-session."""
+    w = _watcher()
+    w._last_accessibility = True
+    w._last_accessibility_check_ts = 0.0
+
+    with patch(NOTIFY) as notify, patch.dict(
+        sys.modules, {"ApplicationServices": _fake_ax(False)}
+    ):
+        w._maybe_log_accessibility_transition()
+
+    notify.assert_called_once()
+
+
+def _fake_appkit():
+    mod = types.ModuleType("AppKit")
+    mod.NSWorkspace = object
+    return mod
+
+
+def test_start_prompts_when_the_grant_is_already_missing():
+    """The CALLSITE guard, and it is the one that matters.
+
+    Every test above drives `_notify_accessibility_required_once` directly, so
+    they all pass whether or not anything calls it — the helper-only shape that
+    lets a fix ship wired to nothing. This one goes through `start()`, which is
+    the path Emilian's device actually takes on every launch and every 60s
+    capture-policy re-assert.
+
+    Both pyobjc modules are injected rather than required, so this runs on the
+    ubuntu gate as well as on a Mac.
+    """
+    w = _watcher()
+    fakes = {"AppKit": _fake_appkit(), "ApplicationServices": _fake_ax(False)}
+
+    with patch(NOTIFY) as notify, patch.dict(sys.modules, fakes), patch.object(w, "_run"):
+        started = w.start()
+
+    assert started is True, "the watcher must still start — titles degrade, capture does not"
+    notify.assert_called_once()
+    w.stop()
+
+
+def test_start_does_not_nag_when_the_grant_is_present():
+    """The permissive direction, witnessed.
+
+    Tests cluster on the firing path, so the line that exists purely to stay
+    QUIET routinely has no guard — and a prompt on every healthy launch would be
+    worse than the silence this fix replaces.
+    """
+    w = _watcher()
+    fakes = {"AppKit": _fake_appkit(), "ApplicationServices": _fake_ax(True)}
+
+    with patch(NOTIFY) as notify, patch.dict(sys.modules, fakes), patch.object(w, "_run"):
+        w.start()
+
+    notify.assert_not_called()
+    w.stop()
+
+
+def test_a_broken_notifier_never_stops_the_watcher():
+    """Best-effort. Losing the prompt must not cost the capture."""
+    w = _watcher()
+    with patch(NOTIFY, side_effect=OSError("no notification centre")):
+        w._notify_accessibility_required_once()  # must not raise
+
+    # And the latch still moved, so a failing notifier cannot become a retry
+    # loop that spawns an osascript every 60s forever.
+    assert w._accessibility_notified is True


### PR DESCRIPTION
Addresses the user-facing half of #194. Deliberately not the whole issue — see "Not in this PR".

## The bug

The window watcher has detected this all along. It calls `AXIsProcessTrusted()` at start-up and again on every transition, and logs:

```
Process does NOT have Accessibility permission — window titles will be empty
```

once a minute. The log is on the user's own disk. The grant can only be given by the person sitting at the machine. Nothing ever connected the two.

Five devices are currently in that state for **9 to 15 days**. Live capture from device 23 (Emilian Popescu) taken during the audit, while syncing normally:

```
15:31:41 - macos_window_watcher - WARNING - Process does NOT have Accessibility permission — window titles will be empty
15:32:41 - macos_window_watcher - WARNING - Process does NOT have Accessibility permission — window titles will be empty
15:33:43 - main - INFO - Sync complete: 3 sent, 0 queued, 15 filtered
```

Nine days of that, one line per minute, read by nobody.

## The change

`_notify_accessibility_required_once()`, mirroring `aw_manager._notify_rosetta_required_once` — same shape, same once-per-launch reasoning, same best-effort failure handling. Called from two places:

- `start()`, the path taken on every launch **and** every 60s capture-policy re-assert;
- the revocation branch of `_maybe_log_accessibility_transition`, so a grant withdrawn mid-session is caught too.

**The latch re-arms on a grant.** One that only ever set would make the *second* revocation exactly as silent as the first — the bug reintroduced one level down.

**The copy says app names and time are still tracked, because they are.** Accessibility gates the window TITLE only; app attribution and categorisation come from the frontmost-application API and need no grant. Verified on the live case: device 23 shows 12 named apps with keystrokes and clicks intact across 4 days. A prompt reading "tracking is broken" would send users to support over an attribution-detail fault.

## Verification

**Every mechanism witnessed failing, each reddening a distinct named test.** Anchors asserted unique before mutating, `cmp` confirming each applied, tree restored after each, committed before mutating:

| mutant | reddens |
|---|---|
| control | exit 0, 8 passed |
| M1 drop the `start()` callsite | `test_start_prompts_when_the_grant_is_already_missing` |
| M2 drop the revocation callsite | `test_a_revocation_while_running_prompts` |
| M3 never re-arm on a grant | `test_a_second_revocation_notifies_again` |
| M4 drop the latch (notify every check) | `test_it_fires_once_per_launch_not_once_per_check` |
| M5 let a broken notifier escape | `test_a_broken_notifier_never_stops_the_watcher` |
| M6 notify regardless of the grant | `test_start_does_not_nag_when_the_grant_is_present` |

M6 is the one tests usually miss: they cluster on the firing path, so the line that exists purely to stay **quiet** routinely has no guard — and a prompt on every healthy launch would be worse than the silence this replaces.

M2's first attempt had an anchor matching twice, deleted both sites and produced a collection error (exit 2). That mutant tested nothing and was rerun against a unique anchor rather than counted.

**The tests are not gated on Darwin, on purpose.** `tests/test_macos_window_watcher.py` carries `importorskip("AppKit")` + `skipif(system() != "Darwin")`, which is right for tests driving the real AX API — but the PR gate runs on `ubuntu-latest`, so a guard living only there executes in no merge-gating job at all. The watcher class imports without pyobjc (both frameworks are imported inside methods), so the fixtures inject fake modules instead of requiring real ones.

One trap worth recording: the fake must carry `AXUIElementCreateApplication` as well as `AXIsProcessTrusted`, because `start()` imports both in one statement — omit either and the import raises, sending `start()` down its "pyobjc not installed" branch and returning `False` *before* the permission check. That reads as the feature not working when it is the fixture not reaching the subject. Caught by the callsite test asserting `started is True`, not by reading.

**Gates.** Full suite **1679 passed, 1 skipped, exit 0** — up from 1671, +8, reconciling exactly with the tests added. `ruff` clean on both files.

## Not in this PR

**Forwarding the Accessibility state on the heartbeat**, which is the other half of #194 and the half that would let the server state a cause instead of inferring one. The server has no reader for the field, so shipping the agent side alone is a write with no reader — the same reason the hardware-architecture heartbeat field was held back on #184. It needs the internal-tool2 side to move first.

This half needs no server change, and it is the half that actually ends the nine days.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
