### PR TITLE
Record whether the session greeting was actually delivered (#220)

### DIFF
--- a/src/main.py
+++ b/src/main.py
@@ -2754,6 +2754,45 @@ class BetterFlowApp:
     def _ensure_update_checks_started(self) -> None:
         self.update_handler.ensure_update_checks_started()
 
+    def _announce_session(self, state, *, cold_launch: bool) -> None:
+        """Tell the user they are logged in, and record whether that arrived.
+
+        This notification is the only signal a user gets that BetterFlow
+        started and is tracking them. When it silently does not arrive the
+        app is indistinguishable from one that never launched, and #220
+        found the deeper cost: the caller threw away the delivery outcome
+        #204 added, so support could not tell "macOS suppressed it" from
+        "the code path never ran". send_notification never raises and
+        never lies -- it returns the strongest claim the platform
+        supports -- so the only way to get a silent failure here is to
+        discard what it said.
+
+        Four login paths used to build this notification inline, three of
+        them byte-identical, so a fix to one reached none of the others.
+        """
+        first_name = (state.user_name or "").split()[0] if state.user_name else ""
+        if cold_launch:
+            title = f"{_greeting()}, {first_name}!" if first_name else f"{_greeting()}!"
+        else:
+            # A resumed session, not a cold launch: "Welcome back" rather
+            # than the time-of-day launch greeting.
+            title = f"Welcome back, {first_name}!" if first_name else "Welcome back!"
+
+        outcome = send_notification(title, _day_greeting())
+        # NotificationOutcome.__bool__ is truthy ONLY for a verified
+        # delivery, so this cannot read FAILED as success.
+        if outcome:
+            logger.info(
+                "Session greeting delivered (not proof the user saw it)"
+            )
+        else:
+            logger.warning(
+                "Session greeting NOT delivered (%s) -- the user has no "
+                "confirmation that BetterFlow started or that tracking is "
+                "running",
+                outcome.name,
+            )
+
     def _finish_logged_in_startup(
         self,
         state,
@@ -2786,9 +2825,7 @@ class BetterFlowApp:
         self._ensure_update_checks_started()
 
         if send_greeting:
-            first_name = (state.user_name or "").split()[0] if state.user_name else ""
-            greeting = f"{_greeting()}, {first_name}!" if first_name else f"{_greeting()}!"
-            send_notification(greeting, _day_greeting())
+            self._announce_session(state, cold_launch=True)
 
     def _background_startup(self, wizard_login_state=None) -> None:
         """Restore session and services without delaying tray visibility."""
@@ -2900,9 +2937,7 @@ class BetterFlowApp:
                     # "Welcome back" convention as the manual re-login path
                     # (do_browser_login), not the time-of-day launch greeting.
                     self._finish_logged_in_startup(state, send_greeting=False)
-                    first_name = (state.user_name or "").split()[0] if state.user_name else ""
-                    greeting = f"Welcome back, {first_name}!" if first_name else "Welcome back!"
-                    send_notification(greeting, _day_greeting())
+                    self._announce_session(state, cold_launch=False)
                     return
                 if not getattr(state, "transient", False):
                     # Credentials are genuinely gone now — prompt re-auth. This
@@ -3488,9 +3523,7 @@ class BetterFlowApp:
                         send_greeting=False,
                         initial_permissions_delay_seconds=1.0,
                     )
-                    first_name = (state.user_name or "").split()[0] if state.user_name else ""
-                    greeting = f"Welcome back, {first_name}!" if first_name else "Welcome back!"
-                    send_notification(greeting, _day_greeting())
+                    self._announce_session(state, cold_launch=False)
                 else:
                     self.coordinator.logged_in = False
                     error = state.error or "Login failed"
@@ -3889,9 +3922,7 @@ class BetterFlowApp:
                     send_greeting=False,
                     initial_permissions_delay_seconds=1.0,
                 )
-                first_name = (state.user_name or "").split()[0] if state.user_name else ""
-                greeting = f"Welcome back, {first_name}!" if first_name else "Welcome back!"
-                send_notification(greeting, _day_greeting())
+                self._announce_session(state, cold_launch=False)
             else:
                 self.coordinator.logged_in = False
                 error = state.error or "Login failed"

--- a/tests/test_startup_greeting_delivery.py
+++ b/tests/test_startup_greeting_delivery.py
@@ -1,0 +1,131 @@
+"""The session greeting must report whether it actually arrived (#220).
+
+The greeting is the only signal a user gets that BetterFlow started and is
+tracking them. Before this fix all four login paths called
+``send_notification(...)`` and dropped the return value, so a greeting macOS
+suppressed and one it presented were indistinguishable from the logs -- the
+field report ("good morning notification not sent on opening") could not be
+investigated at all, because the grep for it returns 0 across the whole log
+history whether it worked or not.
+
+#204 added the delivery outcome precisely so a caller could tell. These tests
+pin that this caller reads it.
+"""
+
+import logging
+import re
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+from src.main import BetterFlowApp
+from src.notifications import NotificationOutcome
+
+
+def _app() -> BetterFlowApp:
+    return BetterFlowApp.__new__(BetterFlowApp)
+
+
+def _state(name="Timea Pop"):
+    s = MagicMock()
+    s.user_name = name
+    return s
+
+
+class TestGreetingReportsItsOwnDelivery:
+    def test_undelivered_greeting_is_logged_with_the_outcome(self, caplog):
+        """The whole point: a greeting that did not arrive must say so."""
+        app = _app()
+        with caplog.at_level(logging.DEBUG), patch(
+            "src.main.send_notification",
+            return_value=NotificationOutcome.SUPPRESSED,
+        ) as send:
+            app._announce_session(_state(), cold_launch=True)
+
+        # Precondition: the subject was actually reached. Without this the
+        # assertions below pass just as well when nothing ran at all.
+        assert send.call_count == 1, "fixture never reached send_notification"
+
+        warnings = [r for r in caplog.records if r.levelno >= logging.WARNING]
+        assert warnings, "an undelivered greeting logged nothing -- #220"
+        assert "suppressed" in warnings[0].getMessage().lower(), (
+            "the log must name WHICH outcome, or support still cannot tell "
+            "a suppressed notification from a broken code path"
+        )
+
+    def test_failed_greeting_is_not_read_as_success(self, caplog):
+        """FAILED is falsy via NotificationOutcome.__bool__ -- pin that here,
+        because `if send_notification(...)` on a bare Enum would be truthy."""
+        app = _app()
+        with caplog.at_level(logging.DEBUG), patch(
+            "src.main.send_notification", return_value=NotificationOutcome.FAILED
+        ):
+            app._announce_session(_state(), cold_launch=False)
+        assert [r for r in caplog.records if r.levelno >= logging.WARNING]
+
+    def test_delivered_greeting_is_recorded_too(self, caplog):
+        """A silent success is the other half of an uninvestigable failure."""
+        app = _app()
+        with caplog.at_level(logging.DEBUG), patch(
+            "src.main.send_notification", return_value=NotificationOutcome.DELIVERED
+        ):
+            app._announce_session(_state(), cold_launch=True)
+
+        msgs = " ".join(r.getMessage() for r in caplog.records)
+        assert "delivered" in msgs.lower()
+        assert not [r for r in caplog.records if r.levelno >= logging.WARNING], (
+            "a delivered greeting must not warn"
+        )
+
+
+class TestGreetingWording:
+    def test_cold_launch_uses_the_time_of_day_greeting(self):
+        app = _app()
+        with patch(
+            "src.main.send_notification", return_value=NotificationOutcome.DELIVERED
+        ) as send:
+            app._announce_session(_state("Timea Pop"), cold_launch=True)
+        title = send.call_args[0][0]
+        assert "Timea" in title
+        assert "Welcome back" not in title
+
+    def test_resumed_session_says_welcome_back(self):
+        app = _app()
+        with patch(
+            "src.main.send_notification", return_value=NotificationOutcome.DELIVERED
+        ) as send:
+            app._announce_session(_state("Timea Pop"), cold_launch=False)
+        assert send.call_args[0][0] == "Welcome back, Timea!"
+
+    def test_missing_name_does_not_produce_a_dangling_comma(self):
+        app = _app()
+        with patch(
+            "src.main.send_notification", return_value=NotificationOutcome.DELIVERED
+        ) as send:
+            app._announce_session(_state(None), cold_launch=False)
+        assert send.call_args[0][0] == "Welcome back!"
+
+
+class TestNoLoginPathRerollsTheGreeting:
+    """Callsite guard (one-rule-one-implementation).
+
+    The extraction only helps if every login path uses it. Three of the four
+    sites were byte-identical copies, so a fix to one reached none of the
+    others -- that is the shape this guard exists to stop coming back.
+    """
+
+    def test_no_inline_greeting_send_survives_in_main(self):
+        src = Path(__file__).resolve().parents[1] / "src" / "main.py"
+        # Skip comment lines rather than regex-stripping comment BLOCKS: a
+        # path glob inside a `#` comment would open a block that never closes.
+        code = "\n".join(
+            l for l in src.read_text().splitlines() if not l.strip().startswith("#")
+        )
+        assert not re.search(r"send_notification\(\s*greeting\b", code), (
+            "a login path is building the greeting inline again instead of "
+            "calling _announce_session, so its delivery outcome is dropped"
+        )
+        # Control: the guard must be able to SEE greeting sends at all.
+        assert "_announce_session(" in code
+        assert code.count("self._announce_session(") == 4, (
+            "expected all four login paths to route through the helper"
+        )


### PR DESCRIPTION
## What this fixes

The session greeting is the only signal a user gets that BetterFlow started
and is tracking them. All four login paths called `send_notification(...)`
and discarded the return value, so the field report of 2026-08-25 ("good
morning notification not sent on opening") was **uninvestigable**: the log
grep returns `0` across the whole history whether the notification was
presented, suppressed by macOS, or never attempted.

#204 added `NotificationOutcome` for exactly this. This caller threw it away.

## Scope — read this before merging

This makes the failure **visible**. It does **not** claim to fix delivery.
The cause of the field report stays UNDETERMINED until a log from an
affected machine says which outcome it hit. Merging this is what makes that
log exist.

## Also collapsed a triplication

Three of the four greeting sites were byte-identical copies of the same
three lines, so a fix to one would have reached none of the others. All four
now route through `_announce_session(state, cold_launch=)`.

## Verification

| check | result |
|---|---|
| new tests pre-fix (`git show origin/main:src/main.py`) | **7 failed** |
| new tests post-fix | 7 passed |
| consequence mutant — helper still sends, outcome no longer read | **kills 3 named tests**, the 4 wording/callsite tests correctly stay green |
| full suite | 2025 passed, 1 skipped, 0 failed |
| CI replicated locally (`pytest tests/`, `verify_tracker_pins.py`) | both green, exit 0 |

The mutation matrix is the load-bearing one: 6 of the 7 tests fail pre-fix
only because the new helper does not exist yet, which is a spec rather than
a proof. The consequence mutant is what shows the outcome-reading itself is
witnessed.

`NotificationOutcome.__bool__` is truthy only for `DELIVERED`, so `if
outcome:` cannot read `FAILED` as success.

## Not covered

31 of 33 `send_notification` call sites still discard the outcome. That is
mostly **deliberate** — #204's design says only callers carrying an
instruction the agent cannot otherwise deliver must read it. This PR moves
the greeting into that category because it carries the tracking
confirmation, and leaves routine notices (Update, Tracking Paused) alone.
