### PR TITLE
Say which kind of 'not right now' this is, on all eight states that know

### DIFF
--- a/src/main.py
+++ b/src/main.py
@@ -814,6 +814,16 @@ class SyncCoordinator:
                 else:
                     if current_state == TrayState.NEEDS_PERMISSIONS:
                         self.tray.model.state = TrayState.SYNCING
+                        # Clear the hint we wrote above. This block is the only
+                        # place that moves state WITHOUT going through
+                        # set_state, so neither of its clears runs here. The
+                        # stale text is currently unreachable — SYNCING does not
+                        # render the field, and every later entry into a state
+                        # that does trips the entry-clear — but that is an
+                        # argument about the whole state machine holding, made
+                        # afresh by anyone who adds an owner. One line removes
+                        # the dependency on it.
+                        self.tray.model.status_text = None
                         should_update_icon = True
                     else:
                         should_update_icon = False
@@ -1808,7 +1818,8 @@ class SyncCoordinator:
             is_idle = self.idle_paused
 
             if self.paused_by_network:
-                self.tray.set_state(TrayState.QUEUED, "Offline")
+                # No text: the label is STATUS_TEXT_STATES[QUEUED].
+                self.tray.set_state(TrayState.QUEUED)
                 self.tray.update_stats(queue_size=self.queue.size())
                 # A network outage suspends UPLOAD, not capture: suspend_upload()
                 # keeps the trackers recording and queueing locally, often for
@@ -2022,7 +2033,8 @@ class SyncCoordinator:
         except Exception:
             reachable = False
         if not reachable:
-            self.tray.set_state(TrayState.QUEUED, "Offline")
+            # No text: the label is STATUS_TEXT_STATES[QUEUED].
+            self.tray.set_state(TrayState.QUEUED)
         else:
             self.tray.set_state(TrayState.ERROR, error_message)
 

--- a/src/system_event_handler.py
+++ b/src/system_event_handler.py
@@ -144,6 +144,11 @@ class SystemEventHandler:
             return
         if self.coordinator.is_on_break:
             logger.info("System wake - staying on break")
+            # Second reason to stay paused, same stale sentence as the branch
+            # above. PAUSED is re-asserted rather than ON_BREAK because the
+            # state is not this handler's to change — it only has to stop the
+            # tray claiming a cause that has ended.
+            self.tray.set_state(TrayState.PAUSED)
             return
         # Private Time is intentionally NOT auto-restored: it was ended at the
         # sleep boundary (on_system_sleep), so a sleep cleanly ends a private
@@ -203,6 +208,11 @@ class SystemEventHandler:
             return
         if self.coordinator.is_on_break:
             logger.info("Screen unlocked - staying on break")
+            # Second reason to stay paused, same stale sentence as the branch
+            # above. PAUSED is re-asserted rather than ON_BREAK because the
+            # state is not this handler's to change — it only has to stop the
+            # tray claiming a cause that has ended.
+            self.tray.set_state(TrayState.PAUSED)
             return
         if pre_lock_private:
             logger.info("Screen unlocked - restoring private time")

--- a/src/system_event_handler.py
+++ b/src/system_event_handler.py
@@ -134,6 +134,13 @@ class SystemEventHandler:
                 logger.warning("send_sleep_event failed: %s", e)
         if user_paused:
             logger.info("System wake - staying paused (user-initiated pause active)")
+            # Re-assert PAUSED with no text. The state is unchanged, so this is
+            # a no-op for the icon — but the tray now RENDERS status_text, and
+            # the sentence still sitting there is "Sleeping", written on the way
+            # down. Returning without this leaves an awake laptop reporting that
+            # it is asleep. The cause is now the user's pause, which has no
+            # sentence of its own: the generic "Paused" is the true answer.
+            self.tray.set_state(TrayState.PAUSED)
             return
         if self.coordinator.is_on_break:
             logger.info("System wake - staying on break")
@@ -189,6 +196,10 @@ class SystemEventHandler:
             pre_lock_private = self._pre_lock_private
         if user_paused:
             logger.info("Screen unlocked - staying paused (user-initiated pause active)")
+            # Same as the wake path above: "Screen locked" is still stored and
+            # now renders, so an unlocked screen would keep reporting itself
+            # locked.
+            self.tray.set_state(TrayState.PAUSED)
             return
         if self.coordinator.is_on_break:
             logger.info("Screen unlocked - staying on break")
@@ -237,4 +248,6 @@ class SystemEventHandler:
             logger.info("Network offline - suspending upload (capture continues)")
             self.sync_engine.suspend_upload("network offline")
             self.coordinator.paused_by_network = True
-            self.tray.set_state(TrayState.QUEUED, "Offline")
+            # No text: "Offline" is STATUS_TEXT_STATES[QUEUED] and passing it
+            # here would be a second copy of the label to keep in step.
+            self.tray.set_state(TrayState.QUEUED)

--- a/src/ui/tray.py
+++ b/src/ui/tray.py
@@ -449,6 +449,42 @@ class TrayState(Enum):
     WAITING_AUTH = "waiting_auth"  # Amber - waiting for browser login
 
 
+# The one answer to "which states own ``status_text``?", and the label each one
+# falls back to when its writer had nothing specific to say.
+#
+# It was previously two answers. ``set_state`` cleared the field for
+# ``(ERROR, QUEUE_WARNING)`` and ``_get_status_text`` rendered it for ERROR
+# alone, so QUEUE_WARNING was cleared by a rule that no longer matched the rule
+# that read it. That disagreement is not cosmetic: the clears are the only thing
+# stopping one state's sentence rendering under the next state's label, so
+# "renders it" and "is cleared on entry to it" must name the same set or a
+# widened branch is worse than the generic label it replaced.
+#
+# Membership and the floor live together deliberately. A state added to the
+# render path without a floor would show ``App status:`` with nothing after it
+# the first time its writer passed a blank; keying the label off the same dict
+# makes that unrepresentable.
+STATUS_TEXT_STATES: dict["TrayState", str] = {
+    TrayState.ERROR: "Error",
+    TrayState.QUEUE_WARNING: "Offline (queue full)",
+    TrayState.QUEUED: "Offline",
+    TrayState.WAITING_AUTH: "Waiting for login...",
+    TrayState.PAUSED: "Paused",
+    # Without a floor here a user outside their enforced working-hours window
+    # read "App status: Starting...", which looks like a hung app rather than a
+    # deliberate not-recording state.
+    TrayState.PRIVATE_HOURS: "Outside working hours",
+    # Writes its text directly under the model lock (src/main.py:810) rather
+    # than through set_state, so it is invisible to a grep for
+    # ``set_state(TrayState.X, "…")`` and was missing from #214's own table.
+    TrayState.NEEDS_PERMISSIONS: "Permissions needed",
+    # _set_startup_status feeds real progress here. STARTING is an EXPLICIT
+    # member rather than being folded into the ``else`` fallback below: the
+    # fallback catches states nothing handles, and a fallback that rendered the
+    # field would hand an unknown state a stale sentence.
+    TrayState.STARTING: "Starting...",
+}
+
 # Colors for each state — BetterFlow brand palette
 STATE_COLORS = {
     TrayState.SYNCING: "#7D69B8",  # BetterFlow purple - active
@@ -1080,49 +1116,20 @@ class TrayIcon:
             return f"On Break ({break_minutes_left}m left)"
         elif private_mode:
             return "Private Time"
-        elif state == TrayState.SYNCING:
-            return "Active"
-        elif state == TrayState.QUEUED:
-            return "Offline"
-        elif state == TrayState.QUEUE_WARNING:
-            return "Offline (queue full)"
-        elif state == TrayState.ERROR:
-            # Render the sentence the escalation handed us, not the constant.
+        elif state in STATUS_TEXT_STATES:
+            # Render the sentence the writer handed us, not the constant.
             #
             # ``status_text`` was write-only from the day it shipped: every
-            # producer set it, ``_snapshot_model`` carried it, and no render
-            # path read it. So the tray's persistent line said "Error" through
-            # every outage, whatever the cause, and #188's 90 minutes of a red
-            # tray naming the wrong component could not have been fixed by
-            # improving the message — the message reached nobody. This is the
-            # read that makes the field a field.
-            #
-            # Read INSIDE the branch, not at the top with its siblings: the only
-            # states that write it are the ones this branch covers, and a
-            # top-level read would make every unrelated caller of
-            # ``_get_status_text`` supply a key it has no business knowing about.
-            #
-            # ``or "Error"`` keeps the old constant as the floor. A blank or
-            # whitespace-only text must not render as ``App status:`` with
-            # nothing after it, and a non-string (a test double, a repr) must not
-            # be interpolated in front of the user — the same rule
-            # ``_tracker_fault_message`` applies one layer up, for the same
-            # reason.
-            status_text = s["status_text"] if s else self.model.status_text
-            if isinstance(status_text, str) and status_text.strip():
-                return status_text.strip()
-            return "Error"
-        elif state == TrayState.PAUSED:
-            return "Paused"
-        elif state == TrayState.WAITING_AUTH:
-            return "Waiting for login..."
-        elif state == TrayState.NEEDS_PERMISSIONS:
-            return "Permissions needed"
-        elif state == TrayState.PRIVATE_HOURS:
-            # Without this branch a user outside their enforced working-hours
-            # window read "App status: Starting...", which looks like a hung app
-            # rather than a deliberate not-recording state.
-            return "Outside working hours"
+            # producer set it, ``_snapshot_model`` carried it, and no render path
+            # read it. #213 made ERROR read it — #188's 90 minutes of a red tray
+            # naming the wrong component could not have been fixed by improving
+            # the message, because the message reached nobody. Seven states were
+            # still discarding theirs: a person whose session expired, a person
+            # whose queue is 87% full and a person whose laptop is asleep were
+            # shown one generic word each.
+            return self._owned_status_text(s, STATUS_TEXT_STATES[state])
+        elif state == TrayState.SYNCING:
+            return "Active"
         elif state == TrayState.ON_BREAK:
             # Normally covered by the on_break flag above; this catches the state
             # being set without the model flag, which also fell through to
@@ -1134,6 +1141,26 @@ class TrayIcon:
             return "Private Time"
         else:
             return "Starting..."
+
+    def _owned_status_text(self, s: Optional[dict], generic: str) -> str:
+        """The stored sentence for a state that owns one, else its own label.
+
+        ``.get()`` rather than ``s["status_text"]``: the key is read for eight
+        states now, and a caller passing a partial snapshot must get the label
+        rather than a ``KeyError``. ``_snapshot_model`` always supplies it, so
+        the difference is only visible to callers that build a dict by hand —
+        which the existing suite does.
+
+        The floor is per-state and non-negotiable. A blank or whitespace-only
+        text must not render as ``App status:`` with nothing after it, and a
+        non-string (a test double, a repr) must never be interpolated in front
+        of the user — the same rule ``_tracker_fault_message`` applies one layer
+        up, for the same reason.
+        """
+        status_text = s.get("status_text") if s else self.model.status_text
+        if isinstance(status_text, str) and status_text.strip():
+            return status_text.strip()
+        return generic
 
     # -- Lock-protected checkers for `checked` lambdas ----------------------
 
@@ -1485,17 +1512,22 @@ class TrayIcon:
 
         Args:
             state: New state
-            status_text: Optional status message for error state. Passing None
+            status_text: Optional status message for any state in
+                ``STATUS_TEXT_STATES`` (eight of them, not just ERROR —
+                the docstring said "error state" while eight call sites
+                already passed one for something else). Passing None
                 explicitly when transitioning OUT of an error/queue state
                 clears the previous text so it doesn't leak across transitions.
         """
         with self.model.lock:
             previous_state = self.model.state
             self.model.state = state
-            faulted = (TrayState.ERROR, TrayState.QUEUE_WARNING)
+            # THE shared rule — see STATUS_TEXT_STATES. Re-deriving it here
+            # is what let the clears and the render disagree (#214).
+            owns_status_text = STATUS_TEXT_STATES
             if status_text is not None:
                 self.model.status_text = status_text
-            elif state in faulted and previous_state != state:
+            elif state in owns_status_text and previous_state != state:
                 # ENTERING a fault with nothing to say. Mirror of the recovery
                 # clear below, and it only started to matter once the ERROR
                 # branch of _get_status_text began rendering this field: the
@@ -1507,9 +1539,12 @@ class TrayIcon:
                 # has been running for hours, which reads as a hung app rather
                 # than a reported fault.
                 #
-                # `previous_state != state`, NOT `previous_state not in faulted`.
-                # `faulted` holds TWO states, so the membership test treats a
-                # QUEUE_WARNING → ERROR move as staying put: the queue's
+                # `previous_state != state`, NOT
+                # `previous_state not in owns_status_text`. The set holds EIGHT
+                # states (it held two when this was written), so the membership
+                # test treats a QUEUE_WARNING → ERROR move as staying put — and
+                # widening the set widened that hole from one pair to
+                # fifty-six ordered pairs. The queue's
                 # "Queue 92% full" survived into a red row describing a TRACKER
                 # fault, and a text-less ERROR after a text-less QUEUE_WARNING
                 # resurrected whatever sentence preceded both. Precisely the
@@ -1527,7 +1562,7 @@ class TrayIcon:
                 # and the alternative is a surface that lies whenever someone
                 # adds one that does not.
                 self.model.status_text = None
-            elif previous_state in faulted and state not in faulted:
+            elif previous_state in owns_status_text and state not in owns_status_text:
                 # Recovery transition: ERROR/QUEUE_WARNING → anything-healthy.
                 # Old status_text (e.g. "ActivityWatch is not running") would
                 # leak into the next display path until something else writes

--- a/src/ui/tray.py
+++ b/src/ui/tray.py
@@ -146,7 +146,8 @@ class TrayModel:
         self.state: TrayState = TrayState.STARTING
         self.paused: bool = False
         self.private_mode: bool = False
-        self.status_text: str = "Starting..."
+        # One copy of this label, in STATUS_TEXT_STATES.
+        self.status_text: str = STATUS_TEXT_STATES[TrayState.STARTING]
         self.hours_today: str = "0h 0m"
         self.hours_this_week: str = "---"
         self.hours_this_month: str = "---"
@@ -484,6 +485,28 @@ STATUS_TEXT_STATES: dict["TrayState", str] = {
     # field would hand an unknown state a stale sentence.
     TrayState.STARTING: "Starting...",
 }
+
+# Which of those states keep their sentence when re-entered with nothing new to
+# say. This is the THIRD fact about an owning state, and it was a blanket rule
+# until #214 widened the set — correct while the only re-entrant owners were the
+# two fault states, where re-entry genuinely means "the same thing again".
+#
+# PAUSED broke it. PAUSED has FIVE writers with five different causes (sleep,
+# screen lock, idle, a user pause, a break), so PAUSED → PAUSED is usually a
+# CHANGE of cause, not a repeat of one. Retaining there put "Screen locked" on
+# an unlocked laptop, "Sleeping" on an awake one, and "Idle" on a machine whose
+# user had just clicked Pause — while the pause notification fired beside it
+# saying otherwise. All three render "Paused" on origin/main, so all three were
+# regressions introduced by the widening rather than pre-existing.
+#
+# ERROR and QUEUE_WARNING are SINGLE-cause: re-entry is the same outage or the
+# same full queue reported again, and blanking on the second watchdog tick would
+# darken the surface exactly when the user looks at it. Both diagonals are
+# pinned (test_tray_status_text_renders.py:223, :244). A state earns retention
+# by having one cause, not by owning the field.
+STATUS_TEXT_RETAIN_ON_REENTRY: frozenset = frozenset(
+    {TrayState.ERROR, TrayState.QUEUE_WARNING}
+)
 
 # Colors for each state — BetterFlow brand palette
 STATE_COLORS = {
@@ -1140,7 +1163,9 @@ class TrayIcon:
             # but the state alone must not read as "Starting...".
             return "Private Time"
         else:
-            return "Starting..."
+            # A state nothing handles. Deliberately NOT reading
+            # status_text — see STARTING's note in STATUS_TEXT_STATES.
+            return STATUS_TEXT_STATES[TrayState.STARTING]
 
     def _owned_status_text(self, s: Optional[dict], generic: str) -> str:
         """The stored sentence for a state that owns one, else its own label.
@@ -1522,12 +1547,12 @@ class TrayIcon:
         with self.model.lock:
             previous_state = self.model.state
             self.model.state = state
-            # THE shared rule — see STATUS_TEXT_STATES. Re-deriving it here
-            # is what let the clears and the render disagree (#214).
-            owns_status_text = STATUS_TEXT_STATES
             if status_text is not None:
                 self.model.status_text = status_text
-            elif state in owns_status_text and previous_state != state:
+            elif state in STATUS_TEXT_STATES and (
+                previous_state != state
+                or state not in STATUS_TEXT_RETAIN_ON_REENTRY
+            ):
                 # ENTERING a fault with nothing to say. Mirror of the recovery
                 # clear below, and it only started to matter once the ERROR
                 # branch of _get_status_text began rendering this field: the
@@ -1540,11 +1565,11 @@ class TrayIcon:
                 # than a reported fault.
                 #
                 # `previous_state != state`, NOT
-                # `previous_state not in owns_status_text`. The set holds EIGHT
-                # states (it held two when this was written), so the membership
-                # test treats a QUEUE_WARNING → ERROR move as staying put — and
-                # widening the set widened that hole from one pair to
-                # fifty-six ordered pairs. The queue's
+                # `previous_state not in STATUS_TEXT_STATES`. The set holds
+                # EIGHT states (it held two when this was written), so a
+                # membership test would treat a QUEUE_WARNING → ERROR move as
+                # staying put — and widening the set widened that hole from one
+                # ordered pair to fifty-six. The queue's
                 # "Queue 92% full" survived into a red row describing a TRACKER
                 # fault, and a text-less ERROR after a text-less QUEUE_WARNING
                 # resurrected whatever sentence preceded both. Precisely the
@@ -1553,16 +1578,19 @@ class TrayIcon:
                 # ends and you guard the one you were reasoning about
                 # (diagnosis-discipline.md Rule 3).
                 #
-                # The inequality is also what preserves the deliberate
-                # ERROR → ERROR retention below: same state is one outage
-                # escalating again, not a new one.
+                # The inequality preserves the deliberate ERROR → ERROR
+                # retention — same state is one outage escalating again — but
+                # ONLY for the states STATUS_TEXT_RETAIN_ON_REENTRY names.
+                # Re-entering any other owner clears, because for a multi-cause
+                # state like PAUSED a repeat is a different cause, not the
+                # same one.
                 #
                 # Every escalation in src/ passes a message today, so this is a
                 # guard on the shape rather than on a live caller. It is cheap
                 # and the alternative is a surface that lies whenever someone
                 # adds one that does not.
                 self.model.status_text = None
-            elif previous_state in owns_status_text and state not in owns_status_text:
+            elif previous_state in STATUS_TEXT_STATES and state not in STATUS_TEXT_STATES:
                 # Recovery transition: ERROR/QUEUE_WARNING → anything-healthy.
                 # Old status_text (e.g. "ActivityWatch is not running") would
                 # leak into the next display path until something else writes

--- a/tests/test_offline_status.py
+++ b/tests/test_offline_status.py
@@ -6,10 +6,10 @@ the queued/Offline state — we're still tracking and queuing locally — instea
 of a scary "App status: Error".
 """
 
-from unittest.mock import MagicMock
+from unittest.mock import MagicMock, patch
 
 from src.main import SyncCoordinator
-from src.ui.tray import TrayState
+from src.ui.tray import STATUS_TEXT_STATES, TrayIcon, TrayState
 
 
 def _make_coordinator() -> SyncCoordinator:
@@ -30,7 +30,7 @@ def test_unreachable_shows_offline_not_error():
     coord = _make_coordinator()
     coord.bf.is_reachable.return_value = False
     coord._set_sync_failure_state("Sync failed")
-    coord.tray.set_state.assert_called_once_with(TrayState.QUEUED, "Offline")
+    coord.tray.set_state.assert_called_once_with(TrayState.QUEUED)
 
 
 def test_reachable_failure_shows_error():
@@ -44,4 +44,33 @@ def test_reachability_probe_raising_is_treated_as_offline():
     coord = _make_coordinator()
     coord.bf.is_reachable.side_effect = RuntimeError("dns")
     coord._set_sync_failure_state("Sync error")
-    coord.tray.set_state.assert_called_once_with(TrayState.QUEUED, "Offline")
+    coord.tray.set_state.assert_called_once_with(TrayState.QUEUED)
+
+
+def test_the_queued_state_actually_reads_offline_on_the_surface():
+    """The file's title, asserted where the user reads it.
+
+    The three tests above drive a MagicMock tray and assert on call arguments,
+    so they answer "which state was requested" and cannot answer "what does it
+    say" — a mock renders nothing (Phantom 7). They used to pass the literal
+    "Offline" as an argument, which made the claim look witnessed while still
+    only checking what the producer said.
+
+    The label now has one home (STATUS_TEXT_STATES), so the callers pass no text
+    and this drives the REAL TrayIcon to check the row. Asserted against the
+    hardcoded word rather than the dict entry: importing the constant for both
+    sides would move them together and prove nothing (Rule 6a).
+    """
+    with patch("src.ui.tray.pystray"):
+        tray = TrayIcon(
+            on_login=lambda: None, on_logout=lambda: None, on_pause=lambda: None,
+            on_resume=lambda: None, on_quit=lambda: None,
+        )
+    tray._icon = MagicMock()
+    tray._update_icon = MagicMock()
+    tray._update_menu = MagicMock()
+
+    tray.set_state(TrayState.QUEUED)
+
+    assert tray._get_status_text() == "Offline"
+    assert STATUS_TEXT_STATES[TrayState.QUEUED] == "Offline"

--- a/tests/test_tray_reason_survives_wake_and_unlock.py
+++ b/tests/test_tray_reason_survives_wake_and_unlock.py
@@ -1,0 +1,83 @@
+"""A laptop that wakes must not keep reporting itself asleep.
+
+Once the tray started rendering ``status_text`` for PAUSED (#214), the sentence
+written on the way DOWN — "Sleeping", "Screen locked" — became visible on the
+way back UP. Both resume handlers early-return when the user had also paused
+manually (`system_event_handler.py`, the `user_paused` branches), and neither
+touched the tray on that path, so nothing cleared the stale sentence and nothing
+else would until the next state change.
+
+The mutation matrix is why this file exists: reverting the two re-asserts left
+all 49 tests in the tray suite GREEN. The fix was real and completely
+unwitnessed, which is indistinguishable from not having made it.
+
+Driving the REAL TrayIcon rather than a Mock. A mock tray records the call and
+renders nothing, so it can only answer "was set_state invoked" — the question
+here is what the row SAYS, and a mock cannot be wrong about it (Phantom 7).
+"""
+
+from __future__ import annotations
+
+import threading
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from src.system_event_handler import SystemEventHandler
+from src.ui.tray import TrayIcon, TrayState
+
+
+def _make_tray() -> TrayIcon:
+    with patch("src.ui.tray.pystray"):
+        tray = TrayIcon(
+            on_login=lambda: None, on_logout=lambda: None, on_pause=lambda: None,
+            on_resume=lambda: None, on_quit=lambda: None,
+        )
+    tray._icon = MagicMock()
+    tray._update_icon = MagicMock()
+    tray._update_menu = MagicMock()
+    return tray
+
+
+def _make_handler(tray: TrayIcon) -> SystemEventHandler:
+    coordinator = MagicMock()
+    coordinator.is_on_break = False
+    coordinator.paused_by_network = False
+    sync_engine = MagicMock()
+    sync_engine.is_private = False
+    return SystemEventHandler(
+        sync_engine=sync_engine,
+        tray=tray,
+        coordinator=coordinator,
+        reminder_manager=MagicMock(),
+        bf=MagicMock(),
+        aw=MagicMock(),
+        pause_state_lock=threading.RLock(),
+        shutdown_fn=MagicMock(),
+    )
+
+
+@pytest.mark.parametrize(
+    "down,up,sentence",
+    [
+        ("on_system_sleep", "on_system_wake", "Sleeping"),
+        ("on_screen_lock", "on_screen_unlock", "Screen locked"),
+    ],
+)
+def test_the_resume_path_stops_reporting_the_cause_that_ended(down, up, sentence):
+    """The user had paused manually, so both handlers take the early return that
+    keeps the agent paused. The state is right; the SENTENCE is stale."""
+    tray = _make_tray()
+    handler = _make_handler(tray)
+    with handler._pause_state_lock:
+        handler._user_paused = True
+
+    getattr(handler, down)()
+    assert tray._get_status_text() == sentence, "precondition: the cause is on screen"
+
+    getattr(handler, up)()
+
+    assert tray.model.state is TrayState.PAUSED, "still paused — only the reason ended"
+    assert tray._get_status_text() == "Paused", (
+        f"the tray still says {sentence!r} after {up}"
+    )

--- a/tests/test_tray_reason_survives_wake_and_unlock.py
+++ b/tests/test_tray_reason_survives_wake_and_unlock.py
@@ -57,13 +57,13 @@ def _make_handler(tray: TrayIcon) -> SystemEventHandler:
     )
 
 
-@pytest.mark.parametrize(
-    "down,up,sentence",
-    [
-        ("on_system_sleep", "on_system_wake", "Sleeping"),
-        ("on_screen_lock", "on_screen_unlock", "Screen locked"),
-    ],
-)
+_RESUME_PATHS = [
+    ("on_system_sleep", "on_system_wake", "Sleeping"),
+    ("on_screen_lock", "on_screen_unlock", "Screen locked"),
+]
+
+
+@pytest.mark.parametrize("down,up,sentence", _RESUME_PATHS)
 def test_the_resume_path_stops_reporting_the_cause_that_ended(down, up, sentence):
     """The user had paused manually, so both handlers take the early return that
     keeps the agent paused. The state is right; the SENTENCE is stale."""
@@ -80,4 +80,34 @@ def test_the_resume_path_stops_reporting_the_cause_that_ended(down, up, sentence
     assert tray.model.state is TrayState.PAUSED, "still paused — only the reason ended"
     assert tray._get_status_text() == "Paused", (
         f"the tray still says {sentence!r} after {up}"
+    )
+
+
+@pytest.mark.parametrize("down,up,sentence", _RESUME_PATHS)
+def test_the_same_holds_when_a_BREAK_is_what_keeps_it_paused(down, up, sentence):
+    """The second early return on each resume path, found by walking the class
+    rather than the reported instance.
+
+    Both handlers have TWO reasons to stay paused: a manual pause and an active
+    break. The first was fixed because it was the one under the microscope; this
+    branch sits two lines below it, reached whenever someone's laptop sleeps or
+    locks during a break, and it had exactly the same stale sentence.
+
+    Note ``tray.model.on_break`` stays False here on purpose. ``_get_status_text``
+    checks that FLAG before the state, so a tray that already knows it is on a
+    break renders "On Break (Nm left)" and hides the defect. The failing case is
+    the coordinator knowing about the break while the tray's flag does not —
+    which is precisely the state these handlers are called in.
+    """
+    tray = _make_tray()
+    handler = _make_handler(tray)
+    handler.coordinator.is_on_break = True
+
+    getattr(handler, down)()
+    assert tray._get_status_text() == sentence, "precondition: the cause is on screen"
+
+    getattr(handler, up)()
+
+    assert tray._get_status_text() == "Paused", (
+        f"the tray still says {sentence!r} after {up} during a break"
     )

--- a/tests/test_tray_state_transitions.py
+++ b/tests/test_tray_state_transitions.py
@@ -100,15 +100,43 @@ def test_passing_explicit_status_text_still_overrides():
     assert tray.model.status_text == "Second"
 
 
-def test_transition_between_two_healthy_states_preserves_existing_text():
-    """If status_text was set by something OTHER than ERROR/QUEUE_WARNING
-    (e.g. permissions hint), a transition between two non-error states
-    must NOT clear it — only the explicit recovery path clears."""
+def test_entering_a_state_that_renders_the_field_clears_a_foreign_sentence():
+    """Inverted by #214, deliberately — and this test's own docstring is the
+    argument for inverting it.
+
+    It used to assert that SYNCING → PAUSED preserves a leftover sentence, on
+    the grounds that the writer might be "a permissions hint". That was safe
+    only while PAUSED rendered the constant "Paused": the field was carried but
+    never shown. PAUSED now renders ``status_text``, so preserving a foreign
+    sentence means a permissions hint appearing under a Paused icon on a
+    sleeping laptop — the exact leak the entry-clear exists to stop.
+
+    A state that renders the field must be cleared on entry to it. That is one
+    rule, and STATUS_TEXT_STATES is where it is written.
+    """
     tray = _make_tray()
 
     tray.set_state(TrayState.SYNCING)
     tray.model.status_text = "Some informational status"
     tray.set_state(TrayState.PAUSED)
+
+    assert tray.model.status_text is None
+    assert tray._get_status_text() == "Paused"
+
+
+def test_two_states_that_ignore_the_field_still_leave_it_alone():
+    """The control, and the half of the original test that is still true.
+
+    Neither SYNCING nor PRIVATE renders ``status_text``, so neither clear
+    applies and a hint written by something else survives. Without this, a
+    clear-everything fix would pass the test above while quietly discarding
+    state no render path was harming.
+    """
+    tray = _make_tray()
+
+    tray.set_state(TrayState.SYNCING)
+    tray.model.status_text = "Some informational status"
+    tray.set_state(TrayState.PRIVATE)
 
     assert tray.model.status_text == "Some informational status"
 

--- a/tests/test_tray_status_text_all_owning_states.py
+++ b/tests/test_tray_status_text_all_owning_states.py
@@ -1,0 +1,263 @@
+"""#214: ``status_text`` reached the user on ERROR only, and seven states threw it away.
+
+PR #213 taught ``_get_status_text`` to render ``model.status_text`` — for the
+ERROR branch, because ERROR is the state #188 was about. Every other branch kept
+returning its hard-coded label, so the sentence its writer had already composed
+was stored, snapshotted, and discarded one line before the screen.
+
+The cost is per-state and it is the same shape each time: a person whose session
+expired, a person whose queue is 87% full and a person whose laptop is asleep are
+all shown one generic word, and the sentence that would tell them what happened
+never renders. ``src/main.py:2846`` says why that matters, about its own writer:
+"A keychain we cannot open is not an offline agent, and telling the user it is
+sends them to check their wifi."
+
+**The membership question is the actual defect, not the eight branches.**
+``set_state`` decided which states own the field (``faulted``: ERROR and
+QUEUE_WARNING) and ``_get_status_text`` decided again, differently (ERROR alone).
+One rule, two implementations, disagreeing — and the disagreement is not
+academic: the clears are what stop a stale sentence rendering under the next
+state's label, so a branch that renders without a matching clear is worse than
+the generic label it replaced.
+
+So the fix is a single ``STATUS_TEXT_STATES``, and the guard below is derived
+FROM it rather than hand-listing states: it walks every member of ``TrayState``
+and asserts the partition in both directions. A state added to the enum later
+is covered without anyone remembering to extend a list here.
+
+The eight owners were enumerated from the writers, not from the issue — which
+listed five. ``NEEDS_PERMISSIONS`` writes ``status_text`` directly under the
+model lock at ``src/main.py:810`` rather than through ``set_state``, and
+``STARTING`` receives one from ``_set_startup_status``; both are invisible to a
+grep for ``set_state(TrayState.X, "..."``.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from src.ui import tray as tray_module
+from src.ui.tray import STATUS_TEXT_STATES, TrayIcon, TrayState
+
+SENTINEL = "a sentence only its writer could have composed"
+
+
+def _make_tray() -> TrayIcon:
+    """A real TrayIcon with only the display backend stubbed.
+
+    Same construction as ``tests/test_tray_status_text_renders.py`` — the branch
+    under test is the genuine article.
+    """
+    with patch("src.ui.tray.pystray"):
+        tray = TrayIcon(
+            on_login=lambda: None,
+            on_logout=lambda: None,
+            on_pause=lambda: None,
+            on_resume=lambda: None,
+            on_quit=lambda: None,
+        )
+    tray._icon = MagicMock()
+    tray._update_icon = MagicMock()
+    tray._update_menu = MagicMock()
+    return tray
+
+
+def _menu_labels(tray: TrayIcon) -> list[str]:
+    labels: list[str] = []
+
+    def record(label, *args, **kwargs):
+        if isinstance(label, str):
+            labels.append(label)
+        return MagicMock()
+
+    tray._serial_menu_item = MagicMock()
+    tray._arch_menu_item = MagicMock()
+    with patch("src.ui.tray.pystray"), patch("src.ui.tray.Item", side_effect=record):
+        tray._create_menu()
+    return labels
+
+
+def _app_status_row(tray: TrayIcon) -> str:
+    rows = [line for line in _menu_labels(tray) if line.startswith("App status:")]
+    assert len(rows) == 1, f"expected exactly one App status row, got {rows}"
+    return rows[0]
+
+
+# ── The defect, one test per state that was discarding its sentence ──────
+#
+# Parametrised over the REAL writers' states with the REAL text they write, so a
+# failure names the state rather than an index. The sentences are copied from the
+# writers rather than imported: this file asks "does the tray render what it was
+# handed", and importing the producer's literal would move both sides of the
+# assertion together (diagnosis-discipline.md Rule 6a).
+
+@pytest.mark.parametrize(
+    "state,written,generic",
+    [
+        (TrayState.QUEUE_WARNING, "Queue 87% full", "Offline (queue full)"),
+        (TrayState.PRIVATE_HOURS,
+         "Private hours — not recording (draining 12 queued)",
+         "Outside working hours"),
+        (TrayState.QUEUED, "Offline — reconnecting...", "Offline"),
+        (TrayState.WAITING_AUTH, "Session expired, re-login required",
+         "Waiting for login..."),
+        (TrayState.PAUSED, "Screen locked", "Paused"),
+        (TrayState.NEEDS_PERMISSIONS, "Input Monitoring permission required",
+         "Permissions needed"),
+        (TrayState.STARTING, "Restoring your session...", "Starting..."),
+    ],
+    ids=lambda v: getattr(v, "value", str(v)[:24]),
+)
+def test_each_state_renders_the_sentence_its_writer_composed(state, written, generic):
+    """THE defect. Pre-fix every one of these returns ``generic`` and the text —
+    correctly composed, correctly routed, correctly stored — dies here."""
+    tray = _make_tray()
+
+    tray.set_state(state, written)
+
+    assert tray._get_status_text() == written, (
+        f"{state.value} discarded its sentence and rendered the generic label"
+    )
+    # Equality, not ``generic not in row``: QUEUED's real sentence is
+    # "Offline — reconnecting...", which contains its own generic label as a
+    # substring, so the negative form fails against a correct fix. A test that
+    # cannot pass against the right answer is a broken instrument.
+    assert _app_status_row(tray) == f"App status: {written}"
+
+    # The other direction, so ``generic`` is load-bearing rather than decoration:
+    # the same state with nothing to say falls back to its own label.
+    bare = _make_tray()
+    bare.set_state(state)
+    assert bare._get_status_text() == generic
+
+
+def test_the_menu_row_the_user_reads_carries_it():
+    """The render path, not just the branch. A fix to ``_get_status_text`` that
+    nothing calls would pass the tests above and change nothing on screen."""
+    tray = _make_tray()
+
+    tray.set_state(TrayState.WAITING_AUTH, "Session expired, re-login required")
+
+    assert _app_status_row(tray) == "App status: Session expired, re-login required"
+
+
+# ── The membership rule, derived rather than hand-listed ─────────────────
+
+
+def test_every_state_either_owns_the_field_or_provably_ignores_it():
+    """The partition, walked over the whole enum in BOTH directions.
+
+    The negative half is the half that matters: it fails if the read leaks to the
+    top of the function, which would make SYNCING render a stale fault sentence
+    under a green icon — strictly worse than the generic label, and the exact
+    harm ``set_state``'s entry-clear was added to prevent.
+    """
+    for state in TrayState:
+        tray = _make_tray()
+        tray.set_state(state, SENTINEL)
+        rendered = tray._get_status_text()
+
+        if state in STATUS_TEXT_STATES:
+            assert rendered == SENTINEL, f"{state.value} owns the field but dropped it"
+        else:
+            assert rendered != SENTINEL, (
+                f"{state.value} is not in STATUS_TEXT_STATES yet rendered the field; "
+                "a state that renders it must also be cleared on entry"
+            )
+
+
+def test_the_clear_and_the_render_read_the_same_rule():
+    """``set_state``'s clears and ``_get_status_text``'s reads were two answers to
+    one question, and QUEUE_WARNING was where they disagreed.
+
+    Asserting on the object identity of the tuple, not on its contents: a copy
+    with the same members today is the same defect waiting to drift apart again.
+    """
+    import inspect
+
+    source = inspect.getsource(tray_module.TrayIcon.set_state)
+    assert "STATUS_TEXT_STATES" in source, (
+        "set_state re-derives which states own status_text instead of reading "
+        "the shared tuple"
+    )
+    assert "faulted = (" not in source, "the second, disagreeing copy is still here"
+
+
+# ── Controls: the floors, and no leaking across transitions ──────────────
+
+
+@pytest.mark.parametrize("junk", ["", "   ", None, 12, object()])
+def test_a_missing_or_junk_sentence_falls_back_to_the_states_own_label(junk):
+    """Every owning state needs ERROR's floor, not just ERROR. An empty string
+    would render ``App status:`` with nothing after it; a non-string would put a
+    repr in front of the user."""
+    for state in STATUS_TEXT_STATES:
+        tray = _make_tray()
+        tray.set_state(state, SENTINEL)
+        with tray.model.lock:
+            tray.model.status_text = junk
+
+        rendered = tray._get_status_text()
+        assert isinstance(rendered, str) and rendered.strip(), (state, junk)
+        assert rendered != SENTINEL
+        assert "object at 0x" not in rendered
+
+
+def test_a_sentence_never_survives_into_a_different_state():
+    """The ordering hazard #214 names. Rendering a state's ``status_text``
+    requires that state to be covered by the entry-clear, or the previous
+    state's sentence renders under the new label."""
+    for state in STATUS_TEXT_STATES:
+        tray = _make_tray()
+        tray.set_state(TrayState.ERROR, SENTINEL)
+        tray.set_state(state)  # no text: this state has nothing to say
+
+        if state is TrayState.ERROR:
+            continue  # same-state re-escalation deliberately retains, see #213
+        assert tray._get_status_text() != SENTINEL, (
+            f"a stale ERROR sentence leaked into {state.value}"
+        )
+
+
+def test_recovery_to_a_healthy_state_still_clears():
+    """The #213 guard, re-witnessed now that the owning set is wider: a device
+    that recovers must not keep telling the user to install Rosetta."""
+    tray = _make_tray()
+
+    tray.set_state(TrayState.ERROR, SENTINEL)
+    tray.set_state(TrayState.SYNCING)
+
+    assert _app_status_row(tray) == "App status: Active"
+
+
+def test_a_partial_snapshot_still_answers():
+    """``_get_status_text`` takes a snapshot dict, and a caller passing one
+    without the key must get the generic label rather than a KeyError. Pins the
+    property ``test_the_other_states_are_untouched_by_the_error_branch`` asserts
+    for the ERROR branch, now that seven more branches read the same key."""
+    tray = _make_tray()
+
+    for state in STATUS_TEXT_STATES:
+        partial = {
+            "on_break": False,
+            "private_mode": False,
+            "state": state,
+            "break_minutes_left": 0,
+        }
+        rendered = tray._get_status_text(partial)
+        assert isinstance(rendered, str) and rendered.strip(), state
+
+
+def test_the_break_and_private_flags_still_win_over_the_state():
+    """Ordering control. ``on_break``/``private_mode`` are checked before the
+    state, and widening the owning set must not reorder that."""
+    tray = _make_tray()
+    tray.set_state(TrayState.PAUSED, SENTINEL)
+
+    with tray.model.lock:
+        tray.model.on_break = True
+        tray.model.break_minutes_left = 7
+
+    assert tray._get_status_text() == "On Break (7m left)"

--- a/tests/test_tray_status_text_all_owning_states.py
+++ b/tests/test_tray_status_text_all_owning_states.py
@@ -128,7 +128,15 @@ def test_each_state_renders_the_sentence_its_writer_composed(state, written, gen
 
     # The other direction, so ``generic`` is load-bearing rather than decoration:
     # the same state with nothing to say falls back to its own label.
+    #
+    # Entered from SYNCING rather than from a fresh tray. A fresh tray is seeded
+    # ``state=STARTING, status_text="Starting..."``, so ``set_state(STARTING)``
+    # on one is a same-state re-entry and the value read back is the SEED, not
+    # the fallback — the two strings coincide, so the assertion passed while
+    # testing nothing. A reviewer's in-memory mutant of that dict entry survived
+    # the whole module because of it.
     bare = _make_tray()
+    bare.set_state(TrayState.SYNCING)
     bare.set_state(state)
     assert bare._get_status_text() == generic
 
@@ -168,21 +176,60 @@ def test_every_state_either_owns_the_field_or_provably_ignores_it():
             )
 
 
-def test_the_clear_and_the_render_read_the_same_rule():
-    """``set_state``'s clears and ``_get_status_text``'s reads were two answers to
-    one question, and QUEUE_WARNING was where they disagreed.
+def test_every_ordered_pair_of_states_leaves_the_right_sentence():
+    """The whole 11x11 transition matrix, replacing a source-shape guard.
 
-    Asserting on the object identity of the tuple, not on its contents: a copy
-    with the same members today is the same defect waiting to drift apart again.
+    The first version of this asserted that ``inspect.getsource(set_state)``
+    contains "STATUS_TEXT_STATES" and lacks "faulted = (". Both reviewers broke
+    it, in both directions, and they were right:
+
+    - restoring the exact defect (a local ``(ERROR, QUEUE_WARNING)`` tuple) left
+      it GREEN, because the literal it greps for also appears in the comment
+      above the line and in the docstring — a detector satisfied by prose
+      describing the thing it looks for;
+    - a behaviour-preserving extraction of the clear turned it RED.
+
+    A guard that false-fails on a legitimate refactor gets loosened rather than
+    fixed, so it was a liability rather than coverage. This asserts the RULE
+    instead of the text, and no rename or extraction can defeat it.
     """
-    import inspect
+    for a in TrayState:
+        for b in TrayState:
+            tray = _make_tray()
+            tray.set_state(a, SENTINEL)
+            tray.set_state(b)  # no text: b has nothing of its own to say
 
-    source = inspect.getsource(tray_module.TrayIcon.set_state)
-    assert "STATUS_TEXT_STATES" in source, (
-        "set_state re-derives which states own status_text instead of reading "
-        "the shared tuple"
+            rendered = tray._get_status_text()
+            retains = a is b and b in tray_module.STATUS_TEXT_RETAIN_ON_REENTRY
+
+            if retains:
+                assert rendered == SENTINEL, f"{a.value} -> {b.value} should retain"
+            else:
+                assert rendered != SENTINEL, (
+                    f"{a.value} -> {b.value} leaked the previous sentence"
+                )
+
+
+def test_only_single_cause_states_retain_their_sentence_on_re_entry():
+    """Retention is earned by having ONE cause, not by owning the field.
+
+    PAUSED is the counter-example that forced this to become data: five writers
+    (sleep, screen lock, idle, a user pause, a break) with five different
+    sentences, so PAUSED -> PAUSED is normally a CHANGE of cause. Retaining
+    there put "Screen locked" on an unlocked laptop and "Idle" on a machine
+    whose user had just clicked Pause — while the pause notification fired
+    beside it saying otherwise. All three read "Paused" on origin/main, so the
+    widening introduced them.
+    """
+    assert tray_module.STATUS_TEXT_RETAIN_ON_REENTRY <= set(STATUS_TEXT_STATES), (
+        "a state cannot retain a field it does not own"
     )
-    assert "faulted = (" not in source, "the second, disagreeing copy is still here"
+    assert TrayState.PAUSED not in tray_module.STATUS_TEXT_RETAIN_ON_REENTRY
+
+    tray = _make_tray()
+    tray.set_state(TrayState.PAUSED, "Idle")
+    tray.set_paused(True)  # the real path: main.py:3467 -> tray.py set_state(PAUSED)
+    assert tray._get_status_text() == "Paused"
 
 
 # ── Controls: the floors, and no leaking across transitions ──────────────
@@ -248,6 +295,21 @@ def test_a_partial_snapshot_still_answers():
         }
         rendered = tray._get_status_text(partial)
         assert isinstance(rendered, str) and rendered.strip(), state
+
+    # The other half, which the #213 version of this could not ask: a NON-owner
+    # handed a snapshot that DOES carry the key must ignore it. Omitting the key
+    # cannot distinguish "does not read it" from "reads a key I did not supply"
+    # (Phantom 16, an agreement region) — and that is exactly why the guard
+    # written to catch this widening did not catch it.
+    for state in (TrayState.SYNCING, TrayState.PRIVATE, TrayState.ON_BREAK):
+        supplied = {
+            "on_break": False,
+            "private_mode": False,
+            "state": state,
+            "break_minutes_left": 0,
+            "status_text": SENTINEL,
+        }
+        assert tray._get_status_text(supplied) != SENTINEL, state
 
 
 def test_the_break_and_private_flags_still_win_over_the_state():

--- a/tests/test_tray_status_text_renders.py
+++ b/tests/test_tray_status_text_renders.py
@@ -226,11 +226,11 @@ def test_a_repeat_queue_warning_keeps_its_own_sentence():
     test — a `previous_state == TrayState.ERROR` special-case would satisfy
     every other test in this file and silently blank this one.
 
-    Asserted on the MODEL, deliberately, and it is the one test here that
-    cannot use the menu row: `_get_status_text`'s QUEUE_WARNING branch returns
-    the constant "Offline (queue full)" and reads no field. So this pins what
-    `set_state` stores rather than what is drawn — the honest scope, and it
-    stops being a lie the day that branch starts rendering too.
+    Asserted on the model AND on the menu row. The original could only do the
+    former — the QUEUE_WARNING branch returned a constant and read no field —
+    and its docstring said so, adding that it "stops being a lie the day that
+    branch starts rendering too". #214 is that day, so the row assertion is
+    added rather than the note left standing.
     """
     tray = _make_tray()
 
@@ -239,6 +239,7 @@ def test_a_repeat_queue_warning_keeps_its_own_sentence():
 
     with tray.model.lock:
         assert tray.model.status_text == "Queue 92% full"
+    assert _app_status_row(tray) == "App status: Queue 92% full"
 
 
 def test_a_repeat_escalation_keeps_the_sentence_it_already_carries():


### PR DESCRIPTION
`_get_status_text` rendered `model.status_text` for ERROR and threw it away everywhere else. Seven states composed a specific sentence, stored it, snapshotted it, and showed the user one generic word instead.

Follows PR #213, which made ERROR read the field because ERROR is the state #188 was about.

## Proof of failure

Captured against the pre-fix tree before any edit — the real writers' states with the real text they write:

```
state              written                               rendered
queue_warning      Queue 87% full                        'Offline (queue full)'   DISCARDED
private_hours      Private hours - not recording (...)   'Outside working hours'  DISCARDED
queued             Offline - reconnecting...             'Offline'                DISCARDED
waiting_auth       Session expired, re-login required    'Waiting for login...'   DISCARDED
paused             Screen locked                         'Paused'                 DISCARDED
needs_permissions  Input Monitoring permission required  'Permissions needed'     DISCARDED
starting           Restoring your session...             'Starting...'            DISCARDED
error              the #213 control                      'the #213 control'       OK
```

The ERROR row is the control: it proves the probe can see a rendered sentence, so the seven DISCARDED rows are the subject failing rather than the instrument.

**Eight owners, not the five the issue listed.** `NEEDS_PERMISSIONS` writes its text directly under the model lock (`src/main.py:810`) rather than through `set_state`, and `STARTING` receives one from `_set_startup_status`. Both are invisible to a grep for `set_state(TrayState.X, "…")`, which is how the issue's table came to be short by two.

## The defect is the membership question, not the eight branches

`set_state` decided which states own the field — `faulted = (ERROR, QUEUE_WARNING)` — and `_get_status_text` decided again, differently, for ERROR alone. One rule, two implementations, disagreeing at QUEUE_WARNING.

That is not cosmetic. The clears are the only thing stopping one state's sentence rendering under the next state's label, so *"renders it"* and *"is cleared on entry to it"* have to name the same set. A branch widened without its clear is worse than the generic label it replaced.

- `STATUS_TEXT_STATES` maps each owning state to its floor. Membership and fallback live together, so a state cannot join the render path without a label and show `App status:` with nothing after it.
- `set_state` reads that dict for both clears. The stale comment claiming the set "holds TWO states" is corrected — widening it takes that hole from one ordered pair to fifty-six.
- `_owned_status_text` applies ERROR's existing floor to all eight, and uses `s.get()` so a caller building a partial snapshot by hand still gets a label rather than a `KeyError`.
- `STARTING` is an explicit member rather than folded into the `else` fallback, which stays hard-coded — a fallback that rendered the field would hand an unknown state a stale sentence.

## One existing test asserted the opposite, deliberately inverted

`test_transition_between_two_healthy_states_preserves_existing_text` pinned SYNCING → PAUSED *preserving* a leftover sentence, justified in its own docstring by the writer possibly being "a permissions hint". That was safe only while PAUSED rendered a constant and the field was never shown. Now it would put a permissions hint under a Paused icon on a sleeping laptop.

Replaced with the clear, plus a control (SYNCING → PRIVATE, neither state owning the field) that keeps the half still true — so a clear-everything fix cannot pass by discarding state nothing was harming.

## Mutation matrix

Five mechanisms, each reddening **distinct** named tests. Control clean before and after; tree restored to 0 dirty files.

| mutant | witnesses |
|---|---|
| M1 render → generic label | `test_the_error_status_carries_the_sentence_it_was_given`, `test_the_menu_row_the_user_reads_carries_it`, `test_every_state_either_owns_the_field_or_provably_ignores_it` (+3) |
| M2 entry-clear removed | `test_a_sentence_never_survives_into_a_different_state`, `test_entering_a_state_that_renders_the_field_clears_a_foreign_sentence` (+4) |
| M3 recovery-clear removed | `test_recovery_from_error_clears_stale_status_text`, `test_recovery_from_queue_warning_clears_stale_status_text` |
| M4 floor removed | `test_a_missing_or_junk_sentence_falls_back_to_the_states_own_label`, `test_blank_text_falls_back_rather_than_rendering_an_empty_row` |
| M5 read leaks to every state | `test_every_state_either_owns_the_field_or_provably_ignores_it`, `test_the_other_states_are_untouched_by_the_error_branch` (+4) |

M1 and M2 were separated explicitly (`comm` on their reddened sets) because they share one test — each has six witnesses the other does not, so neither mechanism is riding on the other's coverage.

Two instrument bugs were caught and are worth recording: the first matrix printed **nothing at all** because the helper returned `cmp`'s status, so "files differ" (mutation applied) read as failure and the test run never fired — that would have looked like a clean matrix. And the first version of the render test asserted `generic not in row`, which cannot pass against a correct fix, because QUEUED's real sentence is `Offline — reconnecting...` and contains its own generic label.

The membership guard walks every `TrayState` member and asserts the partition in both directions, so a state added later is covered without anyone extending a list here.

## Verification

- `pytest tests/` → **1899 passed, 1 skipped, exit 0**. That is the whole of what CI's `test` job runs (`pytest tests/ -v --tb=short`, ubuntu-latest); no other non-deploy workflow touches this code.
- `ruff check src/ui/tray.py` → 7 errors, all pre-existing at lines 37–121, rule-set byte-identical to `origin/main`'s. Baseline taken from `git show origin/main:src/ui/tray.py` rather than from the working tree.
- Platform-independent tray logic; no real-environment surface, so no browser/API smoke applies.

Closes #214.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
