### PR TITLE
Show capture-permission state on a surface that cannot be missed

### DIFF
--- a/src/main.py
+++ b/src/main.py
@@ -799,6 +799,7 @@ class SyncCoordinator:
             with self.tray.model.lock:
                 previous_needs_permissions = self.tray.model.needs_permissions
                 previous_input_ok = self.tray.model.input_monitoring_ok
+                previous_accessibility_ok = self.tray.model.accessibility_ok
                 self.tray.model.needs_permissions = not granted
                 self.tray.model.input_monitoring_ok = has_input
                 self.tray.model.accessibility_ok = has_accessibility
@@ -816,9 +817,16 @@ class SyncCoordinator:
                         should_update_icon = True
                     else:
                         should_update_icon = False
+                # accessibility_ok belongs here even though it never changes the
+                # ICON: it is the one grant whose loss produces no warning state,
+                # so if it does not trigger a menu rebuild the Diagnostics row
+                # refreshes only when some UNRELATED field happens to move. That
+                # is the stale-after-the-remedy dead end the row exists to close
+                # — the user fixes the grant and the row keeps saying blocked.
                 should_update_menu = (
                     previous_needs_permissions != self.tray.model.needs_permissions
                     or previous_input_ok != self.tray.model.input_monitoring_ok
+                    or previous_accessibility_ok != self.tray.model.accessibility_ok
                 )
             if should_update_icon:
                 self.tray._update_icon()

--- a/src/main.py
+++ b/src/main.py
@@ -773,10 +773,21 @@ class SyncCoordinator:
         server reads as a jiggler and flags the day as suspicious. App names and
         durations come from NSWorkspace and don't need Accessibility.
 
-        No-op on non-macOS, where the check returns True.
+        Also RECORDS the Accessibility grant, for the Diagnostics row only.
+        Deliberately not part of `granted`: Accessibility gates window TITLES,
+        and losing them costs attribution detail, not tracked time. Raising
+        NEEDS_PERMISSIONS for it would put a red tray icon on a machine that is
+        recording every billable second correctly.
+
+        No-op on non-macOS, where both checks return True.
         """
         try:
             has_input = input_monitoring_active()
+            # input_monitoring_active() (IOKit) is the authoritative probe and is
+            # what the "Input tracking off" banner already renders, so the
+            # Diagnostics row must read the same value or the two can disagree
+            # inside one popup.
+            has_accessibility = check_accessibility()
             granted = has_input
             status = None if has_input else "Input tracking OFF — Fix Permissions"
 
@@ -790,6 +801,7 @@ class SyncCoordinator:
                 previous_input_ok = self.tray.model.input_monitoring_ok
                 self.tray.model.needs_permissions = not granted
                 self.tray.model.input_monitoring_ok = has_input
+                self.tray.model.accessibility_ok = has_accessibility
                 current_state = self.tray.model.state
                 if not granted:
                     if current_state not in high_priority:

--- a/src/ui/tray.py
+++ b/src/ui/tray.py
@@ -61,16 +61,11 @@ except ImportError:
 
 try:
     from ..clipboard import clipboard_available, copy_to_clipboard
-    from .permissions import check_accessibility, check_input_monitoring
     from ..hardware_serial import get_hardware_serial
     from ..machine_arch import ARM64, is_rosetta_translated, true_machine_arch
     from ..notifications import send_notification
 except ImportError:
     from clipboard import clipboard_available, copy_to_clipboard  # type: ignore[no-redef]
-    from ui.permissions import (  # type: ignore[no-redef]
-        check_accessibility,
-        check_input_monitoring,
-    )
     from hardware_serial import get_hardware_serial  # type: ignore[no-redef]
     from machine_arch import (  # type: ignore[no-redef]
         ARM64,
@@ -203,6 +198,12 @@ class TrayModel:
         # macOS Input Monitoring (keystroke/click capture). True until a check
         # proves otherwise so non-macOS platforms never show the warning.
         self.input_monitoring_ok: bool = True
+        # macOS Accessibility (window TITLES). Recorded for the Diagnostics row
+        # only — a missing Accessibility grant must NOT raise NEEDS_PERMISSIONS,
+        # because titles are an attribution detail and tracked time is
+        # unaffected. True until a check proves otherwise, so non-macOS never
+        # shows a warning.
+        self.accessibility_ok: bool = True
 
 
 # On Linux, pystray binds its backend at import time. Choose it explicitly:
@@ -334,63 +335,63 @@ def arch_menu_label(
 
 def capture_permissions_row(
     system: Optional[str] = None,
-    accessibility: Optional[bool] = None,
-    input_monitoring: Optional[bool] = None,
-) -> Optional[str]:
-    """Whether this machine can actually record titles and input, as a readable row.
+    accessibility: bool = True,
+    input_monitoring: bool = True,
+) -> str:
+    """Format the capture-permission state. Pure — it probes nothing.
 
-    Exists because the notification that asks for these grants cannot be shown
-    to have arrived (#204): ``deliverNotification_`` is fire-and-forget and
-    macOS silently discards notifications from an app that was never authorised
-    to post them. A tray row has no such failure mode -- it is there whenever
-    the user looks, and it survives the notification being missed, dismissed or
-    never rendered.
+    Deliberately takes the two booleans rather than reading them. Both siblings
+    say why in their own docstrings: ``_arch_menu_item`` — "the row must never
+    fork sysctl under _menu_lock on the sync cycle" — and the serial row is
+    memoised for the life of the process. ``_create_menu`` runs inside
+    ``_menu_lock``, and ``check_accessibility`` falls through to a real
+    ``AXUIElementCopyAttributeValue`` against the frontmost app whenever
+    ``AXIsProcessTrusted`` returns False, which is exactly the state this row
+    exists to report. Probing here would send IPC to a possibly-wedged app while
+    holding the menu lock, once per rebuild.
 
-    The wording carries the one fact that is not guessable: after a
-    code-signature change macOS shows the toggle ON while the grant is dead (see
-    the header of ``src/ui/permissions.py``), so "enable it" is a no-op
-    instruction. The remedy is to toggle it OFF and back ON. Four devices sat
-    blind for 15-21 days being told to enable something that already looked
-    enabled.
+    Reading the model instead also fixes two things a live probe cannot. The row
+    refreshes when ``_check_permissions`` changes the value (it already forces a
+    menu update), so after the user performs the remedy the row actually
+    changes — for a surface whose whole job is "did my fix work?", saying "still
+    blocked" afterwards is the dead end this exists to close. And it uses the
+    same values as the ``Input tracking off`` banner two rows up, so Diagnostics
+    and the banner cannot contradict each other in one popup.
 
-    Returns None off macOS: Accessibility and Input Monitoring are a macOS
-    concept, and a row about them on Windows is noise rather than diagnosis.
+    Every state carries the ``Capture permissions:`` prefix, like its siblings,
+    so a caller can find the row by one stable key rather than grepping four
+    different sentences.
 
     Args:
         system: Override ``platform.system()`` for testing.
-        accessibility: Override the Accessibility probe for testing.
-        input_monitoring: Override the Input Monitoring probe for testing.
+        accessibility: Whether the Accessibility grant is held.
+        input_monitoring: Whether the Input Monitoring grant is held.
     """
     system = system or platform.system()
     if system != "Darwin":
-        return None
-
-    if accessibility is None:
-        accessibility = check_accessibility()
-    if input_monitoring is None:
-        input_monitoring = check_input_monitoring()
+        # These two grants are a macOS concept. Say so rather than vanishing:
+        # an absent row is indistinguishable from an agent too old to have one.
+        return f"Capture permissions: not applicable on {system}"
 
     if accessibility and input_monitoring:
         return "Capture permissions: OK"
 
-    # Name the grant that failed and the consequence the user can observe. The
-    # two are not interchangeable: Accessibility gates window TITLES, Input
-    # Monitoring gates keystroke and click COUNTS, and they live in different
-    # System Settings panes.
+    # Name the grant that failed and its observable consequence. They are not
+    # interchangeable — Accessibility gates window TITLES, Input Monitoring
+    # gates keystroke and click COUNTS — and naming the wrong one is the
+    # mistake that cost four devices 15-21 blind days.
+    #
+    # Every failure state carries the off-then-on remedy, because after a
+    # code-signature change macOS shows the toggle ON while the grant is dead,
+    # so "enable it" is an instruction the user reads as already done.
     if not accessibility and not input_monitoring:
-        return (
-            "Accessibility + Input Monitoring blocked - re-grant both in "
-            "Privacy & Security (toggle each off, then on)"
-        )
+        return ("Capture permissions: Accessibility + Input Monitoring blocked "
+                "— toggle each off, then on")
     if not accessibility:
-        return (
-            "Accessibility blocked - window titles are empty. Re-grant it in "
-            "Privacy & Security (toggle it off, then on)"
-        )
-    return (
-        "Input Monitoring blocked - keystroke counts are zero. Re-grant it in "
-        "Privacy & Security (toggle it off, then on)"
-    )
+        return ("Capture permissions: Accessibility blocked, no window titles "
+                "— toggle it off, then on")
+    return ("Capture permissions: Input Monitoring blocked, no keystroke counts "
+            "— toggle it off, then on")
 
 
 def serial_menu_row() -> tuple:
@@ -788,6 +789,7 @@ class TrayIcon:
                 "track_display_info": self.model.track_display_info,
                 "needs_permissions": self.model.needs_permissions,
                 "input_monitoring_ok": self.model.input_monitoring_ok,
+                "accessibility_ok": self.model.accessibility_ok,
             }
 
     def _create_menu(self) -> pystray.Menu:
@@ -929,12 +931,9 @@ class TrayIcon:
             Item("─" * 20, None, enabled=False),
             self._serial_menu_item(),
             self._arch_menu_item(),
-            self._capture_permissions_menu_item(),
+            self._capture_permissions_menu_item(s),
             Item("Privacy Policy", self._handle_open_privacy),
         ]
-        # capture_permissions_row() returns None off macOS, so that row simply
-        # is not there rather than saying something meaningless about Windows.
-        diag_items = [i for i in diag_items if i is not None]
         items.append(Item("Diagnostics", pystray.Menu(*diag_items), enabled=logged_in))
         items.append(Item("Sync Now", self._handle_sync_now, enabled=logged_in))
 
@@ -992,18 +991,22 @@ class TrayIcon:
 
         return pystray.Menu(*items)
 
-    def _capture_permissions_menu_item(self) -> Optional["Item"]:
-        """The capture-permission row, or None off macOS.
+    def _capture_permissions_menu_item(self, s: dict) -> "Item":
+        """The capture-permission row, rendered from the snapshot.
 
-        Inert like the other Diagnostics rows: it reports, it does not act. The
-        label lives in the module-level capture_permissions_row() so it can be
-        asserted without a live pystray backend; do not re-derive it here, or
-        the test and the menu drift apart.
+        Inert like its siblings: it reports, it does not act. The label lives in
+        the module-level capture_permissions_row() so it is assertable without a
+        live pystray backend; do not re-derive it here, or the test and the menu
+        drift apart.
         """
-        label = capture_permissions_row()
-        if label is None:
-            return None
-        return Item(label, None, enabled=False)
+        return Item(
+            capture_permissions_row(
+                accessibility=s["accessibility_ok"],
+                input_monitoring=s["input_monitoring_ok"],
+            ),
+            None,
+            enabled=False,
+        )
 
     def _arch_menu_item(self) -> "Item":
         """The architecture row: which build of BetterFlow is actually running.

--- a/src/ui/tray.py
+++ b/src/ui/tray.py
@@ -61,11 +61,16 @@ except ImportError:
 
 try:
     from ..clipboard import clipboard_available, copy_to_clipboard
+    from .permissions import check_accessibility, check_input_monitoring
     from ..hardware_serial import get_hardware_serial
     from ..machine_arch import ARM64, is_rosetta_translated, true_machine_arch
     from ..notifications import send_notification
 except ImportError:
     from clipboard import clipboard_available, copy_to_clipboard  # type: ignore[no-redef]
+    from ui.permissions import (  # type: ignore[no-redef]
+        check_accessibility,
+        check_input_monitoring,
+    )
     from hardware_serial import get_hardware_serial  # type: ignore[no-redef]
     from machine_arch import (  # type: ignore[no-redef]
         ARM64,
@@ -325,6 +330,67 @@ def arch_menu_label(
         # the row is also being told why no update has appeared.
         return f"Architecture: could not determine (process: {machine or 'unknown'})"
     return f"Architecture: Intel ({arch})"
+
+
+def capture_permissions_row(
+    system: Optional[str] = None,
+    accessibility: Optional[bool] = None,
+    input_monitoring: Optional[bool] = None,
+) -> Optional[str]:
+    """Whether this machine can actually record titles and input, as a readable row.
+
+    Exists because the notification that asks for these grants cannot be shown
+    to have arrived (#204): ``deliverNotification_`` is fire-and-forget and
+    macOS silently discards notifications from an app that was never authorised
+    to post them. A tray row has no such failure mode -- it is there whenever
+    the user looks, and it survives the notification being missed, dismissed or
+    never rendered.
+
+    The wording carries the one fact that is not guessable: after a
+    code-signature change macOS shows the toggle ON while the grant is dead (see
+    the header of ``src/ui/permissions.py``), so "enable it" is a no-op
+    instruction. The remedy is to toggle it OFF and back ON. Four devices sat
+    blind for 15-21 days being told to enable something that already looked
+    enabled.
+
+    Returns None off macOS: Accessibility and Input Monitoring are a macOS
+    concept, and a row about them on Windows is noise rather than diagnosis.
+
+    Args:
+        system: Override ``platform.system()`` for testing.
+        accessibility: Override the Accessibility probe for testing.
+        input_monitoring: Override the Input Monitoring probe for testing.
+    """
+    system = system or platform.system()
+    if system != "Darwin":
+        return None
+
+    if accessibility is None:
+        accessibility = check_accessibility()
+    if input_monitoring is None:
+        input_monitoring = check_input_monitoring()
+
+    if accessibility and input_monitoring:
+        return "Capture permissions: OK"
+
+    # Name the grant that failed and the consequence the user can observe. The
+    # two are not interchangeable: Accessibility gates window TITLES, Input
+    # Monitoring gates keystroke and click COUNTS, and they live in different
+    # System Settings panes.
+    if not accessibility and not input_monitoring:
+        return (
+            "Accessibility + Input Monitoring blocked - re-grant both in "
+            "Privacy & Security (toggle each off, then on)"
+        )
+    if not accessibility:
+        return (
+            "Accessibility blocked - window titles are empty. Re-grant it in "
+            "Privacy & Security (toggle it off, then on)"
+        )
+    return (
+        "Input Monitoring blocked - keystroke counts are zero. Re-grant it in "
+        "Privacy & Security (toggle it off, then on)"
+    )
 
 
 def serial_menu_row() -> tuple:
@@ -863,8 +929,12 @@ class TrayIcon:
             Item("─" * 20, None, enabled=False),
             self._serial_menu_item(),
             self._arch_menu_item(),
+            self._capture_permissions_menu_item(),
             Item("Privacy Policy", self._handle_open_privacy),
         ]
+        # capture_permissions_row() returns None off macOS, so that row simply
+        # is not there rather than saying something meaningless about Windows.
+        diag_items = [i for i in diag_items if i is not None]
         items.append(Item("Diagnostics", pystray.Menu(*diag_items), enabled=logged_in))
         items.append(Item("Sync Now", self._handle_sync_now, enabled=logged_in))
 
@@ -921,6 +991,19 @@ class TrayIcon:
         items.append(Item("Quit", self._handle_quit))
 
         return pystray.Menu(*items)
+
+    def _capture_permissions_menu_item(self) -> Optional["Item"]:
+        """The capture-permission row, or None off macOS.
+
+        Inert like the other Diagnostics rows: it reports, it does not act. The
+        label lives in the module-level capture_permissions_row() so it can be
+        asserted without a live pystray backend; do not re-derive it here, or
+        the test and the menu drift apart.
+        """
+        label = capture_permissions_row()
+        if label is None:
+            return None
+        return Item(label, None, enabled=False)
 
     def _arch_menu_item(self) -> "Item":
         """The architecture row: which build of BetterFlow is actually running.

--- a/tests/remedy_wording.py
+++ b/tests/remedy_wording.py
@@ -1,0 +1,28 @@
+"""One definition of "does this text actually give the off-then-on remedy?".
+
+Lived in tests/test_accessibility_prompt.py first. Copied by hand into the tray
+tests, in the naive `"off" in body and "on" in body` form -- which is vacuous:
+"on" is a substring of "Monitoring", so a row reading "Input Monitoring blocked"
+satisfies it with no remedy in it at all. Mutation-proven: stripping the remedy
+from two of three branches left the suite green.
+
+That is the same defect the accessibility-prompt file already carries controls
+for, reintroduced two hours later by copying the assertion instead of importing
+it. Hence one module, imported by both.
+"""
+
+import re
+
+
+def conveys_the_off_then_on_remedy(text: str) -> bool:
+    """True only when the text warns the toggle may lie AND gives BOTH steps.
+
+    Whole words over a small alternation, never substrings. Both steps are
+    required: "switch it off." satisfies a naive check and leaves the user worse
+    off than before, because on a partly-blind machine they turn off the grant
+    that still worked.
+    """
+    low = text.lower()
+    turn_off = re.search(r"\b(off|disable|untick|uncheck)\b", low) is not None
+    turn_on = re.search(r"\b(back on|then on|re-?enable|on again|turn it on)\b", low) is not None
+    return turn_off and turn_on

--- a/tests/test_accessibility_prompt.py
+++ b/tests/test_accessibility_prompt.py
@@ -15,11 +15,11 @@ runs on every runner. The one test that needs the AX symbol injects a fake
 module rather than requiring the real one.
 """
 
-import re
 import sys
 import types
 from unittest.mock import MagicMock, patch
 
+from tests.remedy_wording import conveys_the_off_then_on_remedy
 from src.sync.macos_window_watcher import MacOSWindowWatcher
 
 NOTIFY = "src.notifications.send_notification"
@@ -218,21 +218,13 @@ V1_5_124_BODY = (
 
 
 def _conveys_the_remedy(body: str) -> bool:
-    """Does this text tell the user the toggle may lie, and what to do about it?
+    """Delegates to the one definition (tests/remedy_wording.py).
 
-    Whole words over a small alternation, not substrings. A bare ``"off" in
-    body`` passes on "you may already be offline" — a body with no remedy at all
-    — and fails on "disable it and re-enable it", which is Apple's own phrasing
-    and arguably clearer than what we ship. Measured, both directions.
+    This used to be defined here and hand-copied into the tray tests in a naive
+    substring form that was vacuous. Two copies, one of them broken, is the
+    defect these very tests exist to catch, so there is now one.
     """
-    low = body.lower()
-    warns = re.search(r"\balready\b", low) is not None
-    turn_off = re.search(r"\b(off|disable|untick|uncheck)\b", low) is not None
-    # BOTH steps. "switch it off." satisfies the first two and leaves the user
-    # worse off than before: on a partly-blind machine they turn off the one
-    # grant that still worked. A half remedy is not a remedy.
-    turn_on = re.search(r"\b(back on|re-?enable|on again|turn it on)\b", low) is not None
-    return warns and turn_off and turn_on
+    return conveys_the_off_then_on_remedy(body)
 
 
 def test_the_remedy_check_rejects_the_body_that_left_four_devices_blind():

--- a/tests/test_capture_permission_warning.py
+++ b/tests/test_capture_permission_warning.py
@@ -23,6 +23,8 @@ from datetime import datetime, timedelta, timezone
 from types import SimpleNamespace
 from unittest.mock import Mock
 
+import pytest
+
 import src.main as main
 
 
@@ -230,3 +232,76 @@ def test_the_input_watcher_can_actually_resolve_the_shared_predicate():
     assert callable(getattr(w, "has_capture_permissions", None)), (
         "has_capture_permissions is used in _permission_retry_loop but not imported"
     )
+
+
+# ── The PRODUCER: nothing wrote accessibility_ok, and a mutant proved it ──
+#
+# The Diagnostics row is a pure formatter over model state, which is right --
+# it must not probe the OS under _menu_lock. But that makes _check_permissions
+# the sole writer, and deleting that write left the whole suite green: the row
+# would render "Capture permissions: OK" forever on a blind machine. The
+# surface built to be the honest one becomes the lying one, which is worse than
+# not having it (Phantom 7 -- every test asserted the consumer).
+
+def _coordinator_with_real_model():
+    """A SyncCoordinator with a REAL TrayModel, enough to run _check_permissions."""
+    from src.ui.tray import TrayModel
+
+    c = object.__new__(main.SyncCoordinator)
+    c.tray = Mock()
+    c.tray.model = TrayModel()
+    c._perm_lock = threading.Lock()
+    c._last_perm_warn_at = None
+    c._input_tracking_ok = True
+    c._maybe_warn_input_tracking = Mock()
+    return c
+
+
+@pytest.mark.parametrize("granted", [True, False])
+def test_check_permissions_records_the_accessibility_grant(monkeypatch, granted):
+    c = _coordinator_with_real_model()
+    monkeypatch.setattr(main, "input_monitoring_active", lambda: True)
+    monkeypatch.setattr(main, "check_accessibility", lambda: granted)
+
+    c._check_permissions()
+
+    assert c.tray.model.accessibility_ok is granted, (
+        "nothing else writes this; the Diagnostics row renders whatever it says"
+    )
+
+
+def test_losing_only_accessibility_still_rebuilds_the_menu(monkeypatch):
+    """The row's whole job is "did my fix work?", so the change must trigger a redraw.
+
+    accessibility_ok never moves the tray ICON -- a missing Accessibility grant
+    deliberately does not raise NEEDS_PERMISSIONS -- so if it is also left out of
+    should_update_menu, nothing rebuilds and the row refreshes only when some
+    UNRELATED field happens to move. That is the stale-after-the-remedy dead end.
+    """
+    c = _coordinator_with_real_model()
+    monkeypatch.setattr(main, "input_monitoring_active", lambda: True)
+    monkeypatch.setattr(main, "check_accessibility", lambda: True)
+    c._check_permissions()
+    c.tray._update_menu.reset_mock()
+
+    # Only Accessibility changes. Input Monitoring stays fine throughout.
+    monkeypatch.setattr(main, "check_accessibility", lambda: False)
+    c._check_permissions()
+
+    c.tray._update_menu.assert_called_once()
+
+
+def test_a_missing_accessibility_grant_does_not_raise_the_permissions_warning(monkeypatch):
+    """Scope guard: titles are attribution detail, tracked time is unaffected.
+
+    A red NEEDS_PERMISSIONS tray on a machine recording every billable second
+    correctly would be a worse bug than the one being fixed.
+    """
+    c = _coordinator_with_real_model()
+    monkeypatch.setattr(main, "input_monitoring_active", lambda: True)
+    monkeypatch.setattr(main, "check_accessibility", lambda: False)
+
+    c._check_permissions()
+
+    assert c.tray.model.needs_permissions is False
+    assert c.tray.model.state is not main.TrayState.NEEDS_PERMISSIONS

--- a/tests/test_tray_capture_permissions.py
+++ b/tests/test_tray_capture_permissions.py
@@ -1,0 +1,120 @@
+"""The capture-permission state as something the user can LOOK AT.
+
+#204: the agent asks for a missing Accessibility grant via `send_notification`,
+and `_send_macos_pyobjc` returns True whenever `deliverNotification_` did not
+raise -- which it never does, authorised or not. macOS silently discards
+notifications from an app that has never been granted permission to post them,
+so the one moment the message matters is the moment the channel is least likely
+to work. Five devices sat with empty window titles for up to 21 days; four were
+already running the release that added that prompt.
+
+#204's own suggested direction leads with the durable half: "Do not just make
+the toast louder. Sending the CAUSE to a surface that persists beats a
+notification that may never render." This is that surface. A tray row cannot be
+dropped by the notification centre, can be read at any time, and answers the
+question the user actually has -- is my machine recording titles, and if not,
+what do I do.
+
+The wording carries the one non-obvious fact: on a signature-invalidated grant
+System Settings shows the toggle ON, so "enable it" is a no-op instruction and
+the remedy is to toggle it OFF and back ON.
+
+**These must run headless.** pystray binds its display backend at import time,
+so on the ubuntu PR runner `src.ui.tray.pystray` is None and TrayIcon() raises.
+Same workaround as test_tray_hardware_serial: the label rule is asserted on the
+pure `capture_permissions_row()`, and the callsite guard renders the REAL
+`_create_menu()` with Item swapped for a recorder. Without that second half the
+row could be perfect and unreferenced (Phantom 3).
+"""
+
+from unittest.mock import MagicMock, patch
+
+from src.ui import tray as tray_mod
+from src.ui.tray import TrayIcon, capture_permissions_row
+
+
+class _RecordedItem:
+    instances: list = []
+
+    def __init__(self, text, action=None, enabled=True, **kwargs):
+        self.text = text
+        self.action = action
+        self.enabled = enabled
+        _RecordedItem.instances.append(self)
+
+    def __call__(self, icon=None):
+        if self.action is not None:
+            self.action(icon, self)
+
+
+def _render_real_menu(icon) -> list:
+    _RecordedItem.instances = []
+    with patch.object(tray_mod, "Item", _RecordedItem), \
+            patch.object(tray_mod, "pystray", MagicMock()):
+        icon._create_menu()
+    return list(_RecordedItem.instances)
+
+
+def _make_tray() -> TrayIcon:
+    with patch.object(tray_mod, "pystray", MagicMock()):
+        return TrayIcon()
+
+
+# ── The rule: capture_permissions_row() ────────────────────────────────
+
+def test_row_is_quiet_when_both_grants_are_held():
+    row = capture_permissions_row(system="Darwin", accessibility=True, input_monitoring=True)
+    assert row == "Capture permissions: OK"
+
+
+def test_row_names_accessibility_and_gives_the_off_then_on_remedy():
+    """"Enable it" is the instruction that failed. This row must not repeat it."""
+    row = capture_permissions_row(system="Darwin", accessibility=False, input_monitoring=True)
+    assert "Accessibility" in row
+    assert "window titles" in row.lower()
+    assert "off" in row.lower() and "on" in row.lower()
+    assert "Input Monitoring" not in row
+
+
+def test_row_names_input_monitoring_without_blaming_titles():
+    """Different grant, different consequence, different System Settings pane."""
+    row = capture_permissions_row(system="Darwin", accessibility=True, input_monitoring=False)
+    assert "Input Monitoring" in row
+    assert "window titles" not in row.lower()
+    assert "Accessibility" not in row
+
+
+def test_row_names_BOTH_when_both_are_missing():
+    """The state a fresh install or a post-update signature change produces."""
+    row = capture_permissions_row(system="Darwin", accessibility=False, input_monitoring=False)
+    assert "Accessibility" in row
+    assert "Input Monitoring" in row
+
+
+def test_row_is_omitted_off_macos():
+    """These two grants are a macOS concept. A row about them elsewhere is noise."""
+    assert capture_permissions_row(system="Windows", accessibility=True, input_monitoring=True) is None
+    assert capture_permissions_row(system="Linux", accessibility=True, input_monitoring=True) is None
+
+
+# ── The callsite guard: the row must reach the real menu ───────────────
+
+def test_the_row_is_actually_in_the_diagnostics_menu(monkeypatch):
+    """Phantom 3: a perfect row nothing renders is worth nothing."""
+    monkeypatch.setattr(tray_mod.platform, "system", lambda: "Darwin")
+    monkeypatch.setattr(tray_mod, "check_accessibility", lambda: False)
+    monkeypatch.setattr(tray_mod, "check_input_monitoring", lambda: True)
+    icon = _make_tray()
+    texts = [str(i.text) for i in _render_real_menu(icon)]
+    assert any("Accessibility" in t for t in texts), (
+        f"capture-permission row missing from the rendered menu: {texts}"
+    )
+
+
+def test_no_capture_row_is_rendered_off_macos(monkeypatch):
+    monkeypatch.setattr(tray_mod, "check_accessibility", lambda: False)
+    monkeypatch.setattr(tray_mod, "check_input_monitoring", lambda: False)
+    monkeypatch.setattr(tray_mod.platform, "system", lambda: "Linux")
+    icon = _make_tray()
+    texts = [str(i.text) for i in _render_real_menu(icon)]
+    assert not any("Capture permissions" in t or "re-grant" in t for t in texts)

--- a/tests/test_tray_capture_permissions.py
+++ b/tests/test_tray_capture_permissions.py
@@ -1,36 +1,33 @@
-"""The capture-permission state as something the user can LOOK AT.
+"""Capture-permission state as a surface that cannot be missed.
 
-#204: the agent asks for a missing Accessibility grant via `send_notification`,
+#204: the agent asks for a missing Accessibility grant through a notification,
 and `_send_macos_pyobjc` returns True whenever `deliverNotification_` did not
-raise -- which it never does, authorised or not. macOS silently discards
-notifications from an app that has never been granted permission to post them,
-so the one moment the message matters is the moment the channel is least likely
-to work. Five devices sat with empty window titles for up to 21 days; four were
-already running the release that added that prompt.
+raise -- which it never does. macOS silently discards notifications from an app
+never authorised to post them, so the one moment the message matters is the
+moment the channel is least likely to work. Five devices sat with empty window
+titles for up to 21 days; four were already running the release that added the
+prompt. A Diagnostics row has no such failure mode.
 
-#204's own suggested direction leads with the durable half: "Do not just make
-the toast louder. Sending the CAUSE to a surface that persists beats a
-notification that may never render." This is that surface. A tray row cannot be
-dropped by the notification centre, can be read at any time, and answers the
-question the user actually has -- is my machine recording titles, and if not,
-what do I do.
+The row is a PURE FORMATTER over values the model already carries. It must not
+probe: `_create_menu` runs inside `_menu_lock`, and `check_accessibility` falls
+through to a live AX call against the frontmost app in exactly the state this
+row reports. Both sibling rows say so in their own docstrings.
 
-The wording carries the one non-obvious fact: on a signature-invalidated grant
-System Settings shows the toggle ON, so "enable it" is a no-op instruction and
-the remedy is to toggle it OFF and back ON.
-
-**These must run headless.** pystray binds its display backend at import time,
-so on the ubuntu PR runner `src.ui.tray.pystray` is None and TrayIcon() raises.
-Same workaround as test_tray_hardware_serial: the label rule is asserted on the
-pure `capture_permissions_row()`, and the callsite guard renders the REAL
-`_create_menu()` with Item swapped for a recorder. Without that second half the
-row could be perfect and unreferenced (Phantom 3).
+**Headless.** pystray binds its backend at import, so on the ubuntu PR runner
+`tray.pystray` is None and TrayIcon() raises. Label rules are asserted on the
+pure function; the callsite guard renders the REAL `_create_menu()` with Item
+swapped for a recorder, so dropping the row from production fails a test.
 """
 
 from unittest.mock import MagicMock, patch
 
+import pytest
+
+from tests.remedy_wording import conveys_the_off_then_on_remedy
 from src.ui import tray as tray_mod
 from src.ui.tray import TrayIcon, capture_permissions_row
+
+T, F = True, False
 
 
 class _RecordedItem:
@@ -60,61 +57,122 @@ def _make_tray() -> TrayIcon:
         return TrayIcon()
 
 
-# ── The rule: capture_permissions_row() ────────────────────────────────
-
-def test_row_is_quiet_when_both_grants_are_held():
-    row = capture_permissions_row(system="Darwin", accessibility=True, input_monitoring=True)
-    assert row == "Capture permissions: OK"
+def _capture_rows(icon) -> list:
+    return [str(i.text) for i in _render_real_menu(icon)
+            if str(i.text).startswith("Capture permissions:")]
 
 
-def test_row_names_accessibility_and_gives_the_off_then_on_remedy():
-    """"Enable it" is the instruction that failed. This row must not repeat it."""
-    row = capture_permissions_row(system="Darwin", accessibility=False, input_monitoring=True)
-    assert "Accessibility" in row
-    assert "window titles" in row.lower()
-    assert "off" in row.lower() and "on" in row.lower()
+# ── The label ──────────────────────────────────────────────────────────
+
+def test_healthy_state_says_OK():
+    assert capture_permissions_row("Darwin", accessibility=T, input_monitoring=T) \
+        == "Capture permissions: OK"
+
+
+@pytest.mark.parametrize("a,i", [(F, T), (T, F), (F, F)])
+def test_EVERY_failure_state_carries_the_off_then_on_remedy(a, i):
+    """The non-guessable fact, and it was witnessed on only one branch before.
+
+    Stripping the remedy from the Input Monitoring branch used to leave the
+    suite green, because the naive `"on" in row` is satisfied by the "on" inside
+    "Monitoring". Both-blocked is the commonest real state — one signature
+    change kills both TCC entries together — so the branch most devices hit was
+    the one with no guard at all.
+    """
+    row = capture_permissions_row("Darwin", accessibility=a, input_monitoring=i)
+    assert conveys_the_off_then_on_remedy(row), f"no remedy in: {row}"
+
+
+def test_it_names_accessibility_and_its_consequence_only():
+    row = capture_permissions_row("Darwin", accessibility=F, input_monitoring=T)
+    assert "Accessibility" in row and "window titles" in row.lower()
     assert "Input Monitoring" not in row
 
 
-def test_row_names_input_monitoring_without_blaming_titles():
-    """Different grant, different consequence, different System Settings pane."""
-    row = capture_permissions_row(system="Darwin", accessibility=True, input_monitoring=False)
-    assert "Input Monitoring" in row
+def test_it_names_input_monitoring_without_blaming_titles():
+    row = capture_permissions_row("Darwin", accessibility=T, input_monitoring=F)
+    assert "Input Monitoring" in row and "keystroke" in row.lower()
     assert "window titles" not in row.lower()
     assert "Accessibility" not in row
 
 
-def test_row_names_BOTH_when_both_are_missing():
-    """The state a fresh install or a post-update signature change produces."""
-    row = capture_permissions_row(system="Darwin", accessibility=False, input_monitoring=False)
-    assert "Accessibility" in row
-    assert "Input Monitoring" in row
+def test_it_names_BOTH_when_both_are_missing():
+    row = capture_permissions_row("Darwin", accessibility=F, input_monitoring=F)
+    assert "Accessibility" in row and "Input Monitoring" in row
 
 
-def test_row_is_omitted_off_macos():
-    """These two grants are a macOS concept. A row about them elsewhere is noise."""
-    assert capture_permissions_row(system="Windows", accessibility=True, input_monitoring=True) is None
-    assert capture_permissions_row(system="Linux", accessibility=True, input_monitoring=True) is None
+@pytest.mark.parametrize("a,i", [(T, T), (T, F), (F, T), (F, F)])
+def test_it_says_OK_exactly_when_capture_is_actually_possible(a, i):
+    """The rot guard: OK must track the real conjunction, not drift from it.
+
+    Reddens if someone adds a third grant to the capture definition and teaches
+    only one side about it -- which is the failure that cost the blind days.
+    """
+    row = capture_permissions_row("Darwin", accessibility=a, input_monitoring=i)
+    assert (row == "Capture permissions: OK") == (a and i)
 
 
-# ── The callsite guard: the row must reach the real menu ───────────────
+@pytest.mark.parametrize("system", ["Windows", "Linux"])
+def test_off_macos_it_says_not_applicable_rather_than_vanishing(system):
+    """Adversarial fixture: BOTH grants false, so the platform gate has to win.
 
-def test_the_row_is_actually_in_the_diagnostics_menu(monkeypatch):
-    """Phantom 3: a perfect row nothing renders is worth nothing."""
+    Passing True/True would prove nothing the gate short-circuits anyway. And
+    the row is present rather than absent because an absent row is
+    indistinguishable from an agent too old to have one.
+    """
+    row = capture_permissions_row(system, accessibility=F, input_monitoring=F)
+    assert row == f"Capture permissions: not applicable on {system}"
+
+
+# ── The callsite: the row must reach the real menu, from the MODEL ─────
+
+def test_the_row_is_in_the_menu_and_reads_the_model(monkeypatch):
+    """Phantom 3, plus proof it renders model state rather than a live probe."""
     monkeypatch.setattr(tray_mod.platform, "system", lambda: "Darwin")
-    monkeypatch.setattr(tray_mod, "check_accessibility", lambda: False)
-    monkeypatch.setattr(tray_mod, "check_input_monitoring", lambda: True)
     icon = _make_tray()
-    texts = [str(i.text) for i in _render_real_menu(icon)]
-    assert any("Accessibility" in t for t in texts), (
-        f"capture-permission row missing from the rendered menu: {texts}"
-    )
+    with icon.model.lock:
+        icon.model.accessibility_ok = False
+        icon.model.input_monitoring_ok = True
+
+    rows = _capture_rows(icon)
+    assert len(rows) == 1, f"expected exactly one capture row, got {rows}"
+    assert "Accessibility" in rows[0]
+    assert conveys_the_off_then_on_remedy(rows[0])
 
 
-def test_no_capture_row_is_rendered_off_macos(monkeypatch):
-    monkeypatch.setattr(tray_mod, "check_accessibility", lambda: False)
-    monkeypatch.setattr(tray_mod, "check_input_monitoring", lambda: False)
-    monkeypatch.setattr(tray_mod.platform, "system", lambda: "Linux")
+def test_the_rendered_row_follows_the_model_when_the_user_fixes_it(monkeypatch):
+    """The point of reading the model: the row must CHANGE after the remedy.
+
+    A live probe under _menu_lock could not do this without a rebuild trigger,
+    and the permission booleans were not in the snapshot before. A row still
+    saying "blocked" after the user fixed it is the dead end this closes.
+    """
+    monkeypatch.setattr(tray_mod.platform, "system", lambda: "Darwin")
     icon = _make_tray()
-    texts = [str(i.text) for i in _render_real_menu(icon)]
-    assert not any("Capture permissions" in t or "re-grant" in t for t in texts)
+    with icon.model.lock:
+        icon.model.accessibility_ok = False
+        icon.model.input_monitoring_ok = False
+    assert "blocked" in _capture_rows(icon)[0]
+
+    with icon.model.lock:
+        icon.model.accessibility_ok = True
+        icon.model.input_monitoring_ok = True
+    assert _capture_rows(icon) == ["Capture permissions: OK"]
+
+
+def test_the_menu_never_probes_the_os_for_this_row(monkeypatch):
+    """It must not fork an AX call under _menu_lock. Siblings say so explicitly.
+
+    Rendering with the probes replaced by exploding stubs: if _create_menu still
+    calls either, this test raises rather than silently costing IPC per rebuild.
+    """
+    import src.ui.permissions as perms
+
+    def _boom():  # pragma: no cover - only runs if the row regresses
+        raise AssertionError("capture row probed the OS during _create_menu()")
+
+    monkeypatch.setattr(tray_mod.platform, "system", lambda: "Darwin")
+    monkeypatch.setattr(perms, "check_accessibility", _boom)
+    monkeypatch.setattr(perms, "check_input_monitoring", _boom)
+    icon = _make_tray()
+    assert len(_capture_rows(icon)) == 1


### PR DESCRIPTION
The durable half of #204.

The agent asks for a missing Accessibility grant through a notification, and `_send_macos_pyobjc` returns `True` whenever `deliverNotification_` did not raise. It never raises. macOS silently discards notifications from an app that was never authorised to post them, so the one moment the message matters is the moment the channel is least likely to work. Five devices sat with empty window titles for up to 21 days, four of them already running the release that added that prompt.

#204's own suggested direction leads with this rather than with a louder toast: send the cause to a surface that persists. A Diagnostics row is there whenever the user looks, survives the notification being missed or never rendered, and can be read out over a call.

**The wording is the point.** It names which grant failed, because Accessibility gates window titles and Input Monitoring gates keystroke counts — different consequences, different System Settings panes, and naming the wrong one is what cost the 15-21 days. And it says to toggle the switch **off and back on**, because after a code-signature change macOS shows it ON while the grant is dead, so "enable it" is a no-op instruction.

Returns `None` off macOS, so the row is absent rather than saying something meaningless about Windows.

## Evidence

Mutation matrix, five mechanisms, each killed by a distinct named test:

```
control                              exit=0  7 passed
row shown off macOS                  exit=1  killed: test_row_is_omitted_off_macos
                                                     test_no_capture_row_is_rendered_off_macos
callsite removed from the menu       exit=1  killed: test_the_row_is_actually_in_the_diagnostics_menu
healthy state mislabelled            exit=1  killed: test_row_is_quiet_when_both_grants_are_held
branches swapped + remedy lost       exit=1  killed: test_row_names_accessibility_and_gives_...
both-missing names only one grant    exit=1  killed: test_row_names_BOTH_when_both_are_missing
final control                        exit=0  7 passed
```

Suite 1770 passed, 1 skipped, exit 0 (was 1763). Tray tests also pass with `platform.system()` forced non-darwin, control asserting `_IS_MACOS is False` first, because the gate runs on ubuntu and a mac-only green proves nothing.

## What I did not do

**`_send_macos_pyobjc` is untouched.** Making it honest about delivery needs a real macOS smoke with notifications DENIED and then GRANTED — no unit test can express it, and `browser-platform-verification.md` makes that a human-QA gate rather than something to bundle in on green units. Separate change, so this one does not wait on a machine.

**No live tray smoke.** The label is unit-tested and the row is constructed identically to the two sibling Diagnostics rows (Device serial, Architecture) that already render in production, so the marginal rendering risk is low — but I did not open a real menu, and I would rather say that than imply I did.

Refs #204.