### PR TITLE
Keep the Rosetta answer through a broken re-probe, and read process_arch in the tray

### DIFF
--- a/src/aw_manager.py
+++ b/src/aw_manager.py
@@ -558,6 +558,13 @@ class AWManager:
         # every few minutes for the life of an outage — that is the 60-second
         # log spam the preflight was written to end, arriving by another door.
         self._rosetta_logged: Optional[bool] = None
+        # The last answer the probe actually GAVE, as opposed to the memo above
+        # which force_restart clears on purpose. A probe that raised is not an
+        # answer, and once re-probing exists a transient fork refusal
+        # (EAGAIN/EMFILE, or the 10s timeout) can overwrite a known "Rosetta is
+        # missing" with a guessed "available". Deliberately NOT cleared by
+        # force_restart: its whole job is to survive the memo.
+        self._rosetta_missing_conclusive: Optional[bool] = None
         self._rosetta_notified: bool = False
         # Components whose binary is on disk but cannot EXECUTE (EBADARCH /
         # ENOEXEC). Keeps the capture-dead latch honest when only SOME binaries
@@ -815,6 +822,7 @@ class AWManager:
 
         if sys.platform != "darwin" or platform.machine() != "arm64":
             self._rosetta_missing_cached = False
+            self._rosetta_missing_conclusive = False
             return False
 
         try:
@@ -825,13 +833,33 @@ class AWManager:
                 timeout=10,
             )
             missing = result.returncode != 0
+            self._rosetta_missing_conclusive = missing
         except Exception as e:
             # Probe itself failed. Do NOT claim Rosetta is missing on a broken
             # probe — that would refuse to start trackers on a machine that is
             # fine. Fail towards attempting the start; the EBADARCH handler in
             # _start_component still catches the real thing.
-            logger.warning("Rosetta probe failed, assuming available: %s", e)
-            missing = False
+            # "Fail toward available" is the right default only when we have
+            # never had a real answer. force_restart re-probes every
+            # ROSETTA_REPROBE_INTERVAL, so on an affected Mac this path runs
+            # ~288 times a day, and each run is a fresh chance for a fork
+            # refusal to replace a KNOWN "missing" with a guess. That guess is
+            # not free: it makes capture_blocked_remedy() return None, so the
+            # tray drops the one actionable sentence and falls back to
+            # "ActivityWatch not responding" -- the string #188 exists to
+            # delete -- and it flips _rosetta_logged so the log claims "Rosetta
+            # 2 is now available" on a machine where nothing changed.
+            #
+            # So carry the last CONCLUSIVE answer forward and guess only when
+            # there has never been one. Same determined/conclusive split
+            # machine_arch.ProbeResult already uses, for the same reason: a
+            # failed probe must not masquerade as a result.
+            logger.warning("Rosetta probe failed, keeping last answer: %s", e)
+            missing = (
+                self._rosetta_missing_conclusive
+                if self._rosetta_missing_conclusive is not None
+                else False
+            )
 
         self._rosetta_missing_cached = missing
         self._rosetta_probed_at = time.monotonic()

--- a/src/ui/tray.py
+++ b/src/ui/tray.py
@@ -62,7 +62,7 @@ except ImportError:
 try:
     from ..clipboard import clipboard_available, copy_to_clipboard
     from ..hardware_serial import get_hardware_serial
-    from ..machine_arch import ARM64, is_rosetta_translated, true_machine_arch
+    from ..machine_arch import ARM64, is_rosetta_translated, process_arch, true_machine_arch
     from ..notifications import send_notification
 except ImportError:
     from clipboard import clipboard_available, copy_to_clipboard  # type: ignore[no-redef]
@@ -70,6 +70,7 @@ except ImportError:
     from machine_arch import (  # type: ignore[no-redef]
         ARM64,
         is_rosetta_translated,
+        process_arch,
         true_machine_arch,
     )
     from notifications import send_notification  # type: ignore[no-redef]
@@ -308,7 +309,12 @@ def arch_menu_label(
         translated: Override the Rosetta determination for testing.
     """
     system = system or platform.system()
-    machine = machine or platform.machine()
+    # The architecture of THIS PROCESS, via the named helper rather than a
+    # second inline platform.machine(). Same discipline this function's own
+    # docstring already applies to the hardware arch ("never re-derived here"):
+    # a second copy is how the tray ends up naming one architecture while the
+    # heartbeat reports another.
+    machine = machine or process_arch()
     if translated is None:
         translated = is_rosetta_translated(system=system)
 

--- a/tests/test_process_arch_heartbeat.py
+++ b/tests/test_process_arch_heartbeat.py
@@ -246,3 +246,29 @@ def test_the_pair_maps_an_undeterminable_arch_the_same_way_on_both_halves():
 
     assert telemetry["process_arch"] is None
     assert telemetry["machine_arch"] is None
+
+
+def test_the_tray_reads_process_arch_rather_than_re_deriving_it():
+    """Callsite guard, not a helper test.
+
+    `process_arch()` passing in isolation says nothing about whether the surface
+    the user reads uses it. `arch_menu_label` renders the process architecture
+    in its could-not-determine row; re-deriving it there with a second inline
+    `platform.machine()` is how the tray ends up naming one architecture while
+    the heartbeat reports another.
+    """
+    import inspect
+
+    from src.ui import tray
+
+    source = inspect.getsource(tray.arch_menu_label)
+    # Drop the docstring AND comment lines before matching: both DISCUSS
+    # platform.machine() by name, so a raw scan fires on the prose explaining
+    # the fix and reports the code as broken.
+    body = "\n".join(
+        line
+        for line in source.split('"""')[-1].splitlines()
+        if not line.strip().startswith("#")
+    )
+    assert "process_arch()" in body, "the tray must read the named helper"
+    assert "platform.machine()" not in body, "no second inline re-derivation"

--- a/tests/test_rosetta_probe_carry.py
+++ b/tests/test_rosetta_probe_carry.py
@@ -1,0 +1,93 @@
+"""A broken Rosetta probe must not overwrite an answer we already had.
+
+Separate file on purpose: `test_aw_manager_rosetta_preflight.py` is being
+rewritten by the native-arm64 work (#216/#217), and appending here would put a
+conflict in front of that branch for no reason.
+"""
+
+import contextlib
+import subprocess
+from unittest.mock import patch
+
+from src.aw_manager import AWManager
+
+
+def _mgr() -> AWManager:
+    mgr = AWManager(aw_port=5600)
+    mgr.tracker_download_failed = False
+    mgr._rosetta_missing_cached = None
+    mgr._rosetta_notified = False
+    return mgr
+
+
+@contextlib.contextmanager
+def _probe(result):
+    """Apple Silicon, with `/usr/bin/arch` answering `result`.
+
+    `result` is a CompletedProcess to return, or an exception to raise.
+    """
+    kw = {"side_effect": result} if isinstance(result, BaseException) else {"return_value": result}
+    with patch("src.aw_manager.sys.platform", "darwin"), \
+         patch("src.aw_manager.platform.machine", return_value="arm64"), \
+         patch("src.aw_manager.subprocess.run", **kw):
+        yield
+
+
+MISSING = subprocess.CompletedProcess(args=[], returncode=1)
+PRESENT = subprocess.CompletedProcess(args=[], returncode=0)
+
+
+def test_a_broken_re_probe_keeps_the_answer_it_already_had():
+    """A fork refusal is not evidence that Rosetta appeared.
+
+    force_restart clears the memo every ROSETTA_REPROBE_INTERVAL, so on an
+    affected Mac this runs ~288 times a day. One EAGAIN used to withdraw
+    capture_blocked_remedy(), reverting the tray to "ActivityWatch not
+    responding" -- the string #188 exists to delete.
+    """
+    mgr = _mgr()
+    with _probe(MISSING):
+        assert mgr._rosetta_missing() is True
+    mgr.tracker_download_failed = True
+    assert mgr.capture_blocked_remedy() is not None, "precondition: the remedy is owed"
+
+    mgr._rosetta_missing_cached = None  # what force_restart does after the interval
+    with _probe(OSError("EAGAIN")):
+        assert mgr._rosetta_missing() is True
+
+    assert mgr.capture_blocked_remedy() is not None
+
+
+def test_a_broken_re_probe_does_not_log_a_recovery_it_never_saw(caplog):
+    """That line is the only record that a user's install landed; support reads
+    it to answer exactly that question."""
+    caplog.set_level("INFO")
+    mgr = _mgr()
+    with _probe(MISSING):
+        mgr._rosetta_missing()
+    mgr._rosetta_missing_cached = None
+    with _probe(OSError("EAGAIN")):
+        mgr._rosetta_missing()
+    assert not [r for r in caplog.records if "now available" in r.message]
+
+
+def test_a_broken_FIRST_probe_still_fails_open(caplog):
+    """The control. With no conclusive answer on record a broken probe must
+    still fail toward attempting the start -- refusing there would stop capture
+    on a healthy Mac, which is the harm the original behaviour prevented."""
+    caplog.set_level("INFO")
+    mgr = _mgr()
+    with _probe(OSError("EAGAIN")):
+        assert mgr._rosetta_missing() is False
+    assert not [r for r in caplog.records if "now available" in r.message]
+
+
+def test_rosetta_genuinely_appearing_is_still_noticed():
+    """The carry must not pin the old answer forever."""
+    mgr = _mgr()
+    with _probe(MISSING):
+        assert mgr._rosetta_missing() is True
+    mgr._rosetta_missing_cached = None
+    with _probe(PRESENT):
+        assert mgr._rosetta_missing() is False
+    assert mgr._rosetta_missing_conclusive is False


### PR DESCRIPTION
Two findings from the pre-merge gate on #213 that did not make it into the merge. The messaging half landed; these did not, and the first one lets that fix re-introduce the bug it was written for.

## 1. A broken re-probe throws away an answer we already had

`_rosetta_missing()` collapses every probe failure into "assuming available":

```python
except Exception as e:
    logger.warning("Rosetta probe failed, assuming available: %s", e)
    missing = False
```

That was defensible while the memo was written once per process — the cost was one wasted spawn the EBADARCH handler catches. #213 changed the premise: `force_restart()` now clears the memo every `ROSETTA_REPROBE_INTERVAL`, and the force_restart cadence on a capture-dead device is every 60 seconds indefinitely. So on an affected Mac this path runs roughly **288 times a day, forever**, and each run is a fresh chance for a fork refusal — `EAGAIN`, `EMFILE`, or the 10s `TimeoutExpired`, all `Exception` subclasses — to replace a known "missing" with a guess.

Reproduced against `origin/main`:

```
state 1  memo = True    remedy = 'Not recording — Rosetta 2 required. Open Terminal and run: …'
state 2  _rosetta_missing() = False   memo = False   remedy = None
false RECOVERY log emitted: True
 -> "Rosetta 2 is now available — Capture should resume on this cycle."
```

Two harms, both on the surfaces #188 exists for. `capture_blocked_remedy()` returns `None`, so `_tracker_fault_message()` falls back and the tray reverts to **"ActivityWatch not responding"** — the exact string #188 was filed to delete. And `_rosetta_logged` flips, so the log records a recovery on a machine where nothing changed, on the line the docstring says support reads to answer precisely that question.

The fix carries the last **conclusive** answer forward and guesses only when there has never been one. That is the same `determined` vs `conclusive` split `machine_arch.ProbeResult` already makes, and for the same stated reason — an EMFILE fork failure must not masquerade as a hardware answer. `_rosetta_missing_conclusive` is deliberately not cleared by `force_restart`: its whole job is to survive the memo.

Note this survives #217. That PR rewrites the gating so a native-arm64 install never reaches `_rosetta_missing()` at all, which is the right design — but `_rosetta_required()` still calls it whenever the bundled trackers are x86_64, so the defect stays reachable until every device is on native binaries.

## 2. The tray re-derives the process architecture it was just given a helper for

`arch_menu_label` renders the process architecture in its could-not-determine row via a second inline `platform.machine()`, on the PR that introduced `process_arch()`. The function's own docstring already states the rule for the hardware arch — *"never re-derived here … a second copy of the mapping is how the tray ends up naming one architecture while the updater downloads another."* This applies it to the field added beside it.

## Verification

Proof-of-failure handshake, implementation reverted to `origin/main` with the new tests in place:

```
PRE-FIX   4 failed, 1 passed
POST-FIX  5 passed
```

The one that passes pre-fix is the control — a broken **first** probe must still fail open, because refusing there would stop capture on a healthy Mac, which is the harm the original behaviour prevented. Only the defect-specific cases go red.

Mutation matrix, one mutant per mechanism, full suite each time:

| mutant | reddens |
|---|---|
| carry → `missing = False` | `test_a_broken_re_probe_keeps_the_answer_it_already_had` + the recovery-log test |
| drop the conclusive record | those two plus `test_rosetta_genuinely_appearing_is_still_noticed` |
| tray → `platform.machine()` | `test_the_tray_reads_process_arch_rather_than_re_deriving_it` |
| control (unmutated) | **1946 passed, 1 skipped** |

## Notes for #217

`git merge-tree` says this and `fix/216-native-arm64-trackers` merge **clean** — the exception handler and `tray.py` are untouched by that branch. The new tests are in their own file, `tests/test_rosetta_probe_carry.py`, rather than appended to `test_aw_manager_rosetta_preflight.py`, precisely so #217's 135-line rewrite of that file does not inherit a conflict.

One finding from the same gate is **not** included: the backed-off download return at `aw_manager.py:1138` still returns a bare `server_already_running` without clearing the latch or setting `_using_external`, while the three sibling sites now clear it. It sits inside `_start_locked`, which #217 rewrites heavily, so it belongs after that lands rather than in a race with it. Filed separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
