### PR TITLE
fix(ci): sync the Linux AppImage URL too, instead of leaving it on a hand-bumped fallback

### DIFF
--- a/.github/workflows/sync-downloads.yml
+++ b/.github/workflows/sync-downloads.yml
@@ -59,7 +59,8 @@ jobs:
                 changelog_markdown: (.body // ""),
                 macos_arm64_url: ([.assets[] | select(.name == "BetterFlow-macOS-arm64.dmg") | .browser_download_url] | first // ""),
                 macos_x64_url: ([.assets[] | select(.name == "BetterFlow-macOS-x86_64.dmg") | .browser_download_url] | first // ""),
-                windows_url: ([.assets[] | select(.name == "BetterFlow-Windows-Setup.exe") | .browser_download_url] | first // "")
+                windows_url: ([.assets[] | select(.name == "BetterFlow-Windows-Setup.exe") | .browser_download_url] | first // ""),
+                linux_url: ([.assets[] | select(.name == "BetterFlow-linux-x86_64.AppImage") | .browser_download_url] | first // "")
               }
             ' release.json > payload.json
 
@@ -70,7 +71,8 @@ jobs:
               (.release_name | length) > 0 and
               (.macos_arm64_url | length) > 0 and
               (.macos_x64_url | length) > 0 and
-              (.windows_url | length) > 0
+              (.windows_url | length) > 0 and
+              (.linux_url | length) > 0
             ' payload.json > /dev/null; then
               echo "All platform assets present for ${TAG}."
               break


### PR DESCRIPTION
## What is wrong

The downloads payload has never carried `linux_url`.

```
$ git log -S"linux_url" -- .github/workflows/sync-downloads.yml
(nothing)
```

The jq built three URLs and the readiness gate waited for three assets, while the build matrix has been publishing a fourth the whole time.

The backend treats that field as nullable and merges the synced record over a fallback computed from `config('agent.version')` in internal-tool2, so Linux never took a synced value. It tracked a PHP config constant that somebody bumps by hand, which is why there is a `chore(agent): bump download-page version fallback` commit in that repo's history.

## Caught in the act

Minutes after the v1.5.124 sync went green, following each redirect the download page actually serves:

```
macos_arm64 -> BetterFlow-macOS-arm64.dmg        releases/download/v1.5.124
macos_intel -> BetterFlow-macOS-x86_64.dmg       releases/download/v1.5.124
windows     -> BetterFlow-Windows-Setup.exe      releases/download/v1.5.124
linux       -> BetterFlow-linux-x86_64.AppImage  releases/download/v1.5.123
```

This is the same shape #193 was written for, one field along: a green run reporting the page was updated while part of it was not. #193 made a missing **secret** loud. This makes a missing **asset** loud.

## The change

- `linux_url` added to the payload, matched on `BetterFlow-linux-x86_64.AppImage`.
- The readiness gate now waits for it too. If the Linux leg ever fails while the others succeed, the sync times out and goes red rather than advertising three fresh links and one stale one.

## Proof

Run against the live v1.5.124 release payload, with the jq program **extracted from the workflow file** rather than retyped, so it cannot pass because of my transcription:

```
main (pre-fix)   linux_url present: False  keys=9
branch (fixed)   linux_url present: True   keys=10
```

The fixed program resolves all four assets by name, none empty:

```
macos_arm64_url   -> BetterFlow-macOS-arm64.dmg
macos_x64_url     -> BetterFlow-macOS-x86_64.dmg
windows_url       -> BetterFlow-Windows-Setup.exe
linux_url         -> BetterFlow-linux-x86_64.AppImage
```

After merge I will re-dispatch the sync for v1.5.124 and confirm the Linux redirect moves, since a green workflow run is a claim and the redirect is the fact.

## Not in this change

internal-tool2's `config('agent.version')` fallback is now the only thing that can silently disagree with a real release. It needs no hand-bumping once this lands.