### PR TITLE
Cap the uploaded log tail at the budget it promises

### DIFF
--- a/src/sync/sync_engine.py
+++ b/src/sync/sync_engine.py
@@ -4188,11 +4188,23 @@ class SyncEngine:
         diagnosis (2026-08-23) was gone and the fix shipped marked *inferred*.
 
         This deliberately costs nothing from the trade-offs #225 weighed. The
-        budget is unchanged, so the payload cannot grow. The server still gets
-        one ``log`` file, so the contract is unchanged. Nothing new is written to
-        disk. It only fills the SAME budget from further back when the live file
-        does not fill it alone — which is exactly the post-rotation state that
-        lost the evidence.
+        budget is enforced on the RETURNED bytes, so the payload cannot grow. The
+        server still gets one ``log`` file, so the contract is unchanged. Nothing
+        new is written to disk. It only fills the SAME budget from further back
+        when the live file does not fill it alone — which is exactly the
+        post-rotation state that lost the evidence.
+
+        The final cap is not belt-and-braces. ``_read_log_tail`` normalises each
+        chunk with ``errors="replace"``, and U+FFFD is THREE bytes, so an invalid
+        byte expands 1→3 *after* the budget was decremented. Measured at the real
+        512 KB budget, a rotated file of invalid bytes returned **1,572,864** —
+        three times the cap. That matters twice over, because the server
+        (``AgentLogController``) enforces ``max:1024`` KB and hard-422s above it,
+        and ``logs_requested_at`` clears only on success, so the agent would
+        retry every heartbeat forever and the admin would never get logs. Below
+        that it silently keeps the LAST 512 KB — trimming from the opposite end
+        to the one we fill, which would discard exactly the rotated history this
+        function exists to deliver.
 
         When ``betterflow.log`` already exceeds the budget the result is
         byte-identical to reading it alone, so the common case on every device in
@@ -4201,12 +4213,12 @@ class SyncEngine:
         Returns oldest-first so a reader can follow it, and ``b""`` when there is
         nothing — callers use ``if not tail``, which is unchanged.
         """
-        from pathlib import Path as _Path
+        from pathlib import Path
 
-        live = _Path(path)
+        live = Path(path)
         # Newest first, taking each file's own tail; reversed at the end.
         candidates = [live] + [
-            _Path(f"{live}.{i}") for i in range(1, 4)
+            Path(f"{live}.{i}") for i in range(1, 4)
         ]
 
         chunks: list[bytes] = []
@@ -4225,7 +4237,20 @@ class SyncEngine:
             chunks.append(part)
             remaining -= len(part)
 
-        return b"".join(reversed(chunks))
+        joined = b"".join(reversed(chunks))
+        if len(joined) > max_bytes:
+            # Keep the NEWEST max_bytes — the same end the server keeps, so the
+            # two agree instead of the server silently trimming the other one.
+            joined = joined[-max_bytes:]
+            # A byte slice can land inside a multi-byte character. Drop leading
+            # continuation bytes (0x80-0xBF) so the result stays valid UTF-8 —
+            # one invalid byte makes the server's INSERT fail with MySQL 1366 and
+            # drops the whole upload.
+            i = 0
+            while i < len(joined) and 0x80 <= joined[i] < 0xC0:
+                i += 1
+            joined = joined[i:]
+        return joined
 
     @staticmethod
     def _version_below(current: str, minimum: str) -> bool:

--- a/tests/test_log_tail_spans_rotation.py
+++ b/tests/test_log_tail_spans_rotation.py
@@ -71,14 +71,53 @@ def test_a_full_current_log_is_unchanged(tmp_path):
 
 
 def test_it_never_exceeds_the_budget(tmp_path):
-    """The payload cap is the whole reason this fix is free. Four full files on
-    disk must still produce at most `max_bytes`."""
-    for name in ("betterflow.log.3", "betterflow.log.2", "betterflow.log.1", "betterflow.log"):
+    """The payload cap is the whole reason this fix is free.
+
+    The live file is deliberately SMALLER than the budget. An earlier version
+    made all four files 4096 bytes against a 1000-byte budget, so the live file
+    filled it alone, the loop broke after one iteration and no cross-file
+    accounting ever ran — a mutant giving every file the full cap survived it.
+    Phantom 16: the fixture sat where correct and wrong agree.
+    """
+    for name in ("betterflow.log.3", "betterflow.log.2", "betterflow.log.1"):
         _write(tmp_path / name, "y" * 4096)
+    _write(tmp_path / "betterflow.log", "today\n")
 
     tail = SyncEngine._read_rotated_log_tail(tmp_path / "betterflow.log", max_bytes=1000)
 
     assert len(tail) <= 1000
+
+
+def test_replacement_expansion_cannot_burst_the_budget(tmp_path):
+    """`_read_log_tail` normalises with errors="replace" and U+FFFD is THREE
+    bytes, so an invalid byte expands 1->3 AFTER the budget was decremented.
+
+    Measured at the real 512 KB budget before this was capped: a rotated file of
+    invalid bytes returned 1,572,864 bytes. The server enforces max:1024 KB and
+    hard-422s above it, and `logs_requested_at` clears only on success — so the
+    agent would retry every heartbeat forever and the admin would never get
+    logs. Below that it keeps the LAST 512 KB, trimming the opposite end to the
+    one we fill, discarding the rotated history this function exists to deliver.
+    """
+    (tmp_path / "betterflow.log.1").write_bytes(b"\x97" * 4096)
+    _write(tmp_path / "betterflow.log", "today\n")
+
+    tail = SyncEngine._read_rotated_log_tail(tmp_path / "betterflow.log", max_bytes=1000)
+
+    assert len(tail) <= 1000, f"expansion burst the cap: {len(tail)} bytes"
+    tail.decode("utf-8")  # the trim must not cut a character in half
+
+
+def test_the_trim_keeps_the_newest_end(tmp_path):
+    """When the cap bites, keep the same end the server keeps. Trimming the
+    other one would leave agent and server discarding different halves."""
+    _write(tmp_path / "betterflow.log.1", "OLDEST-" + "o" * 2000)
+    _write(tmp_path / "betterflow.log", "NEWEST-LINE\n")
+
+    tail = SyncEngine._read_rotated_log_tail(tmp_path / "betterflow.log", max_bytes=500)
+
+    assert len(tail) <= 500
+    assert b"NEWEST-LINE" in tail
 
 
 def test_a_missing_rotation_is_not_an_error(tmp_path):


### PR DESCRIPTION
**`main` is currently shipping the bug this fixes.** PR #226 merged without its final commit — see below — so the rotation-spanning tail landed with no cap on the returned bytes.

Reproduced against `origin/main` just now:

```
origin/main returns 1,572,864 bytes for a 524,288 budget
server hard limit is 1,048,576 -> 422, retried every heartbeat forever
```

## The defect

`_read_log_tail` normalises each chunk with `errors="replace"`, and U+FFFD is **three bytes** — so an invalid byte expands 1→3 *after* `remaining` was decremented, and the final chunk was never capped against the return value.

Measured at the real 512 KB budget:

| corpus | before | after |
|---|---|---|
| 512K invalid bytes | 1,572,864 | 524,286 |
| 512K mostly-ASCII cp1252 | 606,208 | 524,288 |
| 512K ASCII + 1 bad byte | 524,290 | 524,288 |

All three now decode as valid UTF-8.

It matters twice over, and a reviewer checked the server rather than assuming. `AgentLogController` enforces `max:1024` KB and hard-422s above it, while `logs_requested_at` clears **only on success** — so the agent retries every heartbeat forever and the admin never gets logs. Below that the server keeps the **last** 512 KB, trimming the opposite end to the one we fill, which would silently discard exactly the rotated history #225 exists to deliver.

The cap therefore keeps the **newest** `max_bytes` — the same end the server keeps, so the two agree instead of the server quietly trimming the other one — and drops leading continuation bytes so a byte slice cannot cut a character in half.

## The test that could not see it

`test_it_never_exceeds_the_budget` wrote four 4096-byte files against a 1000-byte budget, so the **live** file filled the budget alone, the loop broke after one iteration, and no cross-file accounting ever ran. A mutant giving every file the full cap survived it. Phantom 16 — the fixture sat where correct and wrong agree. The live file is now smaller than the budget, plus two new tests for the expansion burst and which end the trim keeps.

## How this escaped #226

The commit existed locally and was never pushed. The merge took `origin`'s HEAD, which lacked it. That is `cross-repo-safety.md` Rule 8's corollary — *the branch you merge is the one on origin, not the one you verified* — and I walked into it with the rule written down.

It was caught by verifying the merge **by content on `origin/main`** rather than by the merge command's exit code. Had I trusted the green tick and the `MERGED` state, this would have shipped silently and #225 would be sitting closed over a live bug.

Guard applied here: `local == origin` asserted before opening this PR.

## Verification

- `pytest tests/` → **1977 passed, 1 skipped, exit 0** (load 111, so slow at 110s; the count is what matters).
- `ruff` → `sync_engine.py` at baseline (7 = 7), new test file clean.
- Overshoot reproduced against `origin/main` and re-measured as fixed here.

Refs #225 (closed by #226, but its fix was incomplete on `main` until this lands).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
