### PR TITLE
Ask the server, not the socket, at the last two sites

### DIFF
--- a/src/aw_manager.py
+++ b/src/aw_manager.py
@@ -1531,7 +1531,16 @@ class AWManager:
         """Check if all managed components are still running."""
         with self._lifecycle_lock:
             if self._using_external:
-                return self._port_in_use()
+                # #215 — ASK THE SERVER, not the socket. A process holding port
+                # 5600 that no longer answers HTTP satisfies a bare TCP connect,
+                # so this branch used to report capture as healthy on a device
+                # recording nothing, and the fleet was told everything was fine.
+                #
+                # `_server_responding()` is the /api/0/info ask `_wait_for_server`
+                # already performs, extracted by PR 213 so the callers cannot
+                # drift. One request, 2s timeout — a health check is exactly the
+                # caller that should pay that.
+                return self._server_responding()
 
             if not self._processes:
                 return False
@@ -1996,10 +2005,22 @@ class AWManager:
                 if permanent else "",
             )
             if permanent:
+                # #215 — same conflation as check_health: a listener is not a
+                # capturing server, and this carve-out decides whether to tell
+                # the machine's owner their tracking is dead.
+                #
+                # Asked BEFORE the lock, deliberately. `_server_responding()`
+                # blocks for up to 2s and `_lifecycle_lock` is held across
+                # component lifecycle work, so doing it inside would hold the
+                # lock on an HTTP timeout. `_using_external` is read-mostly —
+                # it flips only when we adopt or abandon an external server —
+                # so reading it a moment early is a far better trade than a
+                # 2s network wait under the lock.
+                external_serving = self._using_external and self._server_responding()
                 with self._lifecycle_lock:
                     self._exec_failed_components.add(name)
                     self._managed_components_unavailable = True
-                    if self._using_external and self._port_in_use():
+                    if external_serving:
                         # Same carve-out the download-failure path makes: a
                         # server we attached to (never one we started — that
                         # leaves _using_external False) is still capturing on

--- a/tests/test_aw_manager_binary_cannot_execute.py
+++ b/tests/test_aw_manager_binary_cannot_execute.py
@@ -153,6 +153,7 @@ def test_an_attached_external_server_is_not_reported_as_a_blackout():
     with patch("src.aw_manager._resolve_binary_path", return_value="/fake/bf-window-tracker"), \
          patch("src.aw_manager.subprocess.Popen", side_effect=exc), \
          patch.object(mgr, "_port_in_use", return_value=True), \
+         patch.object(mgr, "_server_responding", return_value=True), \
          patch.object(mgr, "_dispatch_download_failure_report") as dispatch:
         started = mgr._start_component("bf-window-tracker", "/fake")
 
@@ -164,8 +165,14 @@ def test_an_attached_external_server_is_not_reported_as_a_blackout():
 
 def test_a_stale_external_flag_still_reports_the_blackout():
     # _using_external is only refreshed on the health tick, so it can outlive
-    # the server it describes. Fall back to the live port check: no listener
+    # the server it describes. Fall back to the live check: nothing SERVING
     # means nothing is capturing and the user must be told.
+    #
+    # #215 — this asks _server_responding now, not _port_in_use. Both are pinned
+    # here deliberately: a bare listener that no longer answers /api/0/info is
+    # exactly the case the old probe could not see, and leaving _server_responding
+    # unpatched let this test reach a real ActivityWatch on the developer's own
+    # machine and pass or fail on whether one happened to be running.
     mgr = _mgr()
     mgr._using_external = True
     exc = OSError(EBADARCH, "Bad CPU type in executable")
@@ -173,6 +180,7 @@ def test_a_stale_external_flag_still_reports_the_blackout():
     with patch("src.aw_manager._resolve_binary_path", return_value="/fake/bf-window-tracker"), \
          patch("src.aw_manager.subprocess.Popen", side_effect=exc), \
          patch.object(mgr, "_port_in_use", return_value=False), \
+         patch.object(mgr, "_server_responding", return_value=False), \
          patch.object(mgr, "_dispatch_download_failure_report") as dispatch:
         mgr._start_component("bf-window-tracker", "/fake")
 

--- a/tests/test_aw_manager_listener_is_not_a_server.py
+++ b/tests/test_aw_manager_listener_is_not_a_server.py
@@ -1,0 +1,115 @@
+"""A listener on port 5600 is not a capturing tracker server. Issue #215.
+
+Two sites decided "an external server is healthy" from ``_port_in_use()`` — a
+bare TCP connect. A process that holds the port and no longer answers HTTP
+satisfies that, so the agent reported capture as healthy on a device recording
+nothing, and the fleet was told everything was fine. PR 213 fixed the third
+instance of the same conflation and extracted ``_server_responding()``.
+
+WHY THESE FIXTURES LOOK ODD, and it is the point. Issue #215 records that
+``_port_in_use`` is supplied by fixtures at six existing test sites, and that at
+every one the surrounding prose calls it "external server healthy" or
+"capturing" — a claim a TCP connect cannot support. Every one of those supplies
+the boolean production computes, so **no test in the suite could distinguish a
+serving ActivityWatch from a dead socket**, and fixing the code without changing
+how it is tested would have left that gap intact.
+
+So every case below pins the two probes to DIFFERENT answers:
+
+    _port_in_use       True   <- something holds the socket
+    _server_responding False  <- but no tracker answers /api/0/info
+
+That divergence is the whole test. A fixture where both agree cannot fail
+against the old code.
+"""
+
+import errno
+from unittest.mock import patch
+
+from src.aw_manager import AWManager
+
+
+def _mgr() -> AWManager:
+    mgr = AWManager(aw_port=5600)
+    mgr.tracker_download_failed = False
+    mgr._rosetta_missing_cached = None
+    mgr._rosetta_notified = False
+    return mgr
+
+
+def _dead_socket():
+    """The case the old code could not see: port accepts, server does not answer."""
+    return (
+        patch.object(AWManager, "_port_in_use", return_value=True),
+        patch.object(AWManager, "_server_responding", return_value=False),
+    )
+
+
+def test_check_health_is_false_when_the_port_answers_but_the_server_does_not():
+    mgr = _mgr()
+    mgr._using_external = True
+
+    port, server = _dead_socket()
+    with port, server:
+        assert mgr.check_health() is False, (
+            "a bare listener was reported as a healthy external tracker"
+        )
+
+
+def test_check_health_is_true_when_the_server_actually_answers():
+    # Control. Without it the assertion above is satisfied by a method that
+    # always returns False.
+    mgr = _mgr()
+    mgr._using_external = True
+
+    with patch.object(AWManager, "_port_in_use", return_value=True), \
+         patch.object(AWManager, "_server_responding", return_value=True):
+        assert mgr.check_health() is True
+
+
+def test_exec_failure_latches_capture_dead_when_the_external_server_is_only_a_socket():
+    """The EBADARCH carve-out.
+
+    On Apple Silicon without Rosetta every managed tracker raises EBADARCH. The
+    carve-out exists so a device that is genuinely recording through an external
+    server is not told its tracking is dead. Against a dead socket that carve-out
+    fired anyway, and the person was told nothing while recording nothing.
+    """
+    mgr = _mgr()
+    mgr._using_external = True
+
+    port, server = _dead_socket()
+    with port, server, \
+         patch("src.aw_manager._resolve_binary_path", return_value="/tmp/bf-window-watcher"), \
+         patch("src.aw_manager.subprocess.Popen",
+               side_effect=OSError(getattr(errno, "EBADARCH", 86), "bad CPU type")), \
+         patch.object(AWManager, "_notify_rosetta_required_once"):
+        started = mgr._start_component("bf-window-watcher", "/tmp")
+
+    # Fixture precondition: _start_component returns early on a missing binary,
+    # and that early return is indistinguishable from the carve-out firing.
+    assert started is False, "fixture never reached the EBADARCH branch"
+    assert mgr.tracker_download_failed is True, (
+        "a dead socket kept the capture-dead flag off — the device reports healthy "
+        "while recording nothing"
+    )
+
+
+def test_exec_failure_keeps_the_carve_out_when_the_server_really_answers():
+    # Control for the case above: a genuinely capturing external server must
+    # still suppress the capture-dead flag, or this fix would just make every
+    # Rosetta-less Mac shout.
+    mgr = _mgr()
+    mgr._using_external = True
+
+    with patch.object(AWManager, "_port_in_use", return_value=True), \
+         patch.object(AWManager, "_server_responding", return_value=True), \
+         patch("src.aw_manager._resolve_binary_path", return_value="/tmp/bf-window-watcher"), \
+         patch("src.aw_manager.subprocess.Popen",
+               side_effect=OSError(getattr(errno, "EBADARCH", 86), "bad CPU type")), \
+         patch.object(AWManager, "_notify_rosetta_required_once"):
+        mgr._start_component("bf-window-watcher", "/tmp")
+
+    assert mgr.tracker_download_failed is False, (
+        "a device recording through a real external server was told its tracking is dead"
+    )


### PR DESCRIPTION
Closes #215.

`check_health`'s external branch and the EBADARCH carve-out both decided "an external tracker is capturing" from `_port_in_use()` — a bare TCP connect. A process holding port 5600 that no longer answers HTTP satisfies that, so the agent reported capture as **healthy on a device recording nothing** and the fleet was told everything was fine.

PR #213 fixed the third instance of this conflation and extracted `_server_responding()`. These are the two it deliberately left.

## The EBADARCH site is asked *before* the lock

That is the concern #215 raises, not a detail. `_server_responding()` blocks up to 2s and `_lifecycle_lock` is held across component lifecycle work, so asking inside would hold the lock through an HTTP timeout.

`_using_external` is read-mostly — it flips only when we adopt or abandon an external server — so reading it a moment early is a far better trade than a network wait under a lock.

## The fixtures were the real work

#215 records that `_port_in_use` is supplied at **six** existing test sites, and that at every one the surrounding prose calls it "healthy" or "capturing" — a claim a TCP connect cannot support. So no test in the suite could tell a serving tracker from a dead socket, and *"fixing these two sites without changing how they are tested would leave that gap intact."*

The new tests pin the two probes to **different** answers:

```
_port_in_use       True    <- something holds the socket
_server_responding False   <- but no tracker answers /api/0/info
```

A fixture where both agree cannot fail against the old code.

**Two existing tests needed the same treatment, and how I found out is worth recording.** They patched only `_port_in_use`, so after this change `_server_responding` was unpatched and reached a **real ActivityWatch on my own machine** — one passed and one failed depending on whether a server happened to be running locally. Both now pin it.

Also asserted: the EBADARCH fixture checks `_start_component` returned `False` before reading the flag, because that function returns early on a missing binary and **the early return is indistinguishable from the carve-out firing**. My first version of the test hit exactly that and proved nothing.

## Verification

Full suite **2029 passed, 1 skipped**, exit 0.

Ruff reports 188 on this branch and a control worktree at `origin/main` reports the **identical 188** — this adds none, and the new test file is clean on its own.

Mutants, control green either side: reverting either site to `_port_in_use` reddens its own named test.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
