### PR TITLE
Read source as UTF-8 in every guard that scans it

### DIFF
--- a/tests/test_disclosure_baseline.py
+++ b/tests/test_disclosure_baseline.py
@@ -464,7 +464,7 @@ def test_heartbeat_egress_allowlist_still_holds():
 
 
 def test_hostname_is_still_embedded_in_every_bucket_id():
-    source = (_SRC / "sync" / "sync_engine.py").read_text()
+    source = (_SRC / "sync" / "sync_engine.py").read_text(encoding="utf-8")
 
     reads_hostname = "self._hostname = socket.gethostname()" in source
     in_bucket_ids = 'bucket_id": f"' in source and "{self._hostname}" in source
@@ -512,7 +512,7 @@ def test_the_baseline_points_at_the_regulament():
     """Greppable from both ends: someone reading the Regulament must be able to
     find the code, and someone reading the code must be able to find the
     Regulament."""
-    text = (_SRC / "disclosure_baseline.py").read_text()
+    text = (_SRC / "disclosure_baseline.py").read_text(encoding="utf-8")
     assert REGULAMENT_ARTICLE in text
     assert DISCLOSURE_CONTACT in text
     assert "art. 68^1" in REGULAMENT_ARTICLE

--- a/tests/test_project_stamp_single_source.py
+++ b/tests/test_project_stamp_single_source.py
@@ -24,8 +24,8 @@ import src.sync.sync_engine as mod
 from src.config import Config
 from src.sync.sync_engine import SyncEngine
 
-_SOURCE = Path(mod.__file__).read_text()
-_AFK_SOURCE = Path(afk_mod.__file__).read_text()
+_SOURCE = Path(mod.__file__).read_text(encoding="utf-8")
+_AFK_SOURCE = Path(afk_mod.__file__).read_text(encoding="utf-8")
 
 
 def test_current_project_is_read_in_exactly_one_place():

--- a/tests/test_server_config_deferral_and_refetch.py
+++ b/tests/test_server_config_deferral_and_refetch.py
@@ -406,7 +406,7 @@ def test_logging_is_configured_before_config_is_loaded():
     import ast
     from pathlib import Path
 
-    src = (Path(__file__).resolve().parents[1] / "src" / "main.py").read_text()
+    src = (Path(__file__).resolve().parents[1] / "src" / "main.py").read_text(encoding="utf-8")
     tree = ast.parse(src)
 
     init = next(

--- a/tests/test_stale_app_copy_cleanup.py
+++ b/tests/test_stale_app_copy_cleanup.py
@@ -325,7 +325,7 @@ def test_the_identity_macos_knows_us_by_is_written_once_per_reason():
 
     assert permissions._BUNDLE_ID == BUNDLE_ID, "same concept, must agree"
 
-    spec = (Path(__file__).parent.parent / "build.spec").read_text()
+    spec = (Path(__file__).parent.parent / "build.spec").read_text(encoding="utf-8")
 
     # The bundle NAME is a second authority, and this branch made it
     # load-bearing: _CANONICAL_STEM is the switch deciding whether the sweep

--- a/tests/test_startup_greeting_delivery.py
+++ b/tests/test_startup_greeting_delivery.py
@@ -118,7 +118,7 @@ class TestNoLoginPathRerollsTheGreeting:
         # Skip comment lines rather than regex-stripping comment BLOCKS: a
         # path glob inside a `#` comment would open a block that never closes.
         code = "\n".join(
-            l for l in src.read_text().splitlines() if not l.strip().startswith("#")
+            l for l in src.read_text(encoding="utf-8").splitlines() if not l.strip().startswith("#")
         )
         assert not re.search(r"send_notification\(\s*greeting\b", code), (
             "a login path is building the greeting inline again instead of "


### PR DESCRIPTION
Closes #231

## What this is

Seven `Path.read_text()` calls across five test files read source with no `encoding=`, so they use the platform default codec. On Windows that is cp1252.

This class already killed the **v1.5.126-beta.1 Windows leg**. `65858e2` fixed the sites that existed then and stated the convention held "everywhere else in tests/" — a census says 20 encoding-less against 8 with. #220 merged two hours later and added one more.

## The one that matters is not the one #231 names

`tests/test_project_stamp_single_source.py` reads at **module level**, so it fails during **collection** and aborts the whole suite before any test runs.

## Proof of failure

`PYTHONUTF8=0 LC_ALL=C` forces a non-UTF-8 platform default on macOS, reproducing the mechanism (US-ASCII rather than cp1252's exact byte set):

| | result |
|---|---|
| pre-fix, forced codec | **1 error during collection, 0 tests ran, exit 2** |
| post-fix, forced codec | 2025 passed, 1 skipped, exit 0 |
| post-fix, normal UTF-8 | 2025 passed, 1 skipped, exit 0 — no regression |

Pre-fix, the file #231 names fails alone at line 121 with `UnicodeDecodeError` while its other 6 tests pass, so the fault is the read and not the guard's logic.

## Scope

Only sites reading **source or generated text known to carry non-ASCII**. The `json.loads(tmp_path/...)` sites read test-authored files and are untouched; whether to close the whole convention stays the open question in #231.

## For whoever picks up the rest

**Em-dashes are not the trigger.** cp1252 maps every byte of `e2 80 94`, so they mojibake rather than raise. Only `0x81/0x8D/0x8F/0x90/0x9D` are undefined, and the trigger is any character whose UTF-8 encoding contains one (`✏` = `e2 9c 8f`, `ā` = `c4 81`). Chasing em-dashes makes this look like it does not reproduce.

## CI

The PR `test` job is ubuntu-only, so **no pull request and no macOS run can see this bug**. It surfaces only in the Windows leg of a tag build. Replicated CI locally: `pytest tests/` on Python 3.11. `verify-tracker-pins.yml` triggers on none of the touched paths.

🤖 Generated with [Claude Code](https://claude.com/claude-code)