### PR TITLE
Say why a Mac records nothing, and which build it is running

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -161,6 +161,17 @@ not the person using it:
   `true_machine_arch()` returned `""`, i.e. the probe never resolved; do not
   coerce that to a string, or "we could not tell" becomes indistinguishable from
   an architecture.
+- `process_arch` (`src/machine_arch.py`) — the CPU architecture of the running
+  **process**, i.e. which BUILD of the agent is installed. Same category as
+  `machine_arch` above: a model of processor, never a person. **Why it is sent
+  separately:** `machine_arch` resolves *through* Rosetta on purpose, so a
+  native arm64 install and an Intel build under Rosetta report the identical
+  value and are byte-identical on the wire. `machine_arch` therefore answers
+  "who is on Intel *silicon*?" while #184 asks "who is on the Intel *build*?" —
+  and only the PAIR separates them (`machine_arch=arm64` with
+  `process_arch=x86_64` is a device sitting on the wrong build). Unlike
+  `machine_arch` it is never `null`: a running process always has an
+  architecture, so there is no "undetermined" state to model.
 
 The serial is shown back to the user in the tray under **Diagnostics > Device
 serial**, next to the Privacy Policy link, and clicking it copies the value.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -169,9 +169,14 @@ not the person using it:
   value and are byte-identical on the wire. `machine_arch` therefore answers
   "who is on Intel *silicon*?" while #184 asks "who is on the Intel *build*?" —
   and only the PAIR separates them (`machine_arch=arm64` with
-  `process_arch=x86_64` is a device sitting on the wrong build). Unlike
-  `machine_arch` it is never `null`: a running process always has an
-  architecture, so there is no "undetermined" state to model.
+  `process_arch=x86_64` is a device sitting on the wrong build). `null` means
+  the same thing it does for `machine_arch` — the architecture could not be
+  determined — and must be handled the same way. A running process essentially
+  always has an architecture, so `null` here should be far rarer than for its
+  sibling, but `platform.machine()` is documented to return `""` when it cannot
+  answer; that is mapped to `null` at the producer rather than shipped as a
+  blank string, because `HEARTBEAT_HEALTH_KEYS` filters by key membership and
+  would otherwise put `""` on the wire.
 
 The serial is shown back to the user in the tray under **Diagnostics > Device
 serial**, next to the Privacy Policy link, and clicking it copies the value.

--- a/src/aw_manager.py
+++ b/src/aw_manager.py
@@ -135,6 +135,13 @@ WINDOW_TITLE_EVENT_LIMIT = 500
 # error reports. start() is retried from the health-check tick, so without this
 # a fail-closed download would toast the user every cycle.
 DOWNLOAD_FAILURE_REPORT_INTERVAL = 3600  # 1 hour
+# The one thing that fixes a zero-recording Apple Silicon Mac, spelled once.
+# Three surfaces quote it — the log line, the toast, and (since #188) the tray
+# state that persists for as long as the fault does. It is the whole remedy, so
+# a typo in any single copy is a user typing a command that does nothing on the
+# day they are already recording nothing; one constant is what stops the three
+# from drifting. The agent cannot run it itself: it needs an admin password.
+ROSETTA_INSTALL_COMMAND = "softwareupdate --install-rosetta"
 # (ops summary, ops fingerprint, user toast) per cause of "this device captures
 # NOTHING". Keyed rather than branched so a new cause is a table row. Both are
 # the same outage to the person using the machine, so both must reach them —
@@ -814,10 +821,55 @@ class AWManager:
             logger.error(
                 "This Mac is Apple Silicon and Rosetta 2 is not installed, so the "
                 "x86_64 ActivityWatch trackers cannot run. Nothing will be tracked "
-                "until it is installed: run `softwareupdate --install-rosetta` "
-                "(needs an admin password, so the agent cannot do it for you)."
+                "until it is installed: run `%s` "
+                "(needs an admin password, so the agent cannot do it for you).",
+                ROSETTA_INSTALL_COMMAND,
             )
         return missing
+
+    def capture_blocked_remedy(self) -> Optional[str]:
+        """One sentence for a surface that PERSISTS, or None.
+
+        Returns the user-facing remedy when this device is recording nothing
+        for a cause the person at the keyboard can actually fix, and ``None``
+        whenever we have not established such a cause. Today that is exactly
+        one cause: Apple Silicon without Rosetta 2.
+
+        **Why this exists.** The Rosetta fault already reached the user twice —
+        a one-shot toast, and a red tray. The toast fires once per process,
+        during the noisiest minute of a new laptop's first launch, and
+        ``clear_notifications()`` wipes it on quit; the tray persisted for the
+        whole outage and said *"ActivityWatch not responding"*, naming a
+        component the user has never heard of. So the fault was reported on a
+        surface nobody could act on and mis-labelled on the surface that lasted.
+        Carmen Lapusan lost ~90 minutes to that on 2026-08-13, after Laszlo
+        Fabian Raul's device recorded zero seconds across 2026-07-22/23. This
+        method is what lets the persistent surface carry the actionable text.
+
+        **Reads the MEMO, never the probe.** ``_rosetta_missing()`` forks
+        ``/usr/bin/arch``; this is called while building a tray message, on the
+        sync cycle, so it consults the cached answer only. The same rule the
+        tray's own ``_arch_menu_item`` and ``serial_menu_row`` carry.
+
+        **Three states, not two.** The memo is ``None`` until something probed:
+
+            True  -> established: no Rosetta, nothing is being recorded
+            False -> established: Rosetta is present, this is some OTHER fault
+            None  -> nobody has asked yet
+
+        Only ``True`` earns a remedy. Treating ``None`` as ``True`` would put a
+        confident Rosetta instruction on every unrelated outage on every
+        platform, including machines that already have it — a guess, on the one
+        surface that exists to stop the user guessing. Fail toward saying
+        nothing, exactly as ``_rosetta_missing()`` itself fails toward
+        attempting the start.
+        """
+        if self._rosetta_missing_cached is not True:
+            return None
+        return (
+            "Not recording — Rosetta 2 required. Open Terminal and run: "
+            f"{ROSETTA_INSTALL_COMMAND}"
+        )
 
     def _notify_rosetta_required_once(self) -> None:
         """Tell the user once per process. The tray state is set by the caller's
@@ -834,7 +886,7 @@ class AWManager:
             outcome = send_notification(
                 "BetterFlow can't track on this Mac",
                 "Rosetta 2 is required. Open Terminal and run: "
-                "softwareupdate --install-rosetta",
+                f"{ROSETTA_INSTALL_COMMAND}",
             )
         except Exception:
             logger.debug("Rosetta notification failed", exc_info=True)

--- a/src/aw_manager.py
+++ b/src/aw_manager.py
@@ -851,21 +851,39 @@ class AWManager:
         sync cycle, so it consults the cached answer only. The same rule the
         tray's own ``_arch_menu_item`` and ``serial_menu_row`` carry.
 
+        **Two conditions, not one, and the second is the one that was missing.**
+        A Rosetta memo of ``True`` says these binaries cannot execute here. It
+        does NOT say this device is recording nothing — a user who installed a
+        native arm64 ActivityWatch themselves has a live server on the port and
+        a memo that will read ``True`` forever. Gating on the memo alone put
+        *"Not recording — Rosetta 2 required"* in front of someone who IS
+        recording, about a component irrelevant to whatever actually failed,
+        the moment any unrelated bucket failure escalated.
+
+        So the remedy also requires ``tracker_download_failed`` — the manager's
+        own latch for "this device captures nothing", set on the same branch of
+        ``_start_locked`` and deliberately NOT set when an external server is
+        attached. ``_managed_components_unavailable`` is the wrong flag for this
+        question: it is true on the recording-via-external device too, by
+        design, because our watchers really are unavailable there.
+
         **Deliberately NOT under ``_lifecycle_lock``**, unlike its sibling
-        ``health_snapshot()`` which reads the capture-dead flags under it. Two
-        reasons, and the second is the one that matters. The memo is write-once
-        and monotonic — whether this Mac can execute x86_64 cannot change
-        without a reboot, so there is no torn read to protect against and a
-        stale read is impossible rather than merely unlikely; the flags
-        ``health_snapshot`` guards are genuinely re-written on every start.
-        And the caller is the tray-message path, which runs while
-        ``force_restart()`` may be holding that lock across process spawns —
-        so taking it here would block a UI update behind tracker teardown to
-        re-read a value that cannot have changed.
+        ``health_snapshot()`` which reads the same latch under it. The caller is
+        the tray-message path, and ``force_restart()`` holds that lock across
+        process spawns — taking it here would block a UI update behind tracker
+        teardown. Both reads are single attribute loads of a bool/tri-state, so
+        there is no torn read; the worst case is a value that was true an
+        instant ago, which is all a tray message can ever claim anyway.
+
+        (Until this commit the argument was "the memo is write-once and
+        monotonic". That stopped being true when ``force_restart()`` began
+        clearing it so an installed Rosetta can be noticed without an agent
+        restart. The conclusion survives; the reason for it did not, and a stale
+        reason is worse than none.)
 
         **Three states, not two.** The memo is ``None`` until something probed:
 
-            True  -> established: no Rosetta, nothing is being recorded
+            True  -> established: no Rosetta, these binaries cannot run
             False -> established: Rosetta is present, this is some OTHER fault
             None  -> nobody has asked yet
 
@@ -877,6 +895,8 @@ class AWManager:
         attempting the start.
         """
         if self._rosetta_missing_cached is not True:
+            return None
+        if not self.tracker_download_failed:
             return None
         return (
             "Not recording — Rosetta 2 required. Open Terminal and run: "
@@ -950,17 +970,44 @@ class AWManager:
             logger.debug("Tracker start refused: capture is suppressed")
             return False
 
+        # Probed BEFORE the Rosetta branch below, not after it. Our managed
+        # binaries being unrunnable says nothing about whether SOMETHING is
+        # capturing on this port: a user who hit the "nothing is being tracked"
+        # wall and installed a native arm64 ActivityWatch themselves is
+        # recording perfectly well. With the probe below the branch, that device
+        # latched the capture-dead flags and never reached the external-attach
+        # path at all, so it reported itself as recording nothing while
+        # recording — and, once capture_blocked_remedy() started reading those
+        # flags, would have been told to install Rosetta over an unrelated
+        # bucket failure. The download-failure path a few lines down has always
+        # asked this question in this order; the Rosetta path did not.
+        server_already_running = self._port_in_use()
+
         # Apple Silicon without Rosetta 2 can never run these binaries. Checked
         # BEFORE spawning rather than after 21 identical EBADARCH failures, and
         # reported rather than retried, because no amount of retrying installs
         # Rosetta. See _rosetta_missing().
         if self._rosetta_missing():
-            self.tracker_download_failed = True
+            # Managed watchers are unavailable either way — these binaries do
+            # not execute on this machine, so nothing here self-heals.
             self._managed_components_unavailable = True
+            if server_already_running:
+                # ...but an external server IS capturing on this port, so this
+                # is not a "capturing nothing" device. Verbatim the rule the
+                # download-failure branch below already applies: attach, log,
+                # and do NOT latch the capture-dead flag or alarm the user.
+                # Telling this person to install Rosetta would name a component
+                # irrelevant to whatever actually went wrong.
+                logger.warning(
+                    "Managed trackers cannot run (no Rosetta 2), but an external "
+                    "server is running on port %s — attaching to it",
+                    self.aw_port,
+                )
+                self._using_external = True
+                return True
+            self.tracker_download_failed = True
             self._notify_rosetta_required_once()
             return False
-
-        server_already_running = self._port_in_use()
 
         binaries_dir = self._get_binaries_dir()
 
@@ -1169,6 +1216,29 @@ class AWManager:
             # Drop external attachment so _start_locked starts our own server
             # if the port is now free after the reap.
             self._using_external = False
+            # Re-probe Rosetta on the way back up. The memo is otherwise written
+            # once per process and cleared nowhere, so a user who read the tray,
+            # ran `softwareupdate --install-rosetta` and watched it finish still
+            # saw "Not recording — Rosetta 2 required" until they thought to
+            # quit and relaunch the agent — and nothing on any surface asked
+            # them to. That is the dead end tray.py's capture_permissions_row()
+            # already names in its own docstring: for a surface whose whole job
+            # is "did my fix work?", still saying "blocked" afterwards is the
+            # failure, not a cosmetic lag.
+            #
+            # Here rather than on a timer because this is the one path that
+            # already exists to rebuild a stack believed dead, and it is exactly
+            # where a device in this state arrives: capture is gone, so the
+            # unreachable watchdog escalates and calls force_restart on every
+            # cycle. Clearing the memo makes the very next start attempt real,
+            # the trackers spawn, and the tray goes green on its own.
+            #
+            # Cost is one `/usr/bin/arch -x86_64 /usr/bin/true` per force
+            # restart, which is a rare escalation path, not the 60s start path
+            # the memo exists to keep clear. A probe that fails still fails
+            # toward "available" (see _rosetta_missing), so the worst case is
+            # one spawn attempt the EBADARCH handler already covers.
+            self._rosetta_missing_cached = None
             return self._start_locked()
 
     def restart_idle_tracker(self, reason: str = "") -> None:

--- a/src/aw_manager.py
+++ b/src/aw_manager.py
@@ -1069,6 +1069,21 @@ class AWManager:
                     self.aw_port,
                 )
                 self._using_external = True
+                # CLEAR the latch, do not merely decline to set it. This branch
+                # returns before the "binaries resolved" clear forty lines down,
+                # so on a Rosetta-missing Mac nothing else ever unsets it — and
+                # a single /info timeout on a healthy external server would
+                # otherwise latch "captures nothing" for the life of the
+                # process, putting a permanent "install Rosetta" in front of
+                # someone who IS recording and reporting a false capture-dead
+                # device to the fleet. Found by walking three cycles with one
+                # transient blip in them, not by reading.
+                #
+                # Safe because of what this branch has just established: a
+                # server ANSWERED /api/0/info on our port. That is the same
+                # evidence the flag's own name asks for, so clearing it here is
+                # the flag being accurate rather than an optimistic reset.
+                self.tracker_download_failed = False
                 return True
             if server_already_running:
                 # Held, but dead. Worth its own line: this device looks

--- a/src/aw_manager.py
+++ b/src/aw_manager.py
@@ -900,6 +900,16 @@ class AWManager:
         question: it is true on the recording-via-external device too, by
         design, because our watchers really are unavailable there.
 
+        **"Attached" means answering ``/api/0/info``, not holding the socket.**
+        The first cut of the condition above rode on ``_port_in_use()``, a bare
+        TCP connect, so ANY process on port 5600 withheld the remedy — and a
+        Rosetta-blocked Mac holding a dead ``bf-data-service`` is precisely a
+        device with a listener and no capture, un-reapable because our binaries
+        have never run there. That returned ``None``, the tray fell back to
+        *"ActivityWatch not responding"*, and the fleet saw
+        ``tracker_download_failed=False``: the exact outage this method exists
+        to name, restored on the exact device it was written for.
+
         **Deliberately NOT under ``_lifecycle_lock``**, unlike its sibling
         ``health_snapshot()`` which reads the same latch under it. The caller is
         the tray-message path, and ``force_restart()`` holds that lock across
@@ -1024,7 +1034,29 @@ class AWManager:
             # Managed watchers are unavailable either way — these binaries do
             # not execute on this machine, so nothing here self-heals.
             self._managed_components_unavailable = True
-            if server_already_running:
+            # `server_already_running` is a TCP connect, and a held socket is
+            # NOT a running tracker. Here — and ONLY here — that distinction
+            # decides whether the user is told anything at all, so this branch
+            # pays for one HTTP ask before granting the carve-out.
+            #
+            # Why this branch and not the download-failure one below: the other
+            # paths use the port answer to decide whether to START something,
+            # and a hung-but-listening server there is recoverable — the
+            # unreachable watchdog escalates to force_restart(), which reaps the
+            # orphan and rebuilds (that is what its docstring describes). On a
+            # Rosetta-missing Mac there is no such recovery: _reap_orphan_
+            # processes is path-scoped to binaries_dir, and OUR binaries have
+            # never executed on this machine, so the listener is un-reapable by
+            # construction. The only decision left on this branch is what to
+            # TELL the person, and getting that wrong cost ~90 minutes once.
+            #
+            # Failing this way is also the safe direction: a false "responding"
+            # withholds the remedy (the regression below), while a false "not
+            # responding" merely offers a Rosetta instruction to a device that
+            # is, in fact, running an ARM ActivityWatch which just failed to
+            # answer /info within 2s — visible, wrong for one cycle, and it
+            # self-corrects on the next probe.
+            if server_already_running and self._server_responding():
                 # ...but an external server IS capturing on this port, so this
                 # is not a "capturing nothing" device. Verbatim the rule the
                 # download-failure branch below already applies: attach, log,
@@ -1038,6 +1070,16 @@ class AWManager:
                 )
                 self._using_external = True
                 return True
+            if server_already_running:
+                # Held, but dead. Worth its own line: this device looks
+                # "started" to every port-level check in the file while
+                # capturing nothing, and nothing here can reap the listener.
+                logger.warning(
+                    "Managed trackers cannot run (no Rosetta 2) and the process "
+                    "holding port %s does not answer /api/0/info — treating this "
+                    "device as capturing nothing",
+                    self.aw_port,
+                )
             self.tracker_download_failed = True
             self._notify_rosetta_required_once()
             return False
@@ -1817,9 +1859,31 @@ class AWManager:
             logger.error(f"Failed to start {name}: {e}")
             return False
 
+    def _server_responding(self) -> bool:
+        """True only if a tracker server ANSWERS ``/api/0/info`` on our port.
+
+        The single HTTP ask that ``_wait_for_server`` polls, lifted out so the
+        two callers cannot drift. This is the difference between *something
+        holds the socket* and *a tracker server is up*, and those are not the
+        same question — ``_port_in_use()`` answers the first and is routinely
+        read as the second. ``force_restart()``'s own docstring names the gap:
+        a ``bf-data-service`` that still holds port 5600 and no longer answers
+        HTTP is exactly what it exists to reclaim.
+
+        One request, one 2s timeout, no retry loop: callers that need to WAIT
+        for a boot own the deadline (``_wait_for_server``); callers deciding
+        what is true right now do not.
+        """
+        url = f"http://localhost:{self.aw_port}/api/0/info"
+        try:
+            req = urllib.request.urlopen(url, timeout=2)
+            req.close()
+            return True
+        except (urllib.error.URLError, OSError):
+            return False
+
     def _wait_for_server(self) -> bool:
         """Wait for tracker server to accept connections."""
-        url = f"http://localhost:{self.aw_port}/api/0/info"
         deadline = time.monotonic() + STARTUP_TIMEOUT
 
         while time.monotonic() < deadline:
@@ -1832,19 +1896,21 @@ class AWManager:
                 )
                 return False
 
-            try:
-                req = urllib.request.urlopen(url, timeout=2)
-                req.close()
+            if self._server_responding():
                 logger.info("Tracker server is ready")
                 return True
-            except (urllib.error.URLError, OSError):
-                time.sleep(0.5)
+            time.sleep(0.5)
 
         logger.error(f"Tracker server not ready after {STARTUP_TIMEOUT}s")
         return False
 
     def _port_in_use(self) -> bool:
-        """Check if something is listening on the tracker port."""
+        """Check if something is listening on the tracker port.
+
+        A bare TCP connect. It proves the socket is held; it does NOT prove a
+        tracker is capturing there — see ``_server_responding()`` for that
+        question, and do not use this one to answer it.
+        """
         import socket
 
         with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as s:

--- a/src/aw_manager.py
+++ b/src/aw_manager.py
@@ -851,6 +851,18 @@ class AWManager:
         sync cycle, so it consults the cached answer only. The same rule the
         tray's own ``_arch_menu_item`` and ``serial_menu_row`` carry.
 
+        **Deliberately NOT under ``_lifecycle_lock``**, unlike its sibling
+        ``health_snapshot()`` which reads the capture-dead flags under it. Two
+        reasons, and the second is the one that matters. The memo is write-once
+        and monotonic — whether this Mac can execute x86_64 cannot change
+        without a reboot, so there is no torn read to protect against and a
+        stale read is impossible rather than merely unlikely; the flags
+        ``health_snapshot`` guards are genuinely re-written on every start.
+        And the caller is the tray-message path, which runs while
+        ``force_restart()`` may be holding that lock across process spawns —
+        so taking it here would block a UI update behind tracker teardown to
+        re-read a value that cannot have changed.
+
         **Three states, not two.** The memo is ``None`` until something probed:
 
             True  -> established: no Rosetta, nothing is being recorded

--- a/src/aw_manager.py
+++ b/src/aw_manager.py
@@ -142,6 +142,14 @@ DOWNLOAD_FAILURE_REPORT_INTERVAL = 3600  # 1 hour
 # day they are already recording nothing; one constant is what stops the three
 # from drifting. The agent cannot run it itself: it needs an admin password.
 ROSETTA_INSTALL_COMMAND = "softwareupdate --install-rosetta"
+# How long a Rosetta answer stands before force_restart() is allowed to re-ask.
+# Installing Rosetta needs no reboot, so the answer CAN change under a running
+# agent and a memo held for the life of the process left the user stuck at "still
+# blocked" with nothing telling them to relaunch. Five minutes because the two
+# costs pull opposite ways: the escalation path that clears this runs every 60s
+# for the whole of a total-capture outage, and re-probing on each one puts a
+# subprocess fork per minute back on precisely the machine the memo protects.
+ROSETTA_REPROBE_INTERVAL = 300.0
 # (ops summary, ops fingerprint, user toast) per cause of "this device captures
 # NOTHING". Keyed rather than branched so a new cause is a table row. Both are
 # the same outage to the person using the machine, so both must reach them —
@@ -538,9 +546,18 @@ class AWManager:
         # nothing, so the backend should know this device is un-self-healing.
         self._managed_components_unavailable: bool = False
         # Tri-state cache for the Apple-Silicon-without-Rosetta check. None =
-        # not probed yet. Rosetta cannot appear or vanish without a reboot, so
-        # this is probed once rather than on every 60s start attempt.
+        # not probed yet. Installing Rosetta needs no reboot, so force_restart()
+        # clears this to let a device that was fixed recover on its own — but
+        # only once per ROSETTA_REPROBE_INTERVAL, because a sustained outage
+        # calls force_restart on every 60s cycle and this memo exists to keep
+        # `/usr/bin/arch` off that path.
         self._rosetta_missing_cached: Optional[bool] = None
+        # monotonic timestamp of the last completed probe, for that interval.
+        self._rosetta_probed_at: float = float("-inf")
+        # The last answer we LOGGED. Re-probing must not reprint the same error
+        # every few minutes for the life of an outage — that is the 60-second
+        # log spam the preflight was written to end, arriving by another door.
+        self._rosetta_logged: Optional[bool] = None
         self._rosetta_notified: bool = False
         # Components whose binary is on disk but cannot EXECUTE (EBADARCH /
         # ENOEXEC). Keeps the capture-dead latch honest when only SOME binaries
@@ -817,14 +834,30 @@ class AWManager:
             missing = False
 
         self._rosetta_missing_cached = missing
-        if missing:
-            logger.error(
-                "This Mac is Apple Silicon and Rosetta 2 is not installed, so the "
-                "x86_64 ActivityWatch trackers cannot run. Nothing will be tracked "
-                "until it is installed: run `%s` "
-                "(needs an admin password, so the agent cannot do it for you).",
-                ROSETTA_INSTALL_COMMAND,
-            )
+        self._rosetta_probed_at = time.monotonic()
+        # Log the ANSWER changing, not the probe running. force_restart clears
+        # the memo so an installed Rosetta is noticed without an agent restart,
+        # which means this function now runs repeatedly during an outage instead
+        # of once per process; reprinting the same error each time would rebuild
+        # the identical-line spam the preflight exists to have ended.
+        if missing is not self._rosetta_logged:
+            if missing:
+                logger.error(
+                    "This Mac is Apple Silicon and Rosetta 2 is not installed, so the "
+                    "x86_64 ActivityWatch trackers cannot run. Nothing will be tracked "
+                    "until it is installed: run `%s` "
+                    "(needs an admin password, so the agent cannot do it for you).",
+                    ROSETTA_INSTALL_COMMAND,
+                )
+            elif self._rosetta_logged is True:
+                # The recovery. Worth a line of its own: it is the only record
+                # that the user's install landed and capture can resume, and
+                # support reads these logs to answer exactly that question.
+                logger.info(
+                    "Rosetta 2 is now available — the x86_64 trackers can start. "
+                    "Capture should resume on this cycle."
+                )
+            self._rosetta_logged = missing
         return missing
 
     def capture_blocked_remedy(self) -> Optional[str]:
@@ -1233,12 +1266,26 @@ class AWManager:
             # cycle. Clearing the memo makes the very next start attempt real,
             # the trackers spawn, and the tray goes green on its own.
             #
-            # Cost is one `/usr/bin/arch -x86_64 /usr/bin/true` per force
-            # restart, which is a rare escalation path, not the 60s start path
-            # the memo exists to keep clear. A probe that fails still fails
-            # toward "available" (see _rosetta_missing), so the worst case is
-            # one spawn attempt the EBADARCH handler already covers.
-            self._rosetta_missing_cached = None
+            # Rate-limited, and that is not tidiness. _note_aw_unreachable
+            # returns True on EVERY cycle once the 180s grace period is up (only
+            # a reachable ActivityWatch resets it), so a device that is capturing
+            # nothing force-restarts every 60 seconds for as long as the outage
+            # lasts — which on a Rosetta-missing Mac is indefinitely. Clearing
+            # unconditionally would therefore fork `/usr/bin/arch` once a minute
+            # on exactly the machine this memo was introduced to protect, which
+            # is the "21 identical failures at 60-second intervals" pattern the
+            # preflight replaced, wearing a different hat.
+            #
+            # ROSETTA_REPROBE_INTERVAL bounds it to one fork per five minutes,
+            # so the user who runs the command waits at most that long for the
+            # tray to go green — a loop that closes slowly still closes, and an
+            # unbounded fork rate on a broken device does not.
+            #
+            # A probe that fails still fails toward "available" (see
+            # _rosetta_missing), so the worst case is one spawn attempt the
+            # EBADARCH handler already covers.
+            if time.monotonic() - self._rosetta_probed_at >= ROSETTA_REPROBE_INTERVAL:
+                self._rosetta_missing_cached = None
             return self._start_locked()
 
     def restart_idle_tracker(self, reason: str = "") -> None:

--- a/src/disclosure_baseline.py
+++ b/src/disclosure_baseline.py
@@ -578,6 +578,18 @@ HEARTBEAT_HEALTH_KEYS: tuple[str, ...] = (
     # counterpart of the capture-dead flags already declared below: it says
     # whether this machine can record at all, never what it recorded.
     "machine_arch",
+    # The architecture of the RUNNING PROCESS — which BUILD of the agent is
+    # installed, as opposed to `machine_arch` above, which is the silicon.
+    # Identical category to it: a model of processor, never a person, and it
+    # cannot distinguish one employee's activity from another's.
+    #
+    # Why it is worth reporting SEPARATELY, given machine_arch is already here:
+    # machine_arch resolves through Rosetta by design, so a native Apple Silicon
+    # install and an Intel build under Rosetta report the same value and are
+    # byte-identical on the wire. machine_arch therefore answers "who is on
+    # Intel SILICON?" while #184 asks "who is on the Intel BUILD?" — and only
+    # this field can tell those apart. Reported as a pair, never alone.
+    "process_arch",
     # Boolean: this device's live timezone disagrees with the one its
     # working-hours schedule is anchored to. Reports a MISCONFIGURATION of the
     # schedule, not a new fact about the person — no location beyond the

--- a/src/machine_arch.py
+++ b/src/machine_arch.py
@@ -445,3 +445,60 @@ def true_machine_arch(
         return ""
 
     return machine
+
+
+def process_arch(
+    system: Optional[str] = None,
+    machine: Optional[str] = None,
+    translated: Optional[bool] = None,
+) -> str:
+    """The architecture of the RUNNING PROCESS — i.e. which BUILD is installed.
+
+    The deliberate counterpart to ``true_machine_arch()`` above, and the reason
+    both exist is that they answer different questions:
+
+        true_machine_arch()  "what silicon is this Mac?"
+        process_arch()       "which build of BetterFlow is running on it?"
+
+    ``true_machine_arch()`` resolves *through* Rosetta on purpose, so a
+    translated x86_64 process reports ``arm64``. That is correct for its
+    question and it is exactly why it cannot answer this one: a native Apple
+    Silicon install and an Intel build under Rosetta return the SAME value from
+    it, and are therefore byte-identical on the heartbeat. Measured on real
+    Apple Silicon (Darwin 25.5.0), running this module under both personalities:
+
+        native                  process=arm64   true_machine_arch=arm64
+        arch -x86_64 (Rosetta)  process=x86_64  true_machine_arch=arm64
+
+    Only the left column moves. So "who is sitting on the Intel build?" (#184)
+    is answerable only from the PAIR, never from either field alone:
+
+        machine_arch=arm64  process_arch=arm64   native build          fine
+        machine_arch=arm64  process_arch=x86_64  Intel build/Rosetta   THIS
+        machine_arch=x86_64 process_arch=x86_64  a genuine Intel Mac   fine
+
+    Three properties worth stating, because each is a way this could have been
+    written wrongly:
+
+    - **It forks nothing.** A process always knows its own ISA;
+      ``platform.machine()`` is the answer and needs no probe. The sibling above
+      forks ``sysctl`` and is memoised for it — this must not acquire that cost,
+      or the tray pays for it under ``_menu_lock`` on the sync cycle.
+    - **It has no "undetermined" state.** ``true_machine_arch()`` returns ``""``
+      when its probe never resolved, and callers must not read that as an
+      architecture. There is no equivalent doubt here: a running process has an
+      architecture by construction, so this never returns ``""`` and consumers
+      need no such branch.
+    - **``translated`` is accepted and ignored.** It is taken only so callers
+      and tests can pass the same keyword set to both helpers; honouring it
+      would re-introduce precisely the Rosetta resolution that makes this field
+      unable to answer its question.
+
+    Args:
+        system: Override ``platform.system()`` for testing. Unused — the answer
+            is platform-independent — and accepted for signature symmetry.
+        machine: Override ``platform.machine()`` for testing.
+        translated: Accepted for signature symmetry with the helpers above and
+            deliberately not consulted. See the note above.
+    """
+    return machine or platform.machine()

--- a/src/machine_arch.py
+++ b/src/machine_arch.py
@@ -484,11 +484,16 @@ def process_arch(
       ``platform.machine()`` is the answer and needs no probe. The sibling above
       forks ``sysctl`` and is memoised for it — this must not acquire that cost,
       or the tray pays for it under ``_menu_lock`` on the sync cycle.
-    - **It has no "undetermined" state.** ``true_machine_arch()`` returns ``""``
-      when its probe never resolved, and callers must not read that as an
-      architecture. There is no equivalent doubt here: a running process has an
-      architecture by construction, so this never returns ``""`` and consumers
-      need no such branch.
+    - **Its "undetermined" state is far rarer, not absent.** ``true_machine_arch()``
+      returns ``""`` whenever its probe never resolved, which is an ordinary
+      outcome. A running process has an architecture by construction, so the
+      honest answer here is essentially always available — but the *source* is
+      ``platform.machine()``, which the stdlib documents as returning ``""`` when
+      it cannot determine one, so this can return ``""`` too. Callers must map it
+      the same way they map its sibling's: to null, never to a string. Reading a
+      blank as an architecture is the failure either helper can cause, and the
+      rarity of the case here makes it likelier to be shipped unhandled, not
+      less costly when it is.
     - **``translated`` is accepted and ignored.** It is taken only so callers
       and tests can pass the same keyword set to both helpers; honouring it
       would re-introduce precisely the Rosetta resolution that makes this field

--- a/src/main.py
+++ b/src/main.py
@@ -29,7 +29,7 @@ try:
     from .browser_tracker import start_browser_tracker
     from .display_info import start_display_tracker
     from .hardware_serial import get_hardware_serial
-    from .machine_arch import is_rosetta_translated, true_machine_arch
+    from .machine_arch import is_rosetta_translated, process_arch, true_machine_arch
     from .privacy_notice import (
         acknowledgement_telemetry,
         needs_acknowledgement,
@@ -64,7 +64,7 @@ except ImportError:
     from browser_tracker import start_browser_tracker
     from display_info import start_display_tracker
     from hardware_serial import get_hardware_serial
-    from machine_arch import is_rosetta_translated, true_machine_arch
+    from machine_arch import is_rosetta_translated, process_arch, true_machine_arch
     from privacy_notice import (
         acknowledgement_telemetry,
         needs_acknowledgement,
@@ -1323,6 +1323,40 @@ class SyncCoordinator:
         self._aw_unreachable_since = None
         self._aw_unreachable_streak = 0
 
+    # What the tray says when the tracker stack is down for a reason we cannot
+    # name. True, and all the user can do with it is call support.
+    _GENERIC_TRACKER_FAULT = "ActivityWatch not responding"
+
+    def _tracker_fault_message(self) -> str:
+        """The sentence the tray carries while capture is dead.
+
+        Both escalation paths below (server unreachable, and a half-hung
+        bf-data-service) set the SAME tray state, and both used to hard-code
+        ``_GENERIC_TRACKER_FAULT``. On an Apple Silicon Mac with no Rosetta 2
+        that string is the only thing standing between a user and hours of
+        silent data loss, and it names a component they have never heard of
+        instead of the one command that fixes it (#188).
+
+        Routed through one helper rather than fixed at each call site: the two
+        are the same outage to the person reading the tray, and a remedy that
+        appears on only one of them is a device that keeps its old, wrong
+        sentence depending on which watchdog happened to fire first.
+
+        Falls back to the generic text on anything unexpected — an absent
+        remedy, a manager that raises, or a non-string. That last case is not
+        hypothetical padding: the message is rendered verbatim into the tray, so
+        a truthy non-string would put a repr in front of the user, and a plain
+        ``remedy or fallback`` would do exactly that against any test double.
+        """
+        try:
+            remedy = self.aw_manager.capture_blocked_remedy()
+        except Exception:  # noqa: BLE001
+            logger.debug("capture_blocked_remedy failed", exc_info=True)
+            return self._GENERIC_TRACKER_FAULT
+        if isinstance(remedy, str) and remedy.strip():
+            return remedy
+        return self._GENERIC_TRACKER_FAULT
+
     def _escalate_aw_unreachable(self, now: Optional[float] = None) -> None:
         """Rebuild the tracker stack and surface the fault.
 
@@ -1348,7 +1382,7 @@ class SyncCoordinator:
             # A rebuild that fails must not swallow the escalation below — that
             # would hide the very fault it was trying to report.
             logger.warning("force_restart failed during escalation", exc_info=True)
-        self.tray.set_state(TrayState.ERROR, "ActivityWatch not responding")
+        self.tray.set_state(TrayState.ERROR, self._tracker_fault_message())
 
     def _handle_aw_bucket_failure(self) -> None:
         """AW answers is_running() (/info) but the bucket fetch (/buckets/) keeps
@@ -1376,7 +1410,7 @@ class SyncCoordinator:
             except Exception:
                 # A failing rebuild must not swallow the tray escalation below.
                 logger.warning("force_restart failed on bucket-fetch escalation", exc_info=True)
-            self.tray.set_state(TrayState.ERROR, "ActivityWatch not responding")
+            self.tray.set_state(TrayState.ERROR, self._tracker_fault_message())
         else:
             logger.info(
                 "ActivityWatch bucket fetch failing (%d/%d) — retrying next cycle "
@@ -2059,6 +2093,21 @@ class SyncCoordinator:
             telemetry["machine_arch"] = arch or None
         except Exception as e:  # noqa: BLE001
             logger.debug("machine-arch telemetry unavailable: %s", e)
+        # ...and the architecture of THIS PROCESS, which is the build that is
+        # installed. Sent alongside the field above rather than instead of it:
+        # true_machine_arch() resolves through Rosetta by design, so a native
+        # arm64 install and an Intel build under Rosetta are indistinguishable
+        # from it, and "who is on the Intel BUILD?" (#184) is answerable only
+        # from the pair. Never null — a running process always has an
+        # architecture — so unlike machine_arch there is no "" to map.
+        #
+        # Its OWN try/except, deliberately: folded into the block above, a
+        # failure here would silently delete the machine_arch that already
+        # ships, trading a working field for a new one.
+        try:
+            telemetry["process_arch"] = process_arch()
+        except Exception as e:  # noqa: BLE001
+            logger.debug("process-arch telemetry unavailable: %s", e)
         # Surface a working-hours anchor that has drifted from this device's real
         # timezone: allows() self-heals by evaluating in machine-local time, but the
         # fleet still needs to see (and re-anchor) the stale schedule. Included only

--- a/src/main.py
+++ b/src/main.py
@@ -2098,14 +2098,20 @@ class SyncCoordinator:
         # true_machine_arch() resolves through Rosetta by design, so a native
         # arm64 install and an Intel build under Rosetta are indistinguishable
         # from it, and "who is on the Intel BUILD?" (#184) is answerable only
-        # from the pair. Never null — a running process always has an
-        # architecture — so unlike machine_arch there is no "" to map.
+        # from the pair. Mapped "" -> None exactly like machine_arch five lines
+        # up: platform.machine() is documented to return "" when it cannot
+        # answer, and while that is vanishingly rare for a running process it is
+        # not impossible (a scrubbed service environment on Windows). An empty
+        # string on the wire is the one outcome the reader must not get —
+        # HEARTBEAT_HEALTH_KEYS filters by membership, not truthiness, so ""
+        # ships, and "we could not tell" would arrive as an architecture whose
+        # name happens to be blank.
         #
         # Its OWN try/except, deliberately: folded into the block above, a
         # failure here would silently delete the machine_arch that already
         # ships, trading a working field for a new one.
         try:
-            telemetry["process_arch"] = process_arch()
+            telemetry["process_arch"] = process_arch() or None
         except Exception as e:  # noqa: BLE001
             logger.debug("process-arch telemetry unavailable: %s", e)
         # Surface a working-hours anchor that has drifted from this device's real

--- a/src/sync/bf_client.py
+++ b/src/sync/bf_client.py
@@ -467,6 +467,16 @@ class BetterFlowClient(BaseApiClient):
         # affected machine. null means true_machine_arch() returned "" (its probe
         # never resolved); do not coerce that to a string.
         "machine_arch",
+        # The architecture of the RUNNING PROCESS, i.e. which BUILD is
+        # installed. The counterpart to machine_arch above and useless without
+        # it: machine_arch sees THROUGH Rosetta on purpose, so a native arm64
+        # install and an Intel build under Rosetta report the identical value
+        # and cannot be told apart on the wire. Only the pair answers #184's
+        # actual question — machine_arch=arm64 with process_arch=x86_64 is a
+        # device sitting on the Intel build, which is the population that issue
+        # exists to enumerate. Unlike machine_arch this is never null: a running
+        # process always has an architecture, so there is no "undetermined".
+        "process_arch",
         # The device's live timezone disagrees with the one its working-hours
         # schedule is anchored to. Carried here because a drifted anchor is
         # otherwise a SILENT failure — it zeroes a whole day ("Outside working

--- a/src/sync/bf_client.py
+++ b/src/sync/bf_client.py
@@ -474,8 +474,13 @@ class BetterFlowClient(BaseApiClient):
         # and cannot be told apart on the wire. Only the pair answers #184's
         # actual question — machine_arch=arm64 with process_arch=x86_64 is a
         # device sitting on the Intel build, which is the population that issue
-        # exists to enumerate. Unlike machine_arch this is never null: a running
-        # process always has an architecture, so there is no "undetermined".
+        # exists to enumerate. null carries the same meaning as it does for
+        # machine_arch: the architecture could not be determined. A running
+        # process essentially always has one, so null here should be very rare —
+        # but platform.machine() is documented to return "" when it cannot
+        # answer, and this loop filters by KEY MEMBERSHIP, not truthiness, so an
+        # unmapped "" would reach the wire as a blank architecture. Mapped at the
+        # producer (main.py).
         "process_arch",
         # The device's live timezone disagrees with the one its working-hours
         # schedule is anchored to. Carried here because a drifted anchor is

--- a/src/ui/tray.py
+++ b/src/ui/tray.py
@@ -1087,6 +1087,30 @@ class TrayIcon:
         elif state == TrayState.QUEUE_WARNING:
             return "Offline (queue full)"
         elif state == TrayState.ERROR:
+            # Render the sentence the escalation handed us, not the constant.
+            #
+            # ``status_text`` was write-only from the day it shipped: every
+            # producer set it, ``_snapshot_model`` carried it, and no render
+            # path read it. So the tray's persistent line said "Error" through
+            # every outage, whatever the cause, and #188's 90 minutes of a red
+            # tray naming the wrong component could not have been fixed by
+            # improving the message — the message reached nobody. This is the
+            # read that makes the field a field.
+            #
+            # Read INSIDE the branch, not at the top with its siblings: the only
+            # states that write it are the ones this branch covers, and a
+            # top-level read would make every unrelated caller of
+            # ``_get_status_text`` supply a key it has no business knowing about.
+            #
+            # ``or "Error"`` keeps the old constant as the floor. A blank or
+            # whitespace-only text must not render as ``App status:`` with
+            # nothing after it, and a non-string (a test double, a repr) must not
+            # be interpolated in front of the user — the same rule
+            # ``_tracker_fault_message`` applies one layer up, for the same
+            # reason.
+            status_text = s["status_text"] if s else self.model.status_text
+            if isinstance(status_text, str) and status_text.strip():
+                return status_text.strip()
             return "Error"
         elif state == TrayState.PAUSED:
             return "Paused"
@@ -1442,11 +1466,27 @@ class TrayIcon:
         with self.model.lock:
             previous_state = self.model.state
             self.model.state = state
+            faulted = (TrayState.ERROR, TrayState.QUEUE_WARNING)
             if status_text is not None:
                 self.model.status_text = status_text
-            elif previous_state in (TrayState.ERROR, TrayState.QUEUE_WARNING) and state not in (
-                TrayState.ERROR, TrayState.QUEUE_WARNING,
-            ):
+            elif state in faulted and previous_state not in faulted:
+                # ENTERING a fault with nothing to say. Mirror of the recovery
+                # clear below, and it only started to matter once the ERROR
+                # branch of _get_status_text began rendering this field: the
+                # model seeds status_text to "Starting...", and every writer
+                # before this point (the NEEDS_PERMISSIONS hint in main.py, an
+                # older escalation) leaves its own sentence behind. Without this
+                # a text-less escalation renders the PREVIOUS state's message
+                # under a red icon — "App status: Starting..." on a machine that
+                # has been running for hours, which reads as a hung app rather
+                # than a reported fault.
+                #
+                # Every escalation in src/ passes a message today, so this is a
+                # guard on the shape rather than on a live caller. It is cheap
+                # and the alternative is a surface that lies whenever someone
+                # adds one that does not.
+                self.model.status_text = None
+            elif previous_state in faulted and state not in faulted:
                 # Recovery transition: ERROR/QUEUE_WARNING → anything-healthy.
                 # Old status_text (e.g. "ActivityWatch is not running") would
                 # leak into the next display path until something else writes

--- a/src/ui/tray.py
+++ b/src/ui/tray.py
@@ -1166,9 +1166,35 @@ class TrayIcon:
         return state not in (TrayState.ERROR, TrayState.STARTING, TrayState.WAITING_AUTH)
 
     def _check_api_status(self, s: Optional[dict] = None) -> bool:
-        """Check if BetterFlow API is reachable (best-effort, non-blocking)."""
+        """Check if BetterFlow API is reachable (best-effort, non-blocking).
+
+        **ERROR is deliberately NOT in this tuple**, and was until #188.
+
+        The queue states are honest signals about the API: QUEUED and
+        QUEUE_WARNING mean events are piling up locally, which is what an
+        unreachable backend looks like from here. ERROR never was one, and this
+        PR made that visible by giving the row above it something specific to
+        say. Read every producer:
+
+        - ``_escalate_aw_unreachable`` / ``_handle_aw_bucket_failure`` — TRACKER
+          faults. The API is demonstrably reachable; the heartbeat carrying
+          ``tracker_download_failed`` is how the fleet learns about the fault at
+          all.
+        - ``_report_sync_failure`` — asks ``bf.is_reachable()`` FIRST and routes
+          an unreachable API to QUEUED("Offline"). It reaches ERROR only on the
+          branch where the API answered.
+        - the login handlers — "Login busy", "Login cancelled". A server that
+          answers.
+
+        So no caller of ``set_state(ERROR, …)`` implies an unreachable API, and
+        the row asserted one on all of them. Harmless while the line above read
+        a vague "Error"; a contradiction the moment it reads "Not recording —
+        Rosetta 2 required", because the first submenu a worried user opens then
+        names a second, false cause for a fault that has just been correctly
+        diagnosed.
+        """
         state = s["state"] if s else self.model.state
-        return state not in (TrayState.QUEUED, TrayState.QUEUE_WARNING, TrayState.ERROR)
+        return state not in (TrayState.QUEUED, TrayState.QUEUE_WARNING)
 
     # -- Menu action handlers ------------------------------------------------
 
@@ -1469,7 +1495,7 @@ class TrayIcon:
             faulted = (TrayState.ERROR, TrayState.QUEUE_WARNING)
             if status_text is not None:
                 self.model.status_text = status_text
-            elif state in faulted and previous_state not in faulted:
+            elif state in faulted and previous_state != state:
                 # ENTERING a fault with nothing to say. Mirror of the recovery
                 # clear below, and it only started to matter once the ERROR
                 # branch of _get_status_text began rendering this field: the
@@ -1480,6 +1506,21 @@ class TrayIcon:
                 # under a red icon — "App status: Starting..." on a machine that
                 # has been running for hours, which reads as a hung app rather
                 # than a reported fault.
+                #
+                # `previous_state != state`, NOT `previous_state not in faulted`.
+                # `faulted` holds TWO states, so the membership test treats a
+                # QUEUE_WARNING → ERROR move as staying put: the queue's
+                # "Queue 92% full" survived into a red row describing a TRACKER
+                # fault, and a text-less ERROR after a text-less QUEUE_WARNING
+                # resurrected whatever sentence preceded both. Precisely the
+                # harm the paragraph above describes, entered by the door the
+                # first version of this guard did not watch — a guard has two
+                # ends and you guard the one you were reasoning about
+                # (diagnosis-discipline.md Rule 3).
+                #
+                # The inequality is also what preserves the deliberate
+                # ERROR → ERROR retention below: same state is one outage
+                # escalating again, not a new one.
                 #
                 # Every escalation in src/ passes a message today, so this is a
                 # guard on the shape rather than on a live caller. It is cheap

--- a/tests/test_aw_manager_rosetta_preflight.py
+++ b/tests/test_aw_manager_rosetta_preflight.py
@@ -12,6 +12,7 @@ intervals, recording zero seconds on both 07-22 and 07-23 while reporting itself
 healthy. No amount of retrying installs Rosetta, so the loop was pure noise.
 """
 
+import contextlib
 import errno
 import subprocess
 from unittest.mock import patch
@@ -101,8 +102,15 @@ def test_start_refuses_and_reports_instead_of_spawning():
     # notifier's own spawn (notify-send on Linux). Without this the assertion
     # below reads that as "a tracker was started" — green on macOS, red on the
     # Linux CI runner.
+    #
+    # _port_in_use is pinned because _start_locked now consults it BEFORE the
+    # Rosetta branch, so an unpinned probe makes this test answer differently
+    # depending on whether the developer happens to have ActivityWatch running.
+    # It found this the honest way: on a laptop with a live server on 5600 the
+    # unpinned version returned True and reddened here.
     with patch.object(AWManager, "_rosetta_missing", return_value=True), \
          patch.object(AWManager, "_notify_rosetta_required_once"), \
+         patch.object(AWManager, "_port_in_use", return_value=False), \
          patch("src.aw_manager.subprocess.Popen") as popen:
         started = mgr._start_locked()
 
@@ -113,9 +121,44 @@ def test_start_refuses_and_reports_instead_of_spawning():
     assert mgr.health_snapshot()["tracker_download_failed"] is True
 
 
+def test_an_external_server_is_attached_to_rather_than_declared_dead():
+    """The other end of the branch above, and the reason it has two.
+
+    Rosetta missing means OUR binaries cannot execute. It does not mean this
+    device records nothing: a user who hit the wall and installed a native arm64
+    ActivityWatch themselves has a live server on the port. Before the port
+    probe moved above the Rosetta branch, that machine latched
+    tracker_download_failed and never reached the external-attach path — so it
+    reported capturing nothing while capturing, and once capture_blocked_remedy
+    began reading that latch it would have been told to install Rosetta over
+    some unrelated outage.
+
+    managed_components_unavailable stays True either way: our watchers really
+    are unavailable, and the backend needs to know the device cannot self-heal.
+    """
+    mgr = _mgr()
+    with patch.object(AWManager, "_rosetta_missing", return_value=True), \
+         patch.object(AWManager, "_notify_rosetta_required_once") as notify, \
+         patch.object(AWManager, "_port_in_use", return_value=True), \
+         patch("src.aw_manager.subprocess.Popen") as popen:
+        started = mgr._start_locked()
+
+    assert started is True
+    popen.assert_not_called()
+    assert mgr._using_external is True
+    # THE assertion: not capture-dead, so no remedy is owed.
+    assert mgr.tracker_download_failed is False
+    assert mgr.capture_blocked_remedy() is None
+    # ...and no toast either. This person is recording.
+    notify.assert_not_called()
+    # Still un-self-healing, and the fleet must still see that.
+    assert mgr._managed_components_unavailable is True
+
+
 def test_the_user_is_told_once_not_every_cycle():
     mgr = _mgr()
     with patch.object(AWManager, "_rosetta_missing", return_value=True), \
+         patch.object(AWManager, "_port_in_use", return_value=False), \
          patch("src.notifications.send_notification") as notify:
         mgr._start_locked()
         mgr._start_locked()
@@ -136,3 +179,110 @@ def test_ebadarch_still_caught_if_the_preflight_is_bypassed():
         assert mgr._start_component("bf-data-service", "/fake") is False
 
     assert mgr.tracker_download_failed is True
+
+
+def _no_tracker_stack(rosetta_ok):
+    """Apple Silicon, a chosen Rosetta answer, and NOTHING that touches the
+    network, the process table or the port.
+
+    ``_download_aw_binaries`` is the one that matters and is easy to miss: with
+    no binaries on disk ``_start_locked`` falls through to the auto-download,
+    and an unpatched run fetches ~100 MB of upstream release archives from a
+    unit test. Found by running it — the first version of the test below hung
+    until the harness killed it at two minutes.
+
+    ``rosetta_ok`` may be a callable so a test can flip the answer mid-run,
+    which is the whole point of the re-probe.
+    """
+    def probe(*_a, **_k):
+        ok = rosetta_ok() if callable(rosetta_ok) else rosetta_ok
+        return subprocess.CompletedProcess(args=[], returncode=0 if ok else 1)
+
+    return (
+        patch("src.aw_manager.sys.platform", "darwin"),
+        patch("src.aw_manager.platform.machine", return_value="arm64"),
+        patch("src.aw_manager.subprocess.run", side_effect=probe),
+        patch("src.aw_manager.subprocess.Popen"),
+        patch("src.aw_manager._download_aw_binaries", return_value=False),
+        patch.object(AWManager, "_notify_rosetta_required_once"),
+        patch.object(AWManager, "_dispatch_download_failure_report"),
+        patch.object(AWManager, "_get_binaries_dir", return_value=None),
+        patch.object(AWManager, "_port_in_use", return_value=False),
+        patch.object(AWManager, "_stop_locked"),
+    )
+
+
+def test_installing_rosetta_is_noticed_without_an_agent_restart():
+    """The user's "did my fix work?" loop has to be able to close.
+
+    The memo is written once per process. Cleared nowhere, a user who read the
+    tray, ran `softwareupdate --install-rosetta` and watched it finish kept
+    seeing "Not recording — Rosetta 2 required" until they thought to quit and
+    relaunch — and no surface asked them to. tray.py's capture_permissions_row()
+    already states that rule for its own row: for a surface whose whole job is
+    "did my fix work?", still saying blocked afterwards is the dead end.
+
+    force_restart is where a device in this state actually arrives: capture is
+    gone, so the unreachable watchdog escalates and calls it every cycle. This
+    drives that real sequence — blocked, remedy owed; user installs Rosetta;
+    next escalation — and asserts the remedy is withdrawn on its own.
+    """
+    mgr = _mgr()
+    installed = {"yet": False}
+
+    with contextlib.ExitStack() as stack:
+        for ctx in _no_tracker_stack(lambda: installed["yet"]):
+            stack.enter_context(ctx)
+
+        # Blocked. The tray owes a remedy.
+        assert mgr._start_locked() is False
+        assert mgr.capture_blocked_remedy() is not None
+
+        # The user runs the command. Nothing in the agent is restarted.
+        installed["yet"] = True
+
+        # The next watchdog escalation force-restarts the stack, as it has been
+        # doing every cycle throughout the outage.
+        mgr.force_restart(reason="server unreachable")
+
+        # THE assertion: the surface can go green on its own.
+        assert mgr._rosetta_missing_cached is False
+        assert mgr.capture_blocked_remedy() is None
+
+
+def test_a_still_missing_rosetta_survives_the_re_probe():
+    """The control for the clear above. Re-probing must not amnesty a machine
+    that is still blocked — the remedy has to persist across every escalation
+    for as long as the fault does, which is the whole reason the tray (not the
+    one-shot toast) is the surface #188 needed."""
+    mgr = _mgr()
+
+    with contextlib.ExitStack() as stack:
+        for ctx in _no_tracker_stack(False):
+            stack.enter_context(ctx)
+
+        assert mgr._start_locked() is False
+        mgr.force_restart(reason="server unreachable")
+
+        assert mgr._rosetta_missing_cached is True
+        assert mgr.capture_blocked_remedy() is not None
+
+
+def test_the_re_probe_does_not_reach_the_sixty_second_start_path():
+    """force_restart is an escalation, not the sync cycle. The memo exists to
+    keep `/usr/bin/arch` off the 60s path, and clearing it there instead of here
+    would have re-forked a subprocess every minute on every Mac in the fleet."""
+    mgr = _mgr()
+    completed = subprocess.CompletedProcess(args=[], returncode=1)
+
+    with patch("src.aw_manager.sys.platform", "darwin"), \
+         patch("src.aw_manager.platform.machine", return_value="arm64"), \
+         patch("src.aw_manager.subprocess.run", return_value=completed) as run, \
+         patch.object(AWManager, "_notify_rosetta_required_once"), \
+         patch.object(AWManager, "_port_in_use", return_value=False), \
+         patch("src.aw_manager.subprocess.Popen"):
+        mgr._start_locked()
+        mgr._start_locked()
+        mgr._start_locked()
+
+    assert run.call_count == 1

--- a/tests/test_aw_manager_rosetta_preflight.py
+++ b/tests/test_aw_manager_rosetta_preflight.py
@@ -14,10 +14,26 @@ healthy. No amount of retrying installs Rosetta, so the loop was pure noise.
 
 import contextlib
 import errno
+import logging
 import subprocess
 from unittest.mock import patch
 
-from src.aw_manager import AWManager
+from src.aw_manager import ROSETTA_REPROBE_INTERVAL, AWManager
+
+
+class _Clock:
+    """A monotonic clock the test drives, so the re-probe interval is exercised
+    rather than waited out. Real time would make these tests either slow or
+    dependent on how fast the runner is."""
+
+    def __init__(self):
+        self.t = 10_000.0
+
+    def __call__(self):
+        return self.t
+
+    def advance(self, seconds):
+        self.t += seconds
 
 
 def _mgr() -> AWManager:
@@ -229,10 +245,12 @@ def test_installing_rosetta_is_noticed_without_an_agent_restart():
     """
     mgr = _mgr()
     installed = {"yet": False}
+    clock = _Clock()
 
     with contextlib.ExitStack() as stack:
         for ctx in _no_tracker_stack(lambda: installed["yet"]):
             stack.enter_context(ctx)
+        stack.enter_context(patch("src.aw_manager.time.monotonic", clock))
 
         # Blocked. The tray owes a remedy.
         assert mgr._start_locked() is False
@@ -243,11 +261,82 @@ def test_installing_rosetta_is_noticed_without_an_agent_restart():
 
         # The next watchdog escalation force-restarts the stack, as it has been
         # doing every cycle throughout the outage.
+        clock.advance(ROSETTA_REPROBE_INTERVAL)
         mgr.force_restart(reason="server unreachable")
 
         # THE assertion: the surface can go green on its own.
         assert mgr._rosetta_missing_cached is False
         assert mgr.capture_blocked_remedy() is None
+
+
+def test_the_re_probe_is_rate_limited_off_the_sixty_second_escalation():
+    """The cost of the clear above, and the reason it is not unconditional.
+
+    _note_aw_unreachable returns True on EVERY cycle once its 180s grace period
+    is up — only a reachable ActivityWatch resets it — so a device capturing
+    nothing force-restarts every 60 seconds for the whole outage. An
+    unconditional clear therefore forks /usr/bin/arch once a minute on exactly
+    the Mac the memo was introduced to protect: the "21 identical failures at
+    60-second intervals" pattern the preflight replaced, arriving by another
+    door. Found by reading the escalation cadence, not by a failing test.
+    """
+    mgr = _mgr()
+    clock = _Clock()
+
+    with contextlib.ExitStack() as stack:
+        for ctx in _no_tracker_stack(False):
+            stack.enter_context(ctx)
+        run = stack.enter_context(
+            patch("src.aw_manager.subprocess.run",
+                  return_value=subprocess.CompletedProcess(args=[], returncode=1))
+        )
+        stack.enter_context(patch("src.aw_manager.time.monotonic", clock))
+
+        assert mgr._start_locked() is False
+        assert run.call_count == 1
+
+        # Escalations at the real 60s cadence, stopping one short of the
+        # interval. Both ends of the boundary are asserted deliberately: the
+        # first draft advanced 5 x 60 = exactly 300, landed ON the `>=`, and
+        # reddened — a fixture bug that reads exactly like a broken rate limit.
+        for _ in range(4):
+            clock.advance(60)
+            mgr.force_restart(reason="server unreachable")
+
+        assert clock.t - 10_000.0 < ROSETTA_REPROBE_INTERVAL, "fixture is past the boundary"
+        assert run.call_count == 1, (
+            "the probe re-forked inside the interval — this is the 60s spam again"
+        )
+
+        # Crossing it, the probe DOES re-ask. Without this half the assertion
+        # above is satisfied by a memo that never re-probes at all, which is the
+        # dead end the clear exists to remove.
+        clock.advance(60)
+        mgr.force_restart(reason="server unreachable")
+        assert run.call_count == 2
+
+
+def test_a_persisting_outage_logs_the_cause_once_not_once_per_re_probe(caplog):
+    """The other half of the same cost. Re-probing makes _rosetta_missing run
+    repeatedly, so it now logs the ANSWER changing rather than the probe
+    running — otherwise the identical error line reappears every interval for
+    the life of the outage."""
+    mgr = _mgr()
+    clock = _Clock()
+
+    with contextlib.ExitStack() as stack:
+        for ctx in _no_tracker_stack(False):
+            stack.enter_context(ctx)
+        stack.enter_context(patch("src.aw_manager.time.monotonic", clock))
+
+        with caplog.at_level(logging.ERROR, logger="src.aw_manager"):
+            mgr._start_locked()
+            for _ in range(3):
+                clock.advance(ROSETTA_REPROBE_INTERVAL)
+                mgr.force_restart(reason="server unreachable")
+
+    blocked = [r for r in caplog.records if "Rosetta 2 is not installed" in r.getMessage()]
+    assert len(blocked) == 1, f"logged the same cause {len(blocked)} times"
 
 
 def test_a_still_missing_rosetta_survives_the_re_probe():
@@ -256,12 +345,15 @@ def test_a_still_missing_rosetta_survives_the_re_probe():
     for as long as the fault does, which is the whole reason the tray (not the
     one-shot toast) is the surface #188 needed."""
     mgr = _mgr()
+    clock = _Clock()
 
     with contextlib.ExitStack() as stack:
         for ctx in _no_tracker_stack(False):
             stack.enter_context(ctx)
+        stack.enter_context(patch("src.aw_manager.time.monotonic", clock))
 
         assert mgr._start_locked() is False
+        clock.advance(ROSETTA_REPROBE_INTERVAL)
         mgr.force_restart(reason="server unreachable")
 
         assert mgr._rosetta_missing_cached is True

--- a/tests/test_aw_manager_rosetta_preflight.py
+++ b/tests/test_aw_manager_rosetta_preflight.py
@@ -240,6 +240,49 @@ def test_a_held_port_that_answers_nothing_is_not_a_recording_device():
     assert mgr._managed_components_unavailable is True
 
 
+def test_a_transient_info_failure_does_not_latch_for_the_life_of_the_process():
+    """The cost of the gate above, and the reason the attach branch CLEARS
+    rather than merely declining to set.
+
+    /info can time out on a healthy server — a busy laptop, a 2s budget. That
+    single cycle latches `tracker_download_failed`, and the Rosetta branch
+    returns before the "binaries resolved" clear forty lines down, so on a
+    Rosetta-missing Mac nothing else ever unsets it. The device would attach
+    externally and record perfectly while showing a permanent "install
+    Rosetta" and reporting itself capture-dead to the fleet: round 1's
+    Important arriving through a blip instead of a config.
+
+    Walks three real cycles with one blip in them. Found this way rather than
+    by reading, which is why the walk is the test.
+    """
+    mgr = _mgr()
+    mgr._rosetta_missing_cached = True
+    answers = iter([False, True, True])
+
+    with patch.object(AWManager, "_rosetta_missing", return_value=True), \
+         patch.object(AWManager, "_notify_rosetta_required_once"), \
+         patch.object(AWManager, "_port_in_use", return_value=True), \
+         patch.object(AWManager, "_server_responding", side_effect=lambda: next(answers)), \
+         patch("src.aw_manager.subprocess.Popen"):
+        # Cycle 1: the blip. Correctly read as capture-dead on the evidence
+        # available at the time — this half must NOT be softened.
+        assert mgr._start_locked() is False
+        assert mgr.tracker_download_failed is True
+        assert mgr.capture_blocked_remedy() is not None
+
+        # Cycle 2: the server answers. The device is recording.
+        assert mgr._start_locked() is True
+        assert mgr._using_external is True
+        # THE assertion: the latch is cleared, so the surface goes green and
+        # the fleet stops seeing a capture-dead device.
+        assert mgr.tracker_download_failed is False
+        assert mgr.capture_blocked_remedy() is None
+
+        # Cycle 3: and it stays that way.
+        assert mgr._start_locked() is True
+        assert mgr.capture_blocked_remedy() is None
+
+
 def test_the_carve_out_asks_over_http_not_over_tcp():
     """Names the mechanism, so a future refactor back to `_port_in_use()` alone
     reddens even if someone rewrites the two tests above.

--- a/tests/test_aw_manager_rosetta_preflight.py
+++ b/tests/test_aw_manager_rosetta_preflight.py
@@ -16,6 +16,7 @@ import contextlib
 import errno
 import logging
 import subprocess
+import urllib.error
 from unittest.mock import patch
 
 from src.aw_manager import ROSETTA_REPROBE_INTERVAL, AWManager
@@ -151,11 +152,33 @@ def test_an_external_server_is_attached_to_rather_than_declared_dead():
 
     managed_components_unavailable stays True either way: our watchers really
     are unavailable, and the backend needs to know the device cannot self-heal.
+
+    **The fixture, not the assertion, was the round-2 defect.** This test used
+    to pin `_port_in_use=True` alone and assert "no remedy" under the sentence
+    *this person is recording* — but a TCP connect cannot establish that
+    premise, so the assertion also certified a device whose port is held by
+    something dead. `_server_responding` is now pinned as well, which is what
+    makes the docstring true of the device the fixture actually builds; the
+    case it was wrongly covering has its own test below.
+
+    **Second defect in the same fixture, found by running the new sibling.**
+    Patching the `_rosetta_missing` METHOD skips the memo write the real probe
+    performs, so `_rosetta_missing_cached` stayed None — and
+    `capture_blocked_remedy()` returns None on a None memo by its own first
+    line. The "THE assertion" below was therefore satisfied by an un-probed
+    memo whatever `tracker_download_failed` said, i.e. it passed identically
+    against the bug, the fix, and no implementation at all. The memo is now set
+    to what the real probe would have written, which is what makes the
+    `tracker_download_failed` half of the condition the thing under test.
     """
     mgr = _mgr()
+    # What `_rosetta_missing()` writes on the real path; the patch below
+    # replaces the method, so the fixture owes the memo.
+    mgr._rosetta_missing_cached = True
     with patch.object(AWManager, "_rosetta_missing", return_value=True), \
          patch.object(AWManager, "_notify_rosetta_required_once") as notify, \
          patch.object(AWManager, "_port_in_use", return_value=True), \
+         patch.object(AWManager, "_server_responding", return_value=True), \
          patch("src.aw_manager.subprocess.Popen") as popen:
         started = mgr._start_locked()
 
@@ -169,6 +192,110 @@ def test_an_external_server_is_attached_to_rather_than_declared_dead():
     notify.assert_not_called()
     # Still un-self-healing, and the fleet must still see that.
     assert mgr._managed_components_unavailable is True
+
+
+def test_a_held_port_that_answers_nothing_is_not_a_recording_device():
+    """The fixture no test could express, and the regression it hid.
+
+    Round 2 hoisted the port probe above the Rosetta branch and gave the
+    external-server carve-out to ANY TCP listener. `_port_in_use()` is a bare
+    connect, so on a Rosetta-blocked Mac holding a hung `bf-data-service` —
+    port 5600 held, HTTP dead, which is the state `force_restart()`'s own
+    docstring exists to describe — `_start_locked` returned True, left
+    `tracker_download_failed` False, and `capture_blocked_remedy()` answered
+    None. The tray then fell back to "ActivityWatch not responding": the
+    literal #188 exists to remove, restored on #188's own device.
+
+    Un-reapable, too: `_reap_orphan_processes` is path-scoped to binaries_dir
+    and our binaries have never executed here, so nothing clears it and the
+    contradictory steady state (started=True, /info dead, fleet sees healthy)
+    persists for the life of the process.
+
+    Both booleans are pinned deliberately — production computes them, so an
+    unpinned probe would answer differently on a developer laptop that happens
+    to run ActivityWatch. The memo is supplied for the same reason: patching
+    the `_rosetta_missing` METHOD skips the write the real probe performs, and
+    `capture_blocked_remedy()` short-circuits on a None memo — which is what
+    made the sibling above pass against the regression.
+    """
+    mgr = _mgr()
+    mgr._rosetta_missing_cached = True
+    with patch.object(AWManager, "_rosetta_missing", return_value=True), \
+         patch.object(AWManager, "_notify_rosetta_required_once") as notify, \
+         patch.object(AWManager, "_port_in_use", return_value=True), \
+         patch.object(AWManager, "_server_responding", return_value=False), \
+         patch("src.aw_manager.subprocess.Popen") as popen:
+        started = mgr._start_locked()
+
+    assert started is False
+    popen.assert_not_called()
+    # Never claim an attachment to something that does not answer.
+    assert mgr._using_external is False
+    # THE assertion: capture IS dead here, so the remedy is owed and the fleet
+    # can see the device.
+    assert mgr.tracker_download_failed is True
+    remedy = mgr.capture_blocked_remedy()
+    assert remedy is not None and "Rosetta" in remedy, remedy
+    notify.assert_called_once()
+    assert mgr._managed_components_unavailable is True
+
+
+def test_the_carve_out_asks_over_http_not_over_tcp():
+    """Names the mechanism, so a future refactor back to `_port_in_use()` alone
+    reddens even if someone rewrites the two tests above.
+
+    Also pins the short-circuit: with nothing on the port there is no reason to
+    pay for an HTTP request, and this branch runs on the 60s start path.
+    """
+    mgr = _mgr()
+    with patch.object(AWManager, "_rosetta_missing", return_value=True), \
+         patch.object(AWManager, "_notify_rosetta_required_once"), \
+         patch.object(AWManager, "_port_in_use", return_value=True), \
+         patch.object(AWManager, "_server_responding", return_value=False) as info, \
+         patch("src.aw_manager.subprocess.Popen"):
+        mgr._start_locked()
+    assert info.call_count == 1, "the carve-out did not consult /api/0/info"
+
+    mgr = _mgr()
+    with patch.object(AWManager, "_rosetta_missing", return_value=True), \
+         patch.object(AWManager, "_notify_rosetta_required_once"), \
+         patch.object(AWManager, "_port_in_use", return_value=False), \
+         patch.object(AWManager, "_server_responding", return_value=True) as info, \
+         patch("src.aw_manager.subprocess.Popen"):
+        mgr._start_locked()
+    assert info.call_count == 0, "asked over HTTP with nothing on the port"
+
+
+def test_server_responding_is_the_http_ask_wait_for_server_polls():
+    """One implementation, two callers. `_wait_for_server` used to inline this
+    request; a second spelling is how the two drift into disagreeing about what
+    "the server is up" means.
+
+    Drives the REAL `_server_responding` against a patched urlopen — the
+    positive AND the negative, because a probe that answers False for every
+    input would satisfy the regression test above while measuring nothing.
+    """
+    mgr = _mgr()
+
+    with patch("src.aw_manager.urllib.request.urlopen") as urlopen:
+        assert mgr._server_responding() is True
+    assert urlopen.call_args[0][0] == "http://localhost:5600/api/0/info"
+    assert urlopen.call_args[1]["timeout"] == 2
+
+    with patch("src.aw_manager.urllib.request.urlopen",
+               side_effect=OSError("connection reset")):
+        assert mgr._server_responding() is False
+
+    # A held-but-dead socket answers the TCP connect and refuses the request;
+    # URLError is what urlopen raises there and it must not escape.
+    with patch("src.aw_manager.urllib.request.urlopen",
+               side_effect=urllib.error.URLError("timed out")):
+        assert mgr._server_responding() is False
+
+    # And _wait_for_server routes through it rather than asking again itself.
+    with patch.object(AWManager, "_server_responding", return_value=True) as ok:
+        assert mgr._wait_for_server() is True
+    assert ok.call_count == 1
 
 
 def test_the_user_is_told_once_not_every_cycle():

--- a/tests/test_process_arch_heartbeat.py
+++ b/tests/test_process_arch_heartbeat.py
@@ -39,7 +39,6 @@ from src.machine_arch import process_arch, true_machine_arch
 from src.main import SyncCoordinator
 from src.sync.bf_client import BetterFlowClient
 
-
 # ── The resolver ────────────────────────────────────────────────────────
 
 

--- a/tests/test_process_arch_heartbeat.py
+++ b/tests/test_process_arch_heartbeat.py
@@ -1,0 +1,190 @@
+"""#184: "who is sitting on the Intel BUILD?" is unanswerable from the wire.
+
+``machine_arch`` resolves *through* Rosetta on purpose — a translated x86_64
+process reports ``arm64``, because the question that field answers is "what
+silicon is this?". The consequence is that a native Apple Silicon install and an
+Intel build running under Rosetta are **byte-identical on the heartbeat**.
+
+Measured on real Apple Silicon (Darwin 25.5.0), running this repo's own helpers
+under both personalities:
+
+    native                  process=arm64    translated=False  true_machine_arch=arm64
+    arch -x86_64 (Rosetta)  process=x86_64   translated=True   true_machine_arch=arm64
+                                    ^^^^^^                                     ^^^^^
+                            differs                                    IDENTICAL
+
+``true_machine_arch()`` is the same in both rows, so no amount of reading it
+answers this issue's title. ``platform.machine()`` — the architecture of the
+running PROCESS, i.e. of the installed build — is the only value that differs,
+which is what makes it the discriminator and why it ships as a second field
+rather than as a change to the first.
+
+The pair is the answer, not either half:
+
+    machine_arch=arm64  process_arch=arm64   native Apple Silicon build   fine
+    machine_arch=arm64  process_arch=x86_64  Intel build under Rosetta    THIS
+    machine_arch=x86_64 process_arch=x86_64  a genuine Intel Mac          fine
+
+Every architecture in here is INJECTED, never read from the runner — the PR gate
+runs on ubuntu and only the tag build sees macOS, so a test that needs Apple
+Silicon to be meaningful runs in no PR-gating job at all, and a skip reads as
+coverage while providing none. Same rule as ``test_arch_heartbeat.py``.
+"""
+
+import threading
+from unittest.mock import MagicMock, patch
+
+from src.disclosure_baseline import HEARTBEAT_HEALTH_KEYS as BASELINE_KEYS
+from src.machine_arch import process_arch, true_machine_arch
+from src.main import SyncCoordinator
+from src.sync.bf_client import BetterFlowClient
+
+
+# ── The resolver ────────────────────────────────────────────────────────
+
+
+def test_process_arch_reports_the_process_not_the_hardware():
+    """THE defect this field exists to close.
+
+    Under Rosetta the two answers must DIVERGE. An implementation that quietly
+    delegates to ``true_machine_arch()`` — the obvious wrong fix, since it is
+    the arch helper already in the file — passes every other test here and
+    leaves the fleet exactly as blind as it is today.
+    """
+    machine = true_machine_arch(system="Darwin", machine="x86_64", translated=True)
+    process = process_arch(system="Darwin", machine="x86_64", translated=True)
+
+    assert machine == "arm64", "unchanged: machine_arch answers 'what silicon?'"
+    assert process == "x86_64", "process_arch answers 'which build?'"
+    assert process != machine, (
+        "if these agree under translation the pair carries no information and "
+        "#184's question stays unanswerable"
+    )
+
+
+def test_the_pair_agrees_on_a_native_apple_silicon_mac():
+    """Control. Divergence must mean something, so it must not be constant."""
+    assert process_arch(system="Darwin", machine="arm64", translated=False) == "arm64"
+    assert true_machine_arch(system="Darwin", machine="arm64", translated=False) == "arm64"
+
+
+def test_the_pair_agrees_on_a_genuine_intel_mac():
+    """Control, and the one that matters most: a real Intel Mac must NOT be
+    reported as being on the wrong build. Confusing it with a translated
+    process would send its owner to an arm64 DMG that cannot run at all —
+    there is no reverse Rosetta."""
+    assert process_arch(system="Darwin", machine="x86_64", translated=False) == "x86_64"
+    assert true_machine_arch(system="Darwin", machine="x86_64", translated=False) == "x86_64"
+
+
+def test_process_arch_is_untouched_off_darwin():
+    """Rosetta is macOS-only. Windows-on-ARM emulation is a different mechanism
+    that ``machine_arch`` deliberately does not model, so an x64 build under it
+    genuinely IS executing x86-64 and reports so."""
+    assert process_arch(system="Windows", machine="AMD64") == "AMD64"
+    assert process_arch(system="Linux", machine="aarch64") == "aarch64"
+
+
+def test_process_arch_never_consults_rosetta(monkeypatch):
+    """It is ``platform.machine()`` by definition — the process's own ISA, which
+    needs no probe. Forking sysctl to answer it would be both wasteful and a
+    route to the empty-string 'undetermined' state, which this field cannot
+    have: a running process always has an architecture."""
+    import subprocess
+
+    def explode(*a, **k):
+        raise AssertionError("process_arch forked a subprocess")
+
+    monkeypatch.setattr(subprocess, "run", explode)
+    monkeypatch.setattr(subprocess, "Popen", explode)
+
+    assert process_arch(system="Darwin", machine="arm64") == "arm64"
+
+
+# ── The wire boundary ───────────────────────────────────────────────────
+
+
+def test_the_allowlist_carries_process_arch():
+    assert "process_arch" in BetterFlowClient.HEARTBEAT_HEALTH_KEYS
+
+
+def test_the_disclosure_baseline_declares_it_too():
+    """``tests/test_disclosure_baseline.py`` already fails on any divergence
+    between the two tuples. Asserted here as well so this file states the whole
+    contract it is adding rather than depending on a sibling to notice half of
+    it."""
+    assert "process_arch" in BASELINE_KEYS
+
+
+def test_a_real_process_arch_reaches_the_request_body():
+    client = BetterFlowClient.__new__(BetterFlowClient)
+    captured = {}
+    client._request = lambda method, path, data=None, **kw: (
+        captured.update(data or {}), {"data": {}}
+    )[1]
+    client._detect_timezone = lambda: "Europe/Bucharest"
+
+    client.heartbeat(
+        agent_version="1.5.125",
+        health={"machine_arch": "arm64", "process_arch": "x86_64"},
+    )
+
+    assert captured["process_arch"] == "x86_64"
+    assert captured["machine_arch"] == "arm64", "the existing field is unharmed"
+
+
+# ── The producer ────────────────────────────────────────────────────────
+#
+# Witnessed separately from the allowlist: an allowlist entry with no producer
+# forwards a field no device ever supplies, and every assertion above still
+# passes.
+
+
+def _telemetry_from_real_app() -> dict:
+    stub = MagicMock()
+    stub._idle_tracker_warn_lock = threading.Lock()
+    stub._blind_tracker_window = 0
+    stub._consecutive_sync_failures = 0
+    stub._last_successful_sync = None
+    stub.aw_manager.health_snapshot.return_value = {}
+    return SyncCoordinator._build_health_telemetry(stub)
+
+
+def test_the_assembler_reports_the_process_arch():
+    with patch("src.main.process_arch", return_value="x86_64"):
+        telemetry = _telemetry_from_real_app()
+
+    assert telemetry["process_arch"] == "x86_64"
+
+
+def test_the_assembler_carries_the_pair_that_identifies_the_wrong_build():
+    """The reading the whole issue exists to enumerate, asserted as a PAIR.
+
+    Neither field alone says "Intel build on Apple Silicon"; only both together
+    do, and only if both survive the same assembly.
+    """
+    with patch("src.main.process_arch", return_value="x86_64"), \
+            patch("src.main.true_machine_arch", return_value="arm64"):
+        telemetry = _telemetry_from_real_app()
+
+    assert telemetry["process_arch"] == "x86_64"
+    assert telemetry["machine_arch"] == "arm64"
+
+
+def test_a_failing_process_arch_probe_never_costs_the_heartbeat():
+    with patch("src.main.process_arch", side_effect=OSError("denied")):
+        telemetry = _telemetry_from_real_app()
+
+    assert isinstance(telemetry, dict)
+    assert "process_arch" not in telemetry
+    assert "consecutive_sync_failures" in telemetry, "the rest of the payload survived"
+
+
+def test_a_failing_process_arch_probe_does_not_take_machine_arch_with_it():
+    """The two live in adjacent try/excepts on purpose. Sharing one would let a
+    failure in the new field silently delete the field that already ships."""
+    with patch("src.main.process_arch", side_effect=OSError("denied")), \
+            patch("src.main.true_machine_arch", return_value="arm64"):
+        telemetry = _telemetry_from_real_app()
+
+    assert telemetry["machine_arch"] == "arm64"

--- a/tests/test_process_arch_heartbeat.py
+++ b/tests/test_process_arch_heartbeat.py
@@ -187,3 +187,62 @@ def test_a_failing_process_arch_probe_does_not_take_machine_arch_with_it():
         telemetry = _telemetry_from_real_app()
 
     assert telemetry["machine_arch"] == "arm64"
+
+
+# ── The fallback branch: platform.machine() answering "" ────────────────
+#
+# Everything above this point either passes `machine=` explicitly or patches
+# `process_arch` wholesale, so `return machine or platform.machine()` -- the
+# only line in the function -- had its right-hand side witnessed by nothing.
+# That is unwitnessed BY CONSTRUCTION, not by oversight: an injected value is
+# what makes the tests above meaningful on an ubuntu runner, and it is exactly
+# what hides this.
+
+
+def test_process_arch_falls_through_to_the_real_probe():
+    """The positive control, and the reason the two below are not vacuous.
+
+    Without this, a mutant deleting the fallback entirely (`return machine`)
+    would leave every assertion in this section passing on None.
+    """
+    with patch("src.machine_arch.platform.machine", return_value="arm64"):
+        assert process_arch() == "arm64"
+
+
+def test_an_undeterminable_architecture_is_empty_not_a_lie():
+    """platform.machine() is documented to return "" when it cannot determine
+    the architecture (reachable on Windows with a scrubbed service
+    environment). The helper must pass that through rather than inventing a
+    value -- the mapping to null is the caller's job, and doing it here would
+    give this helper a different contract from its sibling."""
+    with patch("src.machine_arch.platform.machine", return_value=""):
+        assert process_arch() == ""
+
+
+def test_a_blank_architecture_reaches_the_wire_as_null_not_as_a_string():
+    """THE assertion. HEARTBEAT_HEALTH_KEYS filters by key MEMBERSHIP, not by
+    truthiness, so an unmapped "" ships -- and a consumer written against "this
+    field is never null" reads a blank string as an architecture whose name
+    happens to be empty. `or None` at the producer, matching machine_arch five
+    lines above it, is what keeps "we could not tell" distinguishable.
+
+    Driven through the REAL process_arch rather than a patched return value:
+    patching the function is precisely what made this branch invisible.
+    """
+    with patch("src.machine_arch.platform.machine", return_value=""):
+        telemetry = _telemetry_from_real_app()
+
+    assert "process_arch" in telemetry, "absence is a different claim from null"
+    assert telemetry["process_arch"] is None
+
+
+def test_the_pair_maps_an_undeterminable_arch_the_same_way_on_both_halves():
+    """The sibling has always mapped "" to None. A pair whose two halves
+    disagree about how to say "unknown" is worse than either convention: the
+    reader cannot tell a genuinely blank build from a genuinely unknown one."""
+    with patch("src.machine_arch.platform.machine", return_value=""), \
+            patch("src.main.true_machine_arch", return_value=""):
+        telemetry = _telemetry_from_real_app()
+
+    assert telemetry["process_arch"] is None
+    assert telemetry["machine_arch"] is None

--- a/tests/test_rosetta_capture_blocked_message.py
+++ b/tests/test_rosetta_capture_blocked_message.py
@@ -1,0 +1,236 @@
+"""#188: the persistent surface named the wrong component for 90 minutes.
+
+On a clean Apple Silicon Mac with no Rosetta 2, every bundled x86_64 tracker
+fails to spawn with ``[Errno 86] Bad CPU type in executable``. Capture never
+starts, so the ActivityWatch watchdog escalates and the tray goes ERROR — and
+says **"ActivityWatch not responding"**.
+
+That sentence is true and useless. It names a component the user has never heard
+of, on a machine that is recording zero seconds, when the one thing that would
+have fixed it fits on a line:
+
+    softwareupdate --install-rosetta
+
+Carmen Lapusan lost ~90 minutes to that on 2026-08-13 (agent v1.5.122), and
+Laszlo Fabian Raul's device recorded zero seconds across two days before her.
+The one-shot toast that *did* say the right thing fires once per process, during
+the noisiest moment of a new laptop's first launch, and ``clear_notifications()``
+wipes it again when the app quits. The tray is the surface that persists for as
+long as the fault does, so the tray is where the remedy has to be.
+
+**This is a wording/routing fix on an ALREADY-FIRING surface, not new UI.** The
+tray was red for the whole 90 minutes; it was pointed at the wrong cause.
+
+Scope note, stated plainly: the Rosetta state itself is INJECTED in every test
+here. This machine has Rosetta installed (``arch -x86_64 /usr/bin/true`` exits
+0) and Rosetta cannot be uninstalled, so the genuine zero-capture state is not
+reproducible on this hardware or on the ubuntu PR runner. What is verified here
+is that the message the surface carries is derived from the blocked state and
+names the remedy; that a real Apple Silicon Mac without Rosetta reaches this
+branch is inherited from ``_rosetta_missing()``, which is unchanged and has its
+own tests in ``test_aw_manager_rosetta_preflight.py``.
+"""
+
+import re
+from unittest.mock import MagicMock
+
+import pytest
+
+from src.aw_manager import AWManager
+from src.main import SyncCoordinator
+
+
+# The command is the entire point of the change. A message that says "Rosetta"
+# without it leaves the user exactly where Carmen was: knowing a word, not a fix.
+_INSTALL_COMMAND = "softwareupdate --install-rosetta"
+
+
+def _names_the_remedy(text: str) -> bool:
+    """True only when the text identifies the fault AND gives the command.
+
+    Whole words over substrings, and BOTH halves required, for the reason
+    ``tests/remedy_wording.py`` documents: a naive membership check is satisfied
+    by prose that happens to contain the token and carries no remedy at all.
+    """
+    low = text.lower()
+    names_cause = re.search(r"\brosetta\b", low) is not None
+    gives_command = _INSTALL_COMMAND in low
+    return names_cause and gives_command
+
+
+class _Clock:
+    def __init__(self):
+        self.t = 1000.0
+
+    def __call__(self):
+        return self.t
+
+    def advance(self, seconds):
+        self.t += seconds
+
+
+@pytest.fixture
+def coord():
+    c = SyncCoordinator.__new__(SyncCoordinator)
+    c._aw_unreachable_streak = 0
+    c._aw_unreachable_since = None
+    c._AW_UNREACHABLE_ERROR_THRESHOLD = 2
+    c._AW_UNREACHABLE_ESCALATE_SECONDS = 180.0
+    c._aw_buckets_failed_streak = 0
+    c.error_reporter = None
+    c.aw_manager = MagicMock()
+    c.aw_manager.is_managing = False
+    c.tray = MagicMock()
+    return c
+
+
+def _tray_message(coord) -> str:
+    """The string the tray was actually handed. set_state(state, message)."""
+    assert coord.tray.set_state.call_args is not None, "the tray was never told anything"
+    return coord.tray.set_state.call_args[0][1]
+
+
+def _escalate(coord):
+    clock = _Clock()
+    coord._note_aw_unreachable(now=clock())
+    clock.advance(181)
+    coord._escalate_aw_unreachable(now=clock())
+
+
+# ── The producer: aw_manager knows which of the three causes it is ──────
+
+
+def _manager_with_rosetta_memo(missing):
+    """A real AWManager with ONLY the Rosetta memo populated.
+
+    ``__new__`` rather than a constructed manager: this method must read the
+    memo and nothing else, so a fixture that cannot supply anything else is the
+    strongest available statement of that.
+    """
+    m = AWManager.__new__(AWManager)
+    m._rosetta_missing_cached = missing
+    return m
+
+
+def test_the_manager_reports_the_remedy_when_rosetta_is_the_established_cause():
+    remedy = _manager_with_rosetta_memo(True).capture_blocked_remedy()
+
+    assert remedy is not None, "the one cause we can name must be named"
+    assert _names_the_remedy(remedy), remedy
+
+
+def test_the_manager_withholds_a_remedy_when_rosetta_is_fine():
+    """The control. A manager that has established Rosetta IS present must not
+    volunteer a Rosetta remedy — otherwise every unrelated ActivityWatch outage
+    on every Mac starts telling people to install something they already have."""
+    assert _manager_with_rosetta_memo(False).capture_blocked_remedy() is None
+
+
+def test_the_manager_withholds_a_remedy_when_the_probe_never_ran():
+    """``None`` is the un-probed memo, and is NOT False. Claiming a remedy from
+    a state nobody established would be a confident guess on the one surface
+    that exists to stop guessing."""
+    assert _manager_with_rosetta_memo(None).capture_blocked_remedy() is None
+
+
+def test_the_remedy_never_forks_a_subprocess(monkeypatch):
+    """``capture_blocked_remedy()`` is read while building the tray message, on
+    the sync cycle and under the menu lock. ``_rosetta_missing()`` forks
+    ``/usr/bin/arch``; this must read the MEMO it leaves behind and never run a
+    probe of its own. The tray's own siblings (`_arch_menu_item`,
+    `serial_menu_row`) carry the same rule in their docstrings."""
+    import subprocess
+
+    def explode(*a, **k):
+        raise AssertionError("capture_blocked_remedy forked a subprocess")
+
+    monkeypatch.setattr(subprocess, "run", explode)
+    monkeypatch.setattr(subprocess, "Popen", explode)
+    monkeypatch.setattr(subprocess, "check_output", explode)
+
+    assert _manager_with_rosetta_memo(True).capture_blocked_remedy() is not None
+
+
+# ── The consumer: the tray message the user actually sees ───────────────
+#
+# Witnessed separately from the producer. A producer with no consumer is
+# Phantom 7 — every assertion above passes while the tray still says
+# "ActivityWatch not responding", which is exactly the shipped defect.
+
+
+def test_the_tray_names_rosetta_when_that_is_why_capture_is_dead(coord):
+    """THE defect. 90 minutes of a red tray pointing at the wrong component."""
+    coord.aw_manager.capture_blocked_remedy.return_value = (
+        "Not recording — Rosetta 2 required. Open Terminal and run: "
+        f"{_INSTALL_COMMAND}"
+    )
+
+    _escalate(coord)
+
+    assert _names_the_remedy(_tray_message(coord)), _tray_message(coord)
+
+
+def test_the_bucket_failure_path_says_the_same_thing(coord):
+    """The SECOND call site. Both escalations set the identical literal today,
+    so a fix applied to one leaves a device that reaches the other still reading
+    "ActivityWatch not responding" — the same outage, the same wrong sentence.
+    Mutation: revert either call site alone and exactly one of these two reddens.
+    """
+    coord.aw_manager.capture_blocked_remedy.return_value = (
+        "Not recording — Rosetta 2 required. Open Terminal and run: "
+        f"{_INSTALL_COMMAND}"
+    )
+
+    for _ in range(coord._AW_UNREACHABLE_ERROR_THRESHOLD):
+        coord._handle_aw_bucket_failure()
+
+    assert _names_the_remedy(_tray_message(coord)), _tray_message(coord)
+
+
+def test_an_ordinary_outage_still_reads_as_before(coord):
+    """The control, and it must pass BOTH pre- and post-fix.
+
+    Every Mac with Rosetta, every Windows box and every Linux box reaches this
+    branch. If the Rosetta wording leaked into it, this change would have
+    replaced one wrong sentence with a differently wrong one on the whole fleet.
+    """
+    coord.aw_manager.capture_blocked_remedy.return_value = None
+
+    _escalate(coord)
+
+    message = _tray_message(coord)
+    assert message == "ActivityWatch not responding"
+    assert "rosetta" not in message.lower()
+
+
+def test_a_broken_manager_never_costs_the_escalation(coord):
+    """A manager that raises must not swallow the tray escalation — that would
+    hide the very fault it was trying to report, the rule the sibling
+    force_restart handler already follows."""
+    coord.aw_manager.capture_blocked_remedy.side_effect = RuntimeError("boom")
+
+    _escalate(coord)
+
+    coord.tray.set_state.assert_called_once()
+    assert _tray_message(coord) == "ActivityWatch not responding"
+
+
+def test_a_nonsense_remedy_never_reaches_the_user(coord):
+    """The message is rendered into the tray verbatim. A non-string (or an empty
+    one) must fall back rather than putting a repr in front of the user — and
+    every existing escalation test hands this coordinator a bare MagicMock,
+    which is truthy, so a plain `remedy or fallback` would ship `<MagicMock ...>`
+    as the fault message."""
+    coord.aw_manager.capture_blocked_remedy.return_value = MagicMock()
+
+    _escalate(coord)
+
+    assert _tray_message(coord) == "ActivityWatch not responding"
+
+
+def test_an_empty_remedy_falls_back(coord):
+    coord.aw_manager.capture_blocked_remedy.return_value = "   "
+
+    _escalate(coord)
+
+    assert _tray_message(coord) == "ActivityWatch not responding"

--- a/tests/test_rosetta_capture_blocked_message.py
+++ b/tests/test_rosetta_capture_blocked_message.py
@@ -99,15 +99,28 @@ def _escalate(coord):
 # ── The producer: aw_manager knows which of the three causes it is ──────
 
 
-def _manager_with_rosetta_memo(missing):
-    """A real AWManager with ONLY the Rosetta memo populated.
+def _manager_with_rosetta_memo(missing, capture_dead=True):
+    """A real AWManager carrying only the two fields the remedy may read.
 
-    ``__new__`` rather than a constructed manager: this method must read the
-    memo and nothing else, so a fixture that cannot supply anything else is the
+    ``__new__`` rather than a constructed manager: this method must read these
+    two and nothing else, so a fixture that cannot supply anything else is the
     strongest available statement of that.
+
+    ``capture_dead`` is ``tracker_download_failed`` — the manager's own latch
+    for "this device is capturing nothing". It defaults True because that is the
+    state every caller of this helper was implicitly assuming before the flag
+    was part of the condition at all.
+
+    ``force_restart`` is the one method stubbed, for the escalation tests that
+    hand this object to a coordinator: it tears down process trees and now
+    re-probes Rosetta, which is a separate mechanism with its own tests. Left
+    real it would raise on the absent lock, be swallowed by the caller's
+    try/except, and quietly make this a test of the error path instead.
     """
     m = AWManager.__new__(AWManager)
     m._rosetta_missing_cached = missing
+    m.tracker_download_failed = capture_dead
+    m.force_restart = MagicMock(return_value=False)
     return m
 
 
@@ -116,6 +129,21 @@ def test_the_manager_reports_the_remedy_when_rosetta_is_the_established_cause():
 
     assert remedy is not None, "the one cause we can name must be named"
     assert _names_the_remedy(remedy), remedy
+
+
+def test_the_manager_withholds_a_remedy_from_a_device_that_is_recording():
+    """A missing Rosetta is not the same fact as a dead capture.
+
+    A user who hit the "nothing is being tracked" wall and installed a native
+    arm64 ActivityWatch themselves keeps the memo at True forever while
+    recording perfectly well. Gating on the memo alone put "Not recording —
+    Rosetta 2 required" in front of that person on any unrelated outage, about a
+    component with nothing to do with it. ``tracker_download_failed`` is the
+    manager's own answer to "is this device capturing nothing", and
+    ``_start_locked`` deliberately leaves it False when an external server holds
+    the port.
+    """
+    assert _manager_with_rosetta_memo(True, capture_dead=False).capture_blocked_remedy() is None
 
 
 def test_the_manager_withholds_a_remedy_when_rosetta_is_fine():
@@ -174,16 +202,38 @@ def test_the_bucket_failure_path_says_the_same_thing(coord):
     so a fix applied to one leaves a device that reaches the other still reading
     "ActivityWatch not responding" — the same outage, the same wrong sentence.
     Mutation: revert either call site alone and exactly one of these two reddens.
+
+    Driven by a REAL manager rather than a mocked return value. With a mock this
+    test asserted only that whatever the manager said reached the tray, which is
+    true of a manager answering wrongly — it pinned "a bucket failure renders the
+    Rosetta remedy" as correct, unconditionally, which is exactly the defect its
+    sibling below now covers. The manager here is in the state the sentence
+    actually describes: Rosetta missing AND nothing being captured.
     """
-    coord.aw_manager.capture_blocked_remedy.return_value = (
-        "Not recording — Rosetta 2 required. Open Terminal and run: "
-        f"{_INSTALL_COMMAND}"
-    )
+    coord.aw_manager = _manager_with_rosetta_memo(True)
 
     for _ in range(coord._AW_UNREACHABLE_ERROR_THRESHOLD):
         coord._handle_aw_bucket_failure()
 
     assert _names_the_remedy(_tray_message(coord)), _tray_message(coord)
+
+
+def test_a_bucket_failure_on_a_RECORDING_device_names_no_remedy(coord):
+    """The case the mocked version of the test above could not express.
+
+    Same escalation, same missing Rosetta, but an external native-arm64 server
+    is capturing — so ``tracker_download_failed`` is False and the outage is
+    something else entirely. The tray must fall back to the generic sentence
+    rather than confidently blaming a component that is not the cause.
+    """
+    coord.aw_manager = _manager_with_rosetta_memo(True, capture_dead=False)
+
+    for _ in range(coord._AW_UNREACHABLE_ERROR_THRESHOLD):
+        coord._handle_aw_bucket_failure()
+
+    message = _tray_message(coord)
+    assert message == "ActivityWatch not responding"
+    assert "rosetta" not in message.lower()
 
 
 def test_an_ordinary_outage_still_reads_as_before(coord):

--- a/tests/test_rosetta_capture_blocked_message.py
+++ b/tests/test_rosetta_capture_blocked_message.py
@@ -39,7 +39,6 @@ import pytest
 from src.aw_manager import AWManager
 from src.main import SyncCoordinator
 
-
 # The command is the entire point of the change. A message that says "Rosetta"
 # without it leaves the user exactly where Carmen was: knowing a word, not a fix.
 _INSTALL_COMMAND = "softwareupdate --install-rosetta"

--- a/tests/test_rosetta_capture_blocked_message.py
+++ b/tests/test_rosetta_capture_blocked_message.py
@@ -218,7 +218,7 @@ def test_the_bucket_failure_path_says_the_same_thing(coord):
     assert _names_the_remedy(_tray_message(coord)), _tray_message(coord)
 
 
-def test_a_bucket_failure_on_a_RECORDING_device_names_no_remedy(coord):
+def test_a_bucket_failure_on_a_recording_device_names_no_remedy(coord):
     """The case the mocked version of the test above could not express.
 
     Same escalation, same missing Rosetta, but an external native-arm64 server

--- a/tests/test_tray_status_text_renders.py
+++ b/tests/test_tray_status_text_renders.py
@@ -1,0 +1,244 @@
+"""#188 round 2: the remedy has to reach a surface, and ``status_text`` was not one.
+
+The first pass at #188 routed a better sentence — "Not recording — Rosetta 2
+required. Open Terminal and run: softwareupdate --install-rosetta" — from
+``AWManager`` through ``SyncCoordinator`` into ``TrayIcon.set_state(...)``. Every
+link in that chain was tested and every test passed. The user still saw
+``App status: Error``.
+
+``TrayIcon.model.status_text`` had **zero readers**. ``_snapshot_model`` copied
+it into the snapshot; ``_create_menu`` rendered ``_get_status_text(s)``, whose
+ERROR branch returned the constant ``"Error"`` and never looked at it; the
+tooltip renders hours. So the field was write-only from its first commit, and
+improving the string written into it could not change one character on screen.
+
+**Why the existing suite could not see that.**
+``tests/test_rosetta_capture_blocked_message.py`` sets ``c.tray = MagicMock()``
+and asserts on ``coord.tray.set_state.call_args``. That is the right test for
+the *routing* question it asks, and it is structurally incapable of answering
+this one: the consumer it asserts against is a mock argument one layer ABOVE the
+real consumer. A mock accepts any call and renders nothing (Phantom 7, one level
+up). Every test in this file therefore drives the REAL ``TrayIcon``.
+
+Two levels of witness, deliberately:
+
+- ``_get_status_text`` — the function that holds the branch.
+- ``_create_menu`` — the actual render path, asserted on the label list the menu
+  is built from. That one fails if the branch is correct but nothing calls it,
+  which is the exact class of defect this file exists for.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from src.ui.tray import TrayIcon, TrayState
+
+# The literal the producer emits (src/aw_manager.py capture_blocked_remedy).
+# Spelled out rather than imported: this file's question is "does the tray render
+# the string it was handed", and importing the producer's constant would let a
+# change to that constant move both sides of the assertion together.
+_REMEDY = (
+    "Not recording — Rosetta 2 required. Open Terminal and run: "
+    "softwareupdate --install-rosetta"
+)
+
+
+def _make_tray() -> TrayIcon:
+    """A real TrayIcon with only the display backend stubbed.
+
+    ``pystray`` binds its backend at import time and has none on a headless
+    runner, so the module-level name is patched — but ``TrayIcon`` itself,
+    ``_get_status_text`` and ``_create_menu`` are the genuine article. Same
+    construction ``tests/test_tray_state_transitions.py`` already uses.
+    """
+    with patch("src.ui.tray.pystray"):
+        tray = TrayIcon(
+            on_login=lambda: None,
+            on_logout=lambda: None,
+            on_pause=lambda: None,
+            on_resume=lambda: None,
+            on_quit=lambda: None,
+        )
+    tray._icon = MagicMock()
+    tray._update_icon = MagicMock()
+    tray._update_menu = MagicMock()
+    return tray
+
+
+def _menu_labels(tray: TrayIcon) -> list[str]:
+    """Every label ``_create_menu`` builds, from the REAL menu build.
+
+    ``Item`` is a module-level name in ``src.ui.tray``; recording it captures
+    exactly what the menu is constructed from. The two hardware rows are stubbed
+    because they probe the machine (``sysctl``/``ioreg``) and this test is about
+    a string, not about silicon — everything else in the build runs for real.
+    """
+    labels: list[str] = []
+
+    def record(label, *args, **kwargs):
+        if isinstance(label, str):
+            labels.append(label)
+        return MagicMock()
+
+    tray._serial_menu_item = MagicMock()
+    tray._arch_menu_item = MagicMock()
+    with patch("src.ui.tray.pystray"), patch("src.ui.tray.Item", side_effect=record):
+        tray._create_menu()
+    return labels
+
+
+def _app_status_row(tray: TrayIcon) -> str:
+    rows = [line for line in _menu_labels(tray) if line.startswith("App status:")]
+    assert len(rows) == 1, f"expected exactly one App status row, got {rows}"
+    return rows[0]
+
+
+# ── The branch ──────────────────────────────────────────────────────────
+
+
+def test_the_error_status_carries_the_sentence_it_was_given():
+    """THE defect. Pre-fix this returns the constant "Error" and the remedy —
+    correctly produced, correctly routed, correctly stored — dies here."""
+    tray = _make_tray()
+
+    tray.set_state(TrayState.ERROR, _REMEDY)
+
+    assert tray._get_status_text() == _REMEDY
+
+
+def test_the_error_status_reads_the_snapshot_too():
+    """``_create_menu`` passes a snapshot rather than reading the model, so the
+    snapshot path is a separate branch and gets its own witness. A fix applied
+    to only one of the two leaves the menu — the surface that matters — unchanged.
+    """
+    tray = _make_tray()
+
+    tray.set_state(TrayState.ERROR, _REMEDY)
+
+    assert tray._get_status_text(tray._snapshot_model()) == _REMEDY
+
+
+# ── The render path ─────────────────────────────────────────────────────
+#
+# The tests above pass against a `_get_status_text` nothing calls. These do not.
+
+
+def test_the_menu_row_the_user_reads_names_the_remedy():
+    """The whole point of #188: the persistent surface carries the command.
+
+    Asserted on the label ``_create_menu`` actually builds, so deleting the read
+    OR the call to ``_get_status_text`` reddens it.
+    """
+    tray = _make_tray()
+
+    tray.set_state(TrayState.ERROR, _REMEDY)
+
+    row = _app_status_row(tray)
+    assert "Rosetta" in row, row
+    assert "softwareupdate --install-rosetta" in row, row
+
+
+def test_an_ordinary_error_still_reads_as_before():
+    """The control, and it must degrade to the old constant.
+
+    Also the witness for the ENTRY clear in ``set_state``. The model seeds
+    ``status_text`` to ``"Starting..."``, so before that clear existed this
+    rendered ``App status: Starting...`` under a red icon — found by running
+    this very test, not by reading. Every escalation in ``src/`` passes a
+    message, so nothing live lands here; the guard is on the shape.
+    """
+    tray = _make_tray()
+
+    tray.set_state(TrayState.ERROR)
+
+    assert tray._get_status_text() == "Error"
+    assert _app_status_row(tray) == "App status: Error"
+
+
+def test_a_previous_states_message_never_reappears_under_a_fault():
+    """The realistic form of the case above. ``_check_permissions`` in main.py
+    writes ``status_text`` directly for the NEEDS_PERMISSIONS hint. A later
+    text-less escalation must not render that hint as the cause of THIS fault —
+    a wrong sentence is what #188 was about, and rendering the field is what
+    made that reachable."""
+    tray = _make_tray()
+
+    tray.model.status_text = "Grant Input Monitoring to record activity"
+    tray.set_state(TrayState.NEEDS_PERMISSIONS)
+    tray.set_state(TrayState.ERROR)
+
+    assert _app_status_row(tray) == "App status: Error"
+
+
+def test_a_repeat_escalation_keeps_the_sentence_it_already_carries():
+    """The other side of the entry clear: ERROR → ERROR is the SAME outage
+    escalating again, not a new one. Clearing there would blank the remedy on
+    the second watchdog tick, which is the surface going dark exactly when the
+    user is most likely to look at it."""
+    tray = _make_tray()
+
+    tray.set_state(TrayState.ERROR, _REMEDY)
+    tray.set_state(TrayState.ERROR)
+
+    assert tray._get_status_text() == _REMEDY
+
+
+@pytest.mark.parametrize("junk", ["", "   ", None])
+def test_blank_text_falls_back_rather_than_rendering_an_empty_row(junk):
+    """``App status:`` with nothing after it is worse than ``Error`` — it reads
+    as a broken app rather than a reported fault."""
+    tray = _make_tray()
+
+    tray.set_state(TrayState.ERROR, "something")
+    tray.model.status_text = junk
+
+    assert tray._get_status_text() == "Error"
+    assert _app_status_row(tray) == "App status: Error"
+
+
+def test_a_non_string_never_reaches_the_row():
+    """Mirrors the guard ``_tracker_fault_message`` already carries one layer up:
+    the value is interpolated verbatim, so a truthy non-string would put a repr
+    in front of the user."""
+    tray = _make_tray()
+
+    tray.set_state(TrayState.ERROR, "something")
+    tray.model.status_text = MagicMock()
+
+    assert tray._get_status_text() == "Error"
+
+
+def test_recovery_stops_rendering_the_stale_sentence():
+    """``set_state`` clears ``status_text`` on ERROR → healthy. That clear was
+    previously unobservable — nothing rendered the field either way — so it now
+    needs a witness on the surface: a device that recovers must not keep telling
+    the user to install Rosetta."""
+    tray = _make_tray()
+
+    tray.set_state(TrayState.ERROR, _REMEDY)
+    tray.set_state(TrayState.SYNCING)
+
+    row = _app_status_row(tray)
+    assert row == "App status: Active"
+    assert "Rosetta" not in row
+
+
+def test_the_other_states_are_untouched_by_the_error_branch():
+    """The ERROR branch reads a key its siblings do not. If that read leaked to
+    the top of the function, every other state would start depending on a
+    snapshot key — and callers passing a partial dict would raise instead of
+    answering."""
+    tray = _make_tray()
+
+    def status_for(state):
+        return tray._get_status_text(
+            {"on_break": False, "private_mode": False,
+             "state": state, "break_minutes_left": 0}
+        )
+
+    assert status_for(TrayState.SYNCING) == "Active"
+    assert status_for(TrayState.PRIVATE_HOURS) == "Outside working hours"
+    assert status_for(TrayState.STARTING) == "Starting..."

--- a/tests/test_tray_status_text_renders.py
+++ b/tests/test_tray_status_text_renders.py
@@ -173,6 +173,74 @@ def test_a_previous_states_message_never_reappears_under_a_fault():
     assert _app_status_row(tray) == "App status: Error"
 
 
+def test_a_queue_message_does_not_survive_into_a_tracker_fault():
+    """`faulted` holds TWO states, so the first cut of the entry clear —
+    `previous_state not in faulted` — read QUEUE_WARNING → ERROR as staying
+    put and cleared nothing. The queue's own sentence then rendered as the
+    cause of a tracker fault: a specific, confident, wrong diagnosis on the one
+    surface #188 exists to make trustworthy.
+    """
+    tray = _make_tray()
+
+    tray.set_state(TrayState.ERROR, _REMEDY)
+    tray.set_state(TrayState.QUEUE_WARNING, "Queue 92% full")
+    tray.set_state(TrayState.ERROR)
+
+    assert _app_status_row(tray) == "App status: Error"
+
+
+def test_a_stale_remedy_is_not_resurrected_by_a_hop_through_the_other_fault():
+    """The nastier half of the same hole: two text-less transitions in a row.
+
+    ERROR(remedy) → QUEUE_WARNING(no text) → ERROR(no text) cleared on neither
+    hop, so a remedy from an outage that had already been superseded came back
+    under a later, unrelated fault — the surface asserting a cause nobody
+    established.
+    """
+    tray = _make_tray()
+
+    tray.set_state(TrayState.ERROR, _REMEDY)
+    tray.set_state(TrayState.QUEUE_WARNING)
+    tray.set_state(TrayState.ERROR)
+
+    row = _app_status_row(tray)
+    assert row == "App status: Error"
+    assert "Rosetta" not in row
+
+
+def test_the_guarded_half_still_works():
+    """The control the original guard was written for, kept explicit so a
+    mutant that fixes the new door by breaking the old one is visible."""
+    tray = _make_tray()
+
+    tray.set_state(TrayState.ERROR, _REMEDY)
+    tray.set_state(TrayState.SYNCING)
+    tray.set_state(TrayState.ERROR)
+
+    assert _app_status_row(tray) == "App status: Error"
+
+
+def test_a_repeat_queue_warning_keeps_its_own_sentence():
+    """The ERROR → ERROR retention, in its sibling state. The inequality has to
+    preserve BOTH diagonals of `faulted`, not only the one that already had a
+    test — a `previous_state == TrayState.ERROR` special-case would satisfy
+    every other test in this file and silently blank this one.
+
+    Asserted on the MODEL, deliberately, and it is the one test here that
+    cannot use the menu row: `_get_status_text`'s QUEUE_WARNING branch returns
+    the constant "Offline (queue full)" and reads no field. So this pins what
+    `set_state` stores rather than what is drawn — the honest scope, and it
+    stops being a lie the day that branch starts rendering too.
+    """
+    tray = _make_tray()
+
+    tray.set_state(TrayState.QUEUE_WARNING, "Queue 92% full")
+    tray.set_state(TrayState.QUEUE_WARNING)
+
+    with tray.model.lock:
+        assert tray.model.status_text == "Queue 92% full"
+
+
 def test_a_repeat_escalation_keeps_the_sentence_it_already_carries():
     """The other side of the entry clear: ERROR → ERROR is the SAME outage
     escalating again, not a new one. Clearing there would blank the remedy on
@@ -224,6 +292,55 @@ def test_recovery_stops_rendering_the_stale_sentence():
     row = _app_status_row(tray)
     assert row == "App status: Active"
     assert "Rosetta" not in row
+
+
+# ── The rest of the menu must not contradict the row ────────────────────
+
+
+def _diag_rows(tray: TrayIcon) -> dict[str, str]:
+    rows = {}
+    for line in _menu_labels(tray):
+        for key in ("ActivityWatch: ", "API: "):
+            if line.startswith(key):
+                rows[key.rstrip(": ")] = line
+    return rows
+
+
+def test_a_tracker_fault_does_not_also_claim_the_api_is_unreachable():
+    """The whole menu is read at once, and it used to disagree with itself.
+
+    `_check_api_status` derived `API: Unreachable` from TrayState.ERROR. Not
+    one producer of that state implies an unreachable API — the two tracker
+    escalations reach the backend on the same cycle to report the fault, and
+    `_report_sync_failure` routes an unreachable API to QUEUED before it can
+    get here. Pre-#188 the top row said "Error" and "API: Unreachable" read as
+    elaboration; now the top row makes a specific, correct, actionable claim
+    and the row below it names a different cause.
+    """
+    tray = _make_tray()
+
+    tray.set_state(TrayState.ERROR, _REMEDY)
+
+    rows = _diag_rows(tray)
+    assert rows["ActivityWatch"] == "ActivityWatch: Not running"
+    assert rows["API"] == "API: Connected", (
+        "the menu contradicts the remedy one row above it"
+    )
+
+
+def test_the_queue_states_still_report_the_api_as_unreachable():
+    """The control. ERROR was the wrong signal; the queue states are the right
+    one, and removing them to silence the row above would blind the surface
+    that exists to say "your events are not leaving this machine".
+    """
+    tray = _make_tray()
+
+    for state in (TrayState.QUEUED, TrayState.QUEUE_WARNING):
+        tray.set_state(state, None)
+        assert _diag_rows(tray)["API"] == "API: Unreachable", state
+
+    tray.set_state(TrayState.SYNCING)
+    assert _diag_rows(tray)["API"] == "API: Connected"
 
 
 def test_the_other_states_are_untouched_by_the_error_branch():


### PR DESCRIPTION
Two halves of one Mac-architecture surface. Both are agent-side; neither needs a server change to take effect for the user, and the one field that does need a reader is called out at the bottom.

---

## #188 — the persistent surface named the wrong component for 90 minutes

### Mechanism

**VERIFIED (by reading; the fault state itself is not reproducible here — see Limits).**

On a clean Apple Silicon Mac with no Rosetta 2, `_rosetta_missing()` returns True, so `_start_locked` (`aw_manager.py:893`) latches `tracker_download_failed` / `_managed_components_unavailable`, fires the one-shot toast, and returns False. Capture never starts, ActivityWatch never comes up, and `_note_aw_unreachable` accumulates until `_escalate_aw_unreachable` fires. That path sets:

```python
self.tray.set_state(TrayState.ERROR, "ActivityWatch not responding")
```

So the tray **was already red for the whole 90 minutes** — it was pointed at the wrong cause. It named a component the user has never heard of, on a machine recording zero seconds, when the fix fits on one line. `_handle_aw_bucket_failure` carried the identical literal, so both watchdogs had the same defect.

The toast that *did* say the right thing is structurally unable to cover this: it is one-shot per process, fires during a new laptop's noisiest minute (permission prompts, sign-in, browser redirect), and `clear_notifications()` wipes it on quit. That was already established in this issue's investigation comment — hence a persistent surface, not a louder toast.

**This is not the same mechanism as the Input Monitoring / TCC blindness** the repo documents elsewhere. That one is a *permission* fault where the process runs and the watcher sees nothing; this is `posix_spawn` returning `EBADARCH` before any tracker process exists. Checked before assuming.

### Fix

- **`AWManager.capture_blocked_remedy()`** — returns the actionable sentence when the Rosetta memo is established `True`, else `None`. Three states, not two: an un-probed `None` earns no remedy, so an unrelated outage on any platform never gets a confident Rosetta instruction. Reads the **memo**, never the probe (`_rosetta_missing()` forks `/usr/bin/arch`, and this is called on the sync cycle while building a tray message).
- **`SyncCoordinator._tracker_fault_message()`** — feeds **both** escalation paths. Routed through one helper rather than patched at each call site: they are the same outage to the person reading the tray, so a remedy on only one leaves a device showing the old wrong sentence depending on which watchdog fired first.
- **`ROSETTA_INSTALL_COMMAND`** spelled once, quoted by the log line, the toast, and now the tray. A typo in one copy is a user typing a command that does nothing on the day they are already recording nothing.

Falls back to the existing text on an absent remedy, a raising manager, or a non-`str`. That last guard is not padding: the message renders verbatim into the tray, so a plain `remedy or fallback` would put `<MagicMock ...>` in front of a user against any test double — mutation M5 below confirms it is load-bearing.

---

## #184 — "who is on the Intel BUILD?" was unanswerable from the wire

Per this issue's last comment, the remaining scope was exactly one thing: the agent sending its **process** architecture as a second field. That is what this does.

### Mechanism

**VERIFIED on real Apple Silicon** (Darwin 25.5.0), running this repo's own helpers under both personalities:

```
### NATIVE:
process_arch=arm64   is_rosetta_translated()=False  true_machine_arch()=arm64

### TRANSLATED (arch -x86_64):
process_arch=x86_64  is_rosetta_translated()=True   true_machine_arch()=arm64
```

`true_machine_arch()` is **identical (`arm64`) in both rows** — by design, because it answers "what silicon is this?". That is precisely why it cannot answer this issue's title: a native Apple Silicon install and an Intel build under Rosetta are byte-identical on the heartbeat today. `platform.machine()` is the only value that moves.

### Negative control for the architecture probe

The brief flagged the known trap — `file <bin> | grep -oE 'arm64|x86_64' | head -1` is wrong because universal binaries list both and first-match wins. That probe is not used anywhere here. The probe used is `platform.machine()`, and it was controlled by running **the same code** against a known-arm64 and a known-x86_64 case:

| case | probe answer |
|---|---|
| native (known arm64) | `arm64` |
| `arch -x86_64` (known Intel personality) | `x86_64` |

Two different answers for two known-different inputs, so the probe measures something real rather than returning a constant. `sysctl.proc_translated` was controlled the same way (`0` native / `1` translated). Both control runs asserted `module.__file__` resolved inside this worktree, so the documented editable-install trap (imports silently resolving to the primary checkout) is ruled out rather than assumed.

One control leg initially failed with `arch: /usr/bin/sysctl isn't executable` — that is `/usr/bin/sysctl` being arm64-only, an artifact of the invocation, not a finding. Re-run through a translated Python it returns `1`.

### Fix

- **`machine_arch.process_arch()`** — `platform.machine()`, forking nothing, with no `""`/undetermined state (a running process always has an architecture). Accepts `translated=` for signature symmetry with its siblings and deliberately ignores it; honouring it would reintroduce the exact Rosetta resolution that makes the field unable to answer its question.
- **`process_arch`** added to `HEARTBEAT_HEALTH_KEYS` **and** to `disclosure_baseline`, each with its written reason (the two tuples are parity-enforced by `test_disclosure_baseline.py`), plus the `CLAUDE.md` device-identifiers section the repo documents as the place to update whenever those keys change.
- Producer in **its own** `try/except` — folded into the existing one, a failure here would silently delete the `machine_arch` that already ships. Mutation M7 confirms that is witnessed.

The pair is the answer, never either half:

| `machine_arch` | `process_arch` | reading |
|---|---|---|
| `arm64` | `arm64` | native Apple Silicon build — fine |
| `arm64` | `x86_64` | **Intel build under Rosetta — the population #184 asks about** |
| `x86_64` | `x86_64` | a genuine Intel Mac — fine |

---

## Proof of failure

Both suites were watched failing against the pre-change implementation, loaded with `git checkout HEAD~1 -- <impl paths>` (never `git stash` — `refs/stash` is shared across worktrees).

`test_rosetta_capture_blocked_message.py` — **6 failed, 4 passed** pre-change:

```
FAILED test_the_manager_reports_the_remedy_when_rosetta_is_the_established_cause
FAILED test_the_manager_withholds_a_remedy_when_rosetta_is_fine
FAILED test_the_manager_withholds_a_remedy_when_the_probe_never_ran
FAILED test_the_remedy_never_forks_a_subprocess
FAILED test_the_tray_names_rosetta_when_that_is_why_capture_is_dead
FAILED test_the_bucket_failure_path_says_the_same_thing
PASSED test_an_ordinary_outage_still_reads_as_before
PASSED test_a_broken_manager_never_costs_the_escalation
PASSED test_a_nonsense_remedy_never_reaches_the_user
PASSED test_an_empty_remedy_falls_back
```

Only the defect-specific cases fail; the four correct-behaviour cases pass in **both** versions. The suite isolates the bug rather than describing the new code.

`test_process_arch_heartbeat.py` fails at import pre-change (`cannot import name 'process_arch'`). Post-change both files are green (22 tests).

### Mutation matrix — one mutant per mechanism, each killed by a **distinct** named test

Anchors asserted unique before mutating, and `__pycache__` cleared between every run (`.pyc` invalidation keys on `(mtime, size)`, so a same-length mutant otherwise runs the *previous* mutant's bytecode and the matrix converges on fiction).

| mutant | killed by |
|---|---|
| M1 remedy drops the command | `test_the_manager_reports_the_remedy_when_rosetta_is_the_established_cause` |
| M2 guard admits the un-probed/fine memo | `..._withholds_a_remedy_when_rosetta_is_fine`, `..._when_the_probe_never_ran` |
| M3 escalate call site back to the literal | `test_the_tray_names_rosetta_when_that_is_why_capture_is_dead` |
| M4 bucket call site back to the literal | `test_the_bucket_failure_path_says_the_same_thing` |
| M5 drop the `isinstance`/empty guard | `test_a_nonsense_remedy_never_reaches_the_user`, `test_an_empty_remedy_falls_back` |
| M6 `process_arch` delegates to `true_machine_arch` | `test_process_arch_reports_the_process_not_the_hardware`, `..._never_consults_rosetta` |
| M7 fold `process_arch` into `machine_arch`'s try | `..._does_not_take_machine_arch_with_it`, `..._never_costs_the_heartbeat` |

**7 mutants, 0 survivors**, control green before and after. M3 and M4 dying to *different* tests is the point — it proves the two call sites are separately witnessed, so a future fix to one cannot silently leave the other behind.

M6 is the agreement-region check: it substitutes the *plausible wrong implementation* (delegating to the arch helper already in the file) rather than deleting code, and the fixtures are chosen at inputs where correct and wrong **diverge**. A suite whose every arch fixture sat at a native value could not have seen it.

Honest caveat on the matrix: zero survivors measures the mutants I thought to write, and I wrote them from my own diff. The enumeration was taken per emitted mechanism rather than per changed line, but it shares an author with the code.

## CI — run locally, because Actions is cost-capped org-wide

`ls .github/workflows/` → `build.yml`, `sync-downloads.yml`, `verify-tracker-pins.yml`.

- **`build.yml` → `test`** (the PR gate): `pytest tests/ -v --tb=short` → **1845 passed, 1 skipped, exit 0**. Baseline 1823 + the 22 added here, so the count moved and my tests demonstrably ran.
- **`build.yml` → `build`**: gated `if: startsWith(github.ref, 'refs/tags/v') || workflow_dispatch` — does not run on a PR. Skipped deliberately, not overlooked.
- **`verify-tracker-pins.yml`**: its `push` path filter includes `src/aw_manager.py`, which this branch modifies, so it **will** fire. Run: all 3 upstream archives fetched and hashed, `All 3 pins verified for AW_VERSION v0.13.2`, exit 0.
- **`sync-downloads.yml`**: `release` trigger only — deploy-side, not applicable.
- **ruff** is not in CI, but every touched source file reports the **identical** finding count as on `origin/main` (0/4/8/2/0), and the two new test files are ruff-clean.

## Limits — what this hardware cannot confirm

Stated plainly rather than left to read as coverage:

1. **The zero-capture state itself is not reproducible here.** This Mac has Rosetta installed (`arch -x86_64 /usr/bin/true` → rc 0) and Rosetta cannot be uninstalled. Every test injects the Rosetta memo. What is verified is that the message the surface carries is *derived from* the blocked state and names the remedy; that a real Apple Silicon Mac without Rosetta *reaches* that branch is inherited from `_rosetta_missing()`, which is unchanged and keeps its own tests.
2. **Needs a clean Apple Silicon Mac to confirm end to end:** that the tray tooltip renders the longer string without truncating the command, and that the new text appears at the moment of the first escalation rather than only after a restart.
3. **CI pins Python 3.11; this ran on 3.14.6.** No 3.11 available on this machine. Nothing here is version-sensitive (`platform.machine()`, string formatting), but the gate itself has not been executed on the pinned interpreter.
4. **`process_arch` has no server reader yet — deliberately.** Verified against internal-tool2 `origin/main`: `machine_arch` resolves in 4 files (heartbeat controller, fleet view, stats, model); `process_arch` in none. Also verified that the heartbeat controller gates on `$request->hasAny([...])` presence checks rather than strict validation, so an unknown key is **ignored, not rejected** — this cannot 422 the fleet. This mirrors exactly how `machine_arch` shipped (agent side in #185/#191/#198, server side later in internal-tool2 #2358). The internal-tool2 half is a follow-up and is the thing that makes the field answer the question on a dashboard.
5. **Not attempted here:** the native arm64 trackers (option 1 in #188, still blocked on upstream shipping only `v0.14.0b*` prereleases) and the heartbeat *cause discriminator* that would let the server badge say "Rosetta 2 missing" instead of "failed download". The latter is a second field with no reader, and this issue's own history is the argument for not shipping two of those at once — it needs the internal-tool2 change beside it.

Multi-session check re-run immediately before opening this: 0 open PRs, no remote branch touching this area, `origin/main` still at `4a1f2ab` (this branch's base), and every deleted line in the diff accounted for as one I replaced.

Closes #188.

Closes #184.
