### PR TITLE
Stop reporting an Accessibility grant the process does not have

### DIFF
--- a/src/main.py
+++ b/src/main.py
@@ -42,6 +42,7 @@ try:
     from .system_events import start_system_event_listener
     from .ui.permissions import (
         check_accessibility,
+        has_capture_permissions,
         check_input_monitoring,
         grant_tcc_permissions,
         input_monitoring_active,
@@ -76,6 +77,7 @@ except ImportError:
     from system_events import start_system_event_listener
     from ui.permissions import (
         check_accessibility,
+        has_capture_permissions,
         check_input_monitoring,
         grant_tcc_permissions,
         input_monitoring_active,
@@ -2157,6 +2159,10 @@ class BetterFlowApp:
     and routes tray-menu and system events to the appropriate handler.
     """
 
+    # Mirrors SyncCoordinator._PERM_REWARN_INTERVAL: a permission the user has
+    # not fixed is still worth resurfacing, but not 1,440 times a day.
+    _PERM_REWARN_INTERVAL = timedelta(hours=4)
+
     def __init__(self):
         """Initialize the application."""
         # Logging FIRST, at the default level, because Config.load() itself
@@ -2401,6 +2407,11 @@ class BetterFlowApp:
         # the 60s tick, the post-config-fetch callback and the wake-from-sleep
         # handler all drive it from different threads.
         self._capture_lock = threading.RLock()
+        # Throttle for the still-missing-permission warning. _start_watchers
+        # runs on every 60s tick, so this must not be per-call: see
+        # _maybe_warn_capture_permissions.
+        self._tcc_warn_lock = threading.Lock()
+        self._last_tcc_warn_at: Optional[datetime] = None
         self._capture_allowed: Optional[bool] = None
 
         # Sub-handlers
@@ -2424,22 +2435,59 @@ class BetterFlowApp:
         """Keep the tray visible while background startup progresses."""
         self.tray.set_state(TrayState.STARTING, message)
 
+    def _maybe_warn_capture_permissions(self) -> None:
+        """Report a still-missing capture grant, throttled, naming the right one.
+
+        Two things this must not do, both learned the hard way.
+
+        It must not fire per call. ``_start_watchers`` runs from
+        ``_apply_capture_policy`` on EVERY 60s tick, so an unthrottled line here
+        is ~1,440 a day — which is precisely the once-a-minute log that ran for
+        9-21 days on four devices and changed nothing (#194). A breadcrumb
+        repeated 1,440 times is what makes the log an ops fetch returns
+        unreadable. Same _PERM_REWARN_INTERVAL the input-tracking warning uses.
+
+        It must not blame the wrong grant. The two permissions have different
+        consequences and different System Settings panes: Accessibility gates
+        window TITLES, Input Monitoring gates keystroke/click COUNTS. Saying
+        "titles will be empty" on an Input-Monitoring failure is right about
+        what and wrong about where, which is the mistake that cost the 15-21
+        days in the first place.
+        """
+        missing = []
+        if not check_accessibility():
+            missing.append("Accessibility (window titles will be empty)")
+        if not check_input_monitoring():
+            missing.append("Input Monitoring (keystroke/click capture disabled)")
+
+        now = datetime.now(timezone.utc)
+        with self._tcc_warn_lock:
+            if not missing:
+                # Re-arm, so a later revocation warns again instead of being
+                # swallowed by a stale timestamp.
+                self._last_tcc_warn_at = None
+                return
+            recently_warned = (
+                self._last_tcc_warn_at is not None
+                and (now - self._last_tcc_warn_at) < self._PERM_REWARN_INTERVAL
+            )
+            if recently_warned:
+                return
+            self._last_tcc_warn_at = now
+
+        logger.warning(
+            "macOS permissions still missing after TCC grant attempt: %s "
+            "(System Settings > Privacy & Security)",
+            "; ".join(missing),
+        )
+
     def _start_watchers(self) -> None:
         """Start in-process watchers after the tracker server is available."""
         if sys.platform == "darwin":
-            if not check_accessibility() or not check_input_monitoring():
+            if not has_capture_permissions():
                 logger.info("Missing macOS permissions, attempting TCC grant")
-                if not grant_tcc_permissions():
-                    # Discarding this is how the state stayed invisible: the
-                    # watcher starts either way and emits empty titles, so the
-                    # only record was a debug line nobody reads. The user-facing
-                    # ask lives in the watcher (#197); this is the ops-side
-                    # breadcrumb for a log request.
-                    logger.warning(
-                        "macOS permissions still missing after TCC grant attempt "
-                        "— window titles will be empty until the user re-grants "
-                        "Accessibility (System Settings > Privacy & Security)"
-                    )
+                grant_tcc_permissions()
+                self._maybe_warn_capture_permissions()
         if self.window_watcher:
             self.window_watcher.start()
         if self.input_watcher:

--- a/src/main.py
+++ b/src/main.py
@@ -2429,7 +2429,17 @@ class BetterFlowApp:
         if sys.platform == "darwin":
             if not check_accessibility() or not check_input_monitoring():
                 logger.info("Missing macOS permissions, attempting TCC grant")
-                grant_tcc_permissions()
+                if not grant_tcc_permissions():
+                    # Discarding this is how the state stayed invisible: the
+                    # watcher starts either way and emits empty titles, so the
+                    # only record was a debug line nobody reads. The user-facing
+                    # ask lives in the watcher (#197); this is the ops-side
+                    # breadcrumb for a log request.
+                    logger.warning(
+                        "macOS permissions still missing after TCC grant attempt "
+                        "— window titles will be empty until the user re-grants "
+                        "Accessibility (System Settings > Privacy & Security)"
+                    )
         if self.window_watcher:
             self.window_watcher.start()
         if self.input_watcher:

--- a/src/main.py
+++ b/src/main.py
@@ -2487,7 +2487,11 @@ class BetterFlowApp:
             if not has_capture_permissions():
                 logger.info("Missing macOS permissions, attempting TCC grant")
                 grant_tcc_permissions()
-                self._maybe_warn_capture_permissions()
+            # Unconditional, and that is the point: nested under the guard above,
+            # this could only ever run with a grant already missing, so the
+            # empty-`missing` re-arm was dead code and the stale timestamp
+            # swallowed the NEXT revocation. Its own comment claimed otherwise.
+            self._maybe_warn_capture_permissions()
         if self.window_watcher:
             self.window_watcher.start()
         if self.input_watcher:

--- a/src/sync/macos_input_watcher.py
+++ b/src/sync/macos_input_watcher.py
@@ -14,9 +14,17 @@ from datetime import datetime, timezone
 from typing import Optional
 
 try:
-    from ..ui.permissions import check_accessibility, check_input_monitoring
+    from ..ui.permissions import (
+        check_accessibility,
+        check_input_monitoring,
+        has_capture_permissions,
+    )
 except ImportError:
-    from ui.permissions import check_accessibility, check_input_monitoring
+    from ui.permissions import (
+        check_accessibility,
+        check_input_monitoring,
+        has_capture_permissions,
+    )
 
 logger = logging.getLogger(__name__)
 
@@ -207,9 +215,11 @@ class MacOSInputWatcher:
             if self.is_running:
                 # Another start() call already brought us online.
                 return
-            # prompt=False so we don't keep showing dialogs on every retry;
+            # has_capture_permissions() is the one definition of this pair
+            # (src/ui/permissions.py). check_input_monitoring defaults to
+            # prompt=False, so this does not re-show dialogs on every retry —
             # the first start() already registered the app in System Settings.
-            if check_accessibility() and check_input_monitoring(prompt=False):
+            if has_capture_permissions():
                 logger.info(
                     "Input watcher permissions now granted — starting capture"
                 )

--- a/src/sync/macos_window_watcher.py
+++ b/src/sync/macos_window_watcher.py
@@ -412,6 +412,15 @@ class MacOSWindowWatcher:
         Best-effort. A machine with notifications disabled loses the prompt and
         nothing else — capture is unaffected either way, since app names and
         durations do not need this grant.
+
+        The wording is load-bearing and was wrong in v1.5.124. "Grant
+        Accessibility" is a no-op instruction for the commonest cause: this
+        agent auto-updates, an update changes the code signature, and macOS then
+        shows the toggle as ON while the grant is dead (see the header of
+        ``src/ui/permissions.py``). A user sent to that pane sees BetterFlow
+        already switched on and reasonably concludes there is nothing to do.
+        The remedy is to switch it off and back on, so the notice has to say
+        that (#205).
         """
         if self._accessibility_notified:
             return
@@ -424,9 +433,9 @@ class MacOSWindowWatcher:
 
             send_notification(
                 "BetterFlow can't read window titles",
-                "Grant Accessibility to BetterFlow in System Settings > "
-                "Privacy & Security > Accessibility. App names and time are "
-                "still being tracked.",
+                "Open System Settings > Privacy & Security > Accessibility. "
+                "BetterFlow may already look enabled there — if so, switch it "
+                "off and back on. App names and time are still being tracked.",
             )
         except Exception as e:
             # Never let a failed notification stop the watcher starting.

--- a/src/ui/permissions.py
+++ b/src/ui/permissions.py
@@ -318,6 +318,18 @@ def _tcc_grant_marker() -> Path:
     return Config.get_data_dir() / ".tcc_grant_done"
 
 
+def has_capture_permissions() -> bool:
+    """The single definition of "we hold the grants capture needs".
+
+    Written three times before this existed — ``not A or not B`` at the
+    ``main.py`` callsite, ``A and B`` in the marker branch below, and the pair
+    again while building ``services``. De Morgan-equivalent, so nothing was
+    broken; adding a third grant to one spelling and not the others is a
+    one-line edit away, and it fails silently in both directions (#205).
+    """
+    return check_accessibility() and check_input_monitoring()
+
+
 def grant_tcc_permissions() -> bool:
     """Grant Accessibility and Input Monitoring via TCC database with admin auth.
 
@@ -340,7 +352,7 @@ def grant_tcc_permissions() -> bool:
         # Still no re-prompt — the marker exists so the admin password is asked
         # for once, not on every launch. Only the ANSWER changes: report what is
         # true right now instead of reporting that we once tried.
-        granted = check_accessibility() and check_input_monitoring()
+        granted = has_capture_permissions()
         logger.debug(
             "TCC grant already attempted, skipping admin prompt (granted=%s)",
             granted,
@@ -402,8 +414,12 @@ def grant_tcc_permissions() -> bool:
             capture_output=True, text=True, timeout=120,
         )
         if result.returncode == 0:
+            # returncode 0 means the sqlite write succeeded, NOT that this
+            # process now holds the grant — macOS generally does not re-read TCC
+            # for a running client. Ask, do not assume: this is the same claim
+            # the marker branch above was fixed for, one branch down.
             logger.info("TCC permissions granted via admin auth")
-            return True
+            return has_capture_permissions()
         else:
             stderr = result.stderr.strip()
             if "User canceled" in stderr or "-128" in stderr:

--- a/src/ui/permissions.py
+++ b/src/ui/permissions.py
@@ -325,15 +325,27 @@ def grant_tcc_permissions() -> bool:
     launches skip the prompt — if permissions are still missing, the user
     must grant them manually via System Settings.
 
-    Returns True if the grant succeeded or was already attempted.
+    Returns True only when the permissions are actually held. The marker below
+    records that we ASKED, never that we succeeded: it is written in a finally,
+    so a cancelled prompt and a failed sqlite write both set it. Reporting
+    "attempted" as True made every later launch claim a permission the process
+    did not have, and four devices sat window_titles_blind for 15-21 days with
+    this answering True on each start (#205).
     """
     if not _IS_MACOS:
         return True
 
     marker = _tcc_grant_marker()
     if marker.exists():
-        logger.debug("TCC grant already attempted, skipping admin prompt")
-        return True
+        # Still no re-prompt — the marker exists so the admin password is asked
+        # for once, not on every launch. Only the ANSWER changes: report what is
+        # true right now instead of reporting that we once tried.
+        granted = check_accessibility() and check_input_monitoring()
+        logger.debug(
+            "TCC grant already attempted, skipping admin prompt (granted=%s)",
+            granted,
+        )
+        return granted
 
     services = []
     if not check_accessibility():

--- a/tests/test_accessibility_prompt.py
+++ b/tests/test_accessibility_prompt.py
@@ -15,6 +15,7 @@ runs on every runner. The one test that needs the AX symbol injects a fake
 module rather than requiring the real one.
 """
 
+import re
 import sys
 import types
 from unittest.mock import MagicMock, patch
@@ -204,6 +205,45 @@ def test_the_prompt_warns_the_toggle_may_already_look_enabled():
     with patch(NOTIFY) as notify:
         w._notify_accessibility_required_once()
 
-    body = notify.call_args[0][1].lower()
-    assert "already" in body, "must warn the toggle may already read as enabled"
-    assert "off" in body, "must give the off-then-on remedy, not just 'grant'"
+    assert _conveys_the_remedy(notify.call_args[0][1])
+
+
+# The v1.5.124 body, verbatim. This is the negative control: without it nobody
+# has ever seen the assertion above distinguish a good body from the one that
+# left four devices blind for 15-21 days.
+V1_5_124_BODY = (
+    "Grant Accessibility to BetterFlow in System Settings > Privacy & "
+    "Security > Accessibility. App names and time are still being tracked."
+)
+
+
+def _conveys_the_remedy(body: str) -> bool:
+    """Does this text tell the user the toggle may lie, and what to do about it?
+
+    Whole words over a small alternation, not substrings. A bare ``"off" in
+    body`` passes on "you may already be offline" — a body with no remedy at all
+    — and fails on "disable it and re-enable it", which is Apple's own phrasing
+    and arguably clearer than what we ship. Measured, both directions.
+    """
+    low = body.lower()
+    warns = re.search(r"\balready\b", low) is not None
+    remedies = re.search(r"\b(off|disable|untick|uncheck)\b", low) is not None
+    return warns and remedies
+
+
+def test_the_remedy_check_rejects_the_body_that_left_four_devices_blind():
+    """Control on the guard above — an unwitnessed predicate proves nothing."""
+    assert _conveys_the_remedy(V1_5_124_BODY) is False
+
+
+def test_the_remedy_check_accepts_reasonable_rewordings():
+    """It must not false-fail a better message, or it gets weakened not fixed."""
+    assert _conveys_the_remedy(
+        "BetterFlow may already be listed - disable it and re-enable it."
+    ) is True
+
+
+def test_the_remedy_check_is_not_satisfied_by_the_word_offline():
+    assert _conveys_the_remedy(
+        "You may already be offline. App names and time are still being tracked."
+    ) is False

--- a/tests/test_accessibility_prompt.py
+++ b/tests/test_accessibility_prompt.py
@@ -227,8 +227,12 @@ def _conveys_the_remedy(body: str) -> bool:
     """
     low = body.lower()
     warns = re.search(r"\balready\b", low) is not None
-    remedies = re.search(r"\b(off|disable|untick|uncheck)\b", low) is not None
-    return warns and remedies
+    turn_off = re.search(r"\b(off|disable|untick|uncheck)\b", low) is not None
+    # BOTH steps. "switch it off." satisfies the first two and leaves the user
+    # worse off than before: on a partly-blind machine they turn off the one
+    # grant that still worked. A half remedy is not a remedy.
+    turn_on = re.search(r"\b(back on|re-?enable|on again|turn it on)\b", low) is not None
+    return warns and turn_off and turn_on
 
 
 def test_the_remedy_check_rejects_the_body_that_left_four_devices_blind():
@@ -241,6 +245,13 @@ def test_the_remedy_check_accepts_reasonable_rewordings():
     assert _conveys_the_remedy(
         "BetterFlow may already be listed - disable it and re-enable it."
     ) is True
+
+
+def test_the_remedy_check_rejects_a_half_remedy():
+    """"Switch it off" with no second step is actively harmful, not merely vague."""
+    assert _conveys_the_remedy(
+        "BetterFlow may already look enabled there - if so, switch it off."
+    ) is False
 
 
 def test_the_remedy_check_is_not_satisfied_by_the_word_offline():

--- a/tests/test_accessibility_prompt.py
+++ b/tests/test_accessibility_prompt.py
@@ -181,3 +181,29 @@ def test_a_broken_notifier_never_stops_the_watcher():
     # And the latch still moved, so a failing notifier cannot become a retry
     # loop that spawns an osascript every 60s forever.
     assert w._accessibility_notified is True
+
+
+def test_the_prompt_warns_the_toggle_may_already_look_enabled():
+    """"Grant Accessibility" is a no-op instruction for the commonest cause.
+
+    src/ui/permissions.py's own header records why: "After a fresh build the
+    app's code signature changes. macOS may show the toggle as ON in System
+    Settings while AXIsProcessTrusted() returns False... Toggling the permission
+    off and on again in System Settings re-registers it."
+
+    The agent auto-updates, so that is the path most of the fleet takes into this
+    state. A user told to "grant Accessibility" opens the pane, sees BetterFlow
+    already switched on, concludes the message is stale and closes it. Four
+    devices sat blind for 15-21 days, two of them for five days on v1.5.124 —
+    the release that added this very prompt.
+
+    Asserting the information is PRESENT rather than banning phrasings: the ways
+    to word this are unbounded, so a blocklist would be unfinishable.
+    """
+    w = _watcher()
+    with patch(NOTIFY) as notify:
+        w._notify_accessibility_required_once()
+
+    body = notify.call_args[0][1].lower()
+    assert "already" in body, "must warn the toggle may already read as enabled"
+    assert "off" in body, "must give the off-then-on remedy, not just 'grant'"

--- a/tests/test_capture_permission_warning.py
+++ b/tests/test_capture_permission_warning.py
@@ -20,6 +20,8 @@ monkeypatched here, so nothing touches the real AX API.
 import logging
 import threading
 from datetime import datetime, timedelta, timezone
+from types import SimpleNamespace
+from unittest.mock import Mock
 
 import src.main as main
 
@@ -99,3 +101,132 @@ def test_nothing_is_logged_while_both_grants_are_held(monkeypatch, caplog):
     with caplog.at_level(logging.WARNING):
         app._maybe_warn_capture_permissions()
     assert [r for r in caplog.records if r.levelno == logging.WARNING] == []
+
+
+def test_the_rewarn_interval_is_long_enough_to_not_be_a_per_tick_log():
+    """State the REQUIREMENT, not the code's current choice.
+
+    test_it_warns_again_once_the_interval_has_passed computes its offset FROM
+    _PERM_REWARN_INTERVAL, so both sides move together and no value of the
+    constant can redden it — a mutant setting it to 1 second survived the whole
+    1756-test suite. At 1s, with _start_watchers running every 60s, that is
+    exactly the once-a-minute log this method exists to prevent.
+
+    An hour is not the shipped value (4h); it is the loosest setting that is
+    still defensible, so a deliberate retune stays green and a slip does not.
+    """
+    assert main.BetterFlowApp._PERM_REWARN_INTERVAL >= timedelta(hours=1)
+
+
+def test_it_names_BOTH_grants_when_both_are_missing(monkeypatch, caplog):
+    """The commonest state, and it was unpinned.
+
+    The existing tests exercise one-missing-at-a-time, and the two both-missing
+    tests assert only the COUNT of warning records, never the text. So `if` ->
+    `elif`, or "; ".join(missing) -> missing[0], both survived: the user fixes
+    Accessibility, titles return, and keystroke capture stays dead with nothing
+    ever naming it again.
+    """
+    app = _bare_app()
+    _perms(monkeypatch, accessibility=False, input_monitoring=False)
+    with caplog.at_level(logging.WARNING):
+        app._maybe_warn_capture_permissions()
+    assert "Accessibility" in caplog.text
+    assert "Input Monitoring" in caplog.text
+
+
+def _app_for_start_watchers(monkeypatch):
+    """A BetterFlowApp real enough to run _start_watchers end to end."""
+    app = _bare_app()
+    app.window_watcher = app.input_watcher = app.input_source = None
+    app.browser_tracker = app.display_tracker = object()   # skip the start_* branches
+    app.sync_engine = Mock()
+    cfg = SimpleNamespace(
+        sync=SimpleNamespace(in_process_input=False),
+        privacy=SimpleNamespace(track_browser_urls=False, track_display_info=False),
+    )
+    app.config = cfg
+    monkeypatch.setattr(main.sys, "platform", "darwin")
+    return app
+
+
+def test_start_watchers_actually_calls_the_warning(monkeypatch):
+    """The callsite itself was unwitnessed — deleting it left 1756 tests green.
+
+    Patches main.has_capture_permissions, NOT main.check_accessibility: the
+    latter does not reach has_capture_permissions, which closes over
+    permissions.check_accessibility. Patching the wrong one leaves this probing
+    the real AX API and proving nothing.
+    """
+    app = _app_for_start_watchers(monkeypatch)
+    monkeypatch.setattr(main, "has_capture_permissions", lambda: False)
+    monkeypatch.setattr(main, "grant_tcc_permissions", lambda: False)
+    called = []
+    monkeypatch.setattr(
+        type(app), "_maybe_warn_capture_permissions",
+        lambda self: called.append(True), raising=True,
+    )
+    app._start_watchers()
+    assert called == [True], "_start_watchers must consult the warning path"
+
+
+def test_start_watchers_still_reports_when_the_grants_are_held(monkeypatch):
+    """It must run even on the healthy path — that is what re-arms the throttle.
+
+    Nested under `if not has_capture_permissions()` it could only ever run with
+    a grant already missing, so the re-arm was dead and the next revocation was
+    swallowed by a stale timestamp.
+    """
+    app = _app_for_start_watchers(monkeypatch)
+    monkeypatch.setattr(main, "has_capture_permissions", lambda: True)
+    granted = []
+    monkeypatch.setattr(main, "grant_tcc_permissions", lambda: granted.append(True))
+    called = []
+    monkeypatch.setattr(
+        type(app), "_maybe_warn_capture_permissions",
+        lambda self: called.append(True), raising=True,
+    )
+    app._start_watchers()
+    assert granted == [], "must not attempt a TCC grant when permissions are held"
+    assert called == [True], "must still run, so the throttle re-arms"
+
+
+def test_start_watchers_gates_on_BOTH_grants_not_just_accessibility(monkeypatch):
+    """The discriminating input: Accessibility held, Input Monitoring missing.
+
+    Swapping the unified gate for a bare check_accessibility() survived the
+    whole suite, because every other test here makes the two agree. Only a case
+    where they DISAGREE can tell them apart — and this is the real state of a
+    machine that fixed Accessibility after the off-then-on prompt and still has
+    no keystroke capture.
+    """
+    app = _app_for_start_watchers(monkeypatch)
+    monkeypatch.setattr(main, "has_capture_permissions", lambda: False)
+    monkeypatch.setattr(main, "check_accessibility", lambda: True)
+    monkeypatch.setattr(main, "check_input_monitoring", lambda: False)
+    attempted = []
+    monkeypatch.setattr(main, "grant_tcc_permissions", lambda: attempted.append(True))
+    monkeypatch.setattr(
+        type(app), "_maybe_warn_capture_permissions", lambda self: None, raising=True,
+    )
+    app._start_watchers()
+    assert attempted == [True], (
+        "the gate must consider Input Monitoring too — a bare check_accessibility() "
+        "would skip the grant attempt on this machine"
+    )
+
+
+def test_the_input_watcher_can_actually_resolve_the_shared_predicate():
+    """A NameError in macOS-only code that 1762 green tests cannot see.
+
+    macos_input_watcher._permission_retry_loop runs only on macOS with a grant
+    missing, so no test drives it. Unifying it onto has_capture_permissions()
+    without landing the import left a call to an undefined name — the module
+    still imports, the suite still passes, and it raises on exactly the machines
+    this change is about. This asserts the symbol is bound in the module, which
+    is the cheapest thing that would have caught it.
+    """
+    import src.sync.macos_input_watcher as w
+    assert callable(getattr(w, "has_capture_permissions", None)), (
+        "has_capture_permissions is used in _permission_retry_loop but not imported"
+    )

--- a/tests/test_capture_permission_warning.py
+++ b/tests/test_capture_permission_warning.py
@@ -1,0 +1,101 @@
+"""The still-missing-permission warning must be rare, and must blame the right grant.
+
+Two defects this pins, both found by the pre-merge gate on the first attempt at
+the fix and both verified against the code:
+
+1. ``_start_watchers`` runs from ``_apply_capture_policy`` on EVERY 60s tick
+   (src/main.py:2568; that method's own docstring says "Re-running the desired
+   end state every 60s"). An unthrottled warning there is ~1,440 lines a day —
+   the same once-a-minute log that ran for 9-21 days on four devices and changed
+   nothing (#194). The first version of this fix reintroduced it.
+
+2. The guard fires when EITHER grant is missing, so a message hardcoded to
+   "window titles will be empty ... re-grant Accessibility" is false on an
+   Input-Monitoring failure: titles are fine, keystroke counts are zero, and the
+   pane to open is a different one.
+
+Not gated on Darwin: the PR gate runs on ubuntu, and both permission probes are
+monkeypatched here, so nothing touches the real AX API.
+"""
+import logging
+import threading
+from datetime import datetime, timedelta, timezone
+
+import src.main as main
+
+
+def _bare_app():
+    """Construct without __init__ — the pattern tests/test_capture_policy_integration.py uses."""
+    app = object.__new__(main.BetterFlowApp)
+    app._tcc_warn_lock = threading.Lock()
+    app._last_tcc_warn_at = None
+    return app
+
+
+def _perms(monkeypatch, *, accessibility: bool, input_monitoring: bool):
+    monkeypatch.setattr(main, "check_accessibility", lambda: accessibility)
+    monkeypatch.setattr(main, "check_input_monitoring", lambda: input_monitoring)
+
+
+def test_it_names_accessibility_when_that_is_the_missing_grant(monkeypatch, caplog):
+    app = _bare_app()
+    _perms(monkeypatch, accessibility=False, input_monitoring=True)
+    with caplog.at_level(logging.WARNING):
+        app._maybe_warn_capture_permissions()
+    assert "Accessibility" in caplog.text
+    assert "window titles" in caplog.text
+    assert "Input Monitoring" not in caplog.text
+
+
+def test_it_does_not_blame_titles_when_input_monitoring_is_what_failed(monkeypatch, caplog):
+    """The wrong-blame defect: right about what, wrong about where."""
+    app = _bare_app()
+    _perms(monkeypatch, accessibility=True, input_monitoring=False)
+    with caplog.at_level(logging.WARNING):
+        app._maybe_warn_capture_permissions()
+    assert "Input Monitoring" in caplog.text
+    assert "window titles" not in caplog.text
+
+
+def test_it_is_throttled_rather_than_firing_on_every_60s_tick(monkeypatch, caplog):
+    app = _bare_app()
+    _perms(monkeypatch, accessibility=False, input_monitoring=False)
+    with caplog.at_level(logging.WARNING):
+        for _ in range(10):
+            app._maybe_warn_capture_permissions()
+    warnings = [r for r in caplog.records if r.levelno == logging.WARNING]
+    assert len(warnings) == 1, f"expected 1 warning per interval, got {len(warnings)}"
+
+
+def test_it_warns_again_once_the_interval_has_passed(monkeypatch, caplog):
+    """Throttled must not mean silenced — a long outage still has to resurface."""
+    app = _bare_app()
+    _perms(monkeypatch, accessibility=False, input_monitoring=False)
+    with caplog.at_level(logging.WARNING):
+        app._maybe_warn_capture_permissions()
+        app._last_tcc_warn_at = (
+            datetime.now(timezone.utc) - main.BetterFlowApp._PERM_REWARN_INTERVAL - timedelta(minutes=1)
+        )
+        app._maybe_warn_capture_permissions()
+    assert len([r for r in caplog.records if r.levelno == logging.WARNING]) == 2
+
+
+def test_the_throttle_re_arms_when_the_grants_come_back(monkeypatch, caplog):
+    """A stale timestamp must not swallow the NEXT revocation."""
+    app = _bare_app()
+    _perms(monkeypatch, accessibility=False, input_monitoring=False)
+    app._maybe_warn_capture_permissions()
+    assert app._last_tcc_warn_at is not None
+
+    _perms(monkeypatch, accessibility=True, input_monitoring=True)
+    app._maybe_warn_capture_permissions()
+    assert app._last_tcc_warn_at is None, "must re-arm so a later revocation warns"
+
+
+def test_nothing_is_logged_while_both_grants_are_held(monkeypatch, caplog):
+    """The allowance half. A guard tested only on its denial gets inverted later."""
+    app = _bare_app()
+    _perms(monkeypatch, accessibility=True, input_monitoring=True)
+    with caplog.at_level(logging.WARNING):
+        app._maybe_warn_capture_permissions()
+    assert [r for r in caplog.records if r.levelno == logging.WARNING] == []

--- a/tests/test_permissions.py
+++ b/tests/test_permissions.py
@@ -166,3 +166,40 @@ def test_an_existing_marker_still_suppresses_the_admin_password_prompt(monkeypat
 
     permissions.grant_tcc_permissions()
     assert called == [], "marker present must not spawn osascript"
+
+
+def test_a_successful_sqlite_write_is_not_a_granted_permission(monkeypatch, tmp_path):
+    """The OTHER return-True site — the class had two addresses.
+
+    returncode 0 means the sqlite write into TCC.db succeeded. It does not mean
+    this process now holds the grant: macOS generally does not re-read TCC for a
+    running client. Reporting the write's exit status as the permission state is
+    the same claim the marker branch was fixed for, one branch down in the same
+    function, and it had no test until a surviving mutant said so.
+    """
+    _marker_path(monkeypatch, tmp_path, exists=False)
+    monkeypatch.setattr(permissions, "check_accessibility", lambda: False)
+    monkeypatch.setattr(permissions, "check_input_monitoring", lambda: False)
+    monkeypatch.setattr(
+        permissions.subprocess, "run",
+        lambda *a, **k: MagicMock(returncode=0, stderr=""),
+    )
+
+    assert permissions.grant_tcc_permissions() is False
+
+
+def test_a_write_that_really_did_land_reports_success(monkeypatch, tmp_path):
+    """Allowance half: when the grant IS live afterwards, say so."""
+    marker = _marker_path(monkeypatch, tmp_path, exists=False)
+    state = {"granted": False}
+    monkeypatch.setattr(permissions, "check_accessibility", lambda: state["granted"])
+    monkeypatch.setattr(permissions, "check_input_monitoring", lambda: state["granted"])
+
+    def _write(*a, **k):
+        state["granted"] = True          # the grant takes effect
+        return MagicMock(returncode=0, stderr="")
+
+    monkeypatch.setattr(permissions.subprocess, "run", _write)
+
+    assert permissions.grant_tcc_permissions() is True
+    assert marker.exists(), "the attempt must still be recorded"

--- a/tests/test_permissions.py
+++ b/tests/test_permissions.py
@@ -105,3 +105,64 @@ def test_ax_api_works_false_when_binding_unavailable(monkeypatch):
     broken = types.ModuleType("ApplicationServices")  # missing AX symbols
     monkeypatch.setitem(sys.modules, "ApplicationServices", broken)
     assert permissions._ax_api_works() is False
+
+
+# --- The one-shot TCC grant must not report a permission it does not have (#205) ---
+#
+# grant_tcc_permissions() writes ~/Library/Application Support/BetterFlow/
+# .tcc_grant_done in a `finally`, so a CANCELLED prompt and a FAILED sqlite
+# write both mark the grant "attempted". Every later launch then takes the
+# early return, which answered True — the docstring's "succeeded or was already
+# attempted". Callers read True as "we have permission"; four devices sat
+# window_titles_blind for 15-21 days while this returned True on every launch.
+#
+# The marker's purpose is real (do not re-prompt for an admin password on every
+# launch) so these tests pin BOTH halves: it must still not re-prompt, and it
+# must stop claiming success.
+
+def _marker_path(monkeypatch, tmp_path, *, exists):
+    marker = tmp_path / ".tcc_grant_done"
+    if exists:
+        marker.touch()
+    monkeypatch.setattr(permissions, "_IS_MACOS", True)
+    monkeypatch.setattr(permissions, "_tcc_grant_marker", lambda: marker)
+    return marker
+
+
+def test_grant_does_not_claim_success_when_permission_is_still_missing(monkeypatch, tmp_path):
+    """The defect: marker present, permission absent, answer was True."""
+    _marker_path(monkeypatch, tmp_path, exists=True)
+    monkeypatch.setattr(permissions, "check_accessibility", lambda: False)
+    monkeypatch.setattr(permissions, "check_input_monitoring", lambda: False)
+
+    assert permissions.grant_tcc_permissions() is False
+
+
+def test_grant_reports_success_when_permission_is_actually_present(monkeypatch, tmp_path):
+    """The allowance half. A guard tested only on its denial gets inverted later."""
+    _marker_path(monkeypatch, tmp_path, exists=True)
+    monkeypatch.setattr(permissions, "check_accessibility", lambda: True)
+    monkeypatch.setattr(permissions, "check_input_monitoring", lambda: True)
+
+    assert permissions.grant_tcc_permissions() is True
+
+
+def test_an_existing_marker_still_suppresses_the_admin_password_prompt(monkeypatch, tmp_path):
+    """Control: honesty must not turn into nagging.
+
+    The marker exists precisely so the user is asked for an admin password once,
+    not on every launch. If this test ever goes red the fix has traded a silent
+    failure for a prompt loop, which is worse.
+    """
+    _marker_path(monkeypatch, tmp_path, exists=True)
+    monkeypatch.setattr(permissions, "check_accessibility", lambda: False)
+    monkeypatch.setattr(permissions, "check_input_monitoring", lambda: False)
+
+    called = []
+    monkeypatch.setattr(
+        permissions.subprocess, "run",
+        lambda *a, **k: called.append(a) or MagicMock(returncode=0, stderr=""),
+    )
+
+    permissions.grant_tcc_permissions()
+    assert called == [], "marker present must not spawn osascript"


### PR DESCRIPTION
Four macOS devices have been recording empty window titles for 15 to 21 days. Two of them spent five of those days on v1.5.124, which is the release that added the prompt built to end exactly this. So the prompt shipped and nothing changed, which is what made it worth pulling on.

Three things had to line up. All three are here.

**The agent was reporting a permission it did not have.** `grant_tcc_permissions()` short-circuits on a marker file, and that marker is written in a `finally`. A cancelled password prompt sets it. A failed sqlite write sets it. Every launch after the first then took the early return and answered `True`, which the docstring called "succeeded or was already attempted" and every reader understood as "we have permission". It now answers what is true now. The marker still suppresses the re-prompt, so this does not trade a silent failure for a prompt loop, and there is a control test pinning that.

**`_start_watchers()` threw the answer away.** It now logs a warning naming the consequence, so a log request lands on something. Small, but it is the reason the state left no trace for three weeks.

**The notification told people to do something they had already done.** It said "Grant Accessibility to BetterFlow". `permissions.py`'s own header explains why that is a dead end: an update changes the code signature, and macOS then shows the toggle ON while the grant is dead. Someone sent to that pane sees BetterFlow already switched on and closes the window. The agent auto-updates, so that is the path most of the fleet takes into this state. The notice now says it may look enabled and to switch it off and back on.

## Evidence

Both new guards run against the tree before the change:

```
test_grant_does_not_claim_success_when_permission_is_still_missing
  -> assert True is False

test_the_prompt_warns_the_toggle_may_already_look_enabled
  -> AssertionError: must warn the toggle may already read as enabled
     assert 'already' in 'grant accessibility to betterflow in system settings...'
```

The allowance case and the no-re-prompt control passed before the change and still pass, so the new tests isolate the defect rather than describing what the code happened to do.

Mutation matrix, each mechanism against a distinct named test:

```
control (unmutated)          exit=0  20 passed
return granted -> return True  exit=1  1 failed  FAILED ...test_grant_does_not_claim_success_when_permission_is_still_missing
notice text -> "Please grant it there."  exit=1  1 failed  FAILED ...test_the_prompt_warns_the_toggle_may_already_look_enabled
final control                exit=0  20 passed
```

Full suite: 1745 passed, 1 skipped, exit 0.

CI does not run on merge here, so I ran the PR gate's step myself (`pytest tests/`). It runs on ubuntu and this is a macOS code path, so I also ran the two touched files with `platform.system()` forced to Linux, with a control asserting `_IS_MACOS` is False first. A green run on this Mac would not have proved anything. 20 passed.

## What I did not do

The one-shot sqlite path is untouched. Re-arming it on a version change is the obvious next move, and it depends on a question I could not settle: whether a write into `/Library/Application Support/com.apple.TCC/TCC.db` can succeed at all on current macOS. Reading it from my own shell worked, but that terminal probably holds Full Disk Access, so the probe says nothing about the app's case, and I was not going to sudo-write to my own TCC database to find out. If the write cannot work, re-arming buys one useless admin password prompt per update on machines that are already broken. Detail and both branches are in #205.

The `main.py` warning is not covered by a test. `_start_watchers` is awkward to drive, and the honest options were a source-regex guard that asserts text rather than behaviour or nothing at all. I took nothing, and I am flagging it rather than letting a green suite imply coverage.

Refs #205, #204, #194.
