### PR TITLE
Keep old incidents reachable when the log rotates

### DIFF
--- a/src/sync/sync_engine.py
+++ b/src/sync/sync_engine.py
@@ -4032,7 +4032,7 @@ class SyncEngine:
         except Exception as e:
             logger.debug("logs_requested: could not resolve log dir: %s", e)
             return
-        log_tail = self._read_log_tail(log_dir / "betterflow.log")
+        log_tail = self._read_rotated_log_tail(log_dir / "betterflow.log")
         if not log_tail:
             # WARNING (not debug) so the next successful upload carries a record
             # of why earlier ones were skipped — the admin's flag stays set and
@@ -4172,6 +4172,60 @@ class SyncEngine:
             return None
         # Re-encode so the result is always valid UTF-8 the server can store.
         return raw.decode("utf-8", errors="replace").encode("utf-8")
+
+    @staticmethod
+    def _read_rotated_log_tail(path, max_bytes: int = 512 * 1024) -> bytes:
+        """The last ``max_bytes`` of the LOGICAL log, spanning rotations.
+
+        ``_read_log_tail`` reads one file. ``setup_logging`` configures
+        ``RotatingFileHandler(maxBytes=5 MiB, backupCount=3)``, so up to ~20 MB
+        of history sits beside it in ``betterflow.log.1/.2/.3`` and none of it
+        was ever uploaded — the moment the live file rotated, an incident became
+        unreachable by any means we have.
+
+        #225, and it cost a real answer: a capture from device 14 on 2026-08-25
+        covered only that day, so the line that would have settled #211's
+        diagnosis (2026-08-23) was gone and the fix shipped marked *inferred*.
+
+        This deliberately costs nothing from the trade-offs #225 weighed. The
+        budget is unchanged, so the payload cannot grow. The server still gets
+        one ``log`` file, so the contract is unchanged. Nothing new is written to
+        disk. It only fills the SAME budget from further back when the live file
+        does not fill it alone — which is exactly the post-rotation state that
+        lost the evidence.
+
+        When ``betterflow.log`` already exceeds the budget the result is
+        byte-identical to reading it alone, so the common case on every device in
+        the fleet is untouched.
+
+        Returns oldest-first so a reader can follow it, and ``b""`` when there is
+        nothing — callers use ``if not tail``, which is unchanged.
+        """
+        from pathlib import Path as _Path
+
+        live = _Path(path)
+        # Newest first, taking each file's own tail; reversed at the end.
+        candidates = [live] + [
+            _Path(f"{live}.{i}") for i in range(1, 4)
+        ]
+
+        chunks: list[bytes] = []
+        remaining = max_bytes
+        for candidate in candidates:
+            if remaining <= 0:
+                break
+            # _read_log_tail already normalises each chunk to valid UTF-8, so the
+            # concatenation is valid too. One invalid byte makes the server's
+            # INSERT fail with MySQL 1366 and drops the whole upload silently.
+            part = SyncEngine._read_log_tail(candidate, remaining)
+            if not part:
+                # None (unreadable) and b"" (empty) both just mean "nothing here";
+                # keep going, because one bad rotation must not cost us the rest.
+                continue
+            chunks.append(part)
+            remaining -= len(part)
+
+        return b"".join(reversed(chunks))
 
     @staticmethod
     def _version_below(current: str, minimum: str) -> bool:

--- a/tests/test_log_tail_spans_rotation.py
+++ b/tests/test_log_tail_spans_rotation.py
@@ -129,3 +129,37 @@ def test_the_result_is_valid_utf8(tmp_path):
 
     tail.decode("utf-8")  # must not raise
     assert b"old" in tail and b"new" in tail
+
+
+# ── The callsite, which the helper tests cannot speak for ────────────────
+
+
+def test_the_upload_path_actually_sends_the_rotated_history(tmp_path, monkeypatch):
+    """Phantom 3, caught by mutation: every test above calls
+    `_read_rotated_log_tail` directly, so reverting the CALLER back to
+    `_read_log_tail` left all nine green. The whole fix could ship inert on the
+    fleet and nothing here would notice.
+
+    This drives `_upload_requested_logs` and asserts on the bytes handed to
+    `bf.upload_logs` — the actual payload, not the helper's return value.
+    """
+    from unittest.mock import MagicMock
+
+    from src.sync.sync_engine import SyncEngine
+
+    (tmp_path / "betterflow.log.1").write_bytes(b"OLD-INCIDENT\n")
+    (tmp_path / "betterflow.log").write_bytes(b"today\n")
+
+    engine = SyncEngine.__new__(SyncEngine)  # no __init__: this method needs two attrs
+    engine.config = MagicMock()
+    engine.config.get_log_dir.return_value = tmp_path
+    engine.bf = MagicMock()
+
+    engine._upload_requested_logs()
+
+    engine.bf.upload_logs.assert_called_once()
+    sent = engine.bf.upload_logs.call_args[0][0]
+    assert b"OLD-INCIDENT" in sent, (
+        "the upload path still reads only the live file — the fix is inert"
+    )
+    assert b"today" in sent

--- a/tests/test_log_tail_spans_rotation.py
+++ b/tests/test_log_tail_spans_rotation.py
@@ -1,0 +1,131 @@
+"""#225: the upload stopped at the rotation boundary, so old incidents were unreachable.
+
+The agent uploads `_read_log_tail(log_dir / "betterflow.log")` — the last 512 KB
+of the CURRENT file only. `setup_logging` configures
+`RotatingFileHandler(maxBytes=5 MiB, backupCount=3)`, so up to ~20 MB of history
+sits on disk in `betterflow.log.1/.2/.3` and none of it is ever sent.
+
+Cost, measured on 2026-08-25 while investigating #211: a capture from device 14
+covered only that day. The line that would have settled the diagnosis
+(`Extracted BetterFlow.app from DMG`, 2026-08-23) had rotated out, so the fix
+shipped with its mechanism marked *inferred* and that evidence is gone for good.
+
+The fix deliberately costs nothing from the trade-offs #225 listed. The budget is
+unchanged, so the payload cannot grow; the server still receives one `log` file,
+so the contract is unchanged; nothing new is written to disk. It only fills the
+SAME 512 KB from further back when the current file does not fill it on its own
+— which is exactly the state right after a rotation, and exactly the state that
+lost the #211 evidence.
+
+Consequence worth stating: when `betterflow.log` alone exceeds the budget the
+behaviour is byte-identical to before. `test_a_full_current_log_is_unchanged`
+pins that, because a "fix" that changed the common case would be a payload
+regression on every device in the fleet.
+"""
+
+from __future__ import annotations
+
+from src.sync.sync_engine import SyncEngine
+
+
+def _write(p, text):
+    p.write_bytes(text.encode("utf-8"))
+    return p
+
+
+def test_the_tail_reaches_back_into_the_rotated_file(tmp_path):
+    """THE defect. A small current log means the incident is one file back."""
+    _write(tmp_path / "betterflow.log.1", "OLD-INCIDENT-LINE\n")
+    _write(tmp_path / "betterflow.log", "today\n")
+
+    tail = SyncEngine._read_rotated_log_tail(tmp_path / "betterflow.log")
+
+    assert b"OLD-INCIDENT-LINE" in tail
+    assert b"today" in tail
+
+
+def test_the_oldest_content_comes_first(tmp_path):
+    """Chronological order, or a reader cannot follow it. `.2` is older than
+    `.1`, which is older than the live file."""
+    _write(tmp_path / "betterflow.log.2", "aaa\n")
+    _write(tmp_path / "betterflow.log.1", "bbb\n")
+    _write(tmp_path / "betterflow.log", "ccc\n")
+
+    tail = SyncEngine._read_rotated_log_tail(tmp_path / "betterflow.log")
+
+    assert tail == b"aaa\nbbb\nccc\n"
+
+
+def test_a_full_current_log_is_unchanged(tmp_path):
+    """The control, and the one that protects the fleet. When the live file
+    already fills the budget the result must be byte-identical to reading it
+    alone — otherwise this is a payload regression on every device."""
+    _write(tmp_path / "betterflow.log.1", "OLD\n")
+    _write(tmp_path / "betterflow.log", "x" * 4096)
+
+    spanning = SyncEngine._read_rotated_log_tail(tmp_path / "betterflow.log", max_bytes=1024)
+    single = SyncEngine._read_log_tail(tmp_path / "betterflow.log", max_bytes=1024)
+
+    assert spanning == single
+    assert b"OLD" not in spanning
+
+
+def test_it_never_exceeds_the_budget(tmp_path):
+    """The payload cap is the whole reason this fix is free. Four full files on
+    disk must still produce at most `max_bytes`."""
+    for name in ("betterflow.log.3", "betterflow.log.2", "betterflow.log.1", "betterflow.log"):
+        _write(tmp_path / name, "y" * 4096)
+
+    tail = SyncEngine._read_rotated_log_tail(tmp_path / "betterflow.log", max_bytes=1000)
+
+    assert len(tail) <= 1000
+
+
+def test_a_missing_rotation_is_not_an_error(tmp_path):
+    """The common case on a fresh install: no `.1` exists yet."""
+    _write(tmp_path / "betterflow.log", "only\n")
+
+    assert SyncEngine._read_rotated_log_tail(tmp_path / "betterflow.log") == b"only\n"
+
+
+def test_an_unreadable_rotation_does_not_lose_the_live_log(tmp_path):
+    """One bad file must not cost us the content we CAN read — the same
+    fail-soft posture `prune_old_logs` takes three functions away."""
+    _write(tmp_path / "betterflow.log", "live\n")
+    (tmp_path / "betterflow.log.1").mkdir()  # a directory where a file belongs
+
+    tail = SyncEngine._read_rotated_log_tail(tmp_path / "betterflow.log")
+
+    assert b"live" in tail
+
+
+def test_an_empty_live_log_still_yields_the_rotated_history(tmp_path):
+    """The exact post-rotation window. `betterflow.log` has just been recreated
+    and is empty; today the upload is skipped entirely and the caller logs
+    "empty/unreadable — skipping this cycle", so the request is burned and the
+    history one file back is never sent."""
+    _write(tmp_path / "betterflow.log.1", "INCIDENT\n")
+    _write(tmp_path / "betterflow.log", "")
+
+    tail = SyncEngine._read_rotated_log_tail(tmp_path / "betterflow.log")
+
+    assert b"INCIDENT" in tail
+
+
+def test_a_missing_live_log_is_still_none(tmp_path):
+    """No files at all reads as nothing, so the caller's `if not tail` guard
+    behaves exactly as before."""
+    assert not SyncEngine._read_rotated_log_tail(tmp_path / "betterflow.log")
+
+
+def test_the_result_is_valid_utf8(tmp_path):
+    """Each chunk is normalised before concatenation. Older Windows logs were
+    cp1252, and one invalid byte makes the server's INSERT fail with MySQL 1366
+    — silently dropping the whole upload."""
+    (tmp_path / "betterflow.log.1").write_bytes(b"caf\x97 old\n")
+    (tmp_path / "betterflow.log").write_bytes(b"caf\x97 new\n")
+
+    tail = SyncEngine._read_rotated_log_tail(tmp_path / "betterflow.log")
+
+    tail.decode("utf-8")  # must not raise
+    assert b"old" in tail and b"new" in tail


### PR DESCRIPTION
Closes #225 — the gap I hit while working #211, filed this session and fixed here.

## The problem

The agent uploads `_read_log_tail(log_dir / "betterflow.log")` — the last 512 KB of the **current** file. `setup_logging` configures `RotatingFileHandler(maxBytes=5 MiB, backupCount=3)`, so up to ~20 MB of history sits beside it in `betterflow.log.1/.2/.3` and none of it is ever sent. The moment the live file rotates, that incident is unreachable by any means we have.

It cost a real answer today. A capture from device 14 covered only 2026-08-25, so the line that would have settled #211's diagnosis — `Extracted BetterFlow.app from DMG`, 2026-08-23 — was gone. [#224](https://github.com/Better-Quality-Assurance/betterflow-sync/pull/224) shipped with its mechanism marked *inferred*, and that evidence no longer exists anywhere.

It's a silent gap: `freshness.status` reads `fresh` and is perfectly true — it measures when the upload happened, not what the upload covers.

## Why this fix is free

#225 listed four options and every one cost something: a bigger payload, a server contract change, more disk on every machine, or accepting a one-rotation horizon. This is a fifth that costs none of them.

- **The budget is unchanged** (512 KB), so the payload cannot grow.
- **The server still receives one `log` file**, so the contract is unchanged.
- **Nothing new is written to disk.**

It only fills the *same* budget from further back when the live file doesn't fill it alone — exactly the post-rotation state that lost the evidence.

**When `betterflow.log` already exceeds the budget the result is byte-identical to reading it alone.** `test_a_full_current_log_is_unchanged` asserts that against the original `_read_log_tail`, because a "fix" that changed the common case would be a payload regression on every device in the fleet.

## Two behaviours worth naming

- **Oldest-first**, so a reader can follow it.
- **An empty live log now still yields the rotated history.** Previously that window — `betterflow.log` just recreated, still empty — made the caller log *"empty/unreadable, skipping this cycle"* and burn the request. That is precisely the moment the history one file back is most wanted.

One bad rotation doesn't cost the rest: `_read_log_tail` returns `None` on `OSError` and the loop continues, matching the fail-soft posture `prune_old_logs` takes three functions away. Each chunk is normalised to valid UTF-8 before concatenation — one invalid byte makes the server's INSERT fail with MySQL 1366 and drops the whole upload silently.

## Mutation matrix

| mutant | witnesses |
|---|---|
| don't look at rotations (the defect) | 4 red, incl. `oldest_content_comes_first`, `empty_live_log_still_yields...` |
| newest-first output | `test_the_oldest_content_comes_first` |
| budget not decremented | `test_it_never_exceeds_the_budget`, `test_a_full_current_log_is_unchanged` |
| an unreadable rotation aborts the rest | `test_an_empty_live_log_still_yields_the_rotated_history` |
| **caller reverts to the single-file read** | `test_the_upload_path_actually_sends_the_rotated_history` |

That last one **survived the first matrix**. Every test called `_read_rotated_log_tail` directly, so reverting `_upload_requested_logs` back to `_read_log_tail` left all nine green — the fix could have shipped inert on the whole fleet and the suite would have said nothing. Phantom 3, the same shape that bit #218's wake/unlock re-asserts and #219's startup sweep. The callsite test asserts on the bytes handed to `bf.upload_logs`, not the helper's return value.

## Verification

- `pytest tests/` → **1956 passed, 1 skipped, exit 0**, run at load average 38. An earlier attempt was abandoned at load 315, where per `cross-repo-safety.md` Rule 7 the number describes the machine rather than the tree.
- `ruff` → `sync_engine.py` at baseline (7 errors, all pre-existing, identical to `origin/main`); the new test file clean.
- Not verified end to end against a real rotated device log — that needs a device to rotate and a capture request, ~5-7 minutes apart. The unit coverage drives the real `_upload_requested_logs` with real files on disk.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
