### PR TITLE
Report what macOS actually says about a notification, not that the call returned

### DIFF
--- a/src/aw_manager.py
+++ b/src/aw_manager.py
@@ -828,16 +828,55 @@ class AWManager:
         self._rosetta_notified = True
         try:
             try:
-                from .notifications import send_notification
+                from .notifications import NotificationOutcome, send_notification
             except ImportError:
-                from notifications import send_notification
-            send_notification(
+                from notifications import NotificationOutcome, send_notification
+            outcome = send_notification(
                 "BetterFlow can't track on this Mac",
                 "Rosetta 2 is required. Open Terminal and run: "
                 "softwareupdate --install-rosetta",
             )
         except Exception:
             logger.debug("Rosetta notification failed", exc_info=True)
+            return
+
+        # This device records ZERO time until someone installs Rosetta, and
+        # the notification is the only thing that asks them to. Whether it
+        # arrived was previously unknowable — the notice shipped in v1.5.118
+        # and a user still lost ~90 minutes on v1.5.122 (#204), with nothing
+        # anywhere to say whether they were ever told. Say so now, either way.
+        if outcome is NotificationOutcome.DELIVERED:
+            logger.info(
+                "Rosetta notice accepted by Notification Center. That is not "
+                "proof the user read it — a Focus mode files it silently."
+            )
+            return
+
+        logger.error(
+            "Rosetta notice was NOT delivered (%s). This Mac is recording no "
+            "time and the person at the keyboard has not been asked to fix it; "
+            "the tray state and the tracker_install_failed signal are the only "
+            "remaining routes to them.",
+            outcome.value,
+        )
+        reporter = self.error_reporter
+        if reporter is not None:
+            try:
+                reporter.capture(
+                    "Rosetta required notice not delivered to the user",
+                    level="error",
+                    tags={
+                        "component": "aw_manager",
+                        "platform": _get_platform_key(),
+                        "notification_outcome": outcome.value,
+                    },
+                    context={"aw_version": AW_VERSION},
+                    fingerprint="rosetta-notice-undelivered",
+                )
+            except Exception:
+                logger.warning(
+                    "Failed to report undelivered Rosetta notice", exc_info=True
+                )
 
     def _start_locked(self) -> bool:
         # Every route back to a running tracker funnels through here, so this one

--- a/src/notifications.py
+++ b/src/notifications.py
@@ -10,6 +10,37 @@ This means they:
 
 We fall back to osascript if pyobjc is unavailable (dev environments
 without the bundle); those fallback notifications behave like before.
+
+What this module can and cannot observe
+---------------------------------------
+
+``NSUserNotificationCenter.deliverNotification_`` is fire-and-forget: it
+returns ``None`` whether or not macOS kept the notification, so "the call
+did not raise" has never been evidence that anyone was told. Two shipped
+prompts (Rosetta, #188; Accessibility, #197) were load-bearing on exactly
+that non-evidence.
+
+The one readable signal macOS does offer is
+``NSUserNotificationCenter.deliveredNotifications()``. It reflects the
+system's own record — a separate process can read notifications posted by
+the app — so tagging each notification with a unique identifier and
+looking for it afterwards distinguishes *macOS kept this* from *macOS
+discarded this*. That is what :func:`send_notification` now reports.
+
+Deliberately NOT claimed:
+
+* **That the user saw it.** Do Not Disturb / a Focus mode still files a
+  notification into Notification Center without showing a banner, so
+  ``DELIVERED`` means macOS accepted it, never that a human read it.
+* **An authorisation status.** The legacy center exposes no public
+  ``authorizationStatus``; the only authorisation-shaped selectors on it
+  are private (``_shouldPresentNotification_`` and friends), so the state
+  is inferred from the delivery read or not at all.
+* **Anything about osascript, PowerShell or notify-send.** Those report
+  that the *command* ran. Whether the OS then presented the notification
+  is not readable, and a delivered-list entry cannot be attributed to one
+  of them because none of them can be tagged. Those paths report
+  ``UNKNOWN``, which is not a success.
 """
 
 import logging
@@ -17,6 +48,9 @@ import platform
 import re
 import subprocess
 import sys
+import time
+import uuid
+from enum import Enum
 from pathlib import Path
 from typing import Optional
 
@@ -24,6 +58,58 @@ logger = logging.getLogger(__name__)
 
 _MACOS_PYOBJC_AVAILABLE: bool | None = None
 _CACHED_ICON_PATH: Optional[Path] = None
+
+
+class NotificationOutcome(Enum):
+    """What we actually know about a notification we tried to post.
+
+    Five values because five different things can be true, and collapsing
+    any of them into "success" is the defect this enum exists to close.
+    Each one implies a different follow-up:
+
+    ``DELIVERED``
+        The OS's own delivered-notification list contains the notification
+        we posted, found by an identifier we set. macOS accepted it. This
+        is NOT proof the user saw it — a Focus mode files it silently.
+    ``SUPPRESSED``
+        The post call completed without error and the OS then had no
+        record of it. The user was not reached on this channel; something
+        else has to say the thing.
+    ``FAILED``
+        The sending mechanism itself broke — an exception, a non-zero exit,
+        a missing binary. The channel is broken, not the permission.
+    ``UNKNOWN``
+        The mechanism completed and offers no way to read the result back.
+        Evidence of nothing, and deliberately not ``DELIVERED``.
+    ``UNSUPPORTED``
+        There is no notification channel here at all, so nothing was sent.
+    """
+
+    DELIVERED = "delivered"
+    SUPPRESSED = "suppressed"
+    FAILED = "failed"
+    UNKNOWN = "unknown"
+    UNSUPPORTED = "unsupported"
+
+    def __bool__(self) -> bool:
+        """Truthy only for a verified delivery.
+
+        Enum members are truthy by default, so without this a caller
+        writing the obvious ``if send_notification(...):`` would treat
+        ``FAILED`` as success — the exact bug this type exists to close,
+        rebuilt one layer up. Fail closed: anything short of an observed
+        delivery is falsy.
+        """
+        return self is NotificationOutcome.DELIVERED
+
+
+# How hard to look for our own notification in the delivered list before
+# concluding macOS dropped it. Delivery is asynchronous: measured at ~0.1s
+# on a healthy machine, so this is a generous ceiling and the common case
+# costs one sleep. Bounded because this runs on the notification path, and
+# a notification is not worth blocking a caller for a second.
+_DELIVERY_CONFIRM_ATTEMPTS = 6
+_DELIVERY_CONFIRM_INTERVAL = 0.1
 
 
 def _resolve_icon_path() -> Optional[Path]:
@@ -74,28 +160,67 @@ def _try_load_macos_pyobjc() -> bool:
     return _MACOS_PYOBJC_AVAILABLE
 
 
-def send_notification(title: str, message: str, sound: bool = True) -> None:
-    """Send a native OS notification.
+def send_notification(
+    title: str, message: str, sound: bool = True
+) -> NotificationOutcome:
+    """Send a native OS notification and report what we know about it.
+
+    The return value is the point of this function. Callers that carry a
+    user instruction the agent cannot otherwise deliver — the Rosetta
+    notice (#188) and the Accessibility notice (#197) — must read it,
+    because a notification macOS discarded and one it presented used to be
+    indistinguishable from here.
+
+    Never raises: a notification that cannot be sent must not stop the
+    caller. Failures come back as :class:`NotificationOutcome` values
+    instead, so "it did not blow up" stops being mistaken for "it worked".
 
     Args:
         title: Notification title.
         message: Notification body text.
         sound: Whether to play a sound (macOS only).
+
+    Returns:
+        The strongest claim the platform actually supports. Only
+        ``DELIVERED`` means the OS kept the notification, and even that is
+        not proof the user saw it — see the module docstring.
     """
     system = platform.system()
     try:
         if system == "Darwin":
-            if _try_load_macos_pyobjc() and _send_macos_pyobjc(title, message, sound):
-                return
-            _send_macos_osascript(title, message, sound)
+            outcome = NotificationOutcome.UNKNOWN
+            if _try_load_macos_pyobjc():
+                outcome = _send_macos_pyobjc(title, message, sound)
+                if outcome is NotificationOutcome.DELIVERED:
+                    return outcome
+            # Reachable again. It never was while the pyobjc path returned a
+            # bare True, so a suppressed notification had no second chance.
+            # osascript posts under Script Editor's identity, which carries
+            # its own notification permission, so it is a genuinely
+            # different channel rather than a retry of the same one.
+            fallback = _send_macos_osascript(title, message, sound)
+            if fallback is NotificationOutcome.FAILED:
+                # Both channels are accounted for; keep the pyobjc verdict
+                # when it was the more specific one.
+                return (
+                    outcome
+                    if outcome is NotificationOutcome.SUPPRESSED
+                    else NotificationOutcome.FAILED
+                )
+            # osascript ran and cannot be read back. That downgrades a
+            # SUPPRESSED verdict to UNKNOWN rather than confirming it: we
+            # posted a second time on a channel we cannot observe.
+            return fallback
         elif system == "Windows":
-            _send_windows(title, message)
+            return _send_windows(title, message)
         elif system == "Linux":
-            _send_linux(title, message)
+            return _send_linux(title, message)
         else:
             logger.debug("Notifications not supported on %s", system)
+            return NotificationOutcome.UNSUPPORTED
     except Exception as e:
         logger.warning("Failed to send notification: %s", e)
+        return NotificationOutcome.FAILED
 
 
 def clear_notifications() -> None:
@@ -123,12 +248,26 @@ def clear_notifications() -> None:
 # --------------------------------------------------------------------------
 
 
-def _send_macos_pyobjc(title: str, message: str, sound: bool) -> bool:
-    """Post a notification via NSUserNotification. Returns False on failure."""
+def _send_macos_pyobjc(
+    title: str, message: str, sound: bool
+) -> NotificationOutcome:
+    """Post a notification via NSUserNotification and verify it landed.
+
+    ``deliverNotification_`` returns nothing, so the post itself proves
+    nothing. We tag the notification with a one-shot identifier and then
+    look for that identifier in the center's delivered list, which is the
+    OS's own record and is readable across processes.
+
+    Returns ``DELIVERED`` only on a positive read. An absent identifier is
+    ``SUPPRESSED``; a broken post is ``FAILED``; a post that succeeded
+    while the read-back broke is ``UNKNOWN``, because at that point we
+    genuinely do not know and saying either of the other two would be a
+    guess wearing a verdict's clothes.
+    """
     try:
         from Foundation import NSUserNotification, NSUserNotificationCenter
     except ImportError:
-        return False
+        return NotificationOutcome.FAILED
     try:
         note = NSUserNotification.alloc().init()
         note.setTitle_(title)
@@ -152,12 +291,66 @@ def _send_macos_pyobjc(title: str, message: str, sound: bool) -> bool:
             except Exception as e:
                 logger.debug("Failed to attach notification icon: %s", e)
 
+        # Unique per send, so the read below is attributable to THIS post
+        # and macOS never coalesces two notices into one. Notifications
+        # posted before this change carry no identifier at all, which is
+        # why nothing could be attributed to a send.
+        marker = f"betterflow-{uuid.uuid4()}"
+        note.setIdentifier_(marker)
+
         center = NSUserNotificationCenter.defaultUserNotificationCenter()
+        if center is None:
+            # Nil for a process the notification system will not talk to.
+            # Nothing was posted, so this is not merely unverifiable.
+            logger.warning("No NSUserNotificationCenter available — nothing was posted")
+            return NotificationOutcome.FAILED
         center.deliverNotification_(note)
-        return True
     except Exception as e:
         logger.warning("pyobjc notification failed, will fall back: %s", e)
-        return False
+        return NotificationOutcome.FAILED
+
+    return _confirm_macos_delivery(marker)
+
+
+def _confirm_macos_delivery(marker: str) -> NotificationOutcome:
+    """Look for ``marker`` in macOS's delivered-notification list.
+
+    Split out from the post so a test can drive the read on its own, and
+    so the read's own failure cannot be mistaken for a delivery verdict.
+
+    A false ``SUPPRESSED`` is possible and cheap: if the user (or our own
+    ``clear_notifications()``) clears Notification Center inside the poll
+    window we lose sight of a notification that really was delivered. The
+    cost is one extra osascript post and a warning line. The opposite
+    error — reporting delivery we never saw — is the one that shipped two
+    notices to nobody, so the read is deliberately biased this way.
+    """
+    try:
+        from Foundation import NSUserNotificationCenter
+    except ImportError:
+        return NotificationOutcome.UNKNOWN
+    try:
+        center = NSUserNotificationCenter.defaultUserNotificationCenter()
+        if center is None:
+            return NotificationOutcome.UNKNOWN
+        for attempt in range(_DELIVERY_CONFIRM_ATTEMPTS):
+            if attempt:
+                time.sleep(_DELIVERY_CONFIRM_INTERVAL)
+            for delivered in center.deliveredNotifications():
+                if delivered.identifier() == marker:
+                    return NotificationOutcome.DELIVERED
+    except Exception as e:
+        # The post may well have worked. We simply cannot see, and
+        # "cannot see" is not "delivered" and is not "suppressed".
+        logger.warning("Could not read back macOS notification delivery: %s", e)
+        return NotificationOutcome.UNKNOWN
+
+    logger.warning(
+        "macOS accepted a notification and kept no record of it — it was not "
+        "shown to the user (title suppressed here; check notification "
+        "permission for this app)"
+    )
+    return NotificationOutcome.SUPPRESSED
 
 
 def _clear_macos_pyobjc() -> None:
@@ -178,10 +371,19 @@ def _clear_macos_pyobjc() -> None:
 # --------------------------------------------------------------------------
 
 
-def _send_macos_osascript(title: str, message: str, sound: bool) -> None:
+def _send_macos_osascript(
+    title: str, message: str, sound: bool
+) -> NotificationOutcome:
     """Legacy osascript path. Notifications are attributed to Script Editor
     and CANNOT be cleared by ``clear_notifications()`` — use only as a
     last-resort fallback.
+
+    Reports ``UNKNOWN`` on a clean exit, never ``DELIVERED``. ``osascript``
+    exits 0 once the AppleScript ran; it says nothing about whether macOS
+    then presented the notification. The delivered-list read used by the
+    pyobjc path cannot rescue this either — ``display notification`` takes
+    no identifier, so a delivered entry cannot be attributed to this call
+    rather than to the pyobjc attempt that preceded it.
     """
     safe_title = re.sub(r'[\x00-\x1f\x7f]', '', title)[:200].replace("\\", "\\\\").replace('"', '\\"')
     safe_message = re.sub(r'[\x00-\x1f\x7f]', '', message)[:500].replace("\\", "\\\\").replace('"', '\\"')
@@ -202,6 +404,8 @@ def _send_macos_osascript(title: str, message: str, sound: bool) -> None:
             result.returncode,
             result.stderr.decode(errors="replace")[:200],
         )
+        return NotificationOutcome.FAILED
+    return NotificationOutcome.UNKNOWN
 
 
 # --------------------------------------------------------------------------
@@ -209,8 +413,16 @@ def _send_macos_osascript(title: str, message: str, sound: bool) -> None:
 # --------------------------------------------------------------------------
 
 
-def _send_windows(title: str, message: str) -> None:
-    """Send toast notification via PowerShell on Windows."""
+def _send_windows(title: str, message: str) -> NotificationOutcome:
+    """Send toast notification via PowerShell on Windows.
+
+    ``ToastNotifier.Show`` returns void and Focus Assist can swallow a
+    toast without telling anyone, so a clean PowerShell exit buys
+    ``UNKNOWN`` and nothing better. Windows does expose a readable
+    ``ToastNotifier.Setting`` (``NotificationsDisabledByUser`` and
+    friends); wiring that up would earn a real verdict here, and until
+    someone does, this must not claim one.
+    """
     # Sanitize for PowerShell single-quoted string literals:
     # strip control chars, limit length, escape single quotes.
     safe_title = re.sub(r'[\x00-\x1f\x7f]', '', title)[:200].replace("'", "''")
@@ -256,6 +468,8 @@ def _send_windows(title: str, message: str) -> None:
             result.returncode,
             result.stderr.decode(errors="replace")[:200],
         )
+        return NotificationOutcome.FAILED
+    return NotificationOutcome.UNKNOWN
 
 
 def _clear_windows() -> None:
@@ -284,12 +498,16 @@ def _clear_windows() -> None:
 # --------------------------------------------------------------------------
 
 
-def _send_linux(title: str, message: str) -> None:
+def _send_linux(title: str, message: str) -> NotificationOutcome:
     """Send a desktop notification via notify-send (libnotify).
 
     Arguments are passed as an argv list (no shell), so notify-send handles
     quoting; we still strip control chars and cap length defensively. If
     notify-send is not installed we log at debug and return rather than raise.
+
+    A clean exit is ``UNKNOWN``: notify-send returns as soon as the
+    notification daemon accepts the D-Bus call, which is upstream of
+    whether anything was rendered.
     """
     safe_title = re.sub(r'[\x00-\x1f\x7f]', '', title)[:200]
     safe_message = re.sub(r'[\x00-\x1f\x7f]', '', message)[:500]
@@ -304,10 +522,12 @@ def _send_linux(title: str, message: str) -> None:
         result = subprocess.run(args, capture_output=True, timeout=5)
     except FileNotFoundError:
         logger.debug("notify-send not found — desktop notification skipped")
-        return
+        return NotificationOutcome.FAILED
     if result.returncode != 0:
         logger.warning(
             "notify-send failed (exit %s): %s",
             result.returncode,
             result.stderr.decode(errors="replace")[:200],
         )
+        return NotificationOutcome.FAILED
+    return NotificationOutcome.UNKNOWN

--- a/src/sync/macos_window_watcher.py
+++ b/src/sync/macos_window_watcher.py
@@ -427,16 +427,35 @@ class MacOSWindowWatcher:
         self._accessibility_notified = True
         try:
             try:
-                from ..notifications import send_notification
+                from ..notifications import NotificationOutcome, send_notification
             except ImportError:
-                from notifications import send_notification  # type: ignore[no-redef]
+                from notifications import (  # type: ignore[no-redef]
+                    NotificationOutcome,
+                    send_notification,
+                )
 
-            send_notification(
+            outcome = send_notification(
                 "BetterFlow can't read window titles",
                 "Open System Settings > Privacy & Security > Accessibility. "
                 "BetterFlow may already look enabled there — if so, switch it "
                 "off and back on. App names and time are still being tracked.",
             )
+            # #194 was the same failure one layer down: the log was the only
+            # record and nobody reads it, so five people sat degraded for 12-17
+            # days. Replacing the log with a toast only helps if the toast
+            # arrives, so record whether it did rather than assuming.
+            if outcome is NotificationOutcome.DELIVERED:
+                logger.info(
+                    "Accessibility notice accepted by Notification Center "
+                    "(not proof the user read it)"
+                )
+            else:
+                logger.error(
+                    "Accessibility notice was NOT delivered (%s) — window "
+                    "titles stay empty and the user has not been asked to "
+                    "re-grant the permission",
+                    outcome.value,
+                )
         except Exception as e:
             # Never let a failed notification stop the watcher starting.
             logger.debug("Accessibility notification failed: %s", e)

--- a/tests/test_notice_delivery_is_recorded.py
+++ b/tests/test_notice_delivery_is_recorded.py
@@ -1,0 +1,163 @@
+"""Whether the user was actually told has to end up somewhere readable (#204).
+
+Two notices carry an instruction only the person at the keyboard can act
+on, and the agent is otherwise stuck until they do:
+
+* Rosetta (#188, v1.5.118) — without it the Mac records **zero** time.
+* Accessibility (#197, v1.5.124) — without it window titles are empty.
+
+Both called ``send_notification`` and discarded the result. So when the
+Rosetta notice failed to help Carmen Lapusan on v1.5.122 — four releases
+after it shipped — there was no artifact anywhere saying whether she had
+ever been shown it. These tests pin the outcome into the log, and for the
+zero-time case into the ops ingest, so the question is answerable next
+time.
+
+They assert on the CONSUMER (a log record, a reporter call), never on the
+value ``send_notification`` returned, because a return value nobody reads
+is the shape of the bug being fixed.
+"""
+
+import logging
+from unittest.mock import MagicMock, patch
+
+from src.aw_manager import AWManager
+from src.notifications import NotificationOutcome
+from src.sync.macos_window_watcher import MacOSWindowWatcher
+
+ROSETTA_NOTIFY = "src.notifications.send_notification"
+
+
+def _mgr(reporter=None) -> AWManager:
+    mgr = AWManager(aw_port=5600)
+    mgr._rosetta_notified = False
+    mgr.error_reporter = reporter
+    return mgr
+
+
+def _errors(caplog) -> list[str]:
+    return [r.getMessage() for r in caplog.records if r.levelno >= logging.ERROR]
+
+
+def _infos(caplog) -> list[str]:
+    return [r.getMessage() for r in caplog.records if r.levelno == logging.INFO]
+
+
+class TestRosettaNotice:
+    def test_an_undelivered_rosetta_notice_is_logged_as_an_error(self, caplog):
+        mgr = _mgr()
+        with caplog.at_level(logging.DEBUG), \
+             patch(ROSETTA_NOTIFY, return_value=NotificationOutcome.SUPPRESSED):
+            mgr._notify_rosetta_required_once()
+
+        assert any("NOT delivered" in m for m in _errors(caplog)), (
+            "a notice the user never saw must not pass in silence"
+        )
+        assert any("suppressed" in m for m in _errors(caplog)), (
+            "the log has to say WHICH way it failed"
+        )
+
+    def test_an_undelivered_rosetta_notice_reaches_the_ops_ingest(self):
+        """The device records no time and the user has not been asked to
+        fix it. Nobody reads the agent's local log — that is #194's whole
+        finding — so this one has to leave the machine."""
+        reporter = MagicMock()
+        mgr = _mgr(reporter)
+        with patch(ROSETTA_NOTIFY, return_value=NotificationOutcome.SUPPRESSED):
+            mgr._notify_rosetta_required_once()
+
+        assert reporter.capture.call_count == 1
+        kwargs = reporter.capture.call_args.kwargs
+        assert kwargs["level"] == "error"
+        assert kwargs["fingerprint"] == "rosetta-notice-undelivered"
+        assert kwargs["tags"]["notification_outcome"] == "suppressed"
+
+    def test_a_delivered_rosetta_notice_does_not_page_ops(self):
+        """The negative control. Without it, 'reports undelivered notices'
+        would be satisfied by a reporter that fires on every notice, which
+        is indistinguishable from one that measures nothing."""
+        reporter = MagicMock()
+        mgr = _mgr(reporter)
+        with patch(ROSETTA_NOTIFY, return_value=NotificationOutcome.DELIVERED):
+            mgr._notify_rosetta_required_once()
+
+        reporter.capture.assert_not_called()
+
+    def test_a_delivered_rosetta_notice_does_not_claim_the_user_read_it(self, caplog):
+        """DELIVERED means macOS filed it. A Focus mode files it silently,
+        so the log must not upgrade that into 'the user knows'."""
+        mgr = _mgr()
+        with caplog.at_level(logging.DEBUG), \
+             patch(ROSETTA_NOTIFY, return_value=NotificationOutcome.DELIVERED):
+            mgr._notify_rosetta_required_once()
+
+        assert not _errors(caplog)
+        assert any("not proof" in m.lower() for m in _infos(caplog))
+
+    def test_an_unknown_outcome_is_treated_as_undelivered(self):
+        """UNKNOWN is not success. Reporting it is the conservative
+        direction: a false alarm costs one look, and the alternative is the
+        silence that let five devices sit degraded for 12-17 days."""
+        reporter = MagicMock()
+        mgr = _mgr(reporter)
+        with patch(ROSETTA_NOTIFY, return_value=NotificationOutcome.UNKNOWN):
+            mgr._notify_rosetta_required_once()
+
+        assert reporter.capture.call_count == 1
+        assert (
+            reporter.capture.call_args.kwargs["tags"]["notification_outcome"]
+            == "unknown"
+        )
+
+    def test_a_broken_reporter_does_not_stop_the_agent(self):
+        reporter = MagicMock()
+        reporter.capture.side_effect = RuntimeError("ingest down")
+        mgr = _mgr(reporter)
+        with patch(ROSETTA_NOTIFY, return_value=NotificationOutcome.SUPPRESSED):
+            mgr._notify_rosetta_required_once()  # must not raise
+
+    def test_a_raising_notifier_does_not_stop_the_agent(self, caplog):
+        mgr = _mgr(MagicMock())
+        with patch(ROSETTA_NOTIFY, side_effect=RuntimeError("boom")):
+            mgr._notify_rosetta_required_once()  # must not raise
+        assert mgr._rosetta_notified is True
+
+    def test_the_notice_still_fires_only_once_per_process(self):
+        reporter = MagicMock()
+        mgr = _mgr(reporter)
+        with patch(ROSETTA_NOTIFY, return_value=NotificationOutcome.SUPPRESSED) as n:
+            mgr._notify_rosetta_required_once()
+            mgr._notify_rosetta_required_once()
+        assert n.call_count == 1
+        assert reporter.capture.call_count == 1
+
+
+class TestAccessibilityNotice:
+    def _watcher(self) -> MacOSWindowWatcher:
+        w = MacOSWindowWatcher(MagicMock(), poll_interval=0.1)
+        w._accessibility_notified = False
+        return w
+
+    def test_an_undelivered_accessibility_notice_is_logged_as_an_error(self, caplog):
+        w = self._watcher()
+        with caplog.at_level(logging.DEBUG), \
+             patch(ROSETTA_NOTIFY, return_value=NotificationOutcome.SUPPRESSED):
+            w._notify_accessibility_required_once()
+
+        assert any("NOT delivered" in m for m in _errors(caplog))
+        assert any("suppressed" in m for m in _errors(caplog))
+
+    def test_a_delivered_accessibility_notice_logs_no_error(self, caplog):
+        w = self._watcher()
+        with caplog.at_level(logging.DEBUG), \
+             patch(ROSETTA_NOTIFY, return_value=NotificationOutcome.DELIVERED):
+            w._notify_accessibility_required_once()
+
+        assert not _errors(caplog)
+        assert any("not proof" in m.lower() for m in _infos(caplog))
+
+    def test_a_raising_notifier_does_not_stop_the_watcher(self):
+        w = self._watcher()
+        with patch(ROSETTA_NOTIFY, side_effect=RuntimeError("boom")):
+            w._notify_accessibility_required_once()  # must not raise
+        assert w._accessibility_notified is True

--- a/tests/test_notification_delivery_verification.py
+++ b/tests/test_notification_delivery_verification.py
@@ -1,0 +1,446 @@
+"""The macOS notifier must not report a delivery it never observed (#204).
+
+``NSUserNotificationCenter.deliverNotification_`` returns nothing, so the
+old ``return True`` after it meant "the call did not raise" while reading
+as "the user was told". Two shipped user prompts — the Rosetta notice
+(#188) and the Accessibility notice (#197) — were load-bearing on that.
+
+Every test here drives a FAKE ``Foundation`` module installed into
+``sys.modules``. That is deliberate on two counts: it works identically on
+the Linux CI runner where pyobjc does not exist, and it lets a test stage
+the one arrangement a real Mac will not stage on demand — macOS accepting
+a notification and then keeping no record of it.
+
+The fake's centre is the whole point. ``deliverNotification_`` returns
+``None`` exactly as the real one does, so any code that infers success
+from it is inferring it from nothing.
+"""
+
+# ruff: noqa: N802 — the fakes below must answer to the Objective-C selector
+# names the code under test calls (setTitle_, deliveredNotifications, ...).
+# Renaming them to snake_case would make the fakes stop standing in for the
+# real API, which is the one thing they exist to do.
+import sys
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+import src.notifications as notifications
+
+# ---------------------------------------------------------------------------
+# Fakes
+# ---------------------------------------------------------------------------
+
+
+class FakeNote:
+    """Stands in for NSUserNotification, recording what was set on it."""
+
+    def __init__(self) -> None:
+        self.title = None
+        self.body = None
+        self.sound_name = None
+        self.content_image = None
+        self._identifier = None
+
+    # NSUserNotification.alloc().init()
+    def init(self) -> "FakeNote":
+        return self
+
+    def setTitle_(self, value) -> None:
+        self.title = value
+
+    def setInformativeText_(self, value) -> None:
+        self.body = value
+
+    def setSoundName_(self, value) -> None:
+        self.sound_name = value
+
+    def setContentImage_(self, value) -> None:
+        self.content_image = value
+
+    def setIdentifier_(self, value) -> None:
+        self._identifier = value
+
+    def identifier(self):
+        return self._identifier
+
+
+class FakeNoteFactory:
+    """NSUserNotification: ``alloc()`` then ``init()``."""
+
+    def __init__(self) -> None:
+        self.notes: list[FakeNote] = []
+
+    def alloc(self) -> FakeNote:
+        note = FakeNote()
+        self.notes.append(note)
+        return note
+
+
+class FakeCenter:
+    """NSUserNotificationCenter.
+
+    ``keeps`` models the only thing that actually varies in the wild:
+    whether macOS files the notification or silently drops it.
+    """
+
+    def __init__(self, keeps: bool = True, appear_after: int = 0) -> None:
+        self.keeps = keeps
+        self.appear_after = appear_after
+        self.posted: list[FakeNote] = []
+        self.read_calls = 0
+        self.removed_all = 0
+
+    def deliverNotification_(self, note):
+        self.posted.append(note)
+        # The defect in one line: the real selector returns void, so there
+        # is nothing here for a caller to check.
+        return None
+
+    def deliveredNotifications(self):
+        self.read_calls += 1
+        if not self.keeps:
+            return []
+        if self.read_calls <= self.appear_after:
+            return []
+        return list(self.posted)
+
+    def removeAllDeliveredNotifications(self) -> None:
+        self.removed_all += 1
+
+
+class ExplodingCenter(FakeCenter):
+    """A centre whose read-back breaks after a successful post."""
+
+    def deliveredNotifications(self):
+        self.read_calls += 1
+        raise RuntimeError("distributed object connection died")
+
+
+class FakeFoundation:
+    def __init__(self, center) -> None:
+        self.NSUserNotification = FakeNoteFactory()
+        self.NSUserNotificationCenter = MagicMock()
+        self.NSUserNotificationCenter.defaultUserNotificationCenter.return_value = center
+
+
+@pytest.fixture
+def no_icon():
+    """Keep AppKit out of it — the icon path is not under test here."""
+    with patch.object(notifications, "_resolve_icon_path", return_value=None):
+        yield
+
+
+@pytest.fixture
+def instant_poll(monkeypatch):
+    """Zero the confirmation backoff so the suite does not sleep."""
+    sleeper = MagicMock()
+    monkeypatch.setattr(notifications.time, "sleep", sleeper)
+    return sleeper
+
+
+def install_foundation(monkeypatch, center) -> FakeFoundation:
+    """Put a fake ``Foundation`` where the function-local import will find it.
+
+    Returns the fake so a test can assert against the note that was built.
+    """
+    fake = FakeFoundation(center)
+    monkeypatch.setitem(sys.modules, "Foundation", fake)
+    return fake
+
+
+# ---------------------------------------------------------------------------
+# The defect
+# ---------------------------------------------------------------------------
+
+
+class TestUnearnedSuccess:
+    """These fail against the pre-fix implementation. That is the point."""
+
+    def test_discarded_notification_is_not_reported_as_success(
+        self, monkeypatch, no_icon, instant_poll
+    ):
+        """macOS took the notification and kept no record of it.
+
+        Pre-fix this returns ``True`` — a delivery claim with nothing
+        behind it. Asserted with ``is not True`` rather than against the
+        new enum so the assertion means the same thing in both worlds.
+        """
+        center = FakeCenter(keeps=False)
+        install_foundation(monkeypatch, center)
+
+        outcome = notifications._send_macos_pyobjc("Title", "Body", False)
+
+        assert center.posted, "precondition: the fake centre must have been posted to"
+        assert outcome is not True
+        assert outcome is notifications.NotificationOutcome.SUPPRESSED
+        assert not outcome, "a suppressed notification must be falsy"
+
+    def test_suppression_makes_the_osascript_fallback_reachable(
+        self, monkeypatch, no_icon, instant_poll
+    ):
+        """The fallback was dead code while pyobjc always returned True.
+
+        Also the proof the subprocess is faked: the assertion is on the
+        RECORDED call, so a test that somehow shelled out for real, or that
+        never reached the fallback, cannot satisfy it.
+        """
+        center = FakeCenter(keeps=False)
+        install_foundation(monkeypatch, center)
+
+        with patch.object(notifications.platform, "system", return_value="Darwin"), \
+             patch.object(notifications, "_try_load_macos_pyobjc", return_value=True), \
+             patch.object(notifications.subprocess, "run") as run:
+            run.return_value = MagicMock(returncode=0, stderr=b"")
+            outcome = notifications.send_notification("Title", "Body", sound=False)
+
+        assert isinstance(run, MagicMock), "subprocess.run was not patched"
+        assert run.call_count == 1, "the osascript fallback did not run"
+        argv = run.call_args[0][0]
+        assert argv[0] == "osascript"
+        assert 'display notification "Body" with title "Title"' in argv[2]
+        # A second, unreadable channel was tried, so the honest verdict is
+        # neither the suppression we saw nor a delivery we did not.
+        assert outcome is notifications.NotificationOutcome.UNKNOWN
+
+    def test_delivered_notification_is_reported_delivered(
+        self, monkeypatch, no_icon, instant_poll
+    ):
+        """The positive control. Without this, 'never reports success' would
+        be trivially satisfiable by never reporting success at all."""
+        center = FakeCenter(keeps=True)
+        install_foundation(monkeypatch, center)
+
+        outcome = notifications._send_macos_pyobjc("Title", "Body", False)
+
+        assert outcome is notifications.NotificationOutcome.DELIVERED
+        assert outcome, "a verified delivery must be truthy"
+
+    def test_delivery_is_attributed_by_a_unique_identifier(
+        self, monkeypatch, no_icon, instant_poll
+    ):
+        """Two sends must not confirm each other.
+
+        Every notification this agent has ever posted carries
+        ``identifier() is None``, so a delivered-list read could match any
+        of them. Confirming on an untagged read would let an OLD delivered
+        notification certify a NEW suppressed one.
+        """
+        center = FakeCenter(keeps=True)
+        fake = install_foundation(monkeypatch, center)
+
+        notifications._send_macos_pyobjc("Title", "Body", False)
+        notifications._send_macos_pyobjc("Title", "Body", False)
+
+        markers = [n.identifier() for n in fake.NSUserNotification.notes]
+        assert all(m for m in markers), "every notification must be tagged"
+        assert len(set(markers)) == len(markers), "identifiers must be unique per send"
+
+    def test_a_stale_delivered_notification_cannot_certify_a_new_send(
+        self, monkeypatch, no_icon, instant_poll
+    ):
+        """A centre already holding someone else's notification, which then
+        drops ours, must still read as suppressed."""
+
+        class PrepopulatedCenter(FakeCenter):
+            def deliveredNotifications(self):
+                self.read_calls += 1
+                stale = FakeNote()
+                stale.setIdentifier_("someone-elses-notification")
+                untagged = FakeNote()  # identifier() is None, like every
+                return [stale, untagged]  # notification we have ever posted
+
+        center = PrepopulatedCenter(keeps=False)
+        install_foundation(monkeypatch, center)
+
+        outcome = notifications._send_macos_pyobjc("Title", "Body", False)
+
+        assert center.read_calls > 0, "precondition: the delivered list was read"
+        assert outcome is notifications.NotificationOutcome.SUPPRESSED
+
+
+# ---------------------------------------------------------------------------
+# Unknown is its own answer
+# ---------------------------------------------------------------------------
+
+
+class TestUnknownIsNotSuccess:
+    def test_unreadable_delivery_is_unknown_not_delivered(
+        self, monkeypatch, no_icon, instant_poll
+    ):
+        """The post worked and the read broke. We do not know, and saying
+        either of the other two answers would be a guess."""
+        center = ExplodingCenter(keeps=True)
+        install_foundation(monkeypatch, center)
+
+        outcome = notifications._send_macos_pyobjc("Title", "Body", False)
+
+        assert center.posted, "precondition: the notification WAS posted"
+        assert outcome is notifications.NotificationOutcome.UNKNOWN
+        assert outcome is not notifications.NotificationOutcome.SUPPRESSED
+        assert not outcome
+
+    def test_nil_center_is_a_failure_not_an_unknown(
+        self, monkeypatch, no_icon, instant_poll
+    ):
+        """``defaultUserNotificationCenter()`` is nil for a process the
+        notification system will not talk to. Nothing was posted at all, so
+        this is not merely unverifiable."""
+        install_foundation(monkeypatch, None)
+
+        outcome = notifications._send_macos_pyobjc("Title", "Body", False)
+
+        assert outcome is notifications.NotificationOutcome.FAILED
+
+    def test_osascript_success_is_unknown_never_delivered(self, monkeypatch):
+        """osascript exiting 0 means the AppleScript ran. It says nothing
+        about whether macOS presented anything."""
+        with patch.object(notifications.subprocess, "run") as run:
+            run.return_value = MagicMock(returncode=0, stderr=b"")
+            outcome = notifications._send_macos_osascript("T", "B", False)
+
+        assert run.call_count == 1, "subprocess.run was not exercised"
+        assert outcome is notifications.NotificationOutcome.UNKNOWN
+        assert outcome is not notifications.NotificationOutcome.DELIVERED
+
+    def test_osascript_nonzero_exit_is_a_failure(self, monkeypatch):
+        with patch.object(notifications.subprocess, "run") as run:
+            run.return_value = MagicMock(returncode=1, stderr=b"boom")
+            outcome = notifications._send_macos_osascript("T", "B", False)
+
+        assert run.call_count == 1
+        assert outcome is notifications.NotificationOutcome.FAILED
+
+    def test_unsupported_platform_is_not_unknown(self):
+        """We know perfectly well nothing was sent — that is not 'unknown'."""
+        with patch.object(notifications.platform, "system", return_value="FreeBSD"):
+            outcome = notifications.send_notification("T", "B")
+        assert outcome is notifications.NotificationOutcome.UNSUPPORTED
+
+    def test_windows_clean_exit_is_unknown(self):
+        with patch.object(notifications.platform, "system", return_value="Windows"), \
+             patch.object(notifications.subprocess, "run") as run:
+            run.return_value = MagicMock(returncode=0, stderr=b"")
+            outcome = notifications.send_notification("T", "B")
+        assert run.call_count == 1
+        assert run.call_args[0][0][0] == "powershell"
+        assert outcome is notifications.NotificationOutcome.UNKNOWN
+
+    def test_linux_clean_exit_is_unknown(self):
+        with patch.object(notifications.platform, "system", return_value="Linux"), \
+             patch.object(notifications, "_resolve_icon_path", return_value=None), \
+             patch.object(notifications.subprocess, "run") as run:
+            run.return_value = MagicMock(returncode=0, stderr=b"")
+            outcome = notifications.send_notification("T", "B")
+        assert run.call_count == 1
+        assert run.call_args[0][0][0] == "notify-send"
+        assert outcome is notifications.NotificationOutcome.UNKNOWN
+
+    def test_missing_notify_send_is_a_failure(self):
+        with patch.object(notifications.platform, "system", return_value="Linux"), \
+             patch.object(notifications, "_resolve_icon_path", return_value=None), \
+             patch.object(notifications.subprocess, "run", side_effect=FileNotFoundError):
+            outcome = notifications.send_notification("T", "B")
+        assert outcome is notifications.NotificationOutcome.FAILED
+
+
+# ---------------------------------------------------------------------------
+# The confirmation read itself
+# ---------------------------------------------------------------------------
+
+
+class TestDeliveryConfirmation:
+    def test_confirmation_retries_because_delivery_is_asynchronous(
+        self, monkeypatch, no_icon, instant_poll
+    ):
+        """Measured at ~0.1s on a real Mac, so a single read would call a
+        healthy delivery suppressed."""
+        center = FakeCenter(keeps=True, appear_after=2)
+        install_foundation(monkeypatch, center)
+
+        outcome = notifications._send_macos_pyobjc("Title", "Body", False)
+
+        assert center.read_calls == 3, "the read must be retried, not attempted once"
+        assert outcome is notifications.NotificationOutcome.DELIVERED
+
+    def test_confirmation_backs_off_between_reads(
+        self, monkeypatch, no_icon, instant_poll
+    ):
+        """Witnesses the sleep specifically: without it the retry loop would
+        spin the whole budget away inside one millisecond and read as a
+        single attempt against a slow centre."""
+        center = FakeCenter(keeps=False)
+        install_foundation(monkeypatch, center)
+
+        notifications._send_macos_pyobjc("Title", "Body", False)
+
+        assert instant_poll.call_count == notifications._DELIVERY_CONFIRM_ATTEMPTS - 1
+        assert all(
+            call.args[0] == notifications._DELIVERY_CONFIRM_INTERVAL
+            for call in instant_poll.call_args_list
+        )
+
+    def test_confirmation_gives_up_rather_than_polling_forever(
+        self, monkeypatch, no_icon, instant_poll
+    ):
+        center = FakeCenter(keeps=False)
+        install_foundation(monkeypatch, center)
+
+        notifications._send_macos_pyobjc("Title", "Body", False)
+
+        assert center.read_calls == notifications._DELIVERY_CONFIRM_ATTEMPTS
+
+
+# ---------------------------------------------------------------------------
+# Behaviour that was already correct, pinned so the fix did not move it
+# ---------------------------------------------------------------------------
+
+
+class TestUnchangedBehaviour:
+    def test_title_and_body_still_reach_the_notification(
+        self, monkeypatch, no_icon, instant_poll
+    ):
+        center = FakeCenter(keeps=True)
+        fake = install_foundation(monkeypatch, center)
+
+        notifications._send_macos_pyobjc("A title", "A body", False)
+
+        note = fake.NSUserNotification.notes[0]
+        assert note.title == "A title"
+        assert note.body == "A body"
+
+    def test_sound_flag_is_still_honoured(self, monkeypatch, no_icon, instant_poll):
+        center = FakeCenter(keeps=True)
+        fake = install_foundation(monkeypatch, center)
+
+        notifications._send_macos_pyobjc("T", "B", True)
+        notifications._send_macos_pyobjc("T", "B", False)
+
+        loud, quiet = fake.NSUserNotification.notes
+        assert loud.sound_name == "NSUserNotificationDefaultSoundName"
+        assert quiet.sound_name is None
+
+    def test_a_raising_post_is_still_not_a_success(
+        self, monkeypatch, no_icon, instant_poll
+    ):
+        """Already true pre-fix (it returned False). Pinned so the rewrite
+        did not quietly convert an exception into a delivery."""
+
+        class RaisingCenter(FakeCenter):
+            def deliverNotification_(self, note):
+                raise RuntimeError("nope")
+
+        install_foundation(monkeypatch, RaisingCenter())
+
+        outcome = notifications._send_macos_pyobjc("T", "B", False)
+
+        assert outcome is not True
+        assert not outcome
+
+    def test_send_notification_never_raises(self, monkeypatch):
+        """A notification that cannot be sent must not stop its caller."""
+        with patch.object(notifications.platform, "system", return_value="Darwin"), \
+             patch.object(notifications, "_try_load_macos_pyobjc", return_value=False), \
+             patch.object(notifications.subprocess, "run", side_effect=Exception("x")):
+            outcome = notifications.send_notification("T", "B")
+        assert outcome is notifications.NotificationOutcome.FAILED

--- a/tests/test_notification_delivery_verification.py
+++ b/tests/test_notification_delivery_verification.py
@@ -21,6 +21,7 @@ from it is inferring it from nothing.
 # Renaming them to snake_case would make the fakes stop standing in for the
 # real API, which is the one thing they exist to do.
 import sys
+from types import SimpleNamespace
 from unittest.mock import MagicMock, patch
 
 import pytest
@@ -133,9 +134,19 @@ def no_icon():
 
 @pytest.fixture
 def instant_poll(monkeypatch):
-    """Zero the confirmation backoff so the suite does not sleep."""
+    """Zero the confirmation backoff so the suite does not sleep.
+
+    Replaces the whole ``time`` attribute with ``raising=False`` rather
+    than patching ``notifications.time.sleep``. The pre-fix module does
+    not import ``time`` at all, so the obvious form dies in fixture setup
+    and every test built on it ERRORS instead of failing — which reaches
+    the subject exactly never, and would make a proof-of-failure run prove
+    nothing (test_fixture_discipline Phantom 4).
+    """
     sleeper = MagicMock()
-    monkeypatch.setattr(notifications.time, "sleep", sleeper)
+    monkeypatch.setattr(
+        notifications, "time", SimpleNamespace(sleep=sleeper), raising=False
+    )
     return sleeper
 
 
@@ -281,16 +292,31 @@ class TestUnknownIsNotSuccess:
         assert not outcome
 
     def test_nil_center_is_a_failure_not_an_unknown(
-        self, monkeypatch, no_icon, instant_poll
+        self, monkeypatch, no_icon, instant_poll, caplog
     ):
         """``defaultUserNotificationCenter()`` is nil for a process the
         notification system will not talk to. Nothing was posted at all, so
-        this is not merely unverifiable."""
+        this is not merely unverifiable.
+
+        The log line is asserted too, and that is the half that witnesses
+        the guard. Deleting the nil check leaves the outcome at ``FAILED``
+        anyway — posting to nil raises and the handler catches it — so the
+        outcome alone cannot tell the guard from its absence. What changes
+        is whether the operator reads "the notification system will not
+        talk to this process" or a bare ``NoneType has no attribute``.
+        """
+        import logging
+
         install_foundation(monkeypatch, None)
 
-        outcome = notifications._send_macos_pyobjc("Title", "Body", False)
+        with caplog.at_level(logging.DEBUG):
+            outcome = notifications._send_macos_pyobjc("Title", "Body", False)
 
         assert outcome is notifications.NotificationOutcome.FAILED
+        messages = [r.getMessage() for r in caplog.records]
+        assert any("NSUserNotificationCenter" in m for m in messages), (
+            "a nil centre has to say so, not surface as a generic pyobjc error"
+        )
 
     def test_osascript_success_is_unknown_never_delivered(self, monkeypatch):
         """osascript exiting 0 means the AppleScript ran. It says nothing

--- a/tests/test_notifications.py
+++ b/tests/test_notifications.py
@@ -2,7 +2,11 @@
 
 from unittest.mock import MagicMock, patch
 
-from src.notifications import clear_notifications, send_notification
+from src.notifications import (
+    NotificationOutcome,
+    clear_notifications,
+    send_notification,
+)
 import src.notifications as notifications_module
 
 
@@ -43,26 +47,60 @@ class TestSendNotification:
 
     @patch("src.notifications.platform.system", return_value="Darwin")
     @patch("src.notifications._try_load_macos_pyobjc", return_value=True)
-    @patch("src.notifications._send_macos_pyobjc", return_value=True)
+    @patch(
+        "src.notifications._send_macos_pyobjc",
+        return_value=NotificationOutcome.DELIVERED,
+    )
     @patch("src.notifications._send_macos_osascript")
     def test_macos_pyobjc_preferred(
         self, mock_osascript, mock_pyobjc_send, _mock_try, _mock_sys
     ):
-        """When pyobjc is available, osascript path is skipped entirely."""
+        """A VERIFIED delivery skips osascript entirely.
+
+        The stub returns ``DELIVERED`` rather than ``True`` on purpose: a
+        bare truthy is what used to stand in for a delivery nobody had
+        observed (#204), and it must no longer be enough to short-circuit
+        the fallback.
+        """
         send_notification("Title", "Body")
         mock_pyobjc_send.assert_called_once()
         mock_osascript.assert_not_called()
 
     @patch("src.notifications.platform.system", return_value="Darwin")
     @patch("src.notifications._try_load_macos_pyobjc", return_value=True)
-    @patch("src.notifications._send_macos_pyobjc", return_value=False)
+    @patch(
+        "src.notifications._send_macos_pyobjc",
+        return_value=NotificationOutcome.FAILED,
+    )
     @patch("src.notifications._send_macos_osascript")
     def test_macos_pyobjc_failure_falls_back(
         self, mock_osascript, _mock_pyobjc_send, _mock_try, _mock_sys
     ):
         """If the pyobjc call fails, we still try osascript."""
+        mock_osascript.return_value = NotificationOutcome.UNKNOWN
         send_notification("Title", "Body")
         mock_osascript.assert_called_once()
+
+    @patch("src.notifications.platform.system", return_value="Darwin")
+    @patch("src.notifications._try_load_macos_pyobjc", return_value=True)
+    @patch(
+        "src.notifications._send_macos_pyobjc",
+        return_value=NotificationOutcome.SUPPRESSED,
+    )
+    @patch("src.notifications._send_macos_osascript")
+    def test_macos_suppression_also_falls_back(
+        self, mock_osascript, _mock_pyobjc_send, _mock_try, _mock_sys
+    ):
+        """The case the fallback existed for and could never reach.
+
+        Pre-fix the pyobjc path returned ``True`` whether or not macOS kept
+        the notification, so a suppressed notice short-circuited every
+        alternative and the user was told nothing.
+        """
+        mock_osascript.return_value = NotificationOutcome.UNKNOWN
+        outcome = send_notification("Title", "Body")
+        mock_osascript.assert_called_once()
+        assert outcome is NotificationOutcome.UNKNOWN
 
     @patch("src.notifications.platform.system", return_value="Windows")
     @patch("src.notifications.subprocess.run")
@@ -84,8 +122,8 @@ class TestSendNotification:
     @patch("src.notifications._try_load_macos_pyobjc", return_value=False)
     @patch("src.notifications.subprocess.run", side_effect=Exception("fail"))
     def test_exception_is_swallowed(self, _mock_run, _mock_pyobjc, _mock_sys):
-        # Should not raise
-        send_notification("Title", "Body")
+        # Should not raise — but it must not read as success either.
+        assert send_notification("Title", "Body") is NotificationOutcome.FAILED
 
 
 class TestClearNotifications:


### PR DESCRIPTION
Issue 204: the macOS notifier reported a success it had no way to observe, so
two shipped user prompts had nothing behind them.

## What macOS actually lets us observe

Established against the real API before any code was written, on macOS with
pyobjc:

```
deliverNotification_ returned: None
FOUND in deliveredNotifications after 0.1s; id='bfs-204-probe'
retrieved isPresented(): False        <- False even for a delivered notification
center selectors of interest: ['_shouldPresentNotification_', '_presentedAlerts',
  'deliverNotification_', 'deliveredNotifications', 'removeAllDeliveredNotifications', ...]
```

**Observable**

- `deliveredNotifications()`, and it reflects the *system's* record rather than
  a per-process one. A plain python process reads notifications posted by
  `BetterFlow.app`:

  ```
  'BetterFlow tracking unavailable' | None | 2026-08-23 06:09:57 +0000
  'Welcome back!'                   | None | 2026-08-23 06:10:18 +0000
  ```

  Note the `None` in the middle column. Every notification this agent has ever
  posted is untagged, so even in hindsight no delivered entry can be attributed
  to a particular send. This branch sets a unique identifier per post, which is
  what makes the read mean anything.
- Whether the sending mechanism itself broke — an exception, a non-zero
  `osascript`/PowerShell exit, a missing `notify-send`.

**Not observable**

- **Whether the user saw it.** Do Not Disturb and Focus file a notification into
  Notification Center without showing a banner. `DELIVERED` therefore means
  macOS accepted it, and the code says so in those words.
- **An authorisation status.** The legacy centre exposes no public
  `authorizationStatus`; the only authorisation-shaped selectors on it are
  private. The state is inferred from the delivery read or not at all.
- **`isPresented()`** — returns `False` on a notification that demonstrably WAS
  delivered and carries an `actualDeliveryDate`. It is a false-negative machine
  and is deliberately not used.
- **Anything about osascript / PowerShell / notify-send.** Their exit codes say
  the command ran. The delivered-list read cannot rescue them either, because
  none of them can be tagged, so an entry cannot be attributed to one of them
  rather than to the pyobjc attempt that preceded it.

## The change

`send_notification` returns a `NotificationOutcome` instead of `None`:

| | meaning | what it is not |
|---|---|---|
| `DELIVERED` | found in the OS's own delivered list by our identifier | not proof anyone saw it |
| `SUPPRESSED` | the OS accepted the post and kept no record | |
| `FAILED` | the mechanism itself broke | |
| `UNKNOWN` | the mechanism ran and offers no read-back | **not** a success |
| `UNSUPPORTED` | no channel here; nothing was sent | not "unknown" — we know |

`UNKNOWN` exists because collapsing it into success is the bug being fixed, and
"we know nothing was sent" is a different fact from "we cannot tell", wanting a
different follow-up. `__bool__` is true only for `DELIVERED`, so a caller
writing the obvious `if send_notification(...)` gets the fail-closed reading
rather than rebuilding this one layer up.

The osascript fallback is reachable again. It was dead code for as long as the
pyobjc path returned a bare `True`, which is the second half of what the issue
reports — a suppressed notice had no second chance, and osascript posts under a
different bundle identity carrying its own permission.

The two load-bearing callers now record the verdict rather than discarding it:
a warning either way, plus for the zero-time Rosetta case an ops report
fingerprinted `rosetta-notice-undelivered`. That is the part that makes "were
they ever told?" answerable next time; the agent's local log is not read by
anyone, which was issue 194's whole finding.

## Did the two shipped fixes ever work?

**For the specific machines in the report: cannot be determined, and no artifact
capable of answering it was ever collected.** That is the finding, not a gap in
this investigation.

- VERIFIED — the notify call was present in the releases claimed. Rosetta:
  reachable in `v1.5.118` and in `v1.5.122`, the version Carmen Lapusan was on.
  Accessibility: absent until `v1.5.124`.
- VERIFIED — nothing recorded the outcome. Pre-fix both callers logged only on
  an exception, at debug. No log line, no ops event, no telemetry field carried
  the notification result, on any version.
- VERIFIED — the channel is not universally dead. BetterFlow's own notifications
  reach Notification Center on the machine used for this work, via the same
  `send_notification` path, on multiple days. So "these notices never worked
  anywhere" is refuted.
- UNVERIFIED — whether either notice reached the users in the report. There is
  no way to recover it: the sends were untagged, the outcome was never written
  down, and the machines are not reachable from here.

One part IS determinable and is worth stating plainly: for the five users
degraded 12–17 days under issue 194, the Accessibility notice **did not exist**
for that window. It shipped in `v1.5.124`.

## Human-QA blocker

The `SUPPRESSED` verdict has **not** been observed against real macOS TCC. Doing
so needs a Mac where notification permission for `co.betterqa.betterflow` is
denied — the new-laptop case that matters most for issue 188 — and that state
cannot be staged from here.

What HAS been verified on real macOS, driving the shipped code:

```
module.__file__ = .../bfs-204/src/notifications.py   (worktree, not the primary checkout)
--- real delivery ---                 outcome = DELIVERED   | bool = True
--- marker never posted (control) --- outcome = SUPPRESSED  | bool = False
--- full send_notification() ---      outcome = DELIVERED
```

The negative control is the load-bearing half: the read discriminates rather
than answering `DELIVERED` to everything. What remains unproven is that macOS's
drop behaviour on an unauthorised bundle presents as that same absence. The
issue author reports verifying exactly that; this branch has not reproduced it.

Please smoke it on a Mac with notifications denied for BetterFlow, and confirm
the agent log carries `Rosetta notice was NOT delivered (suppressed)`.

## Verification

**Proof-of-failure**, against `origin/main`'s implementation with the new tests
in place (`git checkout origin/main -- src/notifications.py src/aw_manager.py
src/sync/macos_window_watcher.py`).

Precondition asserted first — the pre-fix files must lack every symbol the fix
introduces, with a positive control on a symbol present in both trees:

```
src/notifications.py 'NotificationOutcome'          -> 0
src/notifications.py '_confirm_macos_delivery'      -> 0
src/aw_manager.py    'rosetta-notice-undelivered'   -> 0
src/sync/macos_window_watcher.py 'NOT delivered'    -> 0
src/notifications.py 'deliverNotification_'         -> 1   (control: probe is alive)
```

```
17 failed, 3 passed in 0.20s
```

The headline failure is the bug verbatim:

```
    assert outcome is not True
E   assert True is not True
```

Two assertions are written `is not True` rather than against the new enum on
purpose, so the red is behavioural and not an `ImportError` on a symbol the old
tree lacks. The 3 that pass pre-fix are the isolation pins — title/body reach
the notification, the sound flag is honoured, a raising post is not a success —
which is what separates a proof of the old bug from a spec for the new code.

An earlier attempt at this handshake produced **13 errors instead of failures**:
the fixture patched `notifications.time.sleep`, and the pre-fix module never
imports `time`, so every test built on it died in fixture setup and reached the
subject exactly never. Fixed with `raising=False` on the whole attribute; the
comment in the fixture says why.

**Mutation matrix** — one mutant per mechanism removing the CHECK, one removing
what the check DOES. Anchors asserted unique before mutating, `cmp` after to
refuse a no-op, and `__pycache__` deleted before every run (CPython invalidates
on `(mtime, size)`, so a same-length mutant inside one mtime second silently
re-runs the previous mutant's bytecode; `-B` does not fix that, it stops
*writing* a `.pyc` and never stops *reading* a stale one).

```
CONTROL (unmutated)   rc=0  43 passed

M1  identifier tagging (check)              KILLED -> 3
M2  confirmation is called (check)          KILLED -> 7
M3  confirmation's verdict (effect)         KILLED -> 3
M4  retry loop (effect)                     KILLED -> 3
M5  backoff sleep (effect)                  KILLED -> 1  test_confirmation_backs_off_between_reads
M6  nil-centre guard (check)                KILLED -> 1  test_nil_center_is_a_failure_not_an_unknown
M7  read-back failure -> UNKNOWN (effect)   KILLED -> 1  test_unreadable_delivery_is_unknown_not_delivered
M8  fallback short-circuit (check)          KILLED -> 3
M9  __bool__ fails closed (effect)          KILLED -> 3
M10 rosetta error log (effect)              KILLED -> 1  test_an_undelivered_rosetta_notice_is_logged_as_an_error
M11 rosetta ops report (effect)             KILLED -> 3
M12 rosetta delivered short-circuit (check) KILLED -> 2
M13 a11y error log (effect)                 KILLED -> 1
M14 a11y delivered short-circuit (check)    KILLED -> 1

survivors: 0
POST-MATRIX CONTROL   rc=0  43 passed   (tree restored)
```

Two things the matrix exposed, recorded rather than tidied away:

- **M6 initially survived.** Deleting the nil-centre guard leaves the outcome at
  `FAILED` either way, because posting to nil raises and the handler catches it,
  so the outcome alone cannot tell the guard from its absence. The
  operator-visible difference is the message — "the notification system will not
  talk to this process" versus a bare `NoneType has no attribute` — so that is
  what the test now asserts.
- **M13 and M14 share their only witness.** The Accessibility caller has no ops
  reporter, so the log is its single observable and both mutants collapse onto
  one named test. Written down rather than answered with a contrived fixture.
  The Rosetta caller has two observables and its mutants separate cleanly.

**Gates.** CI is cost-capped off org-wide, so these were run locally.
`.github/workflows/` holds `build.yml`, `sync-downloads.yml` and
`verify-tracker-pins.yml` — no `ci.yml`.

- `build.yml`, both jobs, step `Run tests` → `pytest tests/ -v --tb=short`:
  `1823 passed, 1 skipped`, exit 0. Baseline on `origin/main`:
  `1791 passed, 1 skipped`, exit 0. Zero failures either side, so failure names
  compare trivially; the delta is 32 new tests.
- Same command under **Python 3.11**, which is what `setup-python` pins (the dev
  box is 3.14): `1823 passed, 1 skipped`, exit 0.
- **Without pyobjc**, which is the actual PR-gate condition — pyobjc is
  `sys_platform == "darwin"` in `requirements.txt`, so `Foundation` does not
  exist on the ubuntu runner and a macOS dev box hides that. Run behind an
  import blocker whose own positive control fires first
  (`BLOCKER CONTROL OK: No module named 'Foundation'`): `65 passed`, exit 0,
  covering the three notification files plus `test_accessibility_prompt.py` and
  `test_aw_manager_rosetta_preflight.py`.
- `verify-tracker-pins.yml` fires on this branch — it triggers on pushes to
  `src/aw_manager.py`, which this diff touches. Its one step,
  `python scripts/verify_tracker_pins.py`, run locally: exit 0,
  `All 3 pins verified for AW_VERSION v0.13.2` (darwin, linux, windows digests
  all matching). It reads only the pin and asset constants; the change to
  `aw_manager.py` is confined to `_notify_rosetta_required_once`.
- `sync-downloads.yml` is a deploy workflow and was not run.
- `ruff check` is not a CI step but is the repo's `make lint`. The tree carries
  pre-existing findings; the four files this branch adds or rewrites are clean,
  and `src/aw_manager.py` and `tests/test_notifications.py` hold the same count
  before and after (4 and 2). The Objective-C selector names in the fakes carry
  a scoped `# ruff: noqa: N802` with a reason — renaming them to snake_case
  would stop the fakes standing in for the API they exist to imitate.

**On the tests shelling out.** They do not. The osascript assertions read the
recorded `subprocess.run` call and assert its argv, `subprocess.run` is asserted
to be a `Mock` inside the test, and the whole file runs in ~0.2s — so a test
cannot pass by timing out into a falsy return.

## Costs accepted, so they are not discovered later

- **Up to 0.5s on the notification path when a notification is not confirmed**
  (six reads, 0.1s apart, returning the moment the identifier appears — measured
  at ~0.1s on a healthy Mac, so the usual cost is one sleep). It is the same
  centre object the existing `deliverNotification_` already talks to, so it adds
  no new deadlock surface; `_report_capture_unavailable` already sends its ops
  signal before the toast for that reason.
- **A duplicate banner is possible** where the pyobjc post succeeded and only
  the read-back broke: the verdict is `UNKNOWN` and the osascript fallback then
  posts a second time. Deliberate — on a machine recording zero time, two
  banners is a much cheaper error than silence.
- **A false `SUPPRESSED`** if the user, or our own `clear_notifications()`,
  empties Notification Center inside the poll window. Costs one extra osascript
  post and a warning line. The read is biased this way on purpose: the opposite
  error is the one that shipped two notices to nobody.

Refers to issue 204. Not auto-closing it: the tray and `tracker_install_failed`
surfaces named in that issue's suggested direction are untouched here, and
whether to move the *cause* onto a persistent surface is a product call.
