### PR TITLE
fix(updater): let an unresolved Rosetta probe reach the updater as doubt

### DIFF
--- a/src/machine_arch.py
+++ b/src/machine_arch.py
@@ -49,6 +49,12 @@ _cached_raw: Optional[str] = None
 _probed = False
 _probe_attempts = 0
 _last_transient_at: Optional[float] = None
+# Did the answer we settled on actually settle it? False means the retry budget
+# ran out with the probe still unresolved, so `_cached_raw is None` records "we
+# never found out" rather than "not translated". Those two states share a return
+# value and only one of them should make the updater withhold a build — see
+# `probe_settled_unresolved`.
+_cached_conclusive: bool = True
 
 
 class ProbeResult(NamedTuple):
@@ -122,7 +128,7 @@ def _read_proc_translated_cached() -> Optional[str]:
     lost the first probe, which is the very failure the previous paragraph
     rejects. The schedule runs past the hour and then settles.
     """
-    global _cached_raw, _probed, _probe_attempts, _last_transient_at
+    global _cached_raw, _probed, _probe_attempts, _last_transient_at, _cached_conclusive
 
     with _lock:
         if _probed:
@@ -145,6 +151,11 @@ def _read_proc_translated_cached() -> Optional[str]:
             _cached_raw = result.raw
             _probed = True
             _last_transient_at = None
+            # Record WHY we stopped. Exhausting the budget memoises `raw=None`
+            # exactly like a genuine "no such key" does, and from here on the two
+            # are indistinguishable by return value alone — which is how a
+            # congested Mac ends up confidently reporting itself as Intel.
+            _cached_conclusive = result.conclusive
         else:
             _last_transient_at = _monotonic()
             wait = _RETRY_BACKOFF_SECONDS[min(_probe_attempts, len(_RETRY_BACKOFF_SECONDS)) - 1]
@@ -160,12 +171,31 @@ def _read_proc_translated_cached() -> Optional[str]:
 
 def reset_cache_for_tests() -> None:
     """Drop the memo. Tests only — the architecture never changes at runtime."""
-    global _cached_raw, _probed, _probe_attempts, _last_transient_at
+    global _cached_raw, _probed, _probe_attempts, _last_transient_at, _cached_conclusive
     with _lock:
         _cached_raw = None
         _probed = False
         _probe_attempts = 0
         _last_transient_at = None
+        _cached_conclusive = True
+
+
+def probe_settled_unresolved() -> bool:
+    """True once we have STOPPED asking and still do not know.
+
+    Deliberately not "the probe has failed so far". A machine that lost one
+    sysctl to a boot storm is mid-backoff, not undetermined — the retry schedule
+    exists precisely to cover that, and reporting it as unknown would withhold
+    updates from a Mac that is merely busy. Only the exhausted-budget state
+    qualifies, and it is permanent for the life of the process.
+
+    Split out rather than folded into ``true_machine_arch`` because the tray row
+    and the updater want different things from it: the updater must refuse to
+    choose, and the row must say so out loud instead of naming an architecture
+    nobody established.
+    """
+    with _lock:
+        return _probed and not _cached_conclusive
 
 
 def _read_proc_translated() -> ProbeResult:
@@ -262,9 +292,24 @@ def true_machine_arch(
 ) -> str:
     """The architecture of the HARDWARE, not of the running process.
 
-    Returns ``platform.machine()`` unchanged everywhere except the one case it
-    gets wrong: an x86_64 process translated by Rosetta 2, which is really
-    running on arm64 silicon.
+    Returns ``platform.machine()`` unchanged everywhere except two cases: an
+    x86_64 process translated by Rosetta 2, which is really running on arm64
+    silicon; and a Mac whose Rosetta probe never resolved, which returns ``""``.
+
+    **The empty string means "we could not determine it", and callers must not
+    read it as an architecture.** ``platform.machine()`` is documented to return
+    ``""`` for the same reason, so this reuses that vocabulary rather than
+    inventing a third one, and ``update_checker._is_wrong_arch`` already refuses
+    every arch-suffixed asset when handed it. Before this, that safety branch was
+    reachable only through a ``platform.machine()`` value that does not occur on
+    macOS: the probe's own doubt was discarded one function earlier, so a
+    congested Mac reported a confident ``"x86_64"`` and was offered the Intel
+    build — the exact outcome the Rosetta work exists to prevent.
+
+    Only the SETTLED-unresolved state qualifies (see ``probe_settled_unresolved``);
+    a machine still inside its retry backoff keeps reporting its process
+    architecture, because withholding updates from a Mac that is briefly busy
+    would be a worse trade than the one this guards against.
 
     Args:
         system: Override ``platform.system()`` for testing.
@@ -280,4 +325,12 @@ def true_machine_arch(
 
     if translated:
         return ARM64
+
+    # Not translated — but on a Mac that can mean "asked and answered no" or
+    # "gave up asking". Only the second is undetermined. Skipped when the caller
+    # injected its own reader: it is simulating a probe, and the module-level
+    # memo it would consult describes a different one.
+    if system == "Darwin" and sysctl_reader is None and probe_settled_unresolved():
+        return ""
+
     return machine

--- a/src/machine_arch.py
+++ b/src/machine_arch.py
@@ -19,7 +19,6 @@ Kept dependency-free and fully injectable (``machine`` / ``translated`` /
 same spirit as ``release_version.py``.
 """
 
-import errno
 import logging
 import platform
 import subprocess
@@ -49,39 +48,64 @@ _cached_raw: Optional[str] = None
 _probed = False
 _probe_attempts = 0
 _last_transient_at: Optional[float] = None
-# Did the answer we settled on actually settle it? False means the retry budget
-# ran out with the probe still unresolved, so `_cached_raw is None` records "we
-# never found out" rather than "not translated". Those two states share a return
-# value and only one of them should make the updater withhold a build — see
-# `probe_settled_unresolved`.
-_cached_conclusive: bool = True
+# Did the kernel ever answer? False means `_cached_raw is None` records "we never
+# found out" rather than "not translated". Those two states share a return value
+# and only one of them should make the updater withhold a build — see
+# `probe_settled_unresolved`. Tracks ProbeResult.determined, NOT .conclusive:
+# a sandbox denial is conclusive (stop asking) and undetermined (we know
+# nothing), and reading the retry flag here is what let an EMFILE fork failure
+# masquerade as a hardware answer.
+_cached_determined: bool = True
 
 
 class ProbeResult(NamedTuple):
-    """What the probe said, and whether it is worth asking again.
+    """What the probe said, whether the kernel answered, and whether to retry.
 
-    ``conclusive`` is False ONLY when we never got an answer — see
-    ``_read_proc_translated``. Returned as a value rather than signalled through
-    module state so the classification cannot be read out of order, and so the
-    producer has no side effect its docstring has to warn about.
+    Two INDEPENDENT questions, and collapsing them is a live defect rather than
+    a tidiness point:
+
+    - ``determined`` — did we learn the hardware's answer? True only where the
+      kernel actually replied: a value, or the "no such key" that IS the answer
+      on a genuine Intel Mac.
+    - ``conclusive`` — is another fork worth it? A retry-policy decision, and
+      deliberately True for some UNDETERMINED outcomes: no sysctl on PATH and a
+      sandbox denial will not lift mid-session, so retrying costs a fork per
+      menu rebuild and buys nothing.
+
+    They were one field until an EMFILE fork failure — the file-descriptor twin
+    of the EAGAIN case this module already reasons about — took the "permanent"
+    branch and so reported a *confident* architecture for a machine that had
+    never been asked. That is the exact shape of the bug the Rosetta work
+    exists to fix, so the epistemic question now has its own field and
+    ``probe_settled_unresolved`` reads THAT one.
+
+    Returned as a value rather than signalled through module state so the
+    classification cannot be read out of order, and so the producer has no side
+    effect its docstring has to warn about.
     """
 
     raw: Optional[str]
+    determined: bool
     conclusive: bool
 
 
-# CONGESTION, in every spelling it reaches us in. A timeout is the obvious one,
-# but the same overloaded machine also refuses a fork outright (EAGAIN, when the
-# per-user process table is exhausted) or has the child killed under memory
-# pressure (jetsam/OOM, which surfaces as a negative returncode). All three say
-# "the machine was too busy", none says anything about its hardware, so none may
-# be memoised.
+# The two OSErrors that are PERMANENT for this process. No sysctl on PATH (every
+# Windows host) and a sandbox/EDR denial will not lift mid-session, so they must
+# be memoised or the memo never engages and menu rebuilds fork forever.
 #
-# The distinction is NOT exception-vs-exit-code, which was this module's second
-# wrong cut at it: FileNotFoundError (no sysctl — every Windows host) and
-# PermissionError (a sandbox denial) are permanent for this process and MUST be
-# memoised, or the memo never engages and menu rebuilds fork forever.
-_TRANSIENT_ERRNOS = frozenset({errno.EAGAIN, errno.ENOMEM})
+# Stated as an allowlist of the permanent cases, NOT as a list of the transient
+# ones. It used to be `_TRANSIENT_ERRNOS = {EAGAIN, ENOMEM}`, and the set of ways
+# a busy Mac can refuse a fork is not enumerable: EMFILE and ENFILE (the file-
+# descriptor twins of the EAGAIN case the paragraph below describes) fell
+# straight through it into "permanent", which is the wrong direction on both
+# axes — no retry AND a confident answer nobody obtained. Everything unlisted is
+# now treated as congestion: retried within the budget, and never determined.
+#
+# Matched on TYPE rather than errno on purpose. `FileNotFoundError("sysctl not
+# found")` raised without an errno has `exc.errno is None`, so an errno-keyed
+# test silently reclassifies it as congestion and reinstates the Windows
+# fork-per-rebuild regression.
+_PERMANENT_OSERRORS = (FileNotFoundError, PermissionError)
 
 # Retries back off, and that is the point rather than politeness. The congestion
 # that loses the first probe is a boot storm — Spotlight reindexing after an OS
@@ -128,7 +152,7 @@ def _read_proc_translated_cached() -> Optional[str]:
     lost the first probe, which is the very failure the previous paragraph
     rejects. The schedule runs past the hour and then settles.
     """
-    global _cached_raw, _probed, _probe_attempts, _last_transient_at, _cached_conclusive
+    global _cached_raw, _probed, _probe_attempts, _last_transient_at, _cached_determined
 
     with _lock:
         if _probed:
@@ -151,11 +175,13 @@ def _read_proc_translated_cached() -> Optional[str]:
             _cached_raw = result.raw
             _probed = True
             _last_transient_at = None
-            # Record WHY we stopped. Exhausting the budget memoises `raw=None`
-            # exactly like a genuine "no such key" does, and from here on the two
-            # are indistinguishable by return value alone — which is how a
-            # congested Mac ends up confidently reporting itself as Intel.
-            _cached_conclusive = result.conclusive
+            # Record whether anyone ever answered. Exhausting the budget memoises
+            # `raw=None` exactly like a genuine "no such key" does, and from here
+            # on the two are indistinguishable by return value alone — which is
+            # how a congested Mac ends up confidently reporting itself as Intel.
+            # `.determined`, never `.conclusive`: this branch is also reached by
+            # the permanent-but-unanswered cases (no sysctl, sandbox denial).
+            _cached_determined = result.determined
         else:
             _last_transient_at = _monotonic()
             wait = _RETRY_BACKOFF_SECONDS[min(_probe_attempts, len(_RETRY_BACKOFF_SECONDS)) - 1]
@@ -171,31 +197,44 @@ def _read_proc_translated_cached() -> Optional[str]:
 
 def reset_cache_for_tests() -> None:
     """Drop the memo. Tests only — the architecture never changes at runtime."""
-    global _cached_raw, _probed, _probe_attempts, _last_transient_at, _cached_conclusive
+    global _cached_raw, _probed, _probe_attempts, _last_transient_at, _cached_determined
     with _lock:
         _cached_raw = None
         _probed = False
         _probe_attempts = 0
         _last_transient_at = None
-        _cached_conclusive = True
+        _cached_determined = True
 
 
 def probe_settled_unresolved() -> bool:
-    """True once we have STOPPED asking and still do not know.
+    """True once we have STOPPED asking and the kernel never answered.
 
     Deliberately not "the probe has failed so far". A machine that lost one
     sysctl to a boot storm is mid-backoff, not undetermined — the retry schedule
     exists precisely to cover that, and reporting it as unknown would withhold
-    updates from a Mac that is merely busy. Only the exhausted-budget state
-    qualifies, and it is permanent for the life of the process.
+    updates from a Mac that is merely busy. Only the settled state qualifies,
+    and it is permanent for the life of the process.
 
-    Split out rather than folded into ``true_machine_arch`` because the tray row
-    and the updater want different things from it: the updater must refuse to
-    choose, and the row must say so out loud instead of naming an architecture
-    nobody established.
+    Two ways to reach it, and the second is easy to miss: the retry budget ran
+    out on a machine that stayed congested, OR the probe hit a permanent
+    obstacle that is not an answer (no sysctl on PATH, a sandbox/EDR denial).
+    Both stop the asking; neither learned anything. Hence ``_cached_determined``
+    rather than the retry flag.
+
+    Split out rather than folded into ``true_machine_arch`` so it can be
+    asserted directly, and because the settled-unresolved state is a fact about
+    the probe rather than about any one caller's architecture question. Note the
+    tray does NOT call this — it reads the ``""`` that ``true_machine_arch``
+    returns, which is the better shape: one translation of this state into a
+    caller-facing answer, not two that can drift.
     """
     with _lock:
-        return _probed and not _cached_conclusive
+        # `_probed and` is belt-and-braces: `_cached_determined` is only set
+        # False in the branch that also sets `_probed = True`, so a mutant
+        # dropping it survives the suite. Kept because the pair is the actual
+        # invariant, and the default `True` protects the un-probed state only by
+        # coincidence of its initial value.
+        return _probed and not _cached_determined
 
 
 def _read_proc_translated() -> ProbeResult:
@@ -206,12 +245,17 @@ def _read_proc_translated() -> ProbeResult:
     blocks the call. Callers must treat None as *not translated*; see
     ``is_rosetta_translated``.
 
-    ``conclusive`` separates "asked and answered no" from "never got an answer",
-    and only a TIMEOUT is the latter. A missing binary or a denied call is an
-    answer: sysctl will not appear mid-session and a sandbox will not lift, so
-    treating those as retryable buys nothing and costs a fork on every menu
-    rebuild — on Windows, where sysctl does not exist at all, it also breaks the
-    memo outright.
+    ``determined`` says whether the KERNEL answered, and only the two
+    ``returncode`` paths below qualify: a value, or the non-zero exit that is
+    the genuine "no such key" of an Intel Mac. Every exception path leaves us
+    knowing nothing about the hardware, whatever we decide about retrying.
+
+    ``conclusive`` is the separate retry decision, and is deliberately True for
+    two UNDETERMINED outcomes: a missing binary and a denied call will not
+    resolve mid-session, so treating them as retryable buys nothing and costs a
+    fork on every menu rebuild — on Windows, where sysctl does not exist at all,
+    it also breaks the memo outright. "Stop asking" and "we found out" are not
+    the same claim, and `probe_settled_unresolved` reads the second one.
     """
     try:
         result = subprocess.run(
@@ -223,37 +267,40 @@ def _read_proc_translated() -> ProbeResult:
     except subprocess.TimeoutExpired as exc:
         # The machine was too busy to answer in two seconds.
         logger.debug(f"Timed out reading {_PROC_TRANSLATED_KEY}: {exc}")
-        return ProbeResult(None, conclusive=False)
+        return ProbeResult(None, determined=False, conclusive=False)
+    except _PERMANENT_OSERRORS as exc:
+        # No sysctl at all (every Windows host) or a sandbox/EDR denial. Neither
+        # resolves mid-session, so stop asking — but neither is an answer about
+        # the hardware, so this is emphatically not `determined`.
+        logger.debug(f"Cannot read {_PROC_TRANSLATED_KEY} on this host: {exc}")
+        return ProbeResult(None, determined=False, conclusive=True)
     except OSError as exc:
-        # Same congestion, different spelling: an overloaded machine refuses the
-        # fork itself with EAGAIN once the per-user process table is full, and
-        # returns ENOMEM under memory pressure. Reproduced under RLIMIT_NPROC as
-        # BlockingIOError, which is an OSError and was being memoised as though
-        # the hardware had answered.
-        #
-        # Everything else here IS permanent for this process — FileNotFoundError
-        # (no sysctl at all, i.e. every Windows host) and PermissionError (a
-        # sandbox denial) will not resolve mid-session, and treating them as
-        # retryable stops the memo engaging and forks on every menu rebuild.
-        transient = exc.errno in _TRANSIENT_ERRNOS
+        # Congestion in one of its many spellings: an overloaded machine refuses
+        # the fork with EAGAIN once the per-user process table is full, ENOMEM
+        # under memory pressure, EMFILE/ENFILE when the fd table is at its cap.
+        # Reproduced under RLIMIT_NPROC as BlockingIOError. Anything that is not
+        # one of the two permanent cases above is treated this way, because the
+        # ways a busy machine can refuse are not enumerable and the cost of
+        # guessing wrong is a confident answer nobody obtained.
         logger.debug(f"Could not read {_PROC_TRANSLATED_KEY} (errno={exc.errno}): {exc}")
-        return ProbeResult(None, conclusive=not transient)
+        return ProbeResult(None, determined=False, conclusive=False)
     except subprocess.SubprocessError as exc:
         logger.debug(f"Could not read {_PROC_TRANSLATED_KEY}: {exc}")
-        return ProbeResult(None, conclusive=True)
+        return ProbeResult(None, determined=False, conclusive=True)
 
     if result.returncode < 0:
         # Killed by a signal — jetsam/OOM under the same memory pressure that
         # produces the timeout. The hardware never got a word in.
         logger.debug(f"{_PROC_TRANSLATED_KEY} probe killed by signal {-result.returncode}")
-        return ProbeResult(None, conclusive=False)
+        return ProbeResult(None, determined=False, conclusive=False)
 
     if result.returncode != 0:
         # Expected on Intel Macs: "second level name 'proc_translated' in
-        # 'sysctl.proc_translated' is invalid". Not an error worth logging loudly.
-        return ProbeResult(None, conclusive=True)
+        # 'sysctl.proc_translated' is invalid". Not an error worth logging loudly
+        # — and it IS the answer, which is why this is determined.
+        return ProbeResult(None, determined=True, conclusive=True)
 
-    return ProbeResult(result.stdout.strip(), conclusive=True)
+    return ProbeResult(result.stdout.strip(), determined=True, conclusive=True)
 
 
 def is_rosetta_translated(
@@ -327,9 +374,21 @@ def true_machine_arch(
         return ARM64
 
     # Not translated — but on a Mac that can mean "asked and answered no" or
-    # "gave up asking". Only the second is undetermined. Skipped when the caller
-    # injected its own reader: it is simulating a probe, and the module-level
-    # memo it would consult describes a different one.
+    # "never got an answer". Only the second is undetermined.
+    #
+    # The two overrides are NOT symmetric here, which is worth stating because
+    # it looks like an oversight:
+    #
+    #   sysctl_reader= replaces the probe itself, so the module memo describes a
+    #     DIFFERENT probe than the one that produced `translated`. Mixing them
+    #     would report this process's doubt about a reader the caller never ran.
+    #     Skipped.
+    #   translated= overrides only the derived boolean. No reader ran, so the
+    #     module memo is still the only — and the correct — record of whether
+    #     THIS process ever got an answer. Consulted.
+    #
+    # That is what lets the tray pass `translated=` to control its Rosetta
+    # wording while still reflecting the real probe's doubt in the arch row.
     if system == "Darwin" and sysctl_reader is None and probe_settled_unresolved():
         return ""
 

--- a/src/machine_arch.py
+++ b/src/machine_arch.py
@@ -237,6 +237,45 @@ def probe_settled_unresolved() -> bool:
         return _probed and not _cached_determined
 
 
+def arch_answer_is_provisional(system: Optional[str] = None) -> bool:
+    """True while the architecture answer could still change (macOS only).
+
+    The companion to ``probe_settled_unresolved``, and the two are NOT
+    opposites: this one is about the mid-backoff window, where we are reporting
+    the process architecture as a working assumption and a later probe may
+    overturn it.
+
+    That assumption is fine to NOTIFY on and fine to show in the tray — the cost
+    of being wrong is a row that corrects itself. It is not fine to SELF-INSTALL
+    on. The launch update check runs with ``apply_now=True`` and
+    ``auto_install_updates`` defaults to True, so an Apple Silicon Mac that lost
+    its probe to a login boot storm would download and apply the Intel DMG
+    within the first ~36 minutes — re-pinning itself to the build this whole
+    module exists to get it off. Notifying is reversible; applying is what the
+    user has to undo by hand.
+
+    Darwin-gated INSIDE the predicate, deliberately. Off macOS the probe never
+    runs at all, so ``_probed`` stays False forever — a caller that asked
+    "unsettled?" without the gate would defer every self-install on Windows and
+    Linux permanently.
+
+    It ASKS before answering, rather than reading the memo and hoping somebody
+    else filled it. Reading passively conflates "still retrying" with "nobody
+    has looked yet", and both come back True: a Mac that reached this without a
+    prior probe would defer its self-install forever. Today `_find_platform_asset`
+    happens to warm the memo first, but depending on that ordering is the same
+    kind of unwritten coupling this module has already been bitten by. The probe
+    is memoised, so on a healthy Mac this costs one fork per process and settles
+    on the spot.
+    """
+    system = system or platform.system()
+    if system != "Darwin":
+        return False
+    _read_proc_translated_cached()
+    with _lock:
+        return not _probed
+
+
 def _read_proc_translated() -> ProbeResult:
     """Return the raw ``sysctl.proc_translated`` value and whether it settles it.
 
@@ -389,7 +428,20 @@ def true_machine_arch(
     #
     # That is what lets the tray pass `translated=` to control its Rosetta
     # wording while still reflecting the real probe's doubt in the arch row.
-    if system == "Darwin" and sysctl_reader is None and probe_settled_unresolved():
+    #
+    # `machine == X86_64` matters and is not belt-and-braces: Rosetta translates
+    # x86 ONTO arm and never the reverse, so an arm64 PROCESS proves arm64
+    # hardware outright and the probe was never needed to establish it. Without
+    # this clause a native Apple Silicon Mac whose sysctl is denied by an EDR
+    # policy is told "could not determine (process: arm64)" and offered no build
+    # at all — a regression against the behaviour this branch inherited, on a
+    # machine whose architecture was never actually in doubt.
+    if (
+        system == "Darwin"
+        and machine == X86_64
+        and sysctl_reader is None
+        and probe_settled_unresolved()
+    ):
         return ""
 
     return machine

--- a/src/ui/tray.py
+++ b/src/ui/tray.py
@@ -316,6 +316,14 @@ def arch_menu_label(
         return "Architecture: Intel build on Apple Silicon — switch to the Apple Silicon version"
     if arch == ARM64:
         return "Architecture: Apple Silicon (native)"
+    if not arch:
+        # true_machine_arch returns "" only when the Rosetta probe gave up (see
+        # its docstring). Say so rather than falling through to the Intel label:
+        # this row exists to answer "which build am I on?", and the one thing it
+        # must never do is answer confidently when nobody established it. The
+        # updater withholds arch-suffixed builds in this state, so a user reading
+        # the row is also being told why no update has appeared.
+        return f"Architecture: could not determine (process: {machine or 'unknown'})"
     return f"Architecture: Intel ({arch})"
 
 

--- a/src/update_handler.py
+++ b/src/update_handler.py
@@ -14,8 +14,10 @@ import time
 from typing import Optional
 
 try:
+    from .machine_arch import true_machine_arch
     from .update_checker import _version_tuple
-except ImportError:
+except ImportError:  # PyInstaller bundle (src/ is import root)
+    from machine_arch import true_machine_arch
     from update_checker import _version_tuple
 
 try:
@@ -47,6 +49,10 @@ class UpdateHandler:
         # self-update" warning, so a root-owned (.pkg) machine gets told once,
         # not every 30-min check.
         self._managed_warned_version: Optional[str] = None
+        # And the same latch for "we could not determine this Mac's architecture,
+        # so we are withholding every arch-suffixed build". Reported once per
+        # version rather than every 30-min check.
+        self._arch_undetermined_version: Optional[str] = None
         self._staged_lock = threading.Lock()
         self._update_jobs_started = False
         self._update_jobs_lock = threading.Lock()
@@ -166,6 +172,35 @@ class UpdateHandler:
         except Exception:
             logger.warning("managed-install-blocked report failed", exc_info=True)
 
+    def _report_arch_undetermined(self, version: str) -> None:
+        """Report once per version that this Mac is being offered no build.
+
+        The sibling of `_report_managed_blocked`, and it exists for the same
+        reason: the machine is now permanently un-auto-updatable and the only
+        person who can see that is whoever opens the tray menu.
+
+        Reachable when the Rosetta probe never got an answer (a Mac congested
+        past the whole retry budget, a sandbox/EDR denial). `true_machine_arch`
+        then returns "", the updater correctly refuses every arch-suffixed
+        asset, and since this repo's releases publish ONLY arm64 and x86_64
+        DMGs — no universal DMG, no macOS ZIP — that means no asset at all, for
+        every release, until the process restarts. The user still gets the
+        release-page notification; ops otherwise gets nothing, and this device
+        would sit at a stale version looking healthy.
+        """
+        reporter = getattr(self.coordinator, "error_reporter", None)
+        if reporter is None:
+            return
+        try:
+            reporter.capture(
+                f"Self-update withheld: machine architecture undetermined, no asset for v{version}",
+                level="warning",
+                tags={"component": "update-handler"},
+                fingerprint="update-arch-undetermined",
+            )
+        except Exception:
+            logger.warning("arch-undetermined report failed", exc_info=True)
+
     def _on_update_available(
         self, version: str, url: str, asset_url: Optional[str] = None, apply_now: bool = False
     ) -> None:
@@ -173,6 +208,21 @@ class UpdateHandler:
         stage it (and maybe apply)."""
         logger.info(f"Update available: v{version} | {url} (asset: {asset_url})")
         self.tray.set_update_available(version, url, asset_url)
+
+        # No asset AND no architecture: this Mac's Rosetta probe never got an
+        # answer, so the updater is refusing every arch-suffixed build on
+        # purpose. Correct, and invisible — tell ops, or the device sits at a
+        # stale version indistinguishable from a healthy one. Checked before the
+        # managed-install gate below, which only fires when an asset EXISTS.
+        # `true_machine_arch()` is last so it is only reached once per version:
+        # it is memoised, but the two cheap latches say the same thing sooner.
+        if (
+            not asset_url
+            and version != self._arch_undetermined_version
+            and not true_machine_arch()
+        ):
+            self._arch_undetermined_version = version
+            self._report_arch_undetermined(version)
 
         # A managed (.pkg / root-owned) install can't replace itself — the
         # self-update rename EPERMs every cycle (see

--- a/src/update_handler.py
+++ b/src/update_handler.py
@@ -14,10 +14,10 @@ import time
 from typing import Optional
 
 try:
-    from .machine_arch import true_machine_arch
+    from .machine_arch import arch_answer_is_provisional, true_machine_arch
     from .update_checker import _version_tuple
 except ImportError:  # PyInstaller bundle (src/ is import root)
-    from machine_arch import true_machine_arch
+    from machine_arch import arch_answer_is_provisional, true_machine_arch
     from update_checker import _version_tuple
 
 try:
@@ -257,6 +257,26 @@ class UpdateHandler:
             send_notification("BetterFlow Update", msg)
 
         if not asset_url or not self.config.auto_install_updates:
+            return
+
+        # Everything above this line has already run: the user has been told a
+        # version is available and the tray carries the release link. What is
+        # gated here is only the SELF-INSTALL.
+        #
+        # While the Rosetta probe is still inside its retry schedule we are
+        # reporting the process architecture as a working assumption, which a
+        # later probe may overturn. Notifying on an assumption is free; applying
+        # one is not. The launch check arrives here with apply_now=True, so on a
+        # congested Apple Silicon Mac this is exactly where the Intel DMG would
+        # get downloaded and applied — re-pinning the machine to the wrong build
+        # inside the first ~36 minutes. Skip this cycle; the 30-minute re-check
+        # picks it up for free once the probe has settled.
+        if arch_answer_is_provisional():
+            logger.info(
+                f"Deferring self-install of v{version}: this Mac's architecture is not "
+                "established yet (Rosetta probe still retrying). The next check will "
+                "pick it up."
+            )
             return
 
         # Already downloaded this version — it applies on idle/restart; don't

--- a/tests/test_arch_undetermined.py
+++ b/tests/test_arch_undetermined.py
@@ -17,11 +17,13 @@ These pin the distinction that makes it real: mid-backoff is NOT undetermined
 """
 
 import errno
+import subprocess
 from types import SimpleNamespace
 from unittest.mock import MagicMock, patch
 
 import pytest
 
+import src.update_handler as uh
 from src import machine_arch as ma
 from src.machine_arch import ARM64, X86_64, ProbeResult, true_machine_arch
 from src.ui.tray import arch_menu_label
@@ -122,6 +124,65 @@ def test_a_fork_refused_with_emfile_is_undetermined_not_intel():
     assert true_machine_arch(system="Darwin", machine=X86_64) == ""
     with patch("platform.machine", lambda: X86_64):
         assert _find_platform_asset(RELEASE, system="Darwin") is None
+
+
+def test_a_timed_out_probe_is_undetermined_not_intel():
+    """The motivating case, and it was witnessed by NOTHING.
+
+    Every other test reaching this state goes through `_exhaust_the_budget`,
+    which stubs `_read_proc_translated` wholesale — so the timeout branch's own
+    `determined=False` was supplied by the fixture rather than tested. Flipping
+    it to True in the source left the entire suite green while restoring the
+    #196 defect verbatim: a Mac that loses all four probes to a boot storm
+    reports a confident "x86_64" and is handed the Intel DMG.
+    """
+    _settle_by_raising(subprocess.TimeoutExpired(cmd="sysctl", timeout=2))
+
+    assert ma.probe_settled_unresolved() is True
+    assert true_machine_arch(system="Darwin", machine=X86_64) == ""
+
+
+def test_a_probe_killed_by_a_signal_is_undetermined_not_intel():
+    """jetsam/OOM under the same memory pressure. The hardware never spoke.
+
+    Reaches the classifier by RETURNING a negative returncode rather than
+    raising, so it exercises the branch the exception tests cannot.
+    """
+    clock = [0.0]
+    with patch.object(
+        ma.subprocess, "run", lambda *a, **k: SimpleNamespace(returncode=-9, stdout="", stderr="")
+    ), patch.object(ma, "_monotonic", lambda: clock[0]):
+        for _ in range(len(ma._RETRY_BACKOFF_SECONDS) + 2):
+            ma._read_proc_translated_cached()
+            clock[0] += 100000.0
+
+    assert ma.probe_settled_unresolved() is True
+    assert true_machine_arch(system="Darwin", machine=X86_64) == ""
+
+
+def test_a_native_arm64_mac_is_never_undetermined():
+    """An arm64 PROCESS proves arm64 HARDWARE — no probe required.
+
+    Rosetta translates x86 onto arm and never the reverse, so the ambiguity this
+    module exists to resolve simply does not arise for an arm64 process. Without
+    the `machine == X86_64` clause, a native Apple Silicon Mac whose sysctl is
+    denied by an EDR policy is told "could not determine (process: arm64)" and
+    offered no build at all — worse than the behaviour this branch inherited, on
+    a machine whose architecture was never in doubt.
+    """
+    _settle_by_raising(PermissionError(errno.EACCES, "Operation not permitted"))
+    assert ma.probe_settled_unresolved() is True
+
+    assert true_machine_arch(system="Darwin", machine=ARM64) == ARM64
+    assert arch_menu_label(system="Darwin", machine=ARM64, translated=False) == (
+        "Architecture: Apple Silicon (native)"
+    )
+    with patch("platform.machine", lambda: ARM64):
+        assert _find_platform_asset(RELEASE, system="Darwin") == "https://x/arm64.dmg"
+
+    # ...while the genuinely ambiguous x86_64 process on the same denied probe
+    # still withholds. Same memo, opposite answer — that is the whole point.
+    assert true_machine_arch(system="Darwin", machine=X86_64) == ""
 
 
 def test_a_sandbox_denial_is_undetermined_while_staying_memoised():
@@ -338,7 +399,14 @@ def test_a_mac_left_with_no_asset_by_an_undetermined_arch_is_reported_once():
     _exhaust_the_budget()
     h = _update_handler()
 
-    with patch.object(h, "_report_arch_undetermined") as report:
+    # `_on_update_available` asks `true_machine_arch()` with no override, so it
+    # reads the REAL platform. Without these patches this test passes only on a
+    # Mac: on the ubuntu runner that gates every PR here, the arch comes back
+    # truthy, the report never fires, and this assertion fails. Patch the
+    # platform rather than stubbing `true_machine_arch`, so the memo built by
+    # `_exhaust_the_budget` is still the thing under test.
+    with patch("platform.system", lambda: "Darwin"), patch("platform.machine", lambda: X86_64), \
+         patch.object(h, "_report_arch_undetermined") as report:
         h._on_update_available("1.5.124", "http://rel", asset_url=None)
         h._on_update_available("1.5.124", "http://rel", asset_url=None)  # 30-min re-check
 
@@ -358,10 +426,129 @@ def test_no_asset_for_an_ordinary_reason_is_not_reported_as_undetermined():
         ma._read_proc_translated_cached()
     h = _update_handler()
 
-    with patch.object(h, "_report_arch_undetermined") as report:
+    # Darwin pinned for the same reason as above — otherwise this control passes
+    # on the CI runner whatever the code does, which is the shape of a test that
+    # proves nothing.
+    with patch("platform.system", lambda: "Darwin"), patch("platform.machine", lambda: X86_64), \
+         patch.object(h, "_report_arch_undetermined") as report:
         h._on_update_available("1.5.124", "http://rel", asset_url=None)
 
     report.assert_not_called()
+
+
+def test_the_ops_report_carries_its_own_fingerprint():
+    """The body itself, unpatched — everything else mocks this method out.
+
+    The error ingest aggregates by fingerprint ALONE (context and message are
+    overwritten newest-wins and the digest reads neither), so the fingerprint
+    is the entire signal. Reusing the managed-install one would silently merge
+    two unrelated ops conditions into a single count, and every other test here
+    would stay green.
+    """
+    h = _update_handler()
+    reporter = MagicMock()
+    h.coordinator.error_reporter = reporter
+
+    h._report_arch_undetermined("1.5.124")
+
+    reporter.capture.assert_called_once()
+    kwargs = reporter.capture.call_args.kwargs
+    assert kwargs["fingerprint"] == "update-arch-undetermined"
+    assert kwargs["level"] == "warning"
+
+
+def test_the_ops_report_never_raises_into_the_update_path():
+    """A broken reporter must not take the updater down with it."""
+    h = _update_handler()
+    h.coordinator.error_reporter = MagicMock()
+    h.coordinator.error_reporter.capture.side_effect = RuntimeError("ingest down")
+
+    h._report_arch_undetermined("1.5.124")  # must not raise
+
+
+# --- notifying on an assumption is free; INSTALLING on one is not ----------
+
+
+def test_no_self_install_while_the_probe_is_still_retrying():
+    """The mid-backoff window, which is ~36 minutes long and auto-applies.
+
+    `true_machine_arch` deliberately still reports the process architecture
+    here — the retry schedule exists to cover a briefly-busy Mac, and issue #196
+    asks for exactly that. But the launch check arrives with `apply_now=True`
+    and `auto_install_updates` defaults True, so an Apple Silicon Mac that lost
+    its probe to a login boot storm would download and APPLY the Intel DMG,
+    re-pinning itself to the build this module exists to get it off.
+
+    The user is still notified — only the self-install is deferred.
+    """
+    # One transient failure: budget intact, so the answer is provisional.
+    with patch.object(ma, "_read_proc_translated", lambda: ProbeResult(None, determined=False, conclusive=False)):
+        ma._read_proc_translated_cached()
+    assert ma.probe_settled_unresolved() is False, "precondition: mid-backoff, not settled"
+
+    h = _update_handler()
+    with patch("platform.system", lambda: "Darwin"), patch("platform.machine", lambda: X86_64), \
+         patch.object(h, "_stage_and_maybe_apply") as stage, \
+         patch.object(uh, "send_notification") as notify:
+        h._on_update_available("1.5.124", "http://rel", asset_url="http://x/x86_64.dmg", apply_now=True)
+
+    stage.assert_not_called()
+    notify.assert_called_once()  # told, just not installed for them
+
+
+def test_the_self_install_resumes_once_the_probe_settles():
+    """The permissive direction — deferring forever would also pass the above."""
+    with patch.object(ma, "_read_proc_translated", lambda: ProbeResult(None, determined=True, conclusive=True)):
+        ma._read_proc_translated_cached()
+
+    h = _update_handler()
+    with patch("platform.system", lambda: "Darwin"), patch("platform.machine", lambda: X86_64), \
+         patch.object(h, "_stage_and_maybe_apply") as stage, \
+         patch.object(uh, "send_notification"):
+        h._on_update_available("1.5.124", "http://rel", asset_url="http://x/x86_64.dmg", apply_now=True)
+
+    stage.assert_called_once()
+
+
+def test_an_unprobed_mac_asks_rather_than_deferring_forever():
+    """"Nobody has looked yet" must not read as "still retrying".
+
+    The first cut of this predicate read the memo passively, so a Mac arriving
+    here before anything had probed saw `_probed is False`, called the answer
+    provisional, and deferred — with nothing scheduled to ever change that. It
+    also broke `test_replaceable_install_proceeds_to_stage`, an existing test of
+    the ordinary healthy-Mac staging path, which is how it was caught.
+    """
+    ma.reset_cache_for_tests()
+    calls = []
+
+    def _answered(*a, **k):
+        calls.append(1)
+        return SimpleNamespace(returncode=1, stdout="", stderr="invalid")  # real Intel Mac
+
+    with patch("platform.system", lambda: "Darwin"), patch.object(ma.subprocess, "run", _answered):
+        assert ma.arch_answer_is_provisional() is False
+
+    assert calls, "the predicate must PROBE, not just read a memo somebody else filled"
+
+
+def test_windows_and_linux_self_installs_are_never_deferred():
+    """The predicate MUST be Darwin-gated inside itself.
+
+    Off macOS the probe never runs, so `_probed` stays False for the life of the
+    process — an ungated "is it unsettled?" would defer every self-install on
+    Windows and Linux permanently.
+    """
+    for sysname, mach in (("Windows", "AMD64"), ("Linux", X86_64)):
+        ma.reset_cache_for_tests()
+        h = _update_handler()
+        with patch("platform.system", lambda s=sysname: s), patch("platform.machine", lambda m=mach: m), \
+             patch.object(h, "_stage_and_maybe_apply") as stage, \
+             patch.object(uh, "send_notification"):
+            h._on_update_available("1.5.124", "http://rel", asset_url="http://x/app.zip", apply_now=True)
+
+        assert ma.arch_answer_is_provisional(system=sysname) is False, sysname
+        stage.assert_called_once()
 
 
 def test_the_tray_row_is_unchanged_when_the_probe_resolved():

--- a/tests/test_arch_undetermined.py
+++ b/tests/test_arch_undetermined.py
@@ -16,7 +16,9 @@ These pin the distinction that makes it real: mid-backoff is NOT undetermined
 (the retry schedule covers a briefly-busy machine), settled-with-no-answer is.
 """
 
-from unittest.mock import patch
+import errno
+from types import SimpleNamespace
+from unittest.mock import MagicMock, patch
 
 import pytest
 
@@ -41,7 +43,7 @@ def _exhaust_the_budget():
     — the same path a permanently congested Mac takes.
     """
     clock = [0.0]
-    with patch.object(ma, "_read_proc_translated", lambda: ProbeResult(None, conclusive=False)), \
+    with patch.object(ma, "_read_proc_translated", lambda: ProbeResult(None, determined=False, conclusive=False)), \
          patch.object(ma, "_monotonic", lambda: clock[0]):
         for _ in range(len(ma._RETRY_BACKOFF_SECONDS) + 2):
             ma._read_proc_translated_cached()
@@ -61,7 +63,7 @@ def test_mid_backoff_is_not_undetermined():
     merely mid-boot-storm — a worse trade than the one this feature guards
     against, and the reason `probe_settled_unresolved` is not just "has failed".
     """
-    with patch.object(ma, "_read_proc_translated", lambda: ProbeResult(None, conclusive=False)):
+    with patch.object(ma, "_read_proc_translated", lambda: ProbeResult(None, determined=False, conclusive=False)):
         ma._read_proc_translated_cached()  # one transient failure, budget intact
 
     assert ma.probe_settled_unresolved() is False
@@ -70,11 +72,144 @@ def test_mid_backoff_is_not_undetermined():
 
 def test_a_conclusive_answer_is_never_undetermined():
     """The control. A real Intel Mac has no proc_translated key, forever."""
-    with patch.object(ma, "_read_proc_translated", lambda: ProbeResult(None, conclusive=True)):
+    with patch.object(ma, "_read_proc_translated", lambda: ProbeResult(None, determined=True, conclusive=True)):
         ma._read_proc_translated_cached()
 
     assert ma.probe_settled_unresolved() is False
     assert true_machine_arch(system="Darwin", machine=X86_64) == X86_64
+
+
+# --- "stop asking" and "we found out" are different claims -----------------
+#
+# The first cut of this fix read ProbeResult.conclusive, which is the RETRY
+# decision. Several outcomes are conclusive-but-unanswered, and each of them
+# reinstated the whole #196 defect through a side door: a confident "x86_64"
+# for a machine the kernel never spoke to. One witness per door.
+
+
+def _settle_by_raising(exc):
+    """Drive the real probe to its settled state with `exc` from every fork.
+
+    Goes through `subprocess.run` rather than stubbing `_read_proc_translated`,
+    because the classification under test IS `_read_proc_translated`'s. Stubbing
+    it would assert the mapping the test itself supplied.
+    """
+    clock = [0.0]
+
+    def _boom(*a, **k):
+        raise exc
+
+    with patch.object(ma.subprocess, "run", _boom), patch.object(ma, "_monotonic", lambda: clock[0]):
+        for _ in range(len(ma._RETRY_BACKOFF_SECONDS) + 2):
+            ma._read_proc_translated_cached()
+            clock[0] += 100000.0
+
+
+def test_a_fork_refused_with_emfile_is_undetermined_not_intel():
+    """EMFILE is congestion, and it used to take the "permanent" branch.
+
+    The old classifier asked `exc.errno in {EAGAIN, ENOMEM}`. A full file-
+    descriptor table refuses posix_spawn with EMFILE, not EAGAIN — the same
+    overloaded machine, one table along — so it fell through to conclusive,
+    memoised as though the hardware had answered, and an Apple Silicon Mac
+    running the Intel build was handed the Intel DMG again. The set of ways a
+    busy machine can refuse a fork is not enumerable, which is why the module
+    now lists the PERMANENT cases instead.
+    """
+    _settle_by_raising(OSError(errno.EMFILE, "Too many open files"))
+
+    assert ma.probe_settled_unresolved() is True
+    assert true_machine_arch(system="Darwin", machine=X86_64) == ""
+    with patch("platform.machine", lambda: X86_64):
+        assert _find_platform_asset(RELEASE, system="Darwin") is None
+
+
+def test_a_sandbox_denial_is_undetermined_while_staying_memoised():
+    """Both halves, because they pull in opposite directions.
+
+    A denied call will not lift mid-session, so the retry policy must still
+    stop after ONE fork — retrying costs a fork per menu rebuild and buys
+    nothing. But it is not an answer about the hardware, so the arch must come
+    back undetermined. `conclusive=True, determined=False` is exactly this
+    cell, and collapsing the two fields loses it.
+    """
+    calls = []
+
+    def _denied(*a, **k):
+        calls.append(1)
+        raise PermissionError(errno.EACCES, "Operation not permitted")
+
+    clock = [0.0]
+    with patch.object(ma.subprocess, "run", _denied), patch.object(ma, "_monotonic", lambda: clock[0]):
+        for _ in range(5):
+            clock[0] += 100000.0
+            ma._read_proc_translated_cached()
+
+    assert len(calls) == 1, "a permanent denial must still be memoised on the first probe"
+    assert ma.probe_settled_unresolved() is True
+    assert true_machine_arch(system="Darwin", machine=X86_64) == ""
+
+
+def test_a_missing_sysctl_is_undetermined_while_staying_memoised():
+    """The same cell reached the other way, and the one that guards Windows.
+
+    `FileNotFoundError("sysctl not found")` carries no errno at all, so any
+    errno-keyed classifier reads `exc.errno is None`, calls it congestion, and
+    reinstates the fork-per-menu-rebuild regression that once broke the
+    windows-latest leg of a tagged release. Matching on the exception TYPE is
+    what makes this stable.
+    """
+    calls = []
+
+    def _absent(*a, **k):
+        calls.append(1)
+        raise FileNotFoundError("sysctl not found")
+
+    clock = [0.0]
+    with patch.object(ma.subprocess, "run", _absent), patch.object(ma, "_monotonic", lambda: clock[0]):
+        for _ in range(5):
+            clock[0] += 100000.0
+            ma._read_proc_translated_cached()
+
+    assert len(calls) == 1, "a permanently absent sysctl must be memoised on the first probe"
+    assert ma.probe_settled_unresolved() is True
+
+
+def test_a_real_intel_mac_is_determined_by_the_answer_it_gets():
+    """The control for all three above, through the same real code path.
+
+    sysctl exits non-zero because the key does not exist — and that IS the
+    answer. If this ever reported undetermined, every genuine Intel Mac would
+    stop being offered its own build, which is the failure mode that makes
+    "withhold when unsure" dangerous rather than free.
+    """
+    clock = [0.0]
+    with patch.object(
+        ma.subprocess, "run", lambda *a, **k: SimpleNamespace(returncode=1, stdout="", stderr="invalid")
+    ), patch.object(ma, "_monotonic", lambda: clock[0]):
+        ma._read_proc_translated_cached()
+
+    assert ma.probe_settled_unresolved() is False
+    assert true_machine_arch(system="Darwin", machine=X86_64) == X86_64
+    with patch("platform.machine", lambda: X86_64):
+        assert _find_platform_asset(RELEASE, system="Darwin") == "https://x/x86_64.dmg"
+
+
+def test_an_injected_reader_is_never_answered_from_this_process_memo():
+    """The `sysctl_reader is None` guard, which nothing witnessed.
+
+    An injected reader REPLACES the probe, so this process's memo describes a
+    different one and must not be mixed in. Injecting `translated=` is the
+    opposite case — no reader ran, so the memo is the only record of whether
+    this process got an answer — and the tray depends on exactly that, which
+    `test_the_tray_row_says_it_could_not_determine` pins.
+    """
+    _exhaust_the_budget()
+    assert ma.probe_settled_unresolved() is True
+
+    # Same settled-unresolved memo, but the caller brought its own probe.
+    assert true_machine_arch(system="Darwin", machine=X86_64, sysctl_reader=lambda: "0") == X86_64
+    assert true_machine_arch(system="Darwin", machine=X86_64, sysctl_reader=lambda: "1") == ARM64
 
 
 def test_undetermined_is_macos_only():
@@ -113,7 +248,7 @@ def test_an_undetermined_mac_is_offered_no_arch_suffixed_build():
 
 def test_a_determined_mac_still_gets_its_build():
     """The permissive direction. Withholding from everyone would also 'pass'."""
-    with patch.object(ma, "_read_proc_translated", lambda: ProbeResult("1", conclusive=True)):
+    with patch.object(ma, "_read_proc_translated", lambda: ProbeResult("1", determined=True, conclusive=True)):
         ma._read_proc_translated_cached()
 
     with patch("platform.machine", lambda: X86_64):
@@ -169,8 +304,68 @@ def test_the_tray_row_says_it_could_not_determine():
     assert X86_64 in label
 
 
+# --- and ops has to be able to see it --------------------------------------
+
+
+def _update_handler():
+    """Hand-built like the other UpdateHandler suites — see test_update_handler.py."""
+    import threading
+
+    from src.update_handler import UpdateHandler
+
+    h = UpdateHandler.__new__(UpdateHandler)
+    h.tray = MagicMock()
+    h.config = MagicMock()
+    h.config.auto_install_updates = True
+    h.coordinator = MagicMock()
+    h._version = "1.5.123"
+    h._notified_version = None
+    h._managed_warned_version = None
+    h._arch_undetermined_version = None
+    h._staged_version = None
+    h._staged_lock = threading.Lock()
+    return h
+
+
+def test_a_mac_left_with_no_asset_by_an_undetermined_arch_is_reported_once():
+    """Withholding correctly is not the same as withholding visibly.
+
+    This repo publishes ONLY arm64 and x86_64 DMGs — no universal DMG, no macOS
+    ZIP — so an undetermined Mac gets no asset for EVERY release until the
+    process restarts. The user still sees the release-page toast; without this,
+    ops sees a device quietly stuck on an old version and nothing else.
+    """
+    _exhaust_the_budget()
+    h = _update_handler()
+
+    with patch.object(h, "_report_arch_undetermined") as report:
+        h._on_update_available("1.5.124", "http://rel", asset_url=None)
+        h._on_update_available("1.5.124", "http://rel", asset_url=None)  # 30-min re-check
+
+    report.assert_called_once()
+
+
+def test_no_asset_for_an_ordinary_reason_is_not_reported_as_undetermined():
+    """The control, and the one that keeps the fingerprint meaningful.
+
+    A release with nothing this platform can use also arrives here with
+    `asset_url=None`. Reporting that as an architecture failure would make the
+    signal fire on healthy machines, and the error ingest aggregates by
+    fingerprint alone — so a noisy fingerprint is not a smaller signal, it is
+    no signal.
+    """
+    with patch.object(ma, "_read_proc_translated", lambda: ProbeResult(None, determined=True, conclusive=True)):
+        ma._read_proc_translated_cached()
+    h = _update_handler()
+
+    with patch.object(h, "_report_arch_undetermined") as report:
+        h._on_update_available("1.5.124", "http://rel", asset_url=None)
+
+    report.assert_not_called()
+
+
 def test_the_tray_row_is_unchanged_when_the_probe_resolved():
-    with patch.object(ma, "_read_proc_translated", lambda: ProbeResult(None, conclusive=True)):
+    with patch.object(ma, "_read_proc_translated", lambda: ProbeResult(None, determined=True, conclusive=True)):
         ma._read_proc_translated_cached()
 
     assert arch_menu_label(system="Darwin", machine=X86_64, translated=False) == (

--- a/tests/test_arch_undetermined.py
+++ b/tests/test_arch_undetermined.py
@@ -406,6 +406,7 @@ def test_a_mac_left_with_no_asset_by_an_undetermined_arch_is_reported_once():
     # platform rather than stubbing `true_machine_arch`, so the memo built by
     # `_exhaust_the_budget` is still the thing under test.
     with patch("platform.system", lambda: "Darwin"), patch("platform.machine", lambda: X86_64), \
+         patch.object(uh, "send_notification"), \
          patch.object(h, "_report_arch_undetermined") as report:
         h._on_update_available("1.5.124", "http://rel", asset_url=None)
         h._on_update_available("1.5.124", "http://rel", asset_url=None)  # 30-min re-check
@@ -430,6 +431,7 @@ def test_no_asset_for_an_ordinary_reason_is_not_reported_as_undetermined():
     # on the CI runner whatever the code does, which is the shape of a test that
     # proves nothing.
     with patch("platform.system", lambda: "Darwin"), patch("platform.machine", lambda: X86_64), \
+         patch.object(uh, "send_notification"), \
          patch.object(h, "_report_arch_undetermined") as report:
         h._on_update_available("1.5.124", "http://rel", asset_url=None)
 

--- a/tests/test_arch_undetermined.py
+++ b/tests/test_arch_undetermined.py
@@ -1,0 +1,181 @@
+"""An unresolved Rosetta probe must reach the updater as doubt, not as a guess.
+
+`update_checker._is_wrong_arch` has always had a safety branch for exactly this:
+
+    if not arch:
+        return any(token in name for token in (ARM64, X86_64))
+
+"When we do not know which build is right, the only safe answer is neither."
+But `true_machine_arch` returned `""` only when `platform.machine()` itself did,
+which does not happen on macOS — so the branch guarded a case that could not
+arise, while a Mac whose probe timed out reported a confident "x86_64" and was
+offered the Intel build. The module knew it was uncertain and discarded that
+knowledge one function before the code that would act on it (#196).
+
+These pin the distinction that makes it real: mid-backoff is NOT undetermined
+(the retry schedule covers a briefly-busy machine), settled-with-no-answer is.
+"""
+
+from unittest.mock import patch
+
+import pytest
+
+from src import machine_arch as ma
+from src.machine_arch import ARM64, X86_64, ProbeResult, true_machine_arch
+from src.ui.tray import arch_menu_label
+from src.update_checker import _find_platform_asset, _is_wrong_arch
+
+
+@pytest.fixture(autouse=True)
+def _clear():
+    ma.reset_cache_for_tests()
+    yield
+    ma.reset_cache_for_tests()
+
+
+def _exhaust_the_budget():
+    """Drive the probe to its settled-unresolved state.
+
+    Every attempt returns a TIMEOUT (conclusive=False) and the clock is advanced
+    past each backoff window, so the retry schedule is spent rather than skipped
+    — the same path a permanently congested Mac takes.
+    """
+    clock = [0.0]
+    with patch.object(ma, "_read_proc_translated", lambda: ProbeResult(None, conclusive=False)), \
+         patch.object(ma, "_monotonic", lambda: clock[0]):
+        for _ in range(len(ma._RETRY_BACKOFF_SECONDS) + 2):
+            ma._read_proc_translated_cached()
+            clock[0] += 100000.0
+
+
+def test_a_settled_unresolved_probe_reports_undetermined():
+    _exhaust_the_budget()
+    assert ma.probe_settled_unresolved() is True
+    assert true_machine_arch(system="Darwin", machine=X86_64) == ""
+
+
+def test_mid_backoff_is_not_undetermined():
+    """A machine that lost ONE probe is busy, not unknowable.
+
+    Reporting it as undetermined would withhold updates from a Mac that is
+    merely mid-boot-storm — a worse trade than the one this feature guards
+    against, and the reason `probe_settled_unresolved` is not just "has failed".
+    """
+    with patch.object(ma, "_read_proc_translated", lambda: ProbeResult(None, conclusive=False)):
+        ma._read_proc_translated_cached()  # one transient failure, budget intact
+
+    assert ma.probe_settled_unresolved() is False
+    assert true_machine_arch(system="Darwin", machine=X86_64) == X86_64
+
+
+def test_a_conclusive_answer_is_never_undetermined():
+    """The control. A real Intel Mac has no proc_translated key, forever."""
+    with patch.object(ma, "_read_proc_translated", lambda: ProbeResult(None, conclusive=True)):
+        ma._read_proc_translated_cached()
+
+    assert ma.probe_settled_unresolved() is False
+    assert true_machine_arch(system="Darwin", machine=X86_64) == X86_64
+
+
+def test_undetermined_is_macos_only():
+    """Windows and Linux never run this probe, so they can never be unknowable.
+
+    Leaking `""` off Darwin would make those hosts refuse assets they have
+    always accepted.
+    """
+    _exhaust_the_budget()
+    assert true_machine_arch(system="Windows", machine="AMD64") == "AMD64"
+    assert true_machine_arch(system="Linux", machine=X86_64) == X86_64
+
+
+# --- the point of all of it: the updater must withhold ---------------------
+
+
+RELEASE = {
+    "assets": [
+        {"name": "BetterFlow-macOS-arm64.dmg", "browser_download_url": "https://x/arm64.dmg"},
+        {"name": "BetterFlow-macOS-x86_64.dmg", "browser_download_url": "https://x/x86_64.dmg"},
+    ]
+}
+
+
+def test_an_undetermined_mac_is_offered_no_arch_suffixed_build():
+    """End to end through the real entry point, not just the helper.
+
+    This is the assertion the whole change exists for: before it, the settled
+    -unresolved Mac matched the Intel DMG in the first loop and `_is_wrong_arch`
+    was never consulted at all.
+    """
+    _exhaust_the_budget()
+    with patch("platform.machine", lambda: X86_64):
+        assert _find_platform_asset(RELEASE, system="Darwin") is None
+
+
+def test_a_determined_mac_still_gets_its_build():
+    """The permissive direction. Withholding from everyone would also 'pass'."""
+    with patch.object(ma, "_read_proc_translated", lambda: ProbeResult("1", conclusive=True)):
+        ma._read_proc_translated_cached()
+
+    with patch("platform.machine", lambda: X86_64):
+        assert _find_platform_asset(RELEASE, system="Darwin") == "https://x/arm64.dmg"
+
+
+def test_the_non_darwin_guard_in_is_wrong_arch_is_witnessed():
+    """Requested on #196: this guard survived deletion against the full suite.
+
+    With an unknown arch the refusal is platform-blind by construction, so
+    without the Darwin gate a Windows host that could not determine its
+    architecture would refuse an asset it has always accepted.
+    """
+    assert _is_wrong_arch("BetterFlow-Windows-x86_64-Update.zip", "", "Windows") is False
+    # ...while the same unknown arch on macOS still refuses both suffixes.
+    assert _is_wrong_arch("BetterFlow-macOS-x86_64.dmg", "", "Darwin") is True
+    assert _is_wrong_arch("BetterFlow-macOS-arm64.dmg", "", "Darwin") is True
+
+    # And through the entry point, because the assertions above test the
+    # PRODUCER: they would all still hold if nothing consulted `_is_wrong_arch`
+    # on the Windows path at all. The consequence a Windows user feels is
+    # whether the download URL comes back.
+    #
+    # `arch=""` cannot be injected as a parameter — `arch or true_machine_arch()`
+    # treats it as "not supplied" — so the unknown has to arrive the way it would
+    # in the wild, out of platform.machine(). That is the exact witness #196
+    # asked for: system="Windows", machine="".
+    windows_release = {
+        "assets": [
+            {
+                "name": "BetterFlow-Windows-x86_64-Update.zip",
+                "browser_download_url": "https://x/win.zip",
+            }
+        ]
+    }
+    with patch("platform.machine", lambda: ""):
+        assert _find_platform_asset(windows_release, system="Windows") == "https://x/win.zip"
+
+
+# --- the tray must not claim an architecture nobody established ------------
+
+
+def test_the_tray_row_says_it_could_not_determine():
+    _exhaust_the_budget()
+    label = arch_menu_label(system="Darwin", machine=X86_64, translated=False)
+
+    assert "could not determine" in label
+    # It must NOT fall through to the Intel wording, which is the pre-fix
+    # rendering and reads as an established fact.
+    assert "Intel (" not in label
+    # The process arch is still worth showing — it is what a support
+    # conversation starts from.
+    assert X86_64 in label
+
+
+def test_the_tray_row_is_unchanged_when_the_probe_resolved():
+    with patch.object(ma, "_read_proc_translated", lambda: ProbeResult(None, conclusive=True)):
+        ma._read_proc_translated_cached()
+
+    assert arch_menu_label(system="Darwin", machine=X86_64, translated=False) == (
+        "Architecture: Intel (x86_64)"
+    )
+    assert arch_menu_label(system="Darwin", machine=ARM64, translated=False) == (
+        "Architecture: Apple Silicon (native)"
+    )

--- a/tests/test_update_checker_arch.py
+++ b/tests/test_update_checker_arch.py
@@ -53,7 +53,7 @@ def _fake_host(monkeypatch, *, machine, proc_translated):
     """
     monkeypatch.setattr(platform, "machine", lambda: machine)
     monkeypatch.setattr(
-        ma, "_read_proc_translated", lambda: ma.ProbeResult(proc_translated, conclusive=True)
+        ma, "_read_proc_translated", lambda: ma.ProbeResult(proc_translated, determined=True, conclusive=True)
     )
 
 


### PR DESCRIPTION
Closes #196.

## The gap

`_read_proc_translated` classifies its own answer, but the memo layer collapsed that back to `Optional[str]`, so `true_machine_arch` could never learn the answer was provisional. It returned `""` only when `platform.machine()` did, which does not happen on macOS.

That left `update_checker._is_wrong_arch` guarding a case it could never see:

```python
if not arch:
    return any(token in name for token in (ARM64, X86_64))
```

A Mac whose sysctl probe stayed congested past the whole backoff budget reported a confident `x86_64`, matched the Intel DMG in the first asset loop, and never reached that branch. The module knew it was uncertain and threw the knowledge away one function before the code that would have acted on it.

## What changed

- `ProbeResult` carries `determined` (did the kernel answer) alongside `conclusive` (is another fork worth it). Those are different questions, and only one of them should decide whether the updater guesses.
- `probe_settled_unresolved()` reads `determined`. `true_machine_arch` returns `""` in that state, but only when the process is `x86_64`. An arm64 process already proves arm64 hardware, since Rosetta translates x86 onto arm and never the reverse.
- The errno set is inverted. `_TRANSIENT_ERRNOS = {EAGAIN, ENOMEM}` was a blocklist over an unbounded space, and everything it failed to name fell to the confident side. `_PERMANENT_OSERRORS = (FileNotFoundError, PermissionError)` is the closed list, matched on type because `FileNotFoundError("sysctl not found")` carries no errno at all.
- The tray says `could not determine (process: x86_64)` instead of falling through to the Intel wording.
- `_report_arch_undetermined` tells ops when a machine ends up with no installable asset, mirroring the existing `_report_managed_blocked`.
- `arch_answer_is_provisional` defers the self-install while the probe is still retrying. The notification and the tray row are untouched.

## What the audit gate found

Three rounds, five reviewers, and two of the rounds turned up a Critical. The detail is worth keeping.

**Round 1.** `conclusive` answers "should we retry?", not "did the kernel answer?". An EMFILE fork refusal, which is the file-descriptor twin of the EAGAIN case this module already reasoned about, fell through to permanent and was memoised as though the hardware had replied. That is the original defect surviving through a side door, on the branch built to close it. Same for a sandbox `PermissionError` and a missing sysctl.

**Round 2**, found independently by both reviewers. The ops-signal test passed only on a Mac. `_on_update_available` asks `true_machine_arch()` with no override, so on the ubuntu runner the arch is truthy and the report never fires. That runner is the only job that runs on a PR here, and the tag build runs the same suite on all four platforms with `release: needs: build`. So this would have gone red on the gate and produced no release at all on tag. Fourth instance of that class in this repo, and three of the earlier ones broke a release.

Also round 2:

- A native Apple Silicon Mac with an EDR-denied sysctl was told "could not determine (process: arm64)" and offered no build. That is worse than the behaviour the branch inherited, on a machine whose architecture was never ambiguous.
- The two congestion doors, timeout and killed-by-signal, had no witness. Every test reaching that state went through a helper that stubs `_read_proc_translated` wholesale, so those branches' `determined=False` was supplied by the fixture rather than tested. Flipping the timeout branch left the whole suite green while restoring the original bug verbatim.
- Mid-backoff still reports the process architecture, as the issue asks. But the launch check arrives with `apply_now=True` and auto-install defaults on, so a Mac that lost its probe to a login boot storm would download and apply the Intel DMG inside the first 36 minutes, re-pinning itself to the build this module exists to get it off. Notifying on a working assumption is free. Installing on one is not.

That last fix was wrong on the first attempt, and an existing test caught it. Reading the memo passively conflates "still retrying" with "nobody has looked yet", both answering True, so a Mac reaching it before any probe would have deferred forever. It now probes before answering rather than depending on `_find_platform_asset` having warmed the memo first.

**Round 3.** No Critical, no Important. Five optional notes, one taken: two tests were posting real macOS notifications.

## Verification

Full suite, which is what CI runs:

```
$ PYTHONPATH=. python3 -m pytest tests/ -q
1717 passed, 1 skipped in 41.32s          # exit 0
```

The ubuntu runner, simulated, because local green on a Mac is what hid the round-2 Critical:

```
$ python3 -m pytest -p fakelinux -q tests/test_arch_undetermined.py ... tests/test_machine_arch.py
79 passed
```

That simulation stubs only `platform.system`/`machine`. Its negative control: strip the platform pin from the ops-report test and it fails again, so the probe has teeth rather than passing everything.

Proof of failure for the original fix, against pre-fix `src/`:

```
5 failed, 4 passed
  test_an_undetermined_mac_is_offered_no_arch_suffixed_build
    assert 'https://x/x86_64.dmg' is None
  test_the_tray_row_says_it_could_not_determine
    assert 'could not determine' in 'Architecture: Intel (x86_64)'
```

The four that pass pre-fix are the ones that should: non-Darwin hosts, a determined Mac still getting its build, the Darwin-guard witness, and the unchanged tray wording.

## Mutation matrix

11 mutants, 11 killed, no survivors. Each anchor was asserted unique before mutating and the file compared after, since a `sed` that matches nothing produces zero failures and reads exactly like an unguarded mechanism. Control runs at both ends.

| Mutant | Killed by |
|---|---|
| memo reads `conclusive` instead of `determined` | sandbox-denial, missing-sysctl |
| all `OSError` treated as permanent | `test_a_refused_fork_is_congestion_not_an_answer` (pre-existing) |
| permanent obstacle claims it learned something | sandbox-denial, missing-sysctl |
| sentinel returns `machine` instead of `""` | 6 tests |
| Darwin gate dropped from the sentinel | `test_undetermined_is_macos_only` |
| injected-reader guard dropped | `test_an_injected_reader_is_never_answered_from_this_process_memo` |
| predicate reads `_last_transient_at` | 9 tests |
| tray's could-not-determine row deleted | `test_the_tray_row_says_it_could_not_determine` |
| updater's non-Darwin gate deleted | `test_the_non_darwin_guard_in_is_wrong_arch_is_witnessed` |
| ops signal never fires | `test_a_mac_left_with_no_asset_by_an_undetermined_arch_is_reported_once` |
| ops signal fires for any missing asset | `test_no_asset_for_an_ordinary_reason_is_not_reported_as_undetermined` |

## Scope

338 source lines against 565 test lines, a ratio of 1.7x. Most of the test weight is the platform and classification witnesses that two rounds proved were missing, but the number is worth stating here rather than discovering later.

## Recorded decisions, not oversights

- During the backoff window the tray still offers "Install & Restart" for the possibly-wrong asset while the row reads `Intel (x86_64)`. Pre-existing, and narrowed rather than widened here.
- `returncode == 0` and the bare `SubprocessError` branch have no real-path witness. Both are production-unobservable: a raw `0`/`1` answer only happens on Apple Silicon, where the arm64 short-circuit fires first, and `subprocess.run(check=False)` essentially cannot raise the latter.

## Found while reviewing, filed separately

`src/main.py:3574` passes `callback=self._on_update_available`, but `BetterFlowApp` has no such method. It lives on `UpdateHandler`. Changing the update channel raises `AttributeError` into its own `except` and logs a misleading warning. Pre-existing, and untouched here.
