### PR TITLE
Stop the duplicate app copies picking which agent version runs

### DIFF
--- a/src/autostart.py
+++ b/src/autostart.py
@@ -114,7 +114,29 @@ def _app_launch_args() -> list[str]:
         # Use 'open -a' with the .app bundle path for a clean launch
         parts = exe.split(".app/Contents/MacOS/")
         bundle_path = parts[0] + ".app"
-        return ["open", "-a", bundle_path]
+        # `open <path>`, NOT `open -a <path>`. They look interchangeable and are
+        # not: `-a` names an APPLICATION, which macOS resolves through the
+        # LaunchServices database rather than by opening the path you handed it.
+        # When several copies are registered under one bundle id, which copy
+        # wins is LaunchServices' choice.
+        #
+        # #211: a device's plist said `/Applications/BetterFlow.app` and the
+        # machine came up running `/Applications/BetterFlow-1.5.119-backup.app`
+        # — below the server's minimum floor — for days, while every sync logged
+        # "update required". Three copies shared `co.betterqa.betterflow`.
+        # Without `-a` the argument is a path again and no other bundle can be
+        # substituted.
+        #
+        # The resolution itself is INFERRED, not witnessed (the issue says so;
+        # tccd logs had aged out). This does not depend on that being the cause:
+        # it removes the only freedom the launch command had, which is worth
+        # doing either way.
+        #
+        # Migration is automatic and needs no code. `_macos_plist_is_current()`
+        # compares the installed ProgramArguments against this list, so every
+        # plist still carrying the `-a` form now reads as stale and
+        # `ensure_synced()` rewrites it on the next startup.
+        return ["open", bundle_path]
     # Running as a Python script
     return [sys.executable, "-m", "src.main"]
 

--- a/src/main.py
+++ b/src/main.py
@@ -2980,6 +2980,33 @@ class BetterFlowApp:
             except Exception as e:
                 logger.warning("Auto-start sync failed (non-fatal): %s", e)
 
+        # Sweep sibling copies of ourselves left by earlier updates (#211).
+        #
+        # Runs at startup rather than after an update, because the copies that
+        # matter are ALREADY on disk — a device carried three, booted the oldest
+        # (below the server's minimum version floor) for days, and had its
+        # Accessibility grant flap, since macOS keeps one row per app and which
+        # copy that row means is not ours to decide. Fixing whichever writer
+        # leaves them behind does nothing for a machine that already has them.
+        #
+        # After _maybe_relocate_to_applications() above, deliberately: that call
+        # can move us, and the sweep is scoped to siblings of where we are NOW.
+        #
+        # Non-fatal on every path. Failing to tidy up must not stop the agent
+        # starting, which is the one job it has.
+        if sys.platform == "darwin" and ".app/Contents/MacOS/" in sys.executable:
+            try:
+                try:
+                    from .self_updater import purge_stale_bundle_copies
+                except ImportError:
+                    from self_updater import purge_stale_bundle_copies
+                running_bundle = Path(
+                    sys.executable.split(".app/Contents/MacOS/")[0] + ".app"
+                )
+                purge_stale_bundle_copies(running_bundle)
+            except Exception as e:
+                logger.warning("Stale-copy sweep failed (non-fatal): %s", e)
+
         # First-run setup wizard.
         #
         # Gate on stored CREDENTIALS, not on the setup_complete flag alone. The

--- a/src/main.py
+++ b/src/main.py
@@ -2980,32 +2980,7 @@ class BetterFlowApp:
             except Exception as e:
                 logger.warning("Auto-start sync failed (non-fatal): %s", e)
 
-        # Sweep sibling copies of ourselves left by earlier updates (#211).
-        #
-        # Runs at startup rather than after an update, because the copies that
-        # matter are ALREADY on disk — a device carried three, booted the oldest
-        # (below the server's minimum version floor) for days, and had its
-        # Accessibility grant flap, since macOS keeps one row per app and which
-        # copy that row means is not ours to decide. Fixing whichever writer
-        # leaves them behind does nothing for a machine that already has them.
-        #
-        # After _maybe_relocate_to_applications() above, deliberately: that call
-        # can move us, and the sweep is scoped to siblings of where we are NOW.
-        #
-        # Non-fatal on every path. Failing to tidy up must not stop the agent
-        # starting, which is the one job it has.
-        if sys.platform == "darwin" and ".app/Contents/MacOS/" in sys.executable:
-            try:
-                try:
-                    from .self_updater import purge_stale_bundle_copies
-                except ImportError:
-                    from self_updater import purge_stale_bundle_copies
-                running_bundle = Path(
-                    sys.executable.split(".app/Contents/MacOS/")[0] + ".app"
-                )
-                purge_stale_bundle_copies(running_bundle)
-            except Exception as e:
-                logger.warning("Stale-copy sweep failed (non-fatal): %s", e)
+        self._sweep_stale_bundle_copies()
 
         # First-run setup wizard.
         #
@@ -3316,6 +3291,52 @@ class BetterFlowApp:
             ],
             start_new_session=True,
         )
+
+    def _sweep_stale_bundle_copies(self) -> None:
+        """Remove sibling copies of ourselves left by earlier updates (#211).
+
+        A device carried three copies in /Applications under one bundle id,
+        booted the oldest (below the server's minimum version floor) for days,
+        and had its Accessibility grant flap — macOS keeps one row per app and
+        which copy that row means is not ours to decide.
+
+        Called from run() AFTER _maybe_relocate_to_applications(), which can
+        move us: the sweep is scoped to siblings of where we are NOW. It also
+        runs after ensure_autostart_synced(), which is the wrong way round on
+        principle — clear the sediment, then write the plist — but sweeping
+        first does not rescue the case that matters, where we are running from a
+        non-canonical copy and the sweep correctly finds nothing either way.
+
+        Non-fatal on every path. Failing to tidy up must not stop the agent
+        starting, which is the one job it has.
+        """
+        if sys.platform != "darwin":
+            return
+        try:
+            try:
+                from .self_updater import (
+                    get_app_bundle_path,
+                    purge_stale_bundle_copies,
+                )
+            except ImportError:
+                from self_updater import (  # type: ignore[no-redef]
+                    get_app_bundle_path,
+                    purge_stale_bundle_copies,
+                )
+            running = get_app_bundle_path()
+            if running is None:
+                return  # dev mode, or not running from a bundle
+            removed = purge_stale_bundle_copies(running)
+            if removed:
+                # One line per DEVICE, not per file. The useful fleet question
+                # is "how many machines carried sediment", which a per-removal
+                # log inside purge_ cannot answer.
+                logger.info(
+                    "Removed %d stale copies of this app: %s",
+                    len(removed), [p.name for p in removed],
+                )
+        except Exception as e:
+            logger.warning("Stale-copy sweep failed (non-fatal): %s", e)
 
     def _maybe_relocate_to_applications(self) -> None:
         """On macOS, offer to move a non-installed .app into /Applications.

--- a/src/main.py
+++ b/src/main.py
@@ -3300,11 +3300,23 @@ class BetterFlowApp:
         and had its Accessibility grant flap — macOS keeps one row per app and
         which copy that row means is not ours to decide.
 
-        Called from run() AFTER _maybe_relocate_to_applications(), which can
-        move us: the sweep is scoped to siblings of where we are NOW. It also
-        runs after ensure_autostart_synced(), which is the wrong way round on
-        principle — clear the sediment, then write the plist — but sweeping
-        first does not rescue the case that matters, where we are running from a
+        Called from run() after _maybe_relocate_to_applications(). An earlier
+        version of this docstring said that was "because that call can move us"
+        — which is wrong, and wrong in the direction that misleads: if it moves
+        us it ends in os._exit(0) (main.py:3275), so the sweep never runs in
+        this process at all. What the ordering actually means is that the sweep
+        only ever runs when we were NOT relocated, i.e. on wherever we happen to
+        be — which for a declined prompt can be ~/Downloads, a mounted DMG, or a
+        Gatekeeper AppTranslocation path, not /Applications.
+
+        That is acceptable rather than intended: every candidate must still be a
+        sibling, match a closed name list, and claim our bundle id, so a sweep
+        from an odd location finds nothing to do. Saying so plainly because this
+        is exactly the kind of rationale a later reader reasons from.
+
+        It also runs after ensure_autostart_synced(), which is the wrong way
+        round on principle — clear the sediment, then write the plist — but
+        sweeping first does not rescue the case that matters, where we are on a
         non-canonical copy and the sweep correctly finds nothing either way.
 
         Non-fatal on every path. Failing to tidy up must not stop the agent

--- a/src/self_updater.py
+++ b/src/self_updater.py
@@ -43,6 +43,23 @@ except ImportError:  # PyInstaller bundle (src/ is import root)
 
 logger = logging.getLogger(__name__)
 
+# Our bundle id. Already spelled in src/autostart.py (as the launchd label,
+# which happens to be the same string) and src/ui/permissions.py; a guard test
+# pins all three rather than a refactor threading one constant through modules
+# that have no other reason to depend on each other.
+BUNDLE_ID = "co.betterqa.betterflow"
+
+# Names our updater has left in /Applications across versions. Each is a
+# FORMAT over the running bundle's stem, so the sweep can only ever match a
+# sibling of the app that is running.
+#
+# Deliberately closed rather than a glob. A leftover copy costs disk; a wrong
+# deletion costs somebody an application, so anything outside the shapes we can
+# show we produced stays put:
+#   <stem>.app.old   the Linux AppImage form, seen on a Mac in #211
+#   <stem>.old.app   what _apply_macos_update creates today
+#   <stem>-<ver>-backup.app   provenance unknown, seen on the #211 device
+
 # The only Apple Developer ID team we ever ship production releases under.
 # Pinned to make _verify_codesign reject updates signed by any other team,
 # even on a fresh install with no prior team-ID context to compare against.
@@ -987,3 +1004,107 @@ def apply_staged_update(
         # finally never runs. On failure we leak hundreds of MB (the DMG)
         # in /tmp unless we clean up here.
         shutil.rmtree(tmp_dir, ignore_errors=True)
+
+
+def _bundle_identifier(app: Path) -> Optional[str]:
+    """The bundle id an .app claims, or None if it will not say.
+
+    None means "I do not know whose this is", which is not permission to delete
+    it — every caller must treat it as a refusal, not as a mismatch.
+    """
+    import plistlib
+
+    try:
+        with open(app / "Contents" / "Info.plist", "rb") as f:
+            data = plistlib.load(f)
+    except Exception:
+        return None
+    value = data.get("CFBundleIdentifier")
+    return value if isinstance(value, str) else None
+
+
+def find_stale_bundle_copies(running_app: Path) -> list[Path]:
+    """Sibling copies of THIS app left behind by an earlier update.
+
+    Returns paths only; deleting is the caller's job, so the decision can be
+    tested without a filesystem that can lose something.
+
+    #211: a device carried three copies under one bundle id, booted the oldest
+    (below the server's minimum version floor) and had its Accessibility grant
+    flap, because macOS keeps one row per app and which copy that row means is
+    not ours to decide.
+
+    Four guards, in order of how much they matter:
+
+    1. **Identity.** The candidate's own Info.plist must name OUR bundle id.
+       This is the one doing the real work: a name pattern is a guess about
+       provenance, and an Info.plist is the bundle stating who it is. Anything
+       that will not answer is left alone.
+    2. **Name.** One of the shapes we can show our updater has produced,
+       derived from the running bundle's stem. Closed list, not a glob.
+    3. **Siblings only**, never recursive. A sweep of /Applications by
+       directory walk is not a thing this should ever grow into.
+    4. **No symlinks.** Deleting through one deletes its target, which by
+       definition is not a copy our updater left here.
+    """
+    import re as _re
+
+    parent = running_app.parent
+    stem = running_app.stem  # "BetterFlow" from "BetterFlow.app"
+    patterns = [
+        _re.compile(rf"^{_re.escape(stem)}\.app\.old$"),
+        _re.compile(rf"^{_re.escape(stem)}\.old\.app$"),
+        _re.compile(rf"^{_re.escape(stem)}-[0-9][0-9.]*-backup\.app$"),
+    ]
+
+    stale: list[Path] = []
+    try:
+        entries = sorted(parent.iterdir())
+    except OSError as e:
+        logger.warning("Could not list %s while looking for stale copies: %s", parent, e)
+        return []
+
+    for entry in entries:
+        # `entry == running_app` is DEFENCE IN DEPTH and a mutation run will
+        # flag it as unwitnessed. It is not a gap — it is unreachable while the
+        # name patterns below are correct, because the running bundle's own
+        # name cannot match a pattern built from its own stem. Proven as a pair
+        # rather than left to argument:
+        #
+        #   neuter the name filter alone       -> running bundle NOT returned
+        #   neuter the name filter AND this    -> running bundle IS returned
+        #
+        # So this line is the only thing standing between a broken name pattern
+        # and deleting the app that is currently executing. Keep it.
+        if entry == running_app or entry.is_symlink() or not entry.is_dir():
+            continue
+        if not any(p.match(entry.name) for p in patterns):
+            continue
+        identifier = _bundle_identifier(entry)
+        if identifier != BUNDLE_ID:
+            logger.info(
+                "Leaving %s alone: bundle id is %r, not ours",
+                entry, identifier,
+            )
+            continue
+        stale.append(entry)
+    return stale
+
+
+def purge_stale_bundle_copies(running_app: Path) -> list[Path]:
+    """Delete what find_stale_bundle_copies names. Returns what went.
+
+    Best-effort by design: a copy we cannot remove (permissions, a file in use)
+    is logged and skipped. Failing to tidy up must never stop the agent
+    starting, which is the one job it has.
+    """
+    removed: list[Path] = []
+    for app in find_stale_bundle_copies(running_app):
+        try:
+            shutil.rmtree(app)
+        except Exception as e:
+            logger.warning("Could not remove stale copy %s: %s", app, e)
+            continue
+        logger.info("Removed stale copy of this app: %s", app)
+        removed.append(app)
+    return removed

--- a/src/self_updater.py
+++ b/src/self_updater.py
@@ -49,6 +49,17 @@ logger = logging.getLogger(__name__)
 # that have no other reason to depend on each other.
 BUNDLE_ID = "co.betterqa.betterflow"
 
+# What _apply_macos_update leaves aside mid-replace. Spelled once because the
+# sweep below has to recognise exactly what that function creates: change the
+# writer and an independent copy in the sweep silently stops matching it, in the
+# reassuring direction ("nothing to clean up") with no test failing.
+_MACOS_BACKUP_SUFFIX = ".old.app"
+
+# The bundle stem every shipped build installs under (build.spec's CFBundleName).
+# The sweep derives its patterns from the RUNNING bundle's stem, so running from
+# anything else means it cannot see the canonical copy's siblings.
+_CANONICAL_STEM = "BetterFlow"
+
 # Names our updater has left in /Applications across versions. Each is a
 # FORMAT over the running bundle's stem, so the sweep can only ever match a
 # sibling of the app that is running.
@@ -405,7 +416,7 @@ def _apply_local_artifact(
                 return False
 
             # 3. Replace: move old aside, move new in place
-            backup_path = app_path.parent / f"{app_path.stem}.old.app"
+            backup_path = app_path.parent / f"{app_path.stem}{_MACOS_BACKUP_SUFFIX}"
             if backup_path.exists():
                 shutil.rmtree(backup_path)
 
@@ -1023,6 +1034,13 @@ def _bundle_identifier(app: Path) -> Optional[str]:
     return value if isinstance(value, str) else None
 
 
+# Public name for the module-private resolver above. Renaming the original
+# would touch 10 call sites across three test files this change has no other
+# business in; an alias gives callers outside the module a public symbol
+# without that blast radius.
+get_app_bundle_path = _get_app_bundle_path
+
+
 def find_stale_bundle_copies(running_app: Path) -> list[Path]:
     """Sibling copies of THIS app left behind by an earlier update.
 
@@ -1047,15 +1065,36 @@ def find_stale_bundle_copies(running_app: Path) -> list[Path]:
     4. **No symlinks.** Deleting through one deletes its target, which by
        definition is not a copy our updater left here.
     """
-    import re as _re
-
     parent = running_app.parent
     stem = running_app.stem  # "BetterFlow" from "BetterFlow.app"
     patterns = [
-        _re.compile(rf"^{_re.escape(stem)}\.app\.old$"),
-        _re.compile(rf"^{_re.escape(stem)}\.old\.app$"),
-        _re.compile(rf"^{_re.escape(stem)}-[0-9][0-9.]*-backup\.app$"),
+        re.compile(rf"^{re.escape(stem)}\.app\.old$"),
+        re.compile(rf"^{re.escape(stem + _MACOS_BACKUP_SUFFIX)}$"),
+        re.compile(rf"^{re.escape(stem)}-[0-9][0-9.]*-backup\.app$"),
     ]
+
+    if stem != _CANONICAL_STEM:
+        # Every pattern is built from the RUNNING bundle's stem, so from a
+        # non-canonical copy the sweep cannot see the canonical install's
+        # siblings and returns [] — which is exactly the state #211 reported:
+        # that device had booted BetterFlow-1.5.119-backup.app, where this
+        # function finds nothing and both duplicates survive.
+        #
+        # Returning [] is still the RIGHT action. The alternative — resolving
+        # the canonical stem from our own Info.plist and sweeping from here —
+        # would have a backup copy delete the newer BetterFlow.app beside it,
+        # which is worse than the sediment. The real repair is to get back into
+        # the canonical bundle; the sweep then works on the next launch.
+        #
+        # What was missing is any trace of it. A device in this state produced
+        # no output at all, and #211 was found by grepping one machine's log.
+        logger.warning(
+            "Running from %r, not the canonical %s.app — the stale-copy sweep "
+            "cannot see the canonical install's siblings and is doing nothing "
+            "(#211). This device is running a non-canonical copy of the agent.",
+            running_app.name, _CANONICAL_STEM,
+        )
+        return []
 
     stale: list[Path] = []
     try:
@@ -1078,7 +1117,7 @@ def find_stale_bundle_copies(running_app: Path) -> list[Path]:
         # and deleting the app that is currently executing. Keep it.
         if entry == running_app or entry.is_symlink() or not entry.is_dir():
             continue
-        if not any(p.match(entry.name) for p in patterns):
+        if not any(p.fullmatch(entry.name) for p in patterns):
             continue
         identifier = _bundle_identifier(entry)
         if identifier != BUNDLE_ID:

--- a/src/self_updater.py
+++ b/src/self_updater.py
@@ -416,7 +416,7 @@ def _apply_local_artifact(
                 return False
 
             # 3. Replace: move old aside, move new in place
-            backup_path = app_path.parent / f"{app_path.stem}{_MACOS_BACKUP_SUFFIX}"
+            backup_path = _macos_backup_path(app_path)
             if backup_path.exists():
                 shutil.rmtree(backup_path)
 
@@ -1015,6 +1015,18 @@ def apply_staged_update(
         # finally never runs. On failure we leak hundreds of MB (the DMG)
         # in /tmp unless we clean up here.
         shutil.rmtree(tmp_dir, ignore_errors=True)
+
+
+def _macos_backup_path(app_path: Path) -> Path:
+    """Where _apply_macos_update moves the old bundle mid-replace.
+
+    A function rather than an inline f-string so the sweep can be tested against
+    the WRITER's own expression instead of against a copy of it. Sharing
+    _MACOS_BACKUP_SUFFIX was not enough on its own: a test that rebuilt the name
+    from the constant had both sides of its assertion tracing back to one
+    artifact, so reverting this line to a literal changed nothing it could see.
+    """
+    return app_path.parent / f"{app_path.stem}{_MACOS_BACKUP_SUFFIX}"
 
 
 def _bundle_identifier(app: Path) -> Optional[str]:

--- a/src/self_updater.py
+++ b/src/self_updater.py
@@ -1068,9 +1068,16 @@ def find_stale_bundle_copies(running_app: Path) -> list[Path]:
     parent = running_app.parent
     stem = running_app.stem  # "BetterFlow" from "BetterFlow.app"
     patterns = [
-        re.compile(rf"^{re.escape(stem)}\.app\.old$"),
-        re.compile(rf"^{re.escape(stem + _MACOS_BACKUP_SUFFIX)}$"),
-        re.compile(rf"^{re.escape(stem)}-[0-9][0-9.]*-backup\.app$"),
+        # IGNORECASE because /Applications is APFS, which is case-INSENSITIVE:
+        # `betterflow.app.old` and `BetterFlow.app.old` are the same file to the
+        # filesystem and were two different strings to this list, so a copy the
+        # sweep exists to remove survived under a different capitalisation.
+        # Safe to widen — the running bundle still cannot self-match under any
+        # casing, since `{stem}.app` is not equal to any of the three shapes
+        # below however it is cased, and the identity guard is unchanged.
+        re.compile(rf"^{re.escape(stem)}\.app\.old$", re.IGNORECASE),
+        re.compile(rf"^{re.escape(stem + _MACOS_BACKUP_SUFFIX)}$", re.IGNORECASE),
+        re.compile(rf"^{re.escape(stem)}-[0-9][0-9.]*-backup\.app$", re.IGNORECASE),
     ]
 
     if stem != _CANONICAL_STEM:
@@ -1115,6 +1122,10 @@ def find_stale_bundle_copies(running_app: Path) -> list[Path]:
         #
         # So this line is the only thing standing between a broken name pattern
         # and deleting the app that is currently executing. Keep it.
+        # `not entry.is_dir()` is also unwitnessed and also kept: a plain file
+        # wearing the name is already refused by the identity guard, because
+        # _bundle_identifier cannot read Contents/Info.plist out of a file. Same
+        # defence-in-depth reasoning as the line's other two clauses.
         if entry == running_app or entry.is_symlink() or not entry.is_dir():
             continue
         if not any(p.fullmatch(entry.name) for p in patterns):

--- a/src/self_updater.py
+++ b/src/self_updater.py
@@ -1038,7 +1038,17 @@ def _bundle_identifier(app: Path) -> Optional[str]:
 # would touch 10 call sites across three test files this change has no other
 # business in; an alias gives callers outside the module a public symbol
 # without that blast radius.
-get_app_bundle_path = _get_app_bundle_path
+def get_app_bundle_path() -> Optional[Path]:
+    """Public wrapper, deliberately a function and not `= _get_app_bundle_path`.
+
+    An assignment binds the function OBJECT at import time, so a test that
+    monkeypatches the private name leaves the alias pointing at the original and
+    silently gets the real resolver — measured: after patching
+    `_get_app_bundle_path`, the alias still returned None. Three existing test
+    files patch only the private name, so that trap was one test away from a
+    green assertion about an early return that never happened.
+    """
+    return _get_app_bundle_path()
 
 
 def find_stale_bundle_copies(running_app: Path) -> list[Path]:
@@ -1128,6 +1138,13 @@ def find_stale_bundle_copies(running_app: Path) -> list[Path]:
         # defence-in-depth reasoning as the line's other two clauses.
         if entry == running_app or entry.is_symlink() or not entry.is_dir():
             continue
+        # fullmatch rather than match. Redundant against the ^...$ anchors for
+        # every ordinary name — reverting EITHER alone survives mutation, only
+        # dropping both reds — and kept for the one case it covers: `$` also
+        # matches before a trailing newline, and APFS permits newlines in
+        # filenames, so `BetterFlow.app.old\n` satisfied a list this comment
+        # calls closed. Same defence-in-depth footing as `entry == running_app`
+        # below, recorded here for the same reason.
         if not any(p.fullmatch(entry.name) for p in patterns):
             continue
         identifier = _bundle_identifier(entry)

--- a/tests/test_autostart_launches_a_specific_bundle.py
+++ b/tests/test_autostart_launches_a_specific_bundle.py
@@ -1,0 +1,106 @@
+"""#211: the LaunchAgent named one copy and macOS started another.
+
+The plist said `open -a /Applications/BetterFlow.app`. The machine came up
+running `/Applications/BetterFlow-1.5.119-backup.app` — a version below the
+server's own minimum floor — and stayed there for days while every sync logged
+"update required".
+
+``open -a X`` does not mean "run the bundle at path X". ``-a`` names an
+APPLICATION, and LaunchServices resolves it through its registration database,
+where all three copies on that machine were registered under one bundle id
+(``co.betterqa.betterflow``). Which copy wins is LaunchServices' choice, not
+ours. Dropping ``-a`` makes the argument a path again: ``open <path>`` opens
+that bundle and no other.
+
+**Scope, stated honestly.** The issue marks the LaunchServices resolution as
+INFERRED — tccd logs had aged out of unified-log retention, so nobody watched
+macOS pick the wrong copy. This change is therefore not "the proven fix for that
+morning"; it is removing the only degree of freedom the launch command had. It
+is strictly more precise whether or not it was the cause, which is why it is
+worth making before the mechanism can be witnessed again.
+
+Guarding it because the argument is invisible at runtime: the wrong form
+launches SOMETHING every time, usually the right copy, so nothing fails and no
+log line records which bundle LaunchServices chose.
+"""
+
+from __future__ import annotations
+
+import sys
+
+import pytest
+
+from src import autostart
+
+
+@pytest.fixture
+def bundled(monkeypatch):
+    """Pretend we are the PyInstaller bundle, which is the only branch that
+    builds an ``open`` command at all."""
+    exe = "/Applications/BetterFlow.app/Contents/MacOS/BetterFlow"
+    monkeypatch.setattr(sys, "executable", exe)
+    return exe
+
+
+def test_the_launch_command_names_a_path_not_an_application(bundled):
+    """THE defect. ``-a`` hands the choice of copy to LaunchServices."""
+    args = autostart._app_launch_args()
+
+    assert "-a" not in args, (
+        "open -a resolves through the LaunchServices database, so a duplicate "
+        "registered under the same bundle id can be launched instead"
+    )
+    assert args == ["open", "/Applications/BetterFlow.app"]
+
+
+def test_the_bundle_path_is_still_derived_from_the_running_executable(bundled):
+    """The control: dropping ``-a`` must not change WHICH bundle we name. A fix
+    that hardcoded a path would pass the test above and break every install
+    that lives somewhere other than /Applications."""
+    monkey_exe = "/Users/someone/Applications/BetterFlow.app/Contents/MacOS/BetterFlow"
+    import sys as _sys
+
+    original = _sys.executable
+    try:
+        _sys.executable = monkey_exe
+        assert autostart._app_launch_args() == [
+            "open",
+            "/Users/someone/Applications/BetterFlow.app",
+        ]
+    finally:
+        _sys.executable = original
+
+
+def test_a_non_bundled_run_is_untouched(monkeypatch):
+    """Running from source must still exec the interpreter, not `open`."""
+    monkeypatch.setattr(sys, "executable", "/usr/local/bin/python3")
+
+    assert autostart._app_launch_args() == ["/usr/local/bin/python3", "-m", "src.main"]
+
+
+def test_an_existing_plist_written_with_the_old_form_reads_as_not_current(
+    bundled, monkeypatch, tmp_path
+):
+    """The migration, which is the whole reason this is safe to ship.
+
+    Every device in the fleet has a plist carrying the ``-a`` form.
+    ``_macos_plist_is_current`` compares the installed ProgramArguments against
+    ``_app_launch_args()``, so changing the latter makes every existing plist
+    read as stale and ``ensure_synced()`` rewrites it on the next startup. No
+    migration code, but also no silent no-op: if this assertion ever flips, the
+    fleet keeps the old command forever and the fix reaches nobody.
+    """
+    import plistlib
+
+    plist = tmp_path / "co.betterqa.betterflow.plist"
+    plist.write_bytes(
+        plistlib.dumps(
+            {"ProgramArguments": ["open", "-a", "/Applications/BetterFlow.app"]}
+        )
+    )
+    monkeypatch.setattr(autostart, "_plist_path", lambda: plist)
+
+    assert autostart._macos_plist_program_args() == [
+        "open", "-a", "/Applications/BetterFlow.app",
+    ]
+    assert autostart._macos_plist_is_current() is False

--- a/tests/test_stale_app_copy_cleanup.py
+++ b/tests/test_stale_app_copy_cleanup.py
@@ -1,0 +1,200 @@
+"""#211: three copies of the agent in /Applications, all under one bundle id.
+
+`/Applications` held `BetterFlow.app` (1.5.125), `BetterFlow.app.old` (1.5.120)
+and `BetterFlow-1.5.119-backup.app` (1.5.119) simultaneously, every one signed
+by us and registered under `co.betterqa.betterflow`. The machine booted the
+1.5.119 copy and stayed below the server's minimum floor for days, and the
+Accessibility grant flapped — macOS keeps ONE row per app, and which copy that
+row is understood to mean is not something we control.
+
+Neither leftover name is one current code produces. `_apply_macos_update` makes
+`<stem>.old.app` and removes it on success; `.app.old` is the shape the Linux
+AppImage path builds. So these are sediment from older versions, which is
+exactly why a sweep is needed rather than a fix to whichever writer is current:
+the copies already exist on machines in the fleet and no future correctness
+removes them.
+
+**This deletes directories in /Applications, so the tests below are mostly about
+what it must REFUSE to touch.** The load-bearing guard is the bundle id: a
+candidate is removed only if its own Info.plist says it is us. Name patterns
+alone are not enough — they are attacker-free but not accident-free, and a
+sweep that trusts a filename is one rename away from deleting somebody's work.
+"""
+
+from __future__ import annotations
+
+import plistlib
+
+import pytest
+
+from src.self_updater import BUNDLE_ID, find_stale_bundle_copies
+
+
+def _make_app(parent, name, bundle_id=BUNDLE_ID, version="1.0.0"):
+    app = parent / name
+    (app / "Contents").mkdir(parents=True)
+    info = {"CFBundleIdentifier": bundle_id, "CFBundleShortVersionString": version}
+    (app / "Contents" / "Info.plist").write_bytes(plistlib.dumps(info))
+    return app
+
+
+def test_it_finds_the_three_shapes_that_have_actually_been_seen(tmp_path):
+    """The two from the incident plus the one current code creates."""
+    running = _make_app(tmp_path, "BetterFlow.app", version="1.5.125")
+    old_suffix = _make_app(tmp_path, "BetterFlow.app.old", version="1.5.120")
+    backup = _make_app(tmp_path, "BetterFlow-1.5.119-backup.app", version="1.5.119")
+    dot_old = _make_app(tmp_path, "BetterFlow.old.app", version="1.5.118")
+
+    found = set(find_stale_bundle_copies(running))
+
+    assert found == {old_suffix, backup, dot_old}
+
+
+def test_it_never_returns_the_running_bundle(tmp_path):
+    """The one deletion that would brick the machine.
+
+    Honest scope: today this passes because of the NAME filter, not the
+    `entry == running_app` check — a bundle's own name cannot match a pattern
+    built from its own stem, so the exclusion is unreachable and a mutation run
+    correctly reports it as unwitnessed. That is defence in depth, not a gap,
+    and it was proven as a pair rather than argued:
+
+        neuter the name filter alone     -> running bundle NOT returned
+        neuter the name filter AND it    -> running bundle IS returned
+
+    Recorded here and at the call site so the next mutation run does not read a
+    surviving mutant as dead code and delete the last guard on the running app.
+    """
+    running = _make_app(tmp_path, "BetterFlow.app")
+
+    assert find_stale_bundle_copies(running) == []
+
+
+def test_a_copy_with_someone_elses_bundle_id_is_left_alone(tmp_path):
+    """THE safety guard. The name matches our pattern exactly; the identity does
+    not. Name-only matching would delete this."""
+    running = _make_app(tmp_path, "BetterFlow.app")
+    _make_app(tmp_path, "BetterFlow.app.old", bundle_id="com.someoneelse.thing")
+
+    assert find_stale_bundle_copies(running) == []
+
+
+def test_a_bundle_we_cannot_identify_is_left_alone(tmp_path):
+    """Fail closed. An unreadable or absent Info.plist means "I do not know
+    whose this is", which is not permission to delete it."""
+    running = _make_app(tmp_path, "BetterFlow.app")
+    (tmp_path / "BetterFlow.app.old" / "Contents").mkdir(parents=True)
+    (tmp_path / "BetterFlow.app.old" / "Contents" / "Info.plist").write_bytes(b"not a plist")
+    _make_app(tmp_path, "BetterFlow.old.app").joinpath("Contents/Info.plist").unlink()
+
+    assert find_stale_bundle_copies(running) == []
+
+
+def test_unrelated_apps_of_ours_are_not_swept(tmp_path):
+    """Scoped to copies of THIS bundle's name. Another BetterQA app that happens
+    to sit in the same folder is not sediment from our updater.
+
+    It carries a different bundle id, so the identity guard already covers it —
+    this pins the NAME scope separately, so a later loosening of one guard does
+    not silently rely on the other.
+    """
+    running = _make_app(tmp_path, "BetterFlow.app")
+    _make_app(tmp_path, "SomeOtherTool.app.old", bundle_id="co.betterqa.othertool")
+
+    assert find_stale_bundle_copies(running) == []
+
+
+def test_it_does_not_leave_the_directory_it_was_given(tmp_path):
+    """Siblings only. A copy one level down is not ours to reason about, and a
+    recursive sweep of /Applications is not a thing this should ever do."""
+    running = _make_app(tmp_path, "BetterFlow.app")
+    nested = tmp_path / "nested"
+    nested.mkdir()
+    _make_app(nested, "BetterFlow.app.old")
+
+    assert find_stale_bundle_copies(running) == []
+
+
+def test_a_symlink_is_never_a_candidate(tmp_path):
+    """Deleting through a symlink deletes the target. Whatever it points at,
+    the link is not a stale copy our updater left."""
+    running = _make_app(tmp_path, "BetterFlow.app")
+    real = _make_app(tmp_path / "elsewhere", "BetterFlow.app")
+    (tmp_path / "BetterFlow.app.old").symlink_to(real)
+
+    assert find_stale_bundle_copies(running) == []
+
+
+def test_a_plain_file_wearing_the_name_is_not_a_bundle(tmp_path):
+    running = _make_app(tmp_path, "BetterFlow.app")
+    (tmp_path / "BetterFlow.app.old").write_text("not a bundle")
+
+    assert find_stale_bundle_copies(running) == []
+
+
+@pytest.mark.parametrize("name", [
+    "BetterFlow.app",           # the running one, under a different parent check
+    "BetterFlowExtra.app",      # prefix match is not a pattern match
+    "MyBetterFlow.app.old",     # suffix match is not a pattern match
+    "BetterFlow.app.old.txt",   # trailing junk
+    "BetterFlow-backup.app",    # no version segment
+])
+def test_names_outside_the_known_patterns_are_ignored(tmp_path, name):
+    """The pattern list is deliberately closed. Anything we did not demonstrably
+    create stays put — a leftover costs disk, a wrong deletion costs an app."""
+    running = _make_app(tmp_path, "BetterFlow.app")
+    if name != "BetterFlow.app":
+        _make_app(tmp_path, name)
+
+    assert find_stale_bundle_copies(running) == []
+
+
+# ── The two things a helper-only test cannot say ────────────────────────
+
+
+def test_the_sweep_is_actually_called_at_startup():
+    """Phantom 3: every test above passes the moment the function EXISTS.
+
+    None of them says anything about whether the agent ever runs it, and an
+    uncalled sweep leaves the #211 device exactly as it was. There is no cheap
+    behavioural way to assert this — the call sits partway through a long
+    startup method that builds a tray, a keychain and a scheduler — so this is
+    a source-shape callsite guard and is worth only what such a guard is worth.
+
+    Matching on a CALL (`name(`) rather than the bare name, and stripping
+    comment lines first, so the guard cannot be satisfied by the prose that
+    explains it (diagnosis-discipline Rule 9 — a detector poisoned by its own
+    corpus). The control below proves the stripping actually happens.
+    """
+    from pathlib import Path as _P
+
+    import src.main  # noqa: F401  — import proves the module is loadable
+
+    source = _P(src.main.__file__).read_text()
+    code = "\n".join(
+        line for line in source.splitlines()
+        if not line.strip().startswith("#")
+    )
+
+    assert "purge_stale_bundle_copies(" in code, (
+        "the sweep is defined but nothing calls it"
+    )
+    # Control: the stripping is real, so the assertion above is about code.
+    commented = "\n".join(
+        line for line in source.splitlines() if line.strip().startswith("#")
+    )
+    assert "purge_stale_bundle_copies(" not in commented
+
+
+def test_every_spelling_of_our_bundle_id_agrees():
+    """The id is written in three modules for three different reasons, and a
+    sweep that deletes on identity must not be reasoning from a stale copy of
+    it. Pinned rather than refactored: threading one constant through the tray
+    and the launch agent would couple modules that have no other reason to know
+    about each other, for a string that changes approximately never.
+    """
+    from src import autostart
+    from src.ui import permissions
+
+    assert autostart.LAUNCHAGENT_LABEL == BUNDLE_ID
+    assert permissions._BUNDLE_ID == BUNDLE_ID

--- a/tests/test_stale_app_copy_cleanup.py
+++ b/tests/test_stale_app_copy_cleanup.py
@@ -24,10 +24,15 @@ sweep that trusts a filename is one rename away from deleting somebody's work.
 from __future__ import annotations
 
 import plistlib
+from pathlib import Path
 
 import pytest
 
-from src.self_updater import BUNDLE_ID, find_stale_bundle_copies
+from src.self_updater import (
+    BUNDLE_ID,
+    find_stale_bundle_copies,
+    purge_stale_bundle_copies,
+)
 
 
 def _make_app(parent, name, bundle_id=BUNDLE_ID, version="1.0.0"):
@@ -152,49 +157,224 @@ def test_names_outside_the_known_patterns_are_ignored(tmp_path, name):
 # ── The two things a helper-only test cannot say ────────────────────────
 
 
-def test_the_sweep_is_actually_called_at_startup():
-    """Phantom 3: every test above passes the moment the function EXISTS.
+def test_run_dispatches_the_sweep():
+    """Phantom 3: everything else here passes the moment the function EXISTS,
+    and an uncalled sweep leaves the #211 device exactly as it was.
 
-    None of them says anything about whether the agent ever runs it, and an
-    uncalled sweep leaves the #211 device exactly as it was. There is no cheap
-    behavioural way to assert this — the call sits partway through a long
-    startup method that builds a tray, a keychain and a scheduler — so this is
-    a source-shape callsite guard and is worth only what such a guard is worth.
+    Scoped to ``BetterFlowApp.run``'s own source rather than the whole 4200-line
+    module, which narrows both error directions at once: a call moved out of
+    ``run()`` reddens (correctly), and a stray mention elsewhere in main.py no
+    longer greens it. Comment lines are stripped so the guard cannot be
+    satisfied by the prose explaining it, with a control below proving the
+    stripping happens.
 
-    Matching on a CALL (`name(`) rather than the bare name, and stripping
-    comment lines first, so the guard cannot be satisfied by the prose that
-    explains it (diagnosis-discipline Rule 9 — a detector poisoned by its own
-    corpus). The control below proves the stripping actually happens.
+    This pins ONE dispatch line, which is all a source grep is good for. What
+    the method does is tested behaviourally below.
     """
-    from pathlib import Path as _P
+    import inspect
 
-    import src.main  # noqa: F401  — import proves the module is loadable
+    from src.main import BetterFlowApp
 
-    source = _P(src.main.__file__).read_text()
+    source = inspect.getsource(BetterFlowApp.run)
     code = "\n".join(
-        line for line in source.splitlines()
-        if not line.strip().startswith("#")
+        line for line in source.splitlines() if not line.strip().startswith("#")
     )
 
-    assert "purge_stale_bundle_copies(" in code, (
-        "the sweep is defined but nothing calls it"
-    )
-    # Control: the stripping is real, so the assertion above is about code.
+    assert "self._sweep_stale_bundle_copies()" in code, "run() does not call the sweep"
     commented = "\n".join(
         line for line in source.splitlines() if line.strip().startswith("#")
     )
-    assert "purge_stale_bundle_copies(" not in commented
+    assert "self._sweep_stale_bundle_copies()" not in commented
 
 
-def test_every_spelling_of_our_bundle_id_agrees():
-    """The id is written in three modules for three different reasons, and a
-    sweep that deletes on identity must not be reasoning from a stale copy of
-    it. Pinned rather than refactored: threading one constant through the tray
-    and the launch agent would couple modules that have no other reason to know
-    about each other, for a string that changes approximately never.
+def test_the_sweep_method_passes_the_resolved_bundle_and_logs_what_went(monkeypatch):
+    """Behavioural, not textual: the method must resolve the running bundle and
+    hand THAT to the purge. An earlier revision re-derived the path by string
+    split, which diverges from the module's own resolver through a symlinked
+    ancestor — different directory scanned, silently."""
+    import src.main as main_mod
+    from src.main import BetterFlowApp
+
+    calls = []
+    monkeypatch.setattr(main_mod.sys, "platform", "darwin")
+    import src.self_updater as su
+
+    monkeypatch.setattr(su, "_get_app_bundle_path", lambda: Path("/Applications/BetterFlow.app"))
+    monkeypatch.setattr(su, "get_app_bundle_path", lambda: Path("/Applications/BetterFlow.app"))
+    monkeypatch.setattr(
+        su, "purge_stale_bundle_copies",
+        lambda running: calls.append(running) or [Path("/Applications/BetterFlow.app.old")],
+    )
+
+    BetterFlowApp._sweep_stale_bundle_copies(object())
+
+    assert calls == [Path("/Applications/BetterFlow.app")]
+
+
+def test_the_sweep_does_nothing_off_macos(monkeypatch):
+    """The patterns and the whole duplicate-registration problem are macOS's."""
+    import src.main as main_mod
+    from src.main import BetterFlowApp
+
+    called = []
+    monkeypatch.setattr(main_mod.sys, "platform", "win32")
+    import src.self_updater as su
+
+    monkeypatch.setattr(su, "purge_stale_bundle_copies", lambda r: called.append(r) or [])
+
+    BetterFlowApp._sweep_stale_bundle_copies(object())
+
+    assert called == []
+
+
+def test_a_failing_sweep_never_stops_the_agent_starting(monkeypatch):
+    """The one job it has. Tidying up is not worth a startup failure."""
+    import src.main as main_mod
+    from src.main import BetterFlowApp
+
+    monkeypatch.setattr(main_mod.sys, "platform", "darwin")
+    import src.self_updater as su
+
+    monkeypatch.setattr(su, "get_app_bundle_path", lambda: Path("/Applications/BetterFlow.app"))
+    monkeypatch.setattr(
+        su, "purge_stale_bundle_copies",
+        lambda r: (_ for _ in ()).throw(RuntimeError("boom")),
+    )
+
+    BetterFlowApp._sweep_stale_bundle_copies(object())  # must not raise
+
+
+def test_dev_mode_is_skipped_rather_than_guessed_at(monkeypatch):
+    """No bundle means nothing to sweep siblings of. Guessing a path here would
+    point the sweep at whatever directory the interpreter happens to live in."""
+    import src.main as main_mod
+    from src.main import BetterFlowApp
+
+    called = []
+    monkeypatch.setattr(main_mod.sys, "platform", "darwin")
+    import src.self_updater as su
+
+    monkeypatch.setattr(su, "get_app_bundle_path", lambda: None)
+    monkeypatch.setattr(su, "purge_stale_bundle_copies", lambda r: called.append(r) or [])
+
+    BetterFlowApp._sweep_stale_bundle_copies(object())
+
+    assert called == []
+
+
+def test_the_identity_macos_knows_us_by_is_written_once_per_reason():
+    """The sweep deletes on identity, so it must not be reasoning from a stale
+    copy of the id — and the AUTHORITY is none of the Python constants.
+
+    What `find_stale_bundle_copies` compares against is `CFBundleIdentifier`
+    out of a candidate's Info.plist, and that value is put there by
+    `build.spec`. Change build.spec alone and two things break while a
+    constants-only guard stays green: the sweep matches nothing, forever and
+    silently; and `permissions._BUNDLE_ID`'s TCC insert writes a grant for a
+    bundle id no installed app claims — Accessibility never granted, which is
+    the OTHER symptom #211 reports.
+
+    A source-shape check over a declaration file with exactly one spelling of
+    the token is the one place such a check is defensible, and it is the only
+    mechanical link to the authority available without doing a build.
     """
-    from src import autostart
     from src.ui import permissions
 
+    assert permissions._BUNDLE_ID == BUNDLE_ID, "same concept, must agree"
+
+    spec = (Path(__file__).parent.parent / "build.spec").read_text()
+    assert f'bundle_identifier="{BUNDLE_ID}"' in spec, (
+        "build.spec is what actually stamps CFBundleIdentifier into the shipped "
+        "bundle; the sweep compares against that, not against this constant"
+    )
+
+
+def test_the_launchd_label_currently_equals_the_bundle_id():
+    """A COINCIDENCE, pinned so a divergence is deliberate — not an invariant.
+
+    `LAUNCHAGENT_LABEL` is a launchd label that happens to equal the bundle id.
+    Apple's own convention routinely gives an agent `<bundleid>.agent`, so a
+    legitimate change there would redden a test documented as protecting the
+    sweep — the "false-fails on a legitimate refactor gets loosened" shape this
+    repo paid for in #218. If the label diverges on purpose, change THIS test,
+    not BUNDLE_ID.
+    """
+    from src import autostart
+
     assert autostart.LAUNCHAGENT_LABEL == BUNDLE_ID
-    assert permissions._BUNDLE_ID == BUNDLE_ID
+
+
+# ── The half that deletes ────────────────────────────────────────────────
+#
+# Everything above pins `find_`, which returns paths and touches nothing.
+# `purge_` is the shipped function — the one with `shutil.rmtree` in it — and
+# had no tests at all: a later edit dropping the `continue`, or widening the
+# target, would have reddened nothing.
+
+
+def test_purge_removes_exactly_what_find_named(tmp_path):
+    running = _make_app(tmp_path, "BetterFlow.app")
+    doomed = _make_app(tmp_path, "BetterFlow.app.old")
+    spared = _make_app(tmp_path, "Unrelated.app", bundle_id="com.other.thing")
+
+    removed = purge_stale_bundle_copies(running)
+
+    assert removed == [doomed]
+    assert not doomed.exists()
+    assert running.exists(), "deleted the app that is executing"
+    assert spared.exists(), "deleted a bundle that is not ours"
+
+
+def test_one_copy_it_cannot_remove_does_not_abort_the_rest(tmp_path, monkeypatch):
+    """The `continue`. Without it a single permissions error leaves every later
+    copy in place, and the sweep quietly does a fraction of its job."""
+    running = _make_app(tmp_path, "BetterFlow.app")
+    stubborn = _make_app(tmp_path, "BetterFlow.app.old")
+    removable = _make_app(tmp_path, "BetterFlow-1.5.119-backup.app")
+
+    import src.self_updater as su
+
+    real_rmtree = su.shutil.rmtree
+
+    def rmtree(path, *a, **k):
+        if Path(path) == stubborn:
+            raise PermissionError("nope")
+        return real_rmtree(path, *a, **k)
+
+    monkeypatch.setattr(su.shutil, "rmtree", rmtree)
+
+    removed = purge_stale_bundle_copies(running)
+
+    assert removed == [removable], "the failure must not swallow the others"
+    assert stubborn.exists()
+    assert not removable.exists()
+
+
+def test_the_return_value_lists_only_what_actually_went(tmp_path, monkeypatch):
+    """A path that failed to delete must not be reported as removed — the
+    caller logs this line as the fleet's record of what it cleaned."""
+    running = _make_app(tmp_path, "BetterFlow.app")
+    _make_app(tmp_path, "BetterFlow.app.old")
+
+    import src.self_updater as su
+
+    monkeypatch.setattr(
+        su.shutil, "rmtree",
+        lambda *a, **k: (_ for _ in ()).throw(OSError("busy")),
+    )
+
+    assert purge_stale_bundle_copies(running) == []
+
+
+def test_purge_is_a_no_op_from_a_non_canonical_copy(tmp_path):
+    """#211's actual device. It had booted BetterFlow-1.5.119-backup.app, where
+    the patterns — built from the RUNNING stem — cannot see the canonical
+    install's siblings. Returning nothing is the correct action (sweeping from
+    here would have a backup copy delete the NEWER app beside it); the defect
+    was that it happened silently, which the warning now fixes."""
+    canonical = _make_app(tmp_path, "BetterFlow.app", version="1.5.125")
+    backup = _make_app(tmp_path, "BetterFlow-1.5.119-backup.app", version="1.5.119")
+    dot_old = _make_app(tmp_path, "BetterFlow.app.old", version="1.5.120")
+
+    assert purge_stale_bundle_copies(backup) == []
+    assert canonical.exists() and dot_old.exists() and backup.exists()

--- a/tests/test_stale_app_copy_cleanup.py
+++ b/tests/test_stale_app_copy_cleanup.py
@@ -122,10 +122,23 @@ def test_it_does_not_leave_the_directory_it_was_given(tmp_path):
 
 def test_a_symlink_is_never_a_candidate(tmp_path):
     """Deleting through a symlink deletes the target. Whatever it points at,
-    the link is not a stale copy our updater left."""
+    the link is not a stale copy our updater left.
+
+    Skipped rather than failed where the OS will not make one. This is the first
+    ``symlink_to`` in the suite, and the tag build runs ``pytest tests/`` on the
+    FOUR-platform matrix including windows-latest, with ``release: needs:
+    build`` — so a hard failure here produces no release artifacts at all. That
+    is precisely how ``os.getuid()`` killed v1.5.119's first tag build (#168,
+    fixed in #171). Windows needs SeCreateSymbolicLinkPrivilege, which a runner
+    may or may not hold; catching the refusal keeps the coverage everywhere it
+    does work instead of trading it for a dead release.
+    """
     running = _make_app(tmp_path, "BetterFlow.app")
     real = _make_app(tmp_path / "elsewhere", "BetterFlow.app")
-    (tmp_path / "BetterFlow.app.old").symlink_to(real)
+    try:
+        (tmp_path / "BetterFlow.app.old").symlink_to(real)
+    except OSError as e:  # pragma: no cover — platform-dependent
+        pytest.skip(f"this OS refused to create a symlink: {e}")
 
     assert find_stale_bundle_copies(running) == []
 
@@ -138,18 +151,24 @@ def test_a_plain_file_wearing_the_name_is_not_a_bundle(tmp_path):
 
 
 @pytest.mark.parametrize("name", [
-    "BetterFlow.app",           # the running one, under a different parent check
+    # "BetterFlow.app" was here and created nothing (guarded by an `if`), so it
+    # asserted nothing that test_it_never_returns_the_running_bundle does not.
     "BetterFlowExtra.app",      # prefix match is not a pattern match
     "MyBetterFlow.app.old",     # suffix match is not a pattern match
     "BetterFlow.app.old.txt",   # trailing junk
     "BetterFlow-backup.app",    # no version segment
+    # Without these the version segment is unwitnessed: a reviewer broadened
+    # `[0-9][0-9.]*` to `.*` and to `[0-9.]*` and no test noticed, so the
+    # "closed list, not a glob" claim had no proof for the third pattern.
+    "BetterFlow-nightly-backup.app",
+    "BetterFlow-v1.5.119-backup.app",
+    "BetterFlow--backup.app",
 ])
 def test_names_outside_the_known_patterns_are_ignored(tmp_path, name):
     """The pattern list is deliberately closed. Anything we did not demonstrably
     create stays put — a leftover costs disk, a wrong deletion costs an app."""
     running = _make_app(tmp_path, "BetterFlow.app")
-    if name != "BetterFlow.app":
-        _make_app(tmp_path, name)
+    _make_app(tmp_path, name)
 
     assert find_stale_bundle_copies(running) == []
 
@@ -378,3 +397,42 @@ def test_purge_is_a_no_op_from_a_non_canonical_copy(tmp_path):
 
     assert purge_stale_bundle_copies(backup) == []
     assert canonical.exists() and dot_old.exists() and backup.exists()
+
+
+def test_a_differently_cased_copy_is_still_found(tmp_path):
+    """/Applications is APFS and case-INSENSITIVE, so `betterflow.app.old` and
+    `BetterFlow.app.old` are one file to the filesystem and were two different
+    strings to the pattern list. The copy survived, in the safe direction and
+    therefore silently.
+
+    Note this fixture only reaches the branch on a case-sensitive filesystem;
+    on a case-insensitive one `_make_app` would collide with the running bundle.
+    The assertion is about the PATTERN, which is why it is written against a
+    name the matcher must accept rather than against filesystem behaviour.
+    """
+    running = _make_app(tmp_path, "BetterFlow.app")
+    odd = _make_app(tmp_path, "betterflow.app.old")
+
+    assert find_stale_bundle_copies(running) == [odd]
+
+
+def test_the_legacy_bundle_name_is_a_known_blind_spot(tmp_path):
+    """Documenting a gap rather than implying coverage.
+
+    This repo renamed "BetterFlow Sync.app" to "BetterFlow.app" (see
+    src/autostart.py's plist-staleness note). A machine still carrying the old
+    name under our bundle id is invisible to the sweep forever — same
+    duplicate-registration condition as #211, one name away — because every
+    pattern is built from the RUNNING stem and the canonical stem check refuses
+    to run from anything else.
+
+    Asserted as the CURRENT behaviour so the next person meets it as a decision
+    rather than as a surprise. Widening to the legacy stem would let a
+    "BetterFlow Sync.app" install delete "BetterFlow.app" beside it, which is
+    the wrong trade.
+    """
+    running = _make_app(tmp_path, "BetterFlow.app")
+    legacy = _make_app(tmp_path, "BetterFlow Sync.app")
+
+    assert find_stale_bundle_copies(running) == []
+    assert legacy.exists()

--- a/tests/test_stale_app_copy_cleanup.py
+++ b/tests/test_stale_app_copy_cleanup.py
@@ -385,6 +385,41 @@ def test_the_return_value_lists_only_what_actually_went(tmp_path, monkeypatch):
     assert purge_stale_bundle_copies(running) == []
 
 
+def test_a_non_canonical_copy_says_so_out_loud(tmp_path, caplog):
+    """The whole deliverable of the #211 headline fix, and it had no witness.
+
+    Removing the `stem != _CANONICAL_STEM` bail-out changed no test, because the
+    patterns are built from the running stem and match nothing from a backup
+    copy either way — so the RETURN value is identical with and without it. What
+    the bail-out exists for is the log line: the affected device produced no
+    output at all, and #211 was found by grepping one machine's log, so a
+    greppable warning is the entire mechanism by which the fleet's remaining
+    cases get discovered.
+
+    Asserting on the emitted record, not on the return, because the return
+    cannot distinguish the two states.
+    """
+    import logging
+
+    canonical = _make_app(tmp_path, "BetterFlow.app", version="1.5.125")
+    backup = _make_app(tmp_path, "BetterFlow-1.5.119-backup.app", version="1.5.119")
+
+    with caplog.at_level(logging.WARNING, logger="src.self_updater"):
+        assert find_stale_bundle_copies(backup) == []
+
+    warnings = [r.getMessage() for r in caplog.records if r.levelno >= logging.WARNING]
+    assert any("BetterFlow-1.5.119-backup.app" in m for m in warnings), warnings
+    assert any("#211" in m for m in warnings), (
+        "the line has to be greppable back to the issue that needs it"
+    )
+
+    # Control: the canonical copy must NOT emit it, or the signal is noise.
+    caplog.clear()
+    with caplog.at_level(logging.WARNING, logger="src.self_updater"):
+        find_stale_bundle_copies(canonical)
+    assert not [r for r in caplog.records if r.levelno >= logging.WARNING]
+
+
 def test_purge_is_a_no_op_from_a_non_canonical_copy(tmp_path):
     """#211's actual device. It had booted BetterFlow-1.5.119-backup.app, where
     the patterns — built from the RUNNING stem — cannot see the canonical

--- a/tests/test_stale_app_copy_cleanup.py
+++ b/tests/test_stale_app_copy_cleanup.py
@@ -556,3 +556,22 @@ def test_running_from_the_legacy_name_bails_out(tmp_path):
     _make_app(tmp_path, "BetterFlow Sync.app.old")
 
     assert find_stale_bundle_copies(legacy) == []
+
+
+def test_the_public_resolver_follows_a_patch_of_the_private_one(monkeypatch):
+    """Witnesses why `get_app_bundle_path` is a wrapper and not an assignment.
+
+    `get_app_bundle_path = _get_app_bundle_path` binds the function OBJECT at
+    import time, so a test patching the private name leaves the alias pointing
+    at the original and silently gets the real resolver. Three existing test
+    files patch only the private name, so that trap was one test away from a
+    green assertion about an early return that never happened.
+
+    Reverting the wrapper to an assignment survives every OTHER test here — they
+    patch both names — so without this the guard has no witness at all.
+    """
+    import src.self_updater as su
+
+    monkeypatch.setattr(su, "_get_app_bundle_path", lambda: Path("/patched/BetterFlow.app"))
+
+    assert su.get_app_bundle_path() == Path("/patched/BetterFlow.app")

--- a/tests/test_stale_app_copy_cleanup.py
+++ b/tests/test_stale_app_copy_cleanup.py
@@ -29,8 +29,8 @@ from pathlib import Path
 import pytest
 
 from src.self_updater import (
-    BUNDLE_ID,
     _CANONICAL_STEM,
+    BUNDLE_ID,
     find_stale_bundle_copies,
     purge_stale_bundle_copies,
 )
@@ -519,16 +519,25 @@ def test_the_name_the_updater_leaves_behind_is_the_name_the_sweep_looks_for(tmp_
     suite green, so the constant's own comment — "change the writer and the
     sweep silently stops matching it" — was still true, one step along.
 
-    This builds the backup name the way the updater does and feeds it to the
-    sweep, so a divergence at either end reddens.
+    This asks the updater's own helper for the name and feeds it to the sweep,
+    so a divergence at either end reddens.
+
+    Honest scope: it exercises _macos_backup_path, not _apply_macos_update
+    itself, which needs a downloaded archive and a real bundle to run. If
+    someone stops CALLING the helper from that function, this test cannot see
+    it — the helper existing is what makes the divergence a one-line change
+    rather than a silent drift, not a proof that the call site remains.
     """
     import src.self_updater as su
 
     running = _make_app(tmp_path, "BetterFlow.app")
 
-    # Exactly the expression at _apply_macos_update's backup line.
-    leftover_name = f"{running.stem}{su._MACOS_BACKUP_SUFFIX}"
-    leftover = _make_app(tmp_path, leftover_name)
+    # _macos_backup_path is what _apply_macos_update now calls, so this asks
+    # the WRITER for the name rather than rebuilding it from the shared
+    # constant. The earlier version did the latter and had both sides of the
+    # assertion tracing to one artifact, so reverting the writer's line to a
+    # literal ".bak.app" changed nothing it could see (Rule 6a).
+    leftover = _make_app(tmp_path, su._macos_backup_path(running).name)
 
     assert find_stale_bundle_copies(running) == [leftover], (
         "the sweep does not recognise the name the updater actually creates"

--- a/tests/test_stale_app_copy_cleanup.py
+++ b/tests/test_stale_app_copy_cleanup.py
@@ -30,6 +30,7 @@ import pytest
 
 from src.self_updater import (
     BUNDLE_ID,
+    _CANONICAL_STEM,
     find_stale_bundle_copies,
     purge_stale_bundle_copies,
 )
@@ -206,7 +207,9 @@ def test_run_dispatches_the_sweep():
     assert "self._sweep_stale_bundle_copies()" not in commented
 
 
-def test_the_sweep_method_passes_the_resolved_bundle_and_logs_what_went(monkeypatch):
+def test_the_sweep_method_passes_the_resolved_bundle_and_logs_what_went(
+    monkeypatch, caplog
+):
     """Behavioural, not textual: the method must resolve the running bundle and
     hand THAT to the purge. An earlier revision re-derived the path by string
     split, which diverges from the module's own resolver through a symlinked
@@ -225,9 +228,20 @@ def test_the_sweep_method_passes_the_resolved_bundle_and_logs_what_went(monkeypa
         lambda running: calls.append(running) or [Path("/Applications/BetterFlow.app.old")],
     )
 
-    BetterFlowApp._sweep_stale_bundle_copies(object())
+    import logging
+
+    with caplog.at_level(logging.INFO, logger="src.main"):
+        BetterFlowApp._sweep_stale_bundle_copies(object())
 
     assert calls == [Path("/Applications/BetterFlow.app")]
+
+    # ...and logs what went. The name said so and nothing asserted it (Phantom
+    # 9: a verb in the test name, no assertion behind it) — deleting the whole
+    # logger.info block survived mutation. That line is one record per DEVICE,
+    # which is the fleet question a per-file log inside purge_ cannot answer.
+    messages = [r.getMessage() for r in caplog.records]
+    assert any("BetterFlow.app.old" in m for m in messages), messages
+    assert any("Removed 1 stale" in m for m in messages), messages
 
 
 def test_the_sweep_does_nothing_off_macos(monkeypatch):
@@ -239,11 +253,21 @@ def test_the_sweep_does_nothing_off_macos(monkeypatch):
     monkeypatch.setattr(main_mod.sys, "platform", "win32")
     import src.self_updater as su
 
+    # Patching the resolver is NOT incidental — without it this test passed for
+    # the wrong reason and the darwin gate had no witness at all. The real
+    # resolver takes its own win32 branch, finds sys.frozen false, returns None,
+    # and the `running is None` guard produces the identical `called == []`.
+    # Removing the platform check entirely left the whole suite green.
+    monkeypatch.setattr(su, "get_app_bundle_path", lambda: Path("/Applications/BetterFlow.app"))
     monkeypatch.setattr(su, "purge_stale_bundle_copies", lambda r: called.append(r) or [])
 
     BetterFlowApp._sweep_stale_bundle_copies(object())
 
-    assert called == []
+    assert called == [], (
+        "the sweep ran off macOS; on Linux every AppImage start would then log "
+        "the '#211 non-canonical copy' warning, turning the fleet-discovery "
+        "signal this branch exists to create into pure noise"
+    )
 
 
 def test_a_failing_sweep_never_stops_the_agent_starting(monkeypatch):
@@ -302,6 +326,19 @@ def test_the_identity_macos_knows_us_by_is_written_once_per_reason():
     assert permissions._BUNDLE_ID == BUNDLE_ID, "same concept, must agree"
 
     spec = (Path(__file__).parent.parent / "build.spec").read_text()
+
+    # The bundle NAME is a second authority, and this branch made it
+    # load-bearing: _CANONICAL_STEM is the switch deciding whether the sweep
+    # runs at all. Renaming it in build.spec alone disables the sweep on every
+    # device forever AND makes every device log the alarming non-canonical
+    # warning — and this repo has already done exactly one such rename
+    # ("BetterFlow Sync.app" -> "BetterFlow.app"). The docstring above reasons
+    # about precisely this class for the id; the name needs the same guard.
+    assert f'name="{_CANONICAL_STEM}.app"' in spec, (
+        "build.spec's bundle name is what _CANONICAL_STEM has to match; a "
+        "rename there silently switches the sweep off fleet-wide"
+    )
+
     assert f'bundle_identifier="{BUNDLE_ID}"' in spec, (
         "build.spec is what actually stamps CFBundleIdentifier into the shipped "
         "bundle; the sweep compares against that, not against this constant"
@@ -440,10 +477,11 @@ def test_a_differently_cased_copy_is_still_found(tmp_path):
     strings to the pattern list. The copy survived, in the safe direction and
     therefore silently.
 
-    Note this fixture only reaches the branch on a case-sensitive filesystem;
-    on a case-insensitive one `_make_app` would collide with the running bundle.
-    The assertion is about the PATTERN, which is why it is written against a
-    name the matcher must accept rather than against filesystem behaviour.
+    An earlier version of this note claimed the fixture "only reaches the
+    branch on a case-sensitive filesystem". That is wrong, and a reviewer had to
+    say so: `betterflow.app.old` and `BetterFlow.app` do not collide even
+    case-insensitively, so this runs and genuinely witnesses IGNORECASE on the
+    Mac it will run on — reverting the flag reddens it.
     """
     running = _make_app(tmp_path, "BetterFlow.app")
     odd = _make_app(tmp_path, "betterflow.app.old")
@@ -471,3 +509,41 @@ def test_the_legacy_bundle_name_is_a_known_blind_spot(tmp_path):
 
     assert find_stale_bundle_copies(running) == []
     assert legacy.exists()
+
+
+def test_the_name_the_updater_leaves_behind_is_the_name_the_sweep_looks_for(tmp_path):
+    """The two ends of _MACOS_BACKUP_SUFFIX, driven rather than asserted equal.
+
+    Sharing a constant is not the same as proving both ends use it: reverting
+    the writer at _apply_macos_update to a literal ".bak.app" left the whole
+    suite green, so the constant's own comment — "change the writer and the
+    sweep silently stops matching it" — was still true, one step along.
+
+    This builds the backup name the way the updater does and feeds it to the
+    sweep, so a divergence at either end reddens.
+    """
+    import src.self_updater as su
+
+    running = _make_app(tmp_path, "BetterFlow.app")
+
+    # Exactly the expression at _apply_macos_update's backup line.
+    leftover_name = f"{running.stem}{su._MACOS_BACKUP_SUFFIX}"
+    leftover = _make_app(tmp_path, leftover_name)
+
+    assert find_stale_bundle_copies(running) == [leftover], (
+        "the sweep does not recognise the name the updater actually creates"
+    )
+
+
+def test_running_from_the_legacy_name_bails_out(tmp_path):
+    """The reverse direction its sibling's docstring describes but never runs.
+
+    "BetterFlow Sync.app" was this app's name before a rename. A machine still
+    on it is not merely unswept — it takes the non-canonical bail-out, so it
+    also announces itself in the log, which is how such a device would now be
+    found at all.
+    """
+    legacy = _make_app(tmp_path, "BetterFlow Sync.app")
+    _make_app(tmp_path, "BetterFlow Sync.app.old")
+
+    assert find_stale_bundle_copies(legacy) == []


### PR DESCRIPTION
Two of the four mechanisms in #211, the pair that together remove the duplicate-copy hazard. **Does not close the issue** — the other two are listed at the bottom.

## What happened on the device

`/Applications` held three copies — `BetterFlow.app` (1.5.125), `BetterFlow.app.old` (1.5.120), `BetterFlow-1.5.119-backup.app` (1.5.119) — all signed by us, all registered under `co.betterqa.betterflow`. The machine booted the **oldest** and sat below the server's own minimum version floor for days while every sync logged `update required`. The Accessibility grant flapped, twice revoked mid-run with no restart in between, because macOS keeps one row per app and which copy that row is understood to mean is not something we control.

## 1. `open -a <path>` was letting LaunchServices choose

`_app_launch_args` built `open -a /Applications/BetterFlow.app`. The two forms look interchangeable and are not: `-a` names an **application**, resolved through the LaunchServices database, so with several copies under one bundle id the choice is LaunchServices' and not ours. Dropping `-a` makes the argument a path again.

```
assert "-a" not in ["open", "-a", "/Applications/BetterFlow.app"]   FAILED pre-fix
assert args == ["open", "/Applications/BetterFlow.app"]             FAILED pre-fix
assert _macos_plist_is_current() is False                           FAILED pre-fix
```

The non-bundled control passed pre-fix and still passes, so the tests isolate the defect rather than describing the new code.

**Scope, stated honestly:** the issue marks the LaunchServices resolution as INFERRED — tccd logs had aged out of unified-log retention, so nobody watched macOS pick the wrong copy. This is not "the proven fix for that morning". It removes the only degree of freedom the launch command had, which is worth doing whether or not it was the cause.

Migration needs no code and is **asserted rather than assumed**: `_macos_plist_is_current()` compares installed ProgramArguments against this list, so every plist in the fleet still carrying `-a` now reads as stale and gets rewritten on next startup. If that assertion ever flips, the fix silently reaches nobody.

## 2. The copies themselves

Neither leftover name is one current code produces — `_apply_macos_update` makes `<stem>.old.app` and removes it on success; `.app.old` is the Linux AppImage shape. They are sediment from older versions, which is exactly why a **sweep** is needed rather than a fix to whichever writer is current: the copies already exist in the fleet and no future correctness removes them.

This deletes directories in `/Applications`, so most of the 15 tests are about what it must **refuse** to touch. Four guards:

| | guard | why |
|---|---|---|
| 1 | **Identity** — the candidate's own `Info.plist` must name our bundle id | The one doing real work. A name pattern is a guess about provenance; an `Info.plist` is the bundle stating who it is. Unreadable means "I don't know whose this is", never "delete it". |
| 2 | **Name** — closed list of three shapes we can show we produced | Not a glob. A leftover costs disk; a wrong deletion costs somebody an application. |
| 3 | **Siblings only**, never recursive | A directory walk of `/Applications` is not something this should grow into. |
| 4 | **No symlinks** | Deleting through one deletes its target, which by definition is not a copy our updater left. |

`find_stale_bundle_copies` returns paths and deletes nothing, so the decision is testable without a filesystem that can lose something. `purge_` does the removal, best-effort — failing to tidy up must never stop the agent starting.

New behaviour, so no pre-fix failure exists to capture. The tests were earned with mutants instead:

```
identity guard removed        -> 2 named tests red
unreadable Info.plist = ours  -> 1 named test red
symlinks become candidates    -> 1 named test red
the startup call deleted      -> 1 named test red
```

### One mutant survives, deliberately

`entry == running_app` is unreachable while the name patterns are correct — a bundle's own name cannot match a pattern built from its own stem. That is defence in depth, not a gap, and it was proven as a **pair** rather than argued:

```
neuter the name filter alone     -> running bundle NOT returned
neuter the name filter AND this  -> running bundle IS returned
```

So it is the only thing standing between a broken name pattern and deleting the app that is currently executing. Recorded at both the call site and the test, so the next mutation run doesn't read a surviving mutant as dead code and remove the last guard on the running app.

### Wiring

At startup, not on the post-update path — the copies that matter are already on disk, and fixing the writer does nothing for a machine that already has them. Placed after `_maybe_relocate_to_applications()`, which can move us, since the sweep is scoped to siblings of where we are *now*.

A helper nobody calls would leave the device exactly as it was, so the callsite has its own guard: it matches on a **call** and strips comment lines first, with a control proving the stripping happens, so it cannot be satisfied by the prose explaining it.

`BUNDLE_ID` was already spelled in `autostart.py` (as the launchd label) and `ui/permissions.py`. The third copy is pinned by a test rather than refactored — threading one constant through the tray and the launch agent couples modules with no other reason to know about each other, for a string that changes approximately never.

## Verification

- `pytest tests/` → **1924 passed, 1 skipped, exit 0**. That is the whole of CI's `test` job.
- `ruff` → `src/self_updater.py` back to *All checks passed*, 8 errors total across the three touched files, identical to `origin/main`. An earlier revision introduced two `E402`s and an `I001` by inserting the constant block between imports — caught by diffing against baseline, not by reading.
- `git diff --numstat` → one deleted line in the whole branch (the `-a` argument).
- **Not smoke-tested on a real Mac with real duplicate copies.** The sweep's filesystem behaviour is covered by tmp_path fixtures; LaunchServices resolution cannot be tested at all off-device. Both are macOS-only paths that the ubuntu CI runner never executes.

## Still open on #211

- Recover from a failed `hdiutil detach` (or copy out of the mount rather than requiring detach before install) — the actual trigger of the incident.
- Alert ops when a device has been below the server's minimum version floor for more than a day.

Refs #211.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
