### PR TITLE
Re-arm the Accessibility grant attempt on each agent version

### DIFF
--- a/src/ui/permissions.py
+++ b/src/ui/permissions.py
@@ -308,6 +308,11 @@ def open_input_monitoring_settings() -> None:
 
 _BUNDLE_ID = "co.betterqa.betterflow"
 
+# Stamped into the TCC marker when the running version cannot be read at all.
+# A constant, so it compares equal to itself: an agent that can never resolve
+# its version still asks exactly once, not on every launch.
+_UNKNOWN_AGENT_VERSION = "unknown"
+
 
 def _tcc_grant_marker() -> Path:
     """Path to the marker file that records the TCC grant was already attempted."""
@@ -316,6 +321,99 @@ def _tcc_grant_marker() -> Path:
     except ImportError:
         from config import Config
     return Config.get_data_dir() / ".tcc_grant_done"
+
+
+def _agent_version() -> str:
+    """The running agent version, used to stamp the TCC grant marker.
+
+    Total by construction: every lookup is wrapped and the fallback is a
+    constant, because a version we cannot read must never be able to raise out
+    of a permission check. ``_UNKNOWN_AGENT_VERSION`` still behaves correctly as
+    a stamp — it simply means the fuse re-arms only when the *reading* starts
+    working, never spuriously.
+
+    Mirrors the bundle-first order ``ui/tray.py`` uses: PyInstaller flattens
+    ``src/`` to the root, so the relative import that works from a checkout is
+    the one that fails in a shipped build.
+    """
+    try:
+        import _build_info as _bi  # PyInstaller bundle (src/ is root)
+
+        version = getattr(_bi, "APP_VERSION", None)
+        if version:
+            return str(version)
+    except Exception:  # noqa: BLE001 - never raise out of a permission check
+        pass
+    try:
+        from .. import __version__
+
+        return str(__version__)
+    except Exception:  # noqa: BLE001
+        pass
+    try:
+        from src import __version__  # type: ignore[no-redef]
+
+        return str(__version__)
+    except Exception:  # noqa: BLE001
+        pass
+    return _UNKNOWN_AGENT_VERSION
+
+
+def _grant_attempt_is_armed(marker: Path, version: str) -> bool:
+    """May this launch spend the user's one admin-password prompt?
+
+    The marker records that we ASKED, and the fuse is per-VERSION rather than
+    per-install. That is the whole of #205: written in a ``finally``, a
+    cancelled prompt and a failed sqlite write both blew a fuse that nothing
+    re-armed, so four devices sat ``window_titles_blind`` for 15-21 days having
+    been asked exactly once, months earlier, on a build whose code signature no
+    longer existed.
+
+    Three states, and each direction was chosen for how it fails:
+
+    * **No marker** -> armed. A fresh install must be able to ask.
+    * **Marker stamped with a DIFFERENT version (or with nothing at all)** ->
+      armed, once. This is the re-arm. The file's own header documents why an
+      update is the right moment: a new build changes the code signature, macOS
+      may keep showing the toggle ON while ``AXIsProcessTrusted()`` returns
+      False, and the grant genuinely needs re-establishing. A legacy marker
+      written by the old ``touch()`` carries no version and reads as "" here,
+      so the already-blind fleet re-arms on upgrade rather than staying blind
+      forever - which is the outcome this issue exists to produce.
+    * **Marker stamped with THIS version** -> spent. This is the half that must
+      not regress: the fuse exists so the admin password is asked for once, not
+      on every launch. Trading a silent failure for a prompt loop is worse than
+      the bug.
+
+    An existing-but-unreadable marker reads as SPENT, not armed. We know an
+    attempt happened (the file is there) and cannot tell which version made it;
+    re-arming on an ``OSError`` we would hit again on the next write is how a
+    single prompt becomes an infinite one. The honest state still reaches the
+    user - the caller reports ``has_capture_permissions()`` and
+    ``_maybe_warn_capture_permissions()`` names the missing grant.
+    """
+    if not marker.exists():
+        return True
+    try:
+        stamped = marker.read_text(encoding="utf-8").strip()
+    except OSError as e:
+        logger.debug("Could not read TCC marker (%s); treating as spent", e)
+        return False
+    return stamped != version
+
+
+def _record_grant_attempt(marker: Path, version: str) -> None:
+    """Stamp the marker with the version that spent the attempt.
+
+    Replaces a bare ``touch()``. The content is the entire re-arm mechanism: an
+    empty marker cannot say WHICH build asked, so it can only ever mean "never
+    ask again".
+    """
+    try:
+        marker.parent.mkdir(parents=True, exist_ok=True)
+        marker.write_text(f"{version}\n", encoding="utf-8")
+    except OSError as e:
+        logger.debug("Could not write TCC marker: %s", e)
 
 
 def has_capture_permissions() -> bool:
@@ -333,28 +431,40 @@ def has_capture_permissions() -> bool:
 def grant_tcc_permissions() -> bool:
     """Grant Accessibility and Input Monitoring via TCC database with admin auth.
 
-    Shows the native macOS password dialog once on first install. Subsequent
-    launches skip the prompt — if permissions are still missing, the user
-    must grant them manually via System Settings.
+    Shows the native macOS password dialog **once per agent version**, not once
+    per install. Later launches on the same version skip the prompt; the next
+    update re-arms it exactly once. If permissions are still missing after
+    that, the user grants them manually via System Settings.
 
-    Returns True only when the permissions are actually held. The marker below
+    Returns True only when the permissions are actually held. The marker
     records that we ASKED, never that we succeeded: it is written in a finally,
-    so a cancelled prompt and a failed sqlite write both set it. Reporting
-    "attempted" as True made every later launch claim a permission the process
-    did not have, and four devices sat window_titles_blind for 15-21 days with
-    this answering True on each start (#205).
+    so a cancelled prompt and a failed sqlite write both set it. Two separate
+    defects came out of that, and only the first is fixed by honesty alone.
+
+    * Reporting "attempted" as True made every later launch claim a permission
+      the process did not have. Four devices sat ``window_titles_blind`` for
+      15-21 days with this answering True on each start (#205).
+    * The record itself was permanent, so the single recovery attempt was spent
+      at first install even when it FAILED. Version-stamping the marker is what
+      re-arms it — see ``_grant_attempt_is_armed`` for why an update is the
+      right moment and why "never write on failure" is not the fix (it turns
+      one prompt into a prompt on every launch, which is worse).
     """
     if not _IS_MACOS:
         return True
 
     marker = _tcc_grant_marker()
-    if marker.exists():
-        # Still no re-prompt — the marker exists so the admin password is asked
-        # for once, not on every launch. Only the ANSWER changes: report what is
-        # true right now instead of reporting that we once tried.
+    version = _agent_version()
+    if not _grant_attempt_is_armed(marker, version):
+        # Still no re-prompt — the fuse is spent for THIS version, so the admin
+        # password is asked for once per build, not on every launch. Only the
+        # ANSWER changes: report what is true right now instead of reporting
+        # that we once tried.
         granted = has_capture_permissions()
         logger.debug(
-            "TCC grant already attempted, skipping admin prompt (granted=%s)",
+            "TCC grant already attempted for %s, skipping admin prompt "
+            "(granted=%s)",
+            version,
             granted,
         )
         return granted
@@ -366,12 +476,9 @@ def grant_tcc_permissions() -> bool:
         services.append("kTCCServiceListenEvent")
 
     if not services:
-        # Permissions already granted — write marker so we don't re-check.
-        try:
-            marker.parent.mkdir(parents=True, exist_ok=True)
-            marker.touch()
-        except OSError as e:
-            logger.debug("Could not write TCC marker: %s", e)
+        # Permissions already granted — stamp the marker so we don't re-check
+        # until the next version, when the signature may have changed.
+        _record_grant_attempt(marker, version)
         return True
 
     # Defensive: refuse to interpolate anything we didn't hardcode ourselves.
@@ -434,10 +541,8 @@ def grant_tcc_permissions() -> bool:
         logger.warning(f"TCC grant error: {e}")
         return False
     finally:
-        # Mark the grant as attempted regardless of outcome so the user
-        # is never prompted again on subsequent launches.
-        try:
-            marker.parent.mkdir(parents=True, exist_ok=True)
-            marker.touch()
-        except OSError as exc:
-            logger.debug("Could not write TCC marker: %s", exc)
+        # Record the attempt regardless of outcome, so a cancelled prompt does
+        # not re-ask on the very next launch — but stamp it with the VERSION,
+        # which is what stops the record meaning "never ask again". The bare
+        # touch() this replaces made a cancel permanent (#205).
+        _record_grant_attempt(marker, version)

--- a/tests/test_permissions.py
+++ b/tests/test_permissions.py
@@ -16,6 +16,8 @@ import sys
 import types
 from unittest.mock import MagicMock
 
+import pytest
+
 import src.ui.permissions as permissions
 
 # AXError codes (from <HIServices/AXError.h>)
@@ -120,12 +122,69 @@ def test_ax_api_works_false_when_binding_unavailable(monkeypatch):
 # launch) so these tests pin BOTH halves: it must still not re-prompt, and it
 # must stop claiming success.
 
-def _marker_path(monkeypatch, tmp_path, *, exists):
+# The version every test pretends to be running, so a stamped marker means
+# "this build already spent its prompt" without depending on src.__version__.
+THIS_VERSION = "9.9.9"
+OLDER_VERSION = "9.9.8"
+
+
+class _RealOsascriptInvoked(BaseException):
+    """Deliberately NOT an Exception subclass.
+
+    ``grant_tcc_permissions`` wraps its ``subprocess.run`` in
+    ``except Exception``, so an ordinary error raised here would be swallowed
+    and reported as a plain ``False`` — the guard would fire and look exactly
+    like a normal denial. Deriving from BaseException makes it escape the
+    handler and fail the test out loud.
+    """
+
+
+@pytest.fixture(autouse=True)
+def _never_spawn_real_osascript(monkeypatch):
+    """No test in this module may reach the real admin-password dialog.
+
+    Not hypothetical. ``test_grant_does_not_claim_success_when_permission_is_
+    still_missing`` sets up a marker and does NOT patch ``subprocess.run``,
+    which was harmless only while an existing marker took the early return.
+    The moment a legacy marker began re-arming (#205) that test fell through to
+    a real ``osascript ... with administrator privileges``, popped a genuine
+    password prompt on the developer's machine, blocked the full 120s
+    subprocess timeout — and then PASSED, because a timeout also returns False.
+
+    A green that arrives via the timeout path is the Phantom 4 shape: the right
+    answer for the wrong reason. Tests that mean to exercise the write patch
+    ``subprocess.run`` themselves and override this fixture; anything else
+    reaching it is a bug in the test, and now says so in under a second.
+    """
+    def _boom(*args, **kwargs):
+        raise _RealOsascriptInvoked(
+            f"test tried to run a real subprocess: {args!r}"
+        )
+
+    monkeypatch.setattr(permissions.subprocess, "run", _boom)
+
+
+def _marker_path(monkeypatch, tmp_path, *, exists, version=THIS_VERSION):
+    """Point permissions at a scratch marker, optionally already stamped.
+
+    ``version`` is what the marker CLAIMS spent the attempt. The default is the
+    running version, i.e. the fuse is spent — which is what every caller of this
+    helper predating #205 meant by ``exists=True``. Pass ``OLDER_VERSION`` for
+    the post-update case, or ``""`` for a legacy marker written by the old bare
+    ``touch()``.
+    """
     marker = tmp_path / ".tcc_grant_done"
     if exists:
-        marker.touch()
+        marker.write_text(version, encoding="utf-8")
     monkeypatch.setattr(permissions, "_IS_MACOS", True)
     monkeypatch.setattr(permissions, "_tcc_grant_marker", lambda: marker)
+    # raising=False so this helper still works against the PRE-FIX module,
+    # where _agent_version does not exist. Without it every test below dies
+    # on an AttributeError during the proof-of-failure run and the handshake
+    # proves only that the symbol is new — not that the defect was real.
+    monkeypatch.setattr(
+        permissions, "_agent_version", lambda: THIS_VERSION, raising=False
+    )
     return marker
 
 
@@ -203,3 +262,173 @@ def test_a_write_that_really_did_land_reports_success(monkeypatch, tmp_path):
 
     assert permissions.grant_tcc_permissions() is True
     assert marker.exists(), "the attempt must still be recorded"
+
+
+# --- The one attempt must not be spent forever by a failure (#205) -----------
+#
+# The three points of #205 were: (1) the fuse is single-use and blows on
+# failure, (2) the early return claimed a grant it did not hold, (3) the caller
+# discarded the result. (2) and (3) shipped earlier. This block is (1), the
+# issue's title: a cancelled prompt burned the agent's only automated recovery
+# path permanently, so four devices sat window_titles_blind for 15-21 days
+# having been asked exactly once, months earlier.
+#
+# Both directions are pinned deliberately. A fix that merely stops recording a
+# failed attempt turns one prompt into a prompt on EVERY launch, which is worse
+# than the bug it replaces — so every "must re-arm" test below has a "must stay
+# spent" partner, and the mutation matrix requires both.
+
+
+def _prompt_recorder(monkeypatch, *, returncode=1, stderr="User canceled."):
+    """Capture osascript invocations instead of running them."""
+    calls = []
+
+    def _run(*args, **kwargs):
+        calls.append(args)
+        return MagicMock(returncode=returncode, stderr=stderr)
+
+    monkeypatch.setattr(permissions.subprocess, "run", _run)
+    return calls
+
+
+def test_a_cancelled_prompt_is_retried_after_an_update(monkeypatch, tmp_path):
+    """THE defect. A marker from an older build must not silence the new one.
+
+    Pre-fix this returns without prompting: the marker merely had to EXIST.
+    That is the whole 15-21 day outage — the agent had one chance, spent it on
+    a cancel, and every later launch (including every auto-update, which is
+    exactly when the code signature changes and the grant needs re-establishing)
+    took the early return.
+    """
+    _marker_path(monkeypatch, tmp_path, exists=True, version=OLDER_VERSION)
+    monkeypatch.setattr(permissions, "check_accessibility", lambda: False)
+    monkeypatch.setattr(permissions, "check_input_monitoring", lambda: False)
+    calls = _prompt_recorder(monkeypatch)
+
+    permissions.grant_tcc_permissions()
+
+    assert calls, "a new version must get its own attempt at the grant"
+
+
+def test_a_legacy_unstamped_marker_re_arms_once(monkeypatch, tmp_path):
+    """The already-blind fleet's second chance.
+
+    Devices 17, 22, 23 and 53 carry a marker written by the old bare touch():
+    zero bytes, no version, indistinguishable from "asked on some build we can
+    no longer name". Reading that as spent would leave them blind forever, so
+    it re-arms — which is the entire point of shipping this.
+    """
+    _marker_path(monkeypatch, tmp_path, exists=True, version="")
+    monkeypatch.setattr(permissions, "check_accessibility", lambda: False)
+    monkeypatch.setattr(permissions, "check_input_monitoring", lambda: False)
+    calls = _prompt_recorder(monkeypatch)
+
+    permissions.grant_tcc_permissions()
+
+    assert calls, "an unstamped legacy marker must re-arm exactly once"
+
+
+def test_the_same_version_never_prompts_twice(monkeypatch, tmp_path):
+    """The other direction, and the one that must never regress.
+
+    Re-arming per LAUNCH instead of per VERSION would trade a silent failure
+    for an admin-password prompt on every start. If this goes red the fix has
+    become worse than the defect.
+    """
+    _marker_path(monkeypatch, tmp_path, exists=True, version=THIS_VERSION)
+    monkeypatch.setattr(permissions, "check_accessibility", lambda: False)
+    monkeypatch.setattr(permissions, "check_input_monitoring", lambda: False)
+    calls = _prompt_recorder(monkeypatch)
+
+    permissions.grant_tcc_permissions()
+
+    assert calls == [], "the fuse is spent for this version — do not re-ask"
+
+
+def test_a_cancelled_attempt_still_records_itself(monkeypatch, tmp_path):
+    """Cancelling must not re-prompt on the very next launch of the SAME build.
+
+    The pair of this and the test above is what makes "one prompt per version"
+    a real contract rather than a hope: the attempt is recorded even when it
+    fails, and it is the STAMP, not the absence of a file, that re-arms later.
+    """
+    marker = _marker_path(monkeypatch, tmp_path, exists=False)
+    monkeypatch.setattr(permissions, "check_accessibility", lambda: False)
+    monkeypatch.setattr(permissions, "check_input_monitoring", lambda: False)
+    _prompt_recorder(monkeypatch)
+
+    assert permissions.grant_tcc_permissions() is False
+    assert marker.read_text(encoding="utf-8").strip() == THIS_VERSION
+
+    # Second launch, same build: the recorded attempt must silence the prompt.
+    calls = _prompt_recorder(monkeypatch)
+    permissions.grant_tcc_permissions()
+    assert calls == [], "a recorded cancel must not re-prompt on the same build"
+
+
+def test_a_successful_grant_does_not_re_prompt_on_the_same_version(monkeypatch, tmp_path):
+    """Success direction: a grant that landed must not keep asking either."""
+    marker = _marker_path(monkeypatch, tmp_path, exists=False)
+    state = {"granted": False}
+    monkeypatch.setattr(permissions, "check_accessibility", lambda: state["granted"])
+    monkeypatch.setattr(permissions, "check_input_monitoring", lambda: state["granted"])
+
+    def _run(*args, **kwargs):
+        state["granted"] = True
+        return MagicMock(returncode=0, stderr="")
+
+    monkeypatch.setattr(permissions.subprocess, "run", _run)
+    assert permissions.grant_tcc_permissions() is True
+    assert marker.read_text(encoding="utf-8").strip() == THIS_VERSION
+
+    calls = _prompt_recorder(monkeypatch)
+    assert permissions.grant_tcc_permissions() is True
+    assert calls == [], "a granted permission must never re-prompt"
+
+
+def test_an_already_granted_machine_restamps_on_upgrade(monkeypatch, tmp_path):
+    """An upgrade re-arms, but must not PROMPT a machine that is already fine.
+
+    Re-arming is permission to ask, not an obligation. With both grants held
+    the services list is empty, so the new version simply re-stamps and returns
+    — no dialog. Without this the re-arm would show a password prompt to the
+    whole healthy fleet on every single update.
+    """
+    marker = _marker_path(monkeypatch, tmp_path, exists=True, version=OLDER_VERSION)
+    monkeypatch.setattr(permissions, "check_accessibility", lambda: True)
+    monkeypatch.setattr(permissions, "check_input_monitoring", lambda: True)
+    calls = _prompt_recorder(monkeypatch)
+
+    assert permissions.grant_tcc_permissions() is True
+    assert calls == [], "a healthy machine must not be prompted by an upgrade"
+    assert marker.read_text(encoding="utf-8").strip() == THIS_VERSION
+
+
+def test_an_unreadable_marker_reads_as_spent(monkeypatch, tmp_path):
+    """Fail toward not-nagging when the marker exists but cannot be read.
+
+    We know an attempt happened — the file is there — and cannot tell which
+    build made it. Re-arming on an OSError we would hit again on the next write
+    is how a single prompt becomes an infinite one.
+    """
+    marker = _marker_path(monkeypatch, tmp_path, exists=True, version=OLDER_VERSION)
+    monkeypatch.setattr(permissions, "check_accessibility", lambda: False)
+    monkeypatch.setattr(permissions, "check_input_monitoring", lambda: False)
+
+    def _explode(*args, **kwargs):
+        raise OSError("permission denied")
+
+    monkeypatch.setattr(permissions.Path, "read_text", _explode)
+    calls = _prompt_recorder(monkeypatch)
+
+    permissions.grant_tcc_permissions()
+
+    assert calls == [], "an unreadable marker must not start a prompt loop"
+    assert marker.exists()
+
+
+def test_agent_version_is_total(monkeypatch):
+    """_agent_version must never raise out of a permission check."""
+    monkeypatch.setitem(sys.modules, "_build_info", None)
+    assert isinstance(permissions._agent_version(), str)
+    assert permissions._agent_version() != ""


### PR DESCRIPTION
## Business impact

Four macOS users have recorded app names and durations with no window titles for 15-21 days and none self-recovered. The agent's only automated recovery path runs once, at first install, and then permanently disables itself — including when it fails and including when the user clicks Cancel. A user who would happily grant permission is never asked twice.

This is the remaining point of #205, and its title. The other two shipped earlier: the early return no longer claims a grant it does not hold, and `_maybe_warn_capture_permissions()` now runs unconditionally.

## What changed

The marker is stamped with the running agent version instead of being `touch()`ed empty.

| Marker state | Before | After |
|---|---|---|
| absent | prompt | prompt (unchanged) |
| stamped with THIS version | prompt suppressed | prompt suppressed (unchanged) |
| stamped with an OLDER version | prompt suppressed **forever** | re-armed **once** |
| empty (legacy `touch()`) | prompt suppressed **forever** | re-armed **once** |
| exists but unreadable | prompt suppressed | prompt suppressed |

An update is the right moment to re-ask, and `permissions.py`'s own header says why: a new build changes the code signature, so macOS can keep showing the toggle ON while `AXIsProcessTrusted()` returns False and the grant genuinely needs re-establishing. The legacy-empty case is what gets devices 17, 22, 23 and 53 a second chance rather than leaving them blind forever.

**"Never write the marker on failure" is not the fix.** It turns one prompt into a prompt on every launch, which is worse than the bug. The attempt is still recorded on cancel — it is the *stamp*, not the file's absence, that re-arms later. `test_the_same_version_never_prompts_twice` and `test_a_cancelled_attempt_still_records_itself` exist to keep it that way, and mutant M2b below is that direction being witnessed.

Re-arming is permission to ask, not an obligation: a machine that already holds both grants has an empty services list, so it re-stamps silently and shows no dialog. Without that, the whole healthy fleet would see a password prompt on every update (`test_an_already_granted_machine_restamps_on_upgrade`).

## Proof of failure

Fix committed, then `git checkout origin/main -- src/ui/permissions.py`, suite re-run, then restored. **6 failed, 15 passed.**

```
FAILED test_a_cancelled_prompt_is_retried_after_an_update
  AssertionError: a new version must get its own attempt at the grant
  assert []                                   <- no prompt: the fuse stayed blown
FAILED test_a_legacy_unstamped_marker_re_arms_once
  AssertionError: an unstamped legacy marker must re-arm exactly once
  assert []
FAILED test_a_cancelled_attempt_still_records_itself          assert '' == '9.9.9'
FAILED test_a_successful_grant_does_not_re_prompt_on_the_same_version   assert '' == '9.9.9'
FAILED test_an_already_granted_machine_restamps_on_upgrade    assert '9.9.8' == '9.9.9'
FAILED test_agent_version_is_total - AttributeError
```

Only the defect-specific cases fail. Both controls — `test_the_same_version_never_prompts_twice` and `test_an_unreadable_marker_reads_as_spent` — pass in **both** versions, as do all 13 pre-existing tests, so the suite isolates the bug rather than describing the new code.

The helper uses `raising=False` when patching `_agent_version` specifically so the pre-fix run fails on the behaviour rather than dying on a missing symbol.

## Mutation matrix

Anchor asserted present exactly once before each mutation, file compared after, `__pycache__` cleared between every run. Control green before and after.

| Mutant | Reddened |
|---|---|
| M1 fresh install never arms | `test_a_cancelled_attempt_still_records_itself` +2 |
| M2a never re-arm (version ignored) | `test_a_cancelled_prompt_is_retried_after_an_update` +2 |
| M2b **always** re-arm (prompt loop) | `test_the_same_version_never_prompts_twice` +3 |
| M3 unreadable marker arms | `test_an_unreadable_marker_reads_as_spent` |
| M4 stamp reverts to bare `touch()` | `test_a_cancelled_attempt_still_records_itself` +2 |
| M5 `finally` records nothing | `test_a_cancelled_attempt_still_records_itself` +2 |
| M6 already-granted path never stamps | `test_an_already_granted_machine_restamps_on_upgrade` |

7/7 killed, each by a distinct named test. M5's first anchor matched **0** times and the anchor assertion caught it — rebuilt against the real text, it then reddened immediately.

## A live hazard fixed in the test file

`test_grant_does_not_claim_success_when_permission_is_still_missing` never patched `subprocess.run`. That was harmless only while an existing marker took the early return. The moment a legacy marker began re-arming, it fell through to a real `osascript ... with administrator privileges` — a genuine password dialog on the developer's machine, blocking the full 120s subprocess timeout, after which it **passed anyway**, because a timeout also returns `False`. A green arriving via the timeout path is the Phantom 4 shape.

An autouse fixture now makes any unpatched `subprocess.run` raise. It derives from `BaseException`, not `Exception`, because `grant_tcc_permissions` catches `Exception` and the guard would otherwise be swallowed and read as an ordinary denial. Module runtime: **120s -> 0.3s**.

## Gate

`pytest tests/` -> **1791 passed, 1 skipped, exit 0**. Baseline on `origin/main` was 1783 passed, 1 skipped; +8 is exactly this branch's new tests, which is the count confirming the run reached the new tree. `.github/workflows/build.yml` runs `pytest tests/` and no lint step.

## Not verified

The issue's open question is untouched and this PR does not answer it: **whether the `sqlite3` write into `TCC.db` can succeed at all on current macOS**, which normally needs Full Disk Access even as root. I did not sudo-write to a real TCC database. If it cannot work, this change makes a dead path re-armable rather than deleting it — strictly better than today (the honest answer still reaches the user, and the warning still names the missing grant) but not the durable fix. Settling that question is what decides between this and deleting the path in favour of #204's persistent surface.

Refs #205
