### PR TITLE
fix(updater): changing the update channel never actually checked for updates

### DIFF
--- a/src/main.py
+++ b/src/main.py
@@ -3568,13 +3568,28 @@ class BetterFlowApp:
         elif key == "update_channel":
             self.config.update_channel = value
             try:
+                # The handler owns this callback, not the app. `self.` here was
+                # an AttributeError raised while EVALUATING the argument, so the
+                # call below never happened and the except logged a
+                # network-sounding warning about a request that was never made
+                # (#199).
+                #
+                # No apply_now wrapper, unlike ensure_update_checks_started's
+                # catch-on-launch: the user is standing in the preferences menu,
+                # and relaunching the app because they switched channel would be
+                # its own bug report. Stage it, exactly as a periodic check does.
                 check_for_update(
                     _VERSION,
                     channel=value,
-                    callback=self._on_update_available,
+                    callback=self.update_handler._on_update_available,
                 )
             except Exception:
-                logger.warning("Failed to check for updates after channel change")
+                # exc_info because a bare message here cost this bug its
+                # visibility: the traceback would have named the AttributeError
+                # instead of implying the network was down.
+                logger.warning(
+                    "Failed to check for updates after channel change", exc_info=True
+                )
         else:
             logger.warning(f"Unknown preference key: {key}")
             return

--- a/tests/test_update_channel_change_checks.py
+++ b/tests/test_update_channel_change_checks.py
@@ -1,0 +1,130 @@
+"""Changing the update channel must actually check for updates (#199).
+
+`BetterFlowApp._on_preferences` passed `callback=self._on_update_available`, but
+that method lives on `UpdateHandler`, not on the app. Evaluating the argument
+raised `AttributeError` before `check_for_update` was ever called, and the
+surrounding `except Exception` logged "Failed to check for updates after channel
+change" — a message that points at GitHub or the network, which is where anyone
+investigating would have looked.
+
+The saved setting was always correct, so the next scheduled check 30 minutes
+later did use the new channel. That is what kept this invisible: the feature
+appears to work, just late, and the log blames something else.
+"""
+
+import logging
+import threading
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+import src.main as main_mod
+from src.main import BetterFlowApp
+from src.update_handler import UpdateHandler
+
+
+def _make_app() -> BetterFlowApp:
+    """Only the attributes `_on_preferences` touches on the update_channel path."""
+    app = BetterFlowApp.__new__(BetterFlowApp)
+    app.config = MagicMock()
+    app.config.update_channel = "stable"
+    # A REAL UpdateHandler, not a MagicMock: a mock answers to any attribute
+    # name, so it would happily supply `_on_update_available` even if the method
+    # were renamed or moved away again. The bug being pinned here is precisely
+    # "this attribute does not exist on the object we asked".
+    handler = UpdateHandler.__new__(UpdateHandler)
+    handler.tray = MagicMock()
+    handler.config = app.config
+    handler.coordinator = MagicMock()
+    handler._version = "1.5.123"
+    handler._notified_version = None
+    handler._managed_warned_version = None
+    handler._arch_undetermined_version = None
+    handler._staged_version = None
+    handler._staged_lock = threading.Lock()
+    app.update_handler = handler
+    return app
+
+
+def test_changing_the_update_channel_actually_checks_for_updates():
+    app = _make_app()
+
+    with patch.object(main_mod, "check_for_update") as check:
+        app._on_preferences("update_channel", "beta")
+
+    check.assert_called_once()
+    assert check.call_args.kwargs["channel"] == "beta"
+    assert app.config.update_channel == "beta"
+    app.config.save.assert_called_once()
+
+
+def test_the_callback_is_the_one_that_can_receive_the_result():
+    """Not just "a callback" — the bound method that handles an available update.
+
+    A fix that passed any callable at all would satisfy the test above. This
+    pins WHICH object answers, because the defect was an attribute lookup on the
+    wrong one.
+    """
+    app = _make_app()
+
+    with patch.object(main_mod, "check_for_update") as check:
+        app._on_preferences("update_channel", "beta")
+
+    cb = check.call_args.kwargs["callback"]
+    assert cb.__self__ is app.update_handler, "callback must be bound to the UpdateHandler"
+    assert cb.__func__ is UpdateHandler._on_update_available
+
+    # And it must accept what check_for_update actually passes it:
+    # callback(latest_tag.lstrip("v"), html_url, asset_url) — three positionals.
+    with patch.object(app.update_handler, "_stage_and_maybe_apply"), \
+         patch.object(main_mod, "send_notification", create=True), \
+         patch("src.update_handler.send_notification"):
+        cb("1.5.124", "http://rel", "http://x/a.dmg")
+
+
+def test_a_channel_change_stages_rather_than_restarting_under_the_user():
+    """apply_now defaults False, unlike the launch check.
+
+    `ensure_update_checks_started` wraps its callback to force `apply_now=True`
+    (catch-on-launch). A preference toggle is not a launch: the user is sitting
+    in the menu, and relaunching the app out from under them because they
+    switched channel would be its own bug report. Staging is the periodic-check
+    behaviour and the right one here.
+    """
+    app = _make_app()
+
+    with patch.object(main_mod, "check_for_update") as check:
+        app._on_preferences("update_channel", "beta")
+    cb = check.call_args.kwargs["callback"]
+
+    with patch.object(app.update_handler, "_stage_and_maybe_apply") as stage, \
+         patch("src.update_handler.send_notification"):
+        cb("1.5.124", "http://rel", "http://x/a.dmg")
+
+    stage.assert_called_once()
+    assert stage.call_args[0][2] is False, "apply_now must be False for a channel change"
+
+
+def test_no_failure_is_logged_when_the_check_is_wired_correctly(caplog):
+    """The swallow is what made this survive: the warning read as a network fault.
+
+    Asserted as an ABSENCE, so it needs the positive control above it — without
+    `check.assert_called_once()` in the sibling test, this would also pass
+    against code that never reached the call at all.
+    """
+    app = _make_app()
+
+    with caplog.at_level(logging.WARNING), patch.object(main_mod, "check_for_update"):
+        app._on_preferences("update_channel", "beta")
+
+    assert "Failed to check for updates" not in caplog.text
+
+
+@pytest.mark.parametrize("channel", ["stable", "beta", "canary"])
+def test_every_channel_is_forwarded_verbatim(channel):
+    app = _make_app()
+
+    with patch.object(main_mod, "check_for_update") as check:
+        app._on_preferences("update_channel", channel)
+
+    assert check.call_args.kwargs["channel"] == channel


### PR DESCRIPTION
Closes #199.

## The bug

`BetterFlowApp._on_preferences` passed `callback=self._on_update_available`, but that method lives on `UpdateHandler`. The `AttributeError` was raised while evaluating the argument, so `check_for_update` was never called at all, and the surrounding `except Exception` logged:

```
Failed to check for updates after channel change
```

which points at GitHub or the network. That is where anyone investigating would have looked.

## Why it stayed hidden

The setting itself saved correctly, so the next scheduled check 30 minutes later did use the new channel. The feature appeared to work, just late, and the log blamed something else. Nothing was ever red.

## The fix

Routes to `self.update_handler._on_update_available`, matching every other call site in the file (`src/main.py:2239`, `:2387`, `:2398`, `:2583`).

No `apply_now` wrapper, unlike `ensure_update_checks_started`'s catch-on-launch. The user is standing in the preferences menu, and relaunching the app because they switched channel would be its own bug report. Staging is what a periodic check does and it is the right behaviour here.

The `except` now carries `exc_info`. A bare message is what cost this bug its visibility for as long as it lived: the traceback would have named the `AttributeError` instead of implying the network was down.

## Proof of failure

All 7 tests in the new file fail against the unfixed `src/`, with the captured log showing the misleading warning at `main.py:3577`:

```
7 failed in 0.61s
  WARNING  src.main:main.py:3577 Failed to check for updates after channel change
  E   AttributeError: 'NoneType' object has no attribute 'kwargs'
```

All 7 pass after. Every assertion failing pre-fix is the honest shape here, because the whole code path was dead rather than partly wrong.

The tests pin more than "it got called":

- **which object answers.** The fixture builds a real `UpdateHandler`, not a `MagicMock`. A mock answers to any attribute name, so it would happily supply `_on_update_available` even if the method moved away again, which is exactly the defect being pinned.
- **that the callback fits its caller.** `check_for_update` invokes it as `callback(tag, html_url, asset_url)`, three positionals, so the test calls it that way.
- **that `apply_now` stays False**, asserted on the argument `_stage_and_maybe_apply` actually receives.
- **the absence of the warning**, which needs the positive assertion beside it or it would pass against code that never reached the call.

## Verification

```
$ PYTHONPATH=. python3 -m pytest tests/ -q
1724 passed, 1 skipped in 43.03s          # exit 0
```

Also run under a simulated ubuntu runner before opening this, since a Mac-only test is the class that bit #198 and it was caught there by reviewers rather than by me:

```
$ python3 -m pytest -p fakelinux -q tests/test_update_channel_change_checks.py
7 passed
```

`ruff check src/main.py` reports the same 8 findings as `main`. The new test file is clean.
