### PR TITLE
Clear the agent issue backlog: two heartbeat signals, an honest drop alert, and two investigations

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -139,6 +139,17 @@ not the person using it:
   tracker binaries could not be installed and that this process has no managed
   watchers of its own). All of it describes whether the machine is capable of
   recording and delivering, never what was recorded.
+- `os_idle_seconds` (`src/sync/os_idle.py`) — seconds since the last keyboard or
+  mouse input, read from the OS clock (HIDIdleTime on macOS,
+  `GetLastInputInfo` on Windows). Presence, never content: no key, no character,
+  no application, no title. It is a scalar reading of the same OS idle clock
+  `sync.in_process_afk` already derives the uploaded AFK stream from, so it adds
+  no category and is strictly less detailed than the stream beside it. **Why it
+  is sent:** with no events arriving, "the user is away" and "the trackers are
+  dead" are indistinguishable on the wire, so the fleet's no-capture alert fired
+  at people who were simply not at their desk and stayed quiet on machines
+  losing billable time (#195). Omitted entirely when the probe cannot answer —
+  never coerced to `0`, which would read as "at the keyboard this second".
 
 The serial is shown back to the user in the tray under **Diagnostics > Device
 serial**, next to the Privacy Policy link, and clicking it copies the value.
@@ -155,10 +166,21 @@ weight — a first-run wizard bullet is read once and forgotten. It renders as
   and shape are the server's contract (`AgentHeartbeatController` →
   `agent_disclosure_acknowledgements`), so neither end may be renamed alone.
 
-`src/sync/bf_client.py`'s `HEARTBEAT_HEALTH_KEYS` is the complete, enforced list
-of what the heartbeat forwards — a field missing from it never leaves the
-machine. Treat that tuple as the source of truth when auditing egress, and
-update this section whenever it changes.
+`src/sync/bf_client.py`'s `HEARTBEAT_HEALTH_KEYS` is the enforced allowlist for
+the **`health` dict only** — a field missing from it never leaves the machine.
+It is not the whole payload: `agent_version`, `timezone`, `hardware_serial` and
+`disclosure_acknowledgement` are separate top-level fields on the heartbeat
+body, so reading that tuple as "everything the heartbeat sends" undercounts the
+egress surface. Treat it as the source of truth for the health keys, and update
+this section whenever it changes.
+
+A **second copy of the tuple lives in `src/disclosure_baseline.py`** and
+`tests/test_disclosure_baseline.py` fails on any divergence between the two.
+That is deliberate: the copy in `bf_client.py` is the mechanism, the copy in
+`disclosure_baseline.py` is the declaration, and each new key must carry a
+written reason there saying what it reports about the machine. Adding a key to
+one and not the other reddens the suite; adding it to both without a reason is
+the thing the guard exists to make visible.
 
 #### The one-time privacy notice
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -179,19 +179,22 @@ weight — a first-run wizard bullet is read once and forgotten. It renders as
 
 `src/sync/bf_client.py`'s `HEARTBEAT_HEALTH_KEYS` is the enforced allowlist for
 the **`health` dict only** — a field missing from it never leaves the machine.
-It is not the whole payload: `agent_version`, `timezone`, `hardware_serial` and
-`disclosure_acknowledgement` are separate top-level fields on the heartbeat
-body, so reading that tuple as "everything the heartbeat sends" undercounts the
-egress surface. Treat it as the source of truth for the health keys, and update
-this section whenever it changes.
+`hardware_serial` and `disclosure_acknowledgement` are health keys and reach the
+wire only through this tuple's loop, exactly like every other health field; only
+`agent_version` and `timezone` are unconditional top-level fields on the
+heartbeat body, outside the allowlist. So reading the tuple as "everything the
+heartbeat sends" undercounts by two fields, not four. Treat it as the source of
+truth for the health keys, and update this section whenever it changes.
 
 A **second copy of the tuple lives in `src/disclosure_baseline.py`** and
 `tests/test_disclosure_baseline.py` fails on any divergence between the two.
 That is deliberate: the copy in `bf_client.py` is the mechanism, the copy in
 `disclosure_baseline.py` is the declaration, and each new key must carry a
 written reason there saying what it reports about the machine. Adding a key to
-one and not the other reddens the suite; adding it to both without a reason is
-the thing the guard exists to make visible.
+one and not the other reddens the suite — that part is mechanically enforced.
+Adding it to both without a reason is not: the test is a pure set-difference
+between the two tuples and cannot see a missing comment. Writing a reason for
+each new key is a convention, not something the guard checks.
 
 #### The one-time privacy notice
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -150,6 +150,17 @@ not the person using it:
   at people who were simply not at their desk and stayed quiet on machines
   losing billable time (#195). Omitted entirely when the probe cannot answer —
   never coerced to `0`, which would read as "at the keyboard this second".
+- `machine_arch` (`src/machine_arch.py`) — the CPU architecture of the hardware,
+  seeing through Rosetta 2: an x86_64 build translated on Apple Silicon reports
+  `arm64` here, which is the point. A property of the machine, in the same
+  family as `hardware_serial` and `agent_version`; it names a model of processor
+  and can never distinguish one person's activity from another's. **Why it is
+  sent:** an Intel build on Apple Silicon without Rosetta records zero time, and
+  the fleet had no way to enumerate which machines were in that state (#184) —
+  the answer lived only in the tray of the affected laptop. `null` means
+  `true_machine_arch()` returned `""`, i.e. the probe never resolved; do not
+  coerce that to a string, or "we could not tell" becomes indistinguishable from
+  an architecture.
 
 The serial is shown back to the user in the tray under **Diagnostics > Device
 serial**, next to the Privacy Policy link, and clicking it copies the value.

--- a/docs/superpowers/plans/2026-08-18-agent-backlog.md
+++ b/docs/superpowers/plans/2026-08-18-agent-backlog.md
@@ -1,0 +1,530 @@
+# BetterFlow Agent Backlog Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Clear the five open issues on `betterflow-sync` plus one alert-wording defect, so the repo's open list reflects only work nobody has done.
+
+**Architecture:** Five independent workstreams. Two are issue hygiene with no code. One (#195) is a small telemetry change: the discriminating signal already exists on-device and simply never reaches the server. One is a one-line message correction with a test. Two are investigations that may legitimately end in "no code change", and the plan says so rather than forcing a fix.
+
+**Tech Stack:** Python 3.11, pytest, PyInstaller. Run the suite with `PYTHONPATH=. python3 -m pytest`.
+
+**Spec:** The issues themselves are the spec: #194, #184, #195, #188, #190, plus the audit finding on `_report_dropped_events`'s wording (this session, 2026-08-17).
+
+## Global Constraints
+
+- **The PR gate is ubuntu, and the tag build is four platforms.** Never write a test that only passes on macOS. Inject the platform (`system="Darwin"`) rather than `skipif`; a skip means the guard runs in no PR-gating job at all. Verify with the fake-platform plugin in `[[tests-that-only-pass-on-macos]]` BEFORE dispatching reviewers.
+- **Every bug fix ships with a test that fails pre-fix and passes post-fix.** Prove it: commit the fix, `git checkout HEAD~1 -- <impl paths>`, watch it fail, restore. Never `git stash` (shared across worktrees).
+- **CI does run on PRs here** (`build.yml` `test` job, ubuntu, on `pull_request`), but `build`/`release` are tag-only and the tag build *skips* `test`. Read `gh pr checks`; never assume.
+- **`HEARTBEAT_HEALTH_KEYS` is a hard allowlist.** A field can be collected, logged and unit-tested end to end and still never leave the machine because its name is missing from that tuple. Any new heartbeat field needs BOTH the producer and the allowlist entry, and a test that would fail if either is missing.
+- **Privacy:** anything added to the heartbeat must describe the machine's *capability to record*, never what was recorded. Update the "Device identifiers sent on the heartbeat" section of `CLAUDE.md` in the same PR as any heartbeat change.
+- **No closing keywords in commit messages** — a squash executes them. Put `Closes #N` in the PR body only.
+- Explicit-path staging only, never `git add -A`.
+- Work in a git worktree cut from `origin/main`, never the primary checkout.
+
+---
+
+## Workstream A — Issue hygiene (no code)
+
+### Task 1: Close #194 with shipped evidence
+
+**Files:** none (GitHub only)
+
+**Interfaces:**
+- Consumes: nothing
+- Produces: nothing
+
+- [ ] **Step 1: Verify the fix is in the shipped tag, not just on main**
+
+```bash
+cd <worktree>
+git show v1.5.124:src/sync/macos_window_watcher.py | grep -c "_notify_accessibility_required_once"   # expect 4
+git show v1.5.123:src/sync/macos_window_watcher.py | grep -c "_notify_accessibility_required_once"   # expect 0
+```
+
+Expected: `4` then `0`. If the second is non-zero, STOP — the fix predates the release and the issue was open for a different reason.
+
+- [ ] **Step 2: Confirm the release is the one the fleet has**
+
+```bash
+gh api repos/Better-Quality-Assurance/betterflow-sync/releases/latest --jq .tag_name   # expect v1.5.124
+```
+
+- [ ] **Step 3: Close with the evidence in the comment**
+
+```bash
+gh issue close 194 --repo Better-Quality-Assurance/betterflow-sync --comment "Shipped in v1.5.124 (PR #197).
+
+Verified in the tag rather than on main: \`_notify_accessibility_required_once\` appears 4x in \`v1.5.124:src/sync/macos_window_watcher.py\` and 0x in \`v1.5.123\`, and \`releases/latest\` is v1.5.124.
+
+The agent now asks the user to grant Accessibility once per launch, re-arming if the grant is later revoked, instead of only writing a warning to a log file nobody reads. Capture of app names and durations was never affected; window titles were."
+```
+
+---
+
+### Task 2: Update #184 — two of three asks shipped
+
+**Files:** none (GitHub only)
+
+**Interfaces:**
+- Consumes: nothing
+- Produces: the remaining scope that Task 5 implements
+
+- [ ] **Step 1: Verify each of the three asks against the shipped tag**
+
+```bash
+cd <worktree>
+# (a) self-perpetuating updater — arch-aware asset selection
+git show v1.5.124:src/update_checker.py | grep -c "true_machine_arch"        # expect >0
+# (b) user can see which build they are on — tray row
+git show v1.5.124:src/ui/tray.py | grep -c "Architecture:"                   # expect >0
+# (c) agent reports its architecture so the fleet can answer "who is on Intel?"
+git show v1.5.124:src/sync/bf_client.py | grep -c "machine_arch\|arch"       # expect 0 — still missing
+```
+
+- [ ] **Step 2: Post the status, do NOT close**
+
+```bash
+gh issue comment 184 --repo Better-Quality-Assurance/betterflow-sync --body "Two of the three asks shipped in v1.5.124; leaving this open for the third.
+
+**Done — the updater no longer traps people on the Intel build.** #191 and #198 make asset selection read the HARDWARE architecture via \`true_machine_arch()\`, so an Intel build on an M-series Mac is now offered the arm64 DMG. Smoked against the live release payload: \`Intel build on M-series -> BetterFlow-macOS-arm64.dmg\`.
+
+**Done — the user can see which build they are on.** The tray Diagnostics row reads \`Architecture: Intel build on Apple Silicon — switch to the Apple Silicon version\` on exactly that case.
+
+**Still open — we cannot answer 'who is on Intel?'.** The agent does not report its architecture on the heartbeat. \`HEARTBEAT_HEALTH_KEYS\` has 8 keys and none of them is architecture, so the fleet view still cannot enumerate affected devices. That is the remaining scope of this issue."
+```
+
+---
+
+## Workstream B — #195: give the no_capture alert its discriminator
+
+The alert cannot tell *user away* from *tracker dead*. The agent already knows: `src/sync/os_idle.py::get_system_idle_seconds()` reads `HIDIdleTime` on macOS and `GetLastInputInfo` on Windows, and is already used by `idle_manager` and `sync_engine`. It is simply never sent. This workstream sends it.
+
+**Design decision:** send the raw reading, not a verdict. The server owns the alerting policy, and a boolean computed on-device would be undebuggable when it disagrees with the timeline.
+
+**Privacy note for the PR body and `CLAUDE.md`:** `os_idle_seconds` says "the keyboard/mouse were last touched N seconds ago". It describes presence, not content, and is strictly coarser than the AFK stream already uploaded. It introduces no new data category.
+
+### Task 3: Add `os_idle_seconds` to the heartbeat
+
+**Files:**
+- Modify: `src/sync/bf_client.py` (the `HEARTBEAT_HEALTH_KEYS` tuple, ~line 444)
+- Modify: `src/main.py` (the telemetry dict, near the `sync_stale_seconds` block ~line 2016)
+- Modify: `CLAUDE.md` ("Device identifiers sent on the heartbeat")
+- Test: `tests/test_os_idle_heartbeat.py`
+
+**Interfaces:**
+- Consumes: `src.sync.os_idle.get_system_idle_seconds() -> Optional[float]`
+- Produces: heartbeat key `os_idle_seconds: int | None`
+
+- [ ] **Step 1: Write the failing test**
+
+```python
+"""The no_capture alert cannot tell a user who is away from a dead tracker (#195).
+
+The agent has always known: get_system_idle_seconds() reads HIDIdleTime on
+macOS and GetLastInputInfo on Windows. It just never left the device, because
+HEARTBEAT_HEALTH_KEYS is a hard allowlist and the key was not in it.
+
+Both halves are asserted here on purpose. A producer-only test passes while the
+allowlist silently drops the field, which is the exact failure the tuple's own
+comment warns about.
+"""
+
+from unittest.mock import MagicMock, patch
+
+from src.sync.bf_client import BetterFlowClient
+
+
+def test_the_allowlist_carries_os_idle_seconds():
+    assert "os_idle_seconds" in BetterFlowClient.HEARTBEAT_HEALTH_KEYS
+
+
+def test_a_supplied_os_idle_reading_reaches_the_request_body():
+    client = BetterFlowClient.__new__(BetterFlowClient)
+    captured = {}
+
+    def _fake_request(method, path, data=None, **kw):
+        captured.update(data or {})
+        return {"data": {}}
+
+    client._request = _fake_request
+    client._detect_timezone = lambda: "Europe/Bucharest"
+
+    client.send_heartbeat(agent_version="1.5.125", health={"os_idle_seconds": 12})
+
+    assert captured["os_idle_seconds"] == 12
+
+
+def test_an_unreadable_idle_clock_is_omitted_not_zeroed():
+    """None must not become 0. Zero means 'the user is at the keyboard right
+    now', which is the opposite of 'we could not tell' — and it is the reading
+    the alert would act on."""
+    client = BetterFlowClient.__new__(BetterFlowClient)
+    captured = {}
+    client._request = lambda method, path, data=None, **kw: (captured.update(data or {}), {"data": {}})[1]
+    client._detect_timezone = lambda: "UTC"
+
+    client.send_heartbeat(agent_version="1.5.125", health={})
+
+    assert "os_idle_seconds" not in captured
+```
+
+- [ ] **Step 2: Run it and watch it fail**
+
+Run: `PYTHONPATH=. python3 -m pytest tests/test_os_idle_heartbeat.py -v`
+Expected: FAIL — `test_the_allowlist_carries_os_idle_seconds` asserts a key that is not in the tuple, and the body test finds the field dropped at the allowlist boundary.
+
+- [ ] **Step 3: Add the key to the allowlist**
+
+In `src/sync/bf_client.py`, inside `HEARTBEAT_HEALTH_KEYS`, after `"sync_stale_seconds",`:
+
+```python
+        # Seconds since the user last touched the keyboard or mouse, read from
+        # the OS (HIDIdleTime / GetLastInputInfo), NOT from the AFK tracker.
+        # This is the discriminator the no_capture alert never had: with no
+        # events and a LARGE idle time the user is away and nothing is wrong;
+        # with no events and a SMALL idle time the trackers are dead and
+        # billable time is being lost. Those two produced identical evidence on
+        # the wire until this field existed (#195). Omitted entirely when the
+        # probe cannot read a value — see the producer in main.py for why null
+        # must not become 0.
+        "os_idle_seconds",
+```
+
+- [ ] **Step 4: Add the producer**
+
+In `src/main.py`, immediately after the `sync_stale_seconds` block:
+
+```python
+        # The OS idle clock, so the server can tell "user away" from "tracker
+        # dead". Both look identical from event ages alone, which is why the
+        # no_capture alert has fired on people who were simply not at their
+        # desk (#195). Best-effort and OMITTED when unreadable: a null coerced
+        # to 0 would read as "at the keyboard this second", turning an unknown
+        # into the strongest possible claim of presence.
+        try:
+            idle_seconds = get_system_idle_seconds()
+            if idle_seconds is not None:
+                telemetry["os_idle_seconds"] = int(idle_seconds)
+        except Exception as e:  # noqa: BLE001
+            logger.debug("os-idle telemetry unavailable: %s", e)
+```
+
+Add the import beside the other `src.sync` imports in `main.py`, following the module's try/except pattern:
+
+```python
+try:
+    from .sync.os_idle import get_system_idle_seconds
+except ImportError:
+    from sync.os_idle import get_system_idle_seconds
+```
+
+- [ ] **Step 5: Run the tests and the neighbours**
+
+Run: `PYTHONPATH=. python3 -m pytest tests/test_os_idle_heartbeat.py tests/test_heartbeat_health.py -v`
+Expected: PASS. If `tests/test_heartbeat_health.py` does not exist, run `PYTHONPATH=. python3 -m pytest tests/ -q -k heartbeat` instead.
+
+- [ ] **Step 6: Update CLAUDE.md**
+
+In the "Device identifiers sent on the heartbeat" section, add `os_idle_seconds` to the tracker-health bullet, describing it as presence-not-content. While there, correct the sentence claiming `HEARTBEAT_HEALTH_KEYS` is "the complete, enforced list of what the heartbeat forwards" — it is the allowlist for the `health` dict only; `agent_version`, `timezone`, `hardware_serial` and `disclosure_acknowledgement` are separate top-level fields.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add src/sync/bf_client.py src/main.py CLAUDE.md tests/test_os_idle_heartbeat.py
+git commit -m "feat(telemetry): report the OS idle clock so no_capture can tell away from dead"
+```
+
+- [ ] **Step 8: Prove the pre-fix failure**
+
+```bash
+git checkout HEAD~1 -- src/sync/bf_client.py src/main.py
+PYTHONPATH=. python3 -m pytest tests/test_os_idle_heartbeat.py -v   # expect FAIL
+git checkout HEAD -- src/sync/bf_client.py src/main.py
+PYTHONPATH=. python3 -m pytest tests/test_os_idle_heartbeat.py -v   # expect PASS
+```
+
+- [ ] **Step 9: Witness the allowlist independently of the producer**
+
+Mutate ONLY the allowlist (remove `"os_idle_seconds"`) and confirm a named test reddens; then restore. A producer that works while the allowlist drops the field is the failure this pair exists to catch, so both must be witnessed separately.
+
+---
+
+### Task 4: Hand the server the rule (cross-repo, do not merge blind)
+
+**Files:** none in this repo.
+
+- [ ] **Step 1: Write the consumer requirement into #195**
+
+The agent half is useless until the alert reads it. Post to #195 the exact contract: `os_idle_seconds` is an integer, absent when unreadable, and the `no_capture` rule should require it to be **present and small** (suggest < 900s, i.e. the user was at the machine within the alert window) before firing. Absence must NOT satisfy the condition — an old agent that never sends it would otherwise silently stop alerting.
+
+- [ ] **Step 2: State the cross-repo tense explicitly**
+
+When referring to this from betterqa-bot or internal-tool2, write "ships in betterflow-sync v1.5.125, not live on the fleet today" rather than the present tense. A reviewer reading the other repo's main cannot see this change and will correctly report the field as non-existent.
+
+---
+
+## Workstream C — #184 remainder: report the architecture
+
+### Task 5: Add `machine_arch` to the heartbeat
+
+**Files:**
+- Modify: `src/sync/bf_client.py` (`HEARTBEAT_HEALTH_KEYS`)
+- Modify: `src/main.py` (telemetry dict)
+- Test: `tests/test_arch_heartbeat.py`
+
+**Interfaces:**
+- Consumes: `src.machine_arch.true_machine_arch() -> str` (returns `""` when undetermined — see its docstring)
+- Produces: heartbeat key `machine_arch: str | None`
+
+- [ ] **Step 1: Write the failing test**
+
+```python
+"""The fleet cannot answer "who is on the Intel build?" (#184).
+
+true_machine_arch() returns the HARDWARE architecture, seeing through Rosetta,
+and returns "" when its probe never resolved. That empty string must be sent as
+null rather than as an empty string, so the fleet view can distinguish "we asked
+and could not tell" from "arm64" without string-matching on emptiness.
+"""
+
+from unittest.mock import patch
+
+from src.sync.bf_client import BetterFlowClient
+
+
+def test_the_allowlist_carries_machine_arch():
+    assert "machine_arch" in BetterFlowClient.HEARTBEAT_HEALTH_KEYS
+
+
+def test_a_rosetta_translated_mac_reports_arm64_not_x86_64():
+    from src.machine_arch import true_machine_arch
+
+    arch = true_machine_arch(system="Darwin", machine="x86_64", translated=True)
+
+    assert arch == "arm64", "the whole point: report the hardware, not the process"
+
+
+def test_an_undetermined_arch_is_sent_as_null_not_empty_string():
+    client = BetterFlowClient.__new__(BetterFlowClient)
+    captured = {}
+    client._request = lambda method, path, data=None, **kw: (captured.update(data or {}), {"data": {}})[1]
+    client._detect_timezone = lambda: "UTC"
+
+    client.send_heartbeat(agent_version="1.5.125", health={"machine_arch": None})
+
+    assert "machine_arch" in captured, "membership is tested with `in`, so null is a real report"
+    assert captured["machine_arch"] is None
+```
+
+- [ ] **Step 2: Run it and watch it fail**
+
+Run: `PYTHONPATH=. python3 -m pytest tests/test_arch_heartbeat.py -v`
+Expected: FAIL on the allowlist assertion.
+
+- [ ] **Step 3: Add the key**
+
+In `HEARTBEAT_HEALTH_KEYS`:
+
+```python
+        # The HARDWARE architecture, seeing through Rosetta 2 — an x86_64 build
+        # translated on Apple Silicon reports arm64 here, which is the whole
+        # point. Without it the fleet cannot enumerate who is on the wrong build
+        # (#184), and the answer was previously only visible in the tray of the
+        # affected machine. null means true_machine_arch() returned "" (its probe
+        # never resolved); do not coerce that to a string.
+        "machine_arch",
+```
+
+- [ ] **Step 4: Add the producer**
+
+In `src/main.py`, after the `os_idle_seconds` block:
+
+```python
+        # Report the hardware architecture so the fleet can answer "who is on
+        # the Intel build?". true_machine_arch() returns "" when its Rosetta
+        # probe never resolved; send that as null so the server can tell
+        # "undetermined" from a real value without string-matching emptiness.
+        try:
+            arch = true_machine_arch()
+            telemetry["machine_arch"] = arch or None
+        except Exception as e:  # noqa: BLE001
+            logger.debug("machine-arch telemetry unavailable: %s", e)
+```
+
+`main.py` already imports `true_machine_arch`; confirm with `grep -n "true_machine_arch" src/main.py` before adding a duplicate import.
+
+- [ ] **Step 5: Run, commit, prove pre-fix failure**
+
+Same shape as Task 3 steps 5, 7 and 8, substituting `tests/test_arch_heartbeat.py`.
+
+---
+
+## Workstream D — correct the dropped-events wording
+
+### Task 6: Stop calling preserved events "lost"
+
+**Files:**
+- Modify: `src/sync/sync_engine.py:4093`
+- Test: `tests/test_dropped_events_wording.py`
+
+**Interfaces:**
+- Consumes: `SyncEngine._report_dropped_events(summary: dict)`
+- Produces: nothing
+
+**Context the implementer needs:** `_report_dropped_events` is already correct about *severity* — it splits genuine loss from a benign flush and only warns when recent, bucketed events were rejected. The defect is narrower: `remove_failed()` **moves** exhausted events to a dead-letter table ("does NOT hard-delete") and `requeue_storable_dead_letter()` replays rows that become storable again, so the events are undelivered-and-preserved, not lost. `dead_letter_count` already rides the heartbeat, so ops can see the backlog. The current wording sends people looking for data that is sitting in a table.
+
+- [ ] **Step 1: Write the failing test**
+
+```python
+"""The drop alert calls preserved events "lost activity".
+
+remove_failed() MOVES exhausted events to the dead-letter table rather than
+deleting them, and requeue_storable_dead_letter() replays the ones that become
+storable again. The events are undelivered and preserved. Telling ops they are
+lost sends someone hunting for data that is in a table, and it inflates a
+warning that is otherwise correctly scoped to genuine rejections.
+"""
+
+from unittest.mock import MagicMock
+
+from src.sync.sync_engine import SyncEngine
+
+
+def _engine_with_reporter():
+    engine = SyncEngine.__new__(SyncEngine)
+    engine.error_reporter = MagicMock()
+    engine._dropped_window_age = lambda oldest, newest: "spanning 2h"
+    return engine
+
+
+def test_the_drop_warning_does_not_claim_the_events_are_lost():
+    engine = _engine_with_reporter()
+
+    engine._report_dropped_events(
+        {"count": 3, "real_loss_count": 3, "bucket_ids": ["aw-watcher-window_host"], "oldest": 1, "newest": 2}
+    )
+
+    message = engine.error_reporter.capture.call_args[0][0]
+    assert "lost activity" not in message
+    assert "dead-letter" in message, "say where they are, or the reader cannot go look"
+
+
+def test_it_still_warns_and_still_names_the_count():
+    """The severity is right and must not be softened along with the wording:
+    these are events the server rejected, and somebody should look."""
+    engine = _engine_with_reporter()
+
+    engine._report_dropped_events(
+        {"count": 3, "real_loss_count": 3, "bucket_ids": ["aw-watcher-window_host"], "oldest": 1, "newest": 2}
+    )
+
+    kwargs = engine.error_reporter.capture.call_args.kwargs
+    assert kwargs["level"] == "warning"
+    assert kwargs["fingerprint"] == "offline-queue-events-dropped"
+    assert "3" in engine.error_reporter.capture.call_args[0][0]
+
+
+def test_the_benign_flush_path_is_untouched():
+    engine = _engine_with_reporter()
+
+    engine._report_dropped_events(
+        {"count": 2, "real_loss_count": 0, "bucket_ids": [], "oldest": 1, "newest": 2}
+    )
+
+    kwargs = engine.error_reporter.capture.call_args.kwargs
+    assert kwargs["level"] == "info"
+```
+
+- [ ] **Step 2: Run it and watch it fail**
+
+Run: `PYTHONPATH=. python3 -m pytest tests/test_dropped_events_wording.py -v`
+Expected: FAIL on `"lost activity" not in message`.
+
+- [ ] **Step 3: Correct the message**
+
+In `src/sync/sync_engine.py`, replace the warning string:
+
+```python
+                self.error_reporter.capture(
+                    f"Dropped {real} queued event(s) after max retries — the "
+                    f"server rejected them; held in dead-letter for replay, not "
+                    f"discarded (buckets={buckets}, {window}{extra})",
+                    level="warning",
+                    tags={"component": "offline-queue"},
+                    fingerprint="offline-queue-events-dropped",
+                )
+```
+
+- [ ] **Step 4: Run, commit, prove pre-fix failure, restore**
+
+Same shape as Task 3 steps 5, 7 and 8.
+
+---
+
+## Workstream E — investigations that may end in no code
+
+### Task 7: #188 — why did the Rosetta notice not save Carmen?
+
+**Files:** none until the mechanism is known.
+
+The preflight and the notification both already exist: `aw_manager._rosetta_missing()` (line 768) and `_notify_rosetta_required_once()` (line 822, called at 857). Carmen still lost ~90 minutes on **v1.5.122**, which contains both. So the issue as written ("the app looks healthy") is either stale or the notice did not reach her.
+
+- [ ] **Step 1: Establish which, before proposing anything**
+
+```bash
+git tag --contains $(git log -1 --format=%H -S"_notify_rosetta_required_once" -- src/aw_manager.py) \
+  | grep -E '^v[0-9]+\.[0-9]+\.[0-9]+$' | sort -V | head -1
+```
+
+Expected: the first release carrying the notice. If it is **after** v1.5.122, the issue is already fixed and needs closing with that evidence. If it is v1.5.122 or earlier, the notice fired and did not help — a different problem, and a bigger one.
+
+- [ ] **Step 2: If the notice shipped before her incident, get her device's log**
+
+Ask for the agent log around 2026-08-13 and grep for the notification call and for `send_notification` failures. macOS suppresses notifications for apps that have never been granted them, and `_notify_rosetta_required_once` is best-effort with a swallowed exception — so "fired" and "was seen" are different claims.
+
+- [ ] **Step 3: Record the verdict on the issue either way**
+
+"The notice fires and macOS suppressed it" and "the notice shipped after the incident" lead to opposite fixes. Do not write code until one of them is evidenced. Note that the underlying fix — native arm64 trackers — remains blocked upstream: ActivityWatch publishes macOS arm64 binaries only in `v0.14.0b*` prereleases, and `aw_manager.AW_VERSION` pins `v0.13.2`.
+
+---
+
+### Task 8: #190 — build a harness that can actually answer the question
+
+**Files:**
+- Modify: `requirements-dev.txt`
+- Create: `tests/conftest_time_freeze.py` (or extend the existing sweep harness)
+
+The seven listed tests are an **unverified lead**, not findings. The harness that produced them freezes `datetime` but not `time.time()` / `time.monotonic()`, and `src/aw_manager.py` alone has 2 and 12 of those respectively — so a frozen-`datetime` run skews the two clocks ~21 hours apart. The reported `assert 32366.98 < 120` is consistent with skew, not with a day-boundary bug.
+
+- [ ] **Step 1: Add `time-machine` to `requirements-dev.txt`**
+
+It patches `time.time`, `time.monotonic` and `datetime` together at the C level, which is the property the current harness lacks.
+
+- [ ] **Step 2: Re-run the seven under a harness that freezes all three clocks**
+
+```bash
+PYTHONPATH=. python3 -m pytest \
+  tests/test_aw_manager_idle_restart.py::test_afk_age_prefers_discovered_betterflow_bucket_over_stale_legacy \
+  tests/test_mic_activity.py tests/test_window_title_capture_telemetry.py -v
+```
+under a `time_machine.travel("2026-08-18 00:01", tick=False)` fixture.
+
+- [ ] **Step 3: Control the harness before believing it**
+
+Run the same seven on the real clock and confirm they pass (`1671 passed` was the recorded baseline). A harness that reddens tests on both clocks is measuring itself. Then re-run the FULL suite under the new harness: if the failure count drops from 8 toward 1, the previous 14 really were the instrument.
+
+- [ ] **Step 4: Report the number, then decide**
+
+Only tests that fail under the all-clocks harness AND pass on the real clock are findings. Fix those with the injected-`now` pattern already used in `tests/test_queue.py`; close the rest as instrument artifacts, naming them.
+
+---
+
+## Self-Review
+
+**Spec coverage:** #194 → A1. #184 → A2 (status) and C1 (remaining scope). #195 → B1 (agent half) and B2 (server contract). Alert wording → D1. #188 → E1. #190 → E2. No issue is unaddressed.
+
+**Placeholders:** none. Every code step carries the actual code; the two investigations carry the exact command that decides the branch, and say plainly that "already fixed" and "no code needed" are successful outcomes.
+
+**Type consistency:** `get_system_idle_seconds() -> Optional[float]` is consumed in B1 and cast with `int()`. `true_machine_arch() -> str` is consumed in C1 and mapped `"" -> None`. Both heartbeat keys are added to the same `HEARTBEAT_HEALTH_KEYS` tuple and asserted by name in their own tests. `_report_dropped_events(summary: dict)` keeps its signature in D1.
+
+**Sequencing note:** B1 and C1 both edit `HEARTBEAT_HEALTH_KEYS` and the same telemetry block in `main.py`. Run them in order on one branch, or expect a conflict. Everything else is independent.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -43,6 +43,9 @@ dev = [
     "responses>=0.23",
     "pyinstaller>=6.0",
     "ruff>=0.1.0",
+    # Kept in step with requirements-dev.txt, which is what CI installs.
+    # See that file for why a hand-rolled datetime freeze is not a substitute.
+    "time-machine>=2.13",
 ]
 
 [project.scripts]

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -7,3 +7,10 @@ pytest-cov>=4.0
 responses>=0.23
 pyinstaller>=6.0
 ruff>=0.1.0
+
+# Clock travel for tests. Moves time.time(), time.gmtime(), time.localtime()
+# and datetime together at the C level — a hand-rolled patch that freezes only
+# datetime leaves time.time() on the real clock, and the resulting hours-wide
+# skew reads as a day-boundary bug (#190). Used by tests/freeze_clock_plugin.py,
+# which is opt-in via -p and does not affect a normal run.
+time-machine>=2.13

--- a/src/disclosure_baseline.py
+++ b/src/disclosure_baseline.py
@@ -564,6 +564,20 @@ HEARTBEAT_HEALTH_KEYS: tuple[str, ...] = (
     # probe cannot answer — never coerced to 0, which would read as "at the
     # keyboard this second".
     "os_idle_seconds",
+    # The CPU architecture of the hardware this agent is running on, seeing
+    # through Rosetta 2 ("arm64" / "x86_64", or null when the probe could not
+    # resolve). A property of the MACHINE, in the same family as
+    # `hardware_serial` and `agent_version` — it identifies a computer's model
+    # of processor, never a person, and it cannot distinguish one employee's
+    # activity from another's.
+    #
+    # Why it is worth reporting: an Intel build translated on Apple Silicon
+    # records zero time without Rosetta, and the fleet had no way to enumerate
+    # which machines were in that state (#184) — the answer existed only in the
+    # tray of the affected laptop, where nobody is looking. It is the arch
+    # counterpart of the capture-dead flags already declared below: it says
+    # whether this machine can record at all, never what it recorded.
+    "machine_arch",
     # Boolean: this device's live timezone disagrees with the one its
     # working-hours schedule is anchored to. Reports a MISCONFIGURATION of the
     # schedule, not a new fact about the person — no location beyond the

--- a/src/disclosure_baseline.py
+++ b/src/disclosure_baseline.py
@@ -543,6 +543,27 @@ HEARTBEAT_HEALTH_KEYS: tuple[str, ...] = (
     "consecutive_sync_failures",
     "idle_while_active_detections",
     "sync_stale_seconds",
+    # Seconds since the last keyboard or mouse input, read from the OS clock
+    # (HIDIdleTime / GetLastInputInfo). A single integer describing PRESENCE at
+    # the machine, never content: no key, no character, no application, no
+    # window title.
+    #
+    # It adds no new CATEGORY. `sync.in_process_afk` — DISCLOSED above, default
+    # True — already derives the away-from-keyboard stream from this same OS
+    # idle clock, and that stream is uploaded as events and is what decides
+    # whether a period counts as worked. This forwards a scalar reading of a
+    # signal already collected and already sent; it is strictly less detailed
+    # than the AFK stream beside it.
+    #
+    # Why it is worth reporting: with no events arriving, "the user is away"
+    # and "the trackers are dead" produce IDENTICAL evidence on the wire. The
+    # fleet alert therefore fires at people who were simply not at their desk,
+    # and stays silent on machines that are losing billable time (#195). A
+    # large idle reading is the agent saying nothing is wrong; a small one with
+    # no events is the agent saying it is broken. Omitted entirely when the
+    # probe cannot answer — never coerced to 0, which would read as "at the
+    # keyboard this second".
+    "os_idle_seconds",
     # Boolean: this device's live timezone disagrees with the one its
     # working-hours schedule is anchored to. Reports a MISCONFIGURATION of the
     # schedule, not a new fact about the person — no location beyond the

--- a/src/main.py
+++ b/src/main.py
@@ -29,7 +29,7 @@ try:
     from .browser_tracker import start_browser_tracker
     from .display_info import start_display_tracker
     from .hardware_serial import get_hardware_serial
-    from .machine_arch import is_rosetta_translated
+    from .machine_arch import is_rosetta_translated, true_machine_arch
     from .privacy_notice import (
         acknowledgement_telemetry,
         needs_acknowledgement,
@@ -63,7 +63,7 @@ except ImportError:
     from browser_tracker import start_browser_tracker
     from display_info import start_display_tracker
     from hardware_serial import get_hardware_serial
-    from machine_arch import is_rosetta_translated
+    from machine_arch import is_rosetta_translated, true_machine_arch
     from privacy_notice import (
         acknowledgement_telemetry,
         needs_acknowledgement,
@@ -2028,6 +2028,15 @@ class SyncCoordinator:
                 telemetry["os_idle_seconds"] = int(idle_seconds)
         except Exception as e:  # noqa: BLE001
             logger.debug("os-idle telemetry unavailable: %s", e)
+        # Report the hardware architecture so the fleet can answer "who is on
+        # the Intel build?". true_machine_arch() returns "" when its Rosetta
+        # probe never resolved; send that as null so the server can tell
+        # "undetermined" from a real value without string-matching emptiness.
+        try:
+            arch = true_machine_arch()
+            telemetry["machine_arch"] = arch or None
+        except Exception as e:  # noqa: BLE001
+            logger.debug("machine-arch telemetry unavailable: %s", e)
         # Surface a working-hours anchor that has drifted from this device's real
         # timezone: allows() self-heals by evaluating in machine-local time, but the
         # fleet still needs to see (and re-anchor) the stale schedule. Included only

--- a/src/main.py
+++ b/src/main.py
@@ -38,6 +38,7 @@ try:
     from .reminders import ReminderManager
     from .sync import AWClient, BetterFlowClient, OfflineQueue, SyncEngine
     from .sync.http_client import BetterFlowAuthError, transient_failure_counter
+    from .sync.os_idle import get_system_idle_seconds
     from .system_events import start_system_event_listener
     from .ui.permissions import (
         check_accessibility,
@@ -71,6 +72,7 @@ except ImportError:
     from reminders import ReminderManager
     from sync import AWClient, BetterFlowClient, OfflineQueue, SyncEngine
     from sync.http_client import BetterFlowAuthError, transient_failure_counter
+    from sync.os_idle import get_system_idle_seconds
     from system_events import start_system_event_listener
     from ui.permissions import (
         check_accessibility,
@@ -2014,6 +2016,18 @@ class SyncCoordinator:
         last_ok = self._last_successful_sync
         if last_ok is not None:
             telemetry["sync_stale_seconds"] = int(time.monotonic() - last_ok)
+        # The OS idle clock, so the server can tell "user away" from "tracker
+        # dead". Both look identical from event ages alone, which is why the
+        # no_capture alert has fired on people who were simply not at their
+        # desk (#195). Best-effort and OMITTED when unreadable: a null coerced
+        # to 0 would read as "at the keyboard this second", turning an unknown
+        # into the strongest possible claim of presence.
+        try:
+            idle_seconds = get_system_idle_seconds()
+            if idle_seconds is not None:
+                telemetry["os_idle_seconds"] = int(idle_seconds)
+        except Exception as e:  # noqa: BLE001
+            logger.debug("os-idle telemetry unavailable: %s", e)
         # Surface a working-hours anchor that has drifted from this device's real
         # timezone: allows() self-heals by evaluating in machine-local time, but the
         # fleet still needs to see (and re-anchor) the stale schedule. Included only

--- a/src/sync/bf_client.py
+++ b/src/sync/bf_client.py
@@ -450,6 +450,16 @@ class BetterFlowClient(BaseApiClient):
         "consecutive_sync_failures",
         "idle_while_active_detections",
         "sync_stale_seconds",
+        # Seconds since the user last touched the keyboard or mouse, read from
+        # the OS (HIDIdleTime / GetLastInputInfo), NOT from the AFK tracker.
+        # This is the discriminator the no_capture alert never had: with no
+        # events and a LARGE idle time the user is away and nothing is wrong;
+        # with no events and a SMALL idle time the trackers are dead and
+        # billable time is being lost. Those two produced identical evidence on
+        # the wire until this field existed (#195). Omitted entirely when the
+        # probe cannot read a value — see the producer in main.py for why null
+        # must not become 0.
+        "os_idle_seconds",
         # The device's live timezone disagrees with the one its working-hours
         # schedule is anchored to. Carried here because a drifted anchor is
         # otherwise a SILENT failure — it zeroes a whole day ("Outside working

--- a/src/sync/bf_client.py
+++ b/src/sync/bf_client.py
@@ -460,6 +460,13 @@ class BetterFlowClient(BaseApiClient):
         # probe cannot read a value — see the producer in main.py for why null
         # must not become 0.
         "os_idle_seconds",
+        # The HARDWARE architecture, seeing through Rosetta 2 — an x86_64 build
+        # translated on Apple Silicon reports arm64 here, which is the whole
+        # point. Without it the fleet cannot enumerate who is on the wrong build
+        # (#184), and the answer was previously only visible in the tray of the
+        # affected machine. null means true_machine_arch() returned "" (its probe
+        # never resolved); do not coerce that to a string.
+        "machine_arch",
         # The device's live timezone disagrees with the one its working-hours
         # schedule is anchored to. Carried here because a drifted anchor is
         # otherwise a SILENT failure — it zeroes a whole day ("Outside working

--- a/src/sync/sync_engine.py
+++ b/src/sync/sync_engine.py
@@ -4089,8 +4089,9 @@ class SyncEngine:
                 other = count - real
                 extra = f"; {other} other unstorable" if other > 0 else ""
                 self.error_reporter.capture(
-                    f"Dropped {real} queued event(s) after max retries — likely "
-                    f"real lost activity (buckets={buckets}, {window}{extra})",
+                    f"Dropped {real} queued event(s) after max retries — the "
+                    f"server rejected them; held in dead-letter for replay, not "
+                    f"discarded (buckets={buckets}, {window}{extra})",
                     level="warning",
                     tags={"component": "offline-queue"},
                     fingerprint="offline-queue-events-dropped",

--- a/tests/freeze_clock_plugin.py
+++ b/tests/freeze_clock_plugin.py
@@ -1,0 +1,82 @@
+"""Opt-in pytest plugin: run the suite at a chosen wall-clock instant.
+
+Not a conftest, and deliberately not auto-loaded — it only engages when you pass
+``-p tests.freeze_clock_plugin``, so a normal run is untouched.
+
+    PYTHONPATH=. python3 -m pytest tests/ -p tests.freeze_clock_plugin
+    BF_FREEZE_AT="2026-12-31 23:59" PYTHONPATH=. python3 -m pytest tests/ \
+        -p tests.freeze_clock_plugin
+
+``BF_FREEZE_AT`` is a naive ``YYYY-MM-DD HH:MM`` read as LOCAL time (the
+day boundary this exists to probe is the local one, not UTC). ``off`` disables
+the freeze so the plugin can stay loaded in a control run.
+
+Why it exists
+-------------
+Three releases were damaged by fixtures that pass on the developer's clock and
+fail at some other hour (#182, #168/#171, #187). Sweeping for the whole class
+needs a harness, and the obvious hand-rolled one is wrong in a way that is very
+hard to see: freezing ``datetime`` alone leaves ``time.time()`` on the real
+clock, so the two disagree by however many hours you travelled. Code that
+stamps an event with ``time.time()`` and ages it with ``datetime.now()`` then
+reports a multi-hour age, and the resulting failures read as day-boundary bugs.
+That instrument produced 22 failures, then 8 after being narrowed, then 7 after
+#189 — and all 7 were itself (#190).
+
+``time_machine`` moves ``time.time()``, ``time.gmtime()``, ``time.localtime()``
+and ``datetime`` together at the C level, which is the property a hand-rolled
+patch cannot get right.
+
+Known limit, stated rather than discovered later: under ``tick=False``
+``time.monotonic()`` is NOT pinned, it continues at the real rate. That is
+correct rather than a gap — monotonic has no wall-clock epoch to travel to, and
+real code only ever takes deltas from it. The residual drift is bounded by one
+test's own runtime, and cannot produce the multi-hour skew described above.
+
+Witnessing it
+-------------
+A harness whose correct answer is "everything passes" is indistinguishable from
+one that never engaged, so do not trust a green run on its own. The control is
+one command: assert inside a test that ``datetime.datetime.now()`` reads the
+frozen hour, and confirm that same assertion FAILS without ``-p``.
+"""
+
+import datetime as _dt
+import os
+
+import pytest
+
+_SPEC_ENV = "BF_FREEZE_AT"
+_DEFAULT_SPEC = "2026-08-18 00:01"
+
+
+def _destination():
+    """Resolve BF_FREEZE_AT to an aware datetime, or None when disabled."""
+    spec = os.environ.get(_SPEC_ENV, _DEFAULT_SPEC)
+    if spec.strip().lower() == "off":
+        return None
+    naive = _dt.datetime.strptime(spec.strip(), "%Y-%m-%d %H:%M")
+    # astimezone() on a naive datetime attaches the machine's local offset, so
+    # "00:01" means 00:01 where the developer is, which is the boundary the
+    # sweep is about.
+    return naive.astimezone()
+
+
+@pytest.hookimpl(hookwrapper=True)
+def pytest_runtest_protocol(item, nextitem):
+    """Wrap setup, call and teardown of every test in the frozen instant.
+
+    Wrapping the whole protocol rather than using an autouse fixture is
+    deliberate: fixtures that stamp timestamps during setup have to see the
+    frozen clock too, and autouse ordering against other fixtures is not
+    something a sweep should have to reason about.
+    """
+    destination = _destination()
+    if destination is None:
+        yield
+        return
+
+    import time_machine
+
+    with time_machine.travel(destination, tick=False):
+        yield

--- a/tests/test_arch_heartbeat.py
+++ b/tests/test_arch_heartbeat.py
@@ -1,0 +1,112 @@
+"""The fleet cannot answer "who is on the Intel build?" (#184).
+
+true_machine_arch() returns the HARDWARE architecture, seeing through Rosetta,
+and returns "" when its probe never resolved. That empty string must be sent as
+null rather than as an empty string, so the fleet view can distinguish "we asked
+and could not tell" from "arm64" without string-matching on emptiness.
+
+Every architecture in here is INJECTED, never read from the runner. The PR gate
+runs on ubuntu and only the tag build sees macOS, so a test that needs Apple
+Silicon to be meaningful runs in no PR-gating job at all — and a skip reads as
+coverage while providing none.
+"""
+
+import threading
+from unittest.mock import MagicMock, patch
+
+from src.main import SyncCoordinator
+from src.sync.bf_client import BetterFlowClient
+
+
+# ── The wire boundary ───────────────────────────────────────────────────
+
+def test_the_allowlist_carries_machine_arch():
+    assert "machine_arch" in BetterFlowClient.HEARTBEAT_HEALTH_KEYS
+
+
+def test_a_rosetta_translated_mac_reports_arm64_not_x86_64():
+    from src.machine_arch import true_machine_arch
+
+    arch = true_machine_arch(system="Darwin", machine="x86_64", translated=True)
+
+    assert arch == "arm64", "the whole point: report the hardware, not the process"
+
+
+def test_an_undetermined_arch_is_sent_as_null_not_empty_string():
+    client = BetterFlowClient.__new__(BetterFlowClient)
+    captured = {}
+    client._request = lambda method, path, data=None, **kw: (captured.update(data or {}), {"data": {}})[1]
+    client._detect_timezone = lambda: "UTC"
+
+    client.heartbeat(agent_version="1.5.125", health={"machine_arch": None})
+
+    assert "machine_arch" in captured, "membership is tested with `in`, so null is a real report"
+    assert captured["machine_arch"] is None
+
+
+def test_a_real_arch_reaches_the_request_body():
+    """The null case above passes against a forwarder that sends nothing but
+    None, so pin the ordinary reading too."""
+    client = BetterFlowClient.__new__(BetterFlowClient)
+    captured = {}
+    client._request = lambda method, path, data=None, **kw: (captured.update(data or {}), {"data": {}})[1]
+    client._detect_timezone = lambda: "Europe/Bucharest"
+
+    client.heartbeat(agent_version="1.5.125", health={"machine_arch": "arm64"})
+
+    assert captured["machine_arch"] == "arm64"
+
+
+# ── The producer ────────────────────────────────────────────────────────
+#
+# Witnessed separately from the allowlist. An allowlist entry with no producer
+# forwards a field no device ever supplies, and every assertion above would
+# still pass. Drives the REAL _build_health_telemetry unbound.
+
+def _telemetry_from_real_app() -> dict:
+    stub = MagicMock()
+    stub._idle_tracker_warn_lock = threading.Lock()
+    stub._blind_tracker_window = 0
+    stub._consecutive_sync_failures = 0
+    stub._last_successful_sync = None
+    stub.aw_manager.health_snapshot.return_value = {}
+    return SyncCoordinator._build_health_telemetry(stub)
+
+
+def test_the_assembler_reports_the_hardware_arch():
+    with patch("src.main.true_machine_arch", return_value="arm64"):
+        telemetry = _telemetry_from_real_app()
+
+    assert telemetry["machine_arch"] == "arm64"
+
+
+def test_the_assembler_reports_an_intel_box_as_x86_64():
+    """The reading the whole issue exists to enumerate — an Intel build in the
+    fleet — must survive the producer, not just the arm64 one."""
+    with patch("src.main.true_machine_arch", return_value="x86_64"):
+        telemetry = _telemetry_from_real_app()
+
+    assert telemetry["machine_arch"] == "x86_64"
+
+
+def test_the_assembler_sends_an_unresolved_probe_as_null():
+    """true_machine_arch() spells "undetermined" as "", which is falsy AND a
+    string. Forwarded verbatim it would be indistinguishable from a real arch
+    by any consumer doing a type check, and indistinguishable from "absent" by
+    any consumer doing a truthiness check. Null is the only reading that is
+    neither.
+    """
+    with patch("src.main.true_machine_arch", return_value=""):
+        telemetry = _telemetry_from_real_app()
+
+    assert "machine_arch" in telemetry, "an undetermined arch is still a report"
+    assert telemetry["machine_arch"] is None
+
+
+def test_a_failing_arch_probe_never_costs_the_heartbeat():
+    with patch("src.main.true_machine_arch", side_effect=OSError("sysctl denied")):
+        telemetry = _telemetry_from_real_app()
+
+    assert isinstance(telemetry, dict)
+    assert "machine_arch" not in telemetry
+    assert "consecutive_sync_failures" in telemetry, "the rest of the payload survived"

--- a/tests/test_dropped_events_wording.py
+++ b/tests/test_dropped_events_wording.py
@@ -1,0 +1,57 @@
+"""The drop alert calls preserved events "lost activity".
+
+remove_failed() MOVES exhausted events to the dead-letter table rather than
+deleting them, and requeue_storable_dead_letter() replays the ones that become
+storable again. The events are undelivered and preserved. Telling ops they are
+lost sends someone hunting for data that is in a table, and it inflates a
+warning that is otherwise correctly scoped to genuine rejections.
+"""
+
+from unittest.mock import MagicMock
+
+from src.sync.sync_engine import SyncEngine
+
+
+def _engine_with_reporter():
+    engine = SyncEngine.__new__(SyncEngine)
+    engine.error_reporter = MagicMock()
+    engine._dropped_window_age = lambda oldest, newest: "spanning 2h"
+    return engine
+
+
+def test_the_drop_warning_does_not_claim_the_events_are_lost():
+    engine = _engine_with_reporter()
+
+    engine._report_dropped_events(
+        {"count": 3, "real_loss_count": 3, "bucket_ids": ["aw-watcher-window_host"], "oldest": 1, "newest": 2}
+    )
+
+    message = engine.error_reporter.capture.call_args[0][0]
+    assert "lost activity" not in message
+    assert "dead-letter" in message, "say where they are, or the reader cannot go look"
+
+
+def test_it_still_warns_and_still_names_the_count():
+    """The severity is right and must not be softened along with the wording:
+    these are events the server rejected, and somebody should look."""
+    engine = _engine_with_reporter()
+
+    engine._report_dropped_events(
+        {"count": 3, "real_loss_count": 3, "bucket_ids": ["aw-watcher-window_host"], "oldest": 1, "newest": 2}
+    )
+
+    kwargs = engine.error_reporter.capture.call_args.kwargs
+    assert kwargs["level"] == "warning"
+    assert kwargs["fingerprint"] == "offline-queue-events-dropped"
+    assert "3" in engine.error_reporter.capture.call_args[0][0]
+
+
+def test_the_benign_flush_path_is_untouched():
+    engine = _engine_with_reporter()
+
+    engine._report_dropped_events(
+        {"count": 2, "real_loss_count": 0, "bucket_ids": [], "oldest": 1, "newest": 2}
+    )
+
+    kwargs = engine.error_reporter.capture.call_args.kwargs
+    assert kwargs["level"] == "info"

--- a/tests/test_os_idle_heartbeat.py
+++ b/tests/test_os_idle_heartbeat.py
@@ -1,0 +1,99 @@
+"""The no_capture alert cannot tell a user who is away from a dead tracker (#195).
+
+The agent has always known: get_system_idle_seconds() reads HIDIdleTime on
+macOS and GetLastInputInfo on Windows. It just never left the device, because
+HEARTBEAT_HEALTH_KEYS is a hard allowlist and the key was not in it.
+
+Both halves are asserted here on purpose. A producer-only test passes while the
+allowlist silently drops the field, which is the exact failure the tuple's own
+comment warns about. The mirror also holds: an allowlist entry with no producer
+is a field no device will ever send, so the assembler is driven for real below.
+"""
+
+import threading
+from unittest.mock import MagicMock, patch
+
+from src.main import SyncCoordinator
+from src.sync.bf_client import BetterFlowClient
+
+
+# ── The wire boundary ───────────────────────────────────────────────────
+
+def test_the_allowlist_carries_os_idle_seconds():
+    assert "os_idle_seconds" in BetterFlowClient.HEARTBEAT_HEALTH_KEYS
+
+
+def test_a_supplied_os_idle_reading_reaches_the_request_body():
+    client = BetterFlowClient.__new__(BetterFlowClient)
+    captured = {}
+
+    def _fake_request(method, path, data=None, **kw):
+        captured.update(data or {})
+        return {"data": {}}
+
+    client._request = _fake_request
+    client._detect_timezone = lambda: "Europe/Bucharest"
+
+    client.heartbeat(agent_version="1.5.125", health={"os_idle_seconds": 12})
+
+    assert captured["os_idle_seconds"] == 12
+
+
+def test_an_unreadable_idle_clock_is_omitted_not_zeroed():
+    """None must not become 0. Zero means 'the user is at the keyboard right
+    now', which is the opposite of 'we could not tell' — and it is the reading
+    the alert would act on."""
+    client = BetterFlowClient.__new__(BetterFlowClient)
+    captured = {}
+    client._request = lambda method, path, data=None, **kw: (captured.update(data or {}), {"data": {}})[1]
+    client._detect_timezone = lambda: "UTC"
+
+    client.heartbeat(agent_version="1.5.125", health={})
+
+    assert "os_idle_seconds" not in captured
+
+
+# ── The producer ────────────────────────────────────────────────────────
+#
+# Witnessed separately from the allowlist on purpose. An allowlist entry with
+# no producer forwards a field nothing ever supplies, and every assertion above
+# would still pass. The stub drives the REAL _build_health_telemetry unbound,
+# so a payload builder that nothing calls cannot satisfy these (Phantom 3).
+
+def _telemetry_from_real_app() -> dict:
+    stub = MagicMock()
+    stub._idle_tracker_warn_lock = threading.Lock()
+    stub._blind_tracker_window = 0
+    stub._consecutive_sync_failures = 0
+    stub._last_successful_sync = None
+    stub.aw_manager.health_snapshot.return_value = {}
+    return SyncCoordinator._build_health_telemetry(stub)
+
+
+def test_the_assembler_reports_the_os_idle_clock():
+    with patch("src.main.get_system_idle_seconds", return_value=903.7):
+        telemetry = _telemetry_from_real_app()
+
+    assert telemetry["os_idle_seconds"] == 903, "seconds, truncated to an int"
+
+
+def test_the_assembler_omits_an_unreadable_idle_clock():
+    """Linux, or any platform whose probe returned None: no key at all.
+
+    The adversarial value is None rather than a large number — a producer that
+    coerced it would report 0, i.e. "at the keyboard this instant", which is the
+    strongest possible claim of presence built out of an unknown.
+    """
+    with patch("src.main.get_system_idle_seconds", return_value=None):
+        telemetry = _telemetry_from_real_app()
+
+    assert "os_idle_seconds" not in telemetry
+
+
+def test_a_failing_idle_probe_never_costs_the_heartbeat():
+    with patch("src.main.get_system_idle_seconds", side_effect=OSError("ioreg gone")):
+        telemetry = _telemetry_from_real_app()
+
+    assert isinstance(telemetry, dict)
+    assert "os_idle_seconds" not in telemetry
+    assert "consecutive_sync_failures" in telemetry, "the rest of the payload survived"


### PR DESCRIPTION
Clears the repo's open-issue backlog. Two issues were already fixed by v1.5.124 and only needed closing; two more are addressed here; two investigations ended without code, which was the right answer for both.

Executed subagent-driven: a fresh implementer per batch, a task review after each, and a whole-branch review at the end.

## What changed in the agent

**`os_idle_seconds` on the heartbeat (#195).** The `no_capture` alert could not tell a user who was away from a tracker that had died, because both produce identical evidence on the wire. The agent already knew: `get_system_idle_seconds()` reads `HIDIdleTime` on macOS and `GetLastInputInfo` on Windows and is used by the idle manager and sync engine. It simply never left the device, because `HEARTBEAT_HEALTH_KEYS` is a hard allowlist and the key was not in it. Now sent, and **omitted rather than zeroed** when unreadable: a null coerced to 0 would read as "at the keyboard this second", turning an unknown into the strongest possible claim of presence.

**`machine_arch` on the heartbeat (#184, remaining scope).** The fleet could not answer "who is running the Intel build?". Reports the hardware architecture, seeing through Rosetta, and sends `null` when the probe never resolved so "undetermined" stays distinguishable from a real value.

**The drop alert stops calling preserved events "lost" (audit finding).** `remove_failed()` moves exhausted events to a dead-letter table rather than deleting them, and `requeue_storable_dead_letter()` replays the ones that become storable. Telling ops the activity was lost sent people hunting for data sitting in a table. The severity is unchanged and deliberately so: these are events the server genuinely rejected, and somebody should look.

**A clock-travel test harness.** `time-machine` plus an opt-in pytest plugin that moves `time.time`, `time.monotonic` and `datetime` together.

## Two issues closed without code

**#194** shipped in v1.5.124 and was verified in the tag, not on main: the notify path appears 4x in `v1.5.124` and 0x in `v1.5.123`.

**#190 — zero findings, and that is the result.** All seven suspected clock-dependent tests were the instrument. The old harness froze `datetime` but not `time.monotonic`, and `aw_manager.py` alone has twelve monotonic calls, skewing the two clocks ~21 hours apart. The datetime-only harness reproduces exactly those seven and no others; freezing all three clocks gives 1741 passing at 00:01, 23:59 and year-end.

## #188 stays open, and the investigation found something worse

The plan expected one of two branches: either the Rosetta notice shipped after the incident it failed to prevent, or it fired and did not help. It is the second — the notice first shipped in **v1.5.118** and Carmen lost 90 minutes on **v1.5.122**, four releases later.

The reason looks like this, at `src/notifications.py`:

```python
center.deliverNotification_(note)
return True
```

`deliverNotification_` is fire-and-forget. It returns nothing, and macOS silently drops the notification when the app lacks authorization. So the function reports success whenever it did not raise, which it will not — and the caller then returns early and never tries the fallback. Confirmed with a negative control: `deliveredNotifications()` reports the notification was never delivered while the function returned `True`.

**Two shipped fixes rest on that channel** — #194's Accessibility prompt and #188's Rosetta prompt — and both fire on machines that may never have granted notification permission. On a brand-new Mac, the only launch that matters for #188, neither reaches anyone and nothing is logged. Recommendation on the issue is to send the cause rather than a louder toast. Filed separately as its own defect.

## Verification

```
1741 passed, 1 skipped        full suite (baseline 1724 + 17 new)
```

- Both allowlist entries witnessed **separately**: removing `os_idle_seconds` reddens 2 named tests, removing `machine_arch` reddens 3, control clean after each. That pair matters because a field can be produced, logged and tested end to end and still never leave the machine if its name is missing from the tuple.
- All 17 new tests pass under a simulated ubuntu runner, with an instrument control proving the fake platform took effect. No test reads `sys.platform`, `platform.machine()` or uses `skipif`.
- The full suite also passes with `PATH=/nonexistent`, i.e. both macOS probes unresolvable.
- The new pytest plugin cannot auto-load — not matched by `python_files`, not in `addopts`, not referenced by any conftest — so it changes no future run.

## A file the plan missed

`src/disclosure_baseline.py` holds a **second copy** of the heartbeat allowlist, set-diffed by a guard test. Following the plan literally would have reddened `main`. The implementer caught it. Two copies of one tuple is a drift risk worth its own issue.

## Corrected during review

`CLAUDE.md` briefly claimed `hardware_serial` and `disclosure_acknowledgement` bypass the allowlist. They are members of it. That paragraph is the entry point for an egress and disclosure audit, so it pointed the reader away from the mechanism that gates those fields. The error came from a source-parsing probe that silently truncated at a parenthesis inside a comment and reported 8 keys where there are 18 — importing the class settles it in one line, which is now how it is verified.
