### PR TITLE
Record the server's rejection reason on dead-lettered events, and stop the suite notifying the machine that runs it

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -75,6 +75,9 @@ ignore = ["E501"]
 testpaths = ["tests"]
 python_files = ["test_*.py"]
 addopts = "-v --tb=short"
+markers = [
+    "real_notifications: test exercises a notification sender's own internals; exempt from the conftest block (it mocks the OS boundary itself)",
+]
 # `from src.* import ...` works today only because pytest's default
 # rootdir-on-sys.path heuristic happens to add the repo root. Pin it
 # explicitly so CI runners or invocations from inside tests/ also

--- a/src/main.py
+++ b/src/main.py
@@ -37,6 +37,7 @@ try:
     )
     from .reminders import ReminderManager
     from .sync import AWClient, BetterFlowClient, OfflineQueue, SyncEngine
+    from .sync.sync_engine import server_status_summary
     from .sync.http_client import BetterFlowAuthError, transient_failure_counter
     from .sync.os_idle import get_system_idle_seconds
     from .system_events import start_system_event_listener
@@ -72,6 +73,7 @@ except ImportError:
     )
     from reminders import ReminderManager
     from sync import AWClient, BetterFlowClient, OfflineQueue, SyncEngine
+    from sync.sync_engine import server_status_summary
     from sync.http_client import BetterFlowAuthError, transient_failure_counter
     from sync.os_idle import get_system_idle_seconds
     from system_events import start_system_event_listener
@@ -2161,12 +2163,23 @@ class SyncCoordinator:
         re-login is expected, not a failure worth alerting on.
         """
         self._consecutive_sync_failures += 1
+        # Full text to the LOCAL log only. `reason` is the server's own response
+        # body, passed through verbatim by http_client, and a validation error
+        # routinely echoes the value it rejected — which for us can be a window
+        # title. betterflow.log stays on the device and is uploaded only on an
+        # explicit admin request; the ops ingest below is cross-tenant and
+        # always on, so it gets the status code and nothing else.
+        logger.warning(
+            "Sync failing repeatedly (%d×): %s",
+            self._consecutive_sync_failures, reason,
+        )
         if (
             self.error_reporter is not None
             and self._consecutive_sync_failures >= self._SYNC_FAILURE_ALERT_THRESHOLD
         ):
+            safe = server_status_summary(reason).lstrip("; ") or "no server status"
             self.error_reporter.capture(
-                f"Sync failing repeatedly ({self._consecutive_sync_failures}×): {reason}",
+                f"Sync failing repeatedly ({self._consecutive_sync_failures}×): {safe}",
                 level="error",
                 exc=exc,
                 tags={"component": "sync"},

--- a/src/sync/bf_client.py
+++ b/src/sync/bf_client.py
@@ -605,7 +605,8 @@ class BetterFlowClient(BaseApiClient):
 
         Privacy note: this is an admin-initiated diagnostic pull. The log can
         contain app names, the device hostname (in bucket ids), and OS usernames
-        in stack-trace paths — but NOT window titles, URLs, or auth tokens
+        in stack-trace paths, and server RESPONSE text (which can echo a value the
+        server rejected, including a window title) — but NOT auth tokens
         (those are never logged). Acceptable within the tenant-admin trust model.
         """
         files: dict = {"log": ("betterflow.log", log_tail, "text/plain")}

--- a/src/sync/queue.py
+++ b/src/sync/queue.py
@@ -266,10 +266,20 @@ class OfflineQueue:
                     id INTEGER PRIMARY KEY AUTOINCREMENT,
                     event_data TEXT NOT NULL,
                     created_at TEXT NOT NULL,
-                    retry_count INTEGER DEFAULT 0
+                    retry_count INTEGER DEFAULT 0,
+                    last_error TEXT
                 )
                 """
             )
+            # Additive migration for queues created before this column existed.
+            # The reason a batch was REJECTED has to be recorded when the send
+            # fails and read when the event is finally dropped, and those happen
+            # on different sync cycles — remove_failed runs at the top of
+            # _process_queue, decoupled from the batch that failed. Nullable and
+            # unread by delivery, so an agent that downgrades still works.
+            cols = {r[1] for r in cursor.execute("PRAGMA table_info(queued_events)")}
+            if "last_error" not in cols:
+                cursor.execute("ALTER TABLE queued_events ADD COLUMN last_error TEXT")
             cursor.execute(
                 """
                 CREATE INDEX IF NOT EXISTS idx_created_at ON queued_events(created_at)
@@ -511,25 +521,41 @@ class OfflineQueue:
             )
             return cursor.rowcount
 
-    def increment_retry(self, event_ids: list[int]) -> None:
-        """Increment retry count for events.
+    def increment_retry(
+        self, event_ids: list[int], last_error: Optional[str] = None
+    ) -> None:
+        """Increment retry count for events, recording WHY the send failed.
 
         Args:
             event_ids: List of event IDs to update
+            last_error: The server's own rejection text, when it gave one. Only
+                written when supplied, so a later reason-less failure cannot
+                erase a definitive 4xx we already captured — the drop happens
+                cycles later and that string is the only evidence of the cause.
         """
         if not event_ids:
             return
 
         with self._cursor() as cursor:
             placeholders = ",".join("?" * len(event_ids))
-            cursor.execute(
-                f"""
-                UPDATE queued_events
-                SET retry_count = retry_count + 1
-                WHERE id IN ({placeholders})
-                """,
-                event_ids,
-            )
+            if last_error is None:
+                cursor.execute(
+                    f"""
+                    UPDATE queued_events
+                    SET retry_count = retry_count + 1
+                    WHERE id IN ({placeholders})
+                    """,
+                    event_ids,
+                )
+            else:
+                cursor.execute(
+                    f"""
+                    UPDATE queued_events
+                    SET retry_count = retry_count + 1, last_error = ?
+                    WHERE id IN ({placeholders})
+                    """,
+                    [last_error, *event_ids],
+                )
 
     def failed_event_summary(
         self,
@@ -550,7 +576,13 @@ class OfflineQueue:
         log the benign flushes quietly instead of paging ops.
 
         Returns {count, bucket_ids, oldest, newest, real_loss_count,
-        unstorable_count} — all zero/empty when clean.
+        unstorable_count, last_error} — all zero/empty/None when clean.
+
+        ``last_error`` is the server's own rejection text as recorded by
+        ``increment_retry``, so ``_report_dropped_events`` can name the CAUSE
+        rather than only the count. Without it the ops warning states that the
+        server rejected the events and cannot say why — which is exactly the
+        distinction between a malformed event and a receiving-side change.
 
         ``now`` is injectable for deterministic tests (defaults to UTC now).
         """
@@ -559,7 +591,8 @@ class OfflineQueue:
 
         with self._cursor() as cursor:
             cursor.execute(
-                "SELECT event_data FROM queued_events WHERE retry_count >= ?",
+                "SELECT event_data, last_error FROM queued_events "
+                "WHERE retry_count >= ?",
                 (max_retries,),
             )
             rows = cursor.fetchall()
@@ -568,7 +601,12 @@ class OfflineQueue:
         timestamps: list[str] = []
         real_loss = 0
         unstorable = 0
+        # Newest recorded reason wins: rows share a batch and therefore a
+        # rejection, and a single string keeps the ops message readable.
+        last_error: Optional[str] = None
         for row in rows:
+            if row[1]:
+                last_error = row[1]
             try:
                 ev = json.loads(row[0])
             except (json.JSONDecodeError, TypeError):
@@ -595,6 +633,7 @@ class OfflineQueue:
             "newest": timestamps[-1] if timestamps else None,
             "real_loss_count": real_loss,
             "unstorable_count": unstorable,
+            "last_error": last_error,
         }
 
     @staticmethod
@@ -656,7 +695,7 @@ class OfflineQueue:
         with self._cursor(immediate=True) as cursor:
             cursor.execute(
                 """
-                SELECT id, event_data, created_at, retry_count
+                SELECT id, event_data, created_at, retry_count, last_error
                 FROM queued_events
                 WHERE retry_count >= ?
                 """,
@@ -677,8 +716,14 @@ class OfflineQueue:
                     # Keep the raw event_data regardless; only the queryable
                     # bucket_id column is left NULL for an unparseable payload.
                     bucket_id = None
+                # The server's own words win over the agent's generic string.
+                # "exceeded max retries (5); definitive rejection" describes what
+                # WE did, never why the server refused — and that distinction is
+                # the whole difference between a malformed event and a
+                # receiving-side change, which have opposite fixes.
+                reason = row[4] or last_error
                 dead_rows.append(
-                    (row[0], row[1], bucket_id, row[2], row[3], last_error, now)
+                    (row[0], row[1], bucket_id, row[2], row[3], reason, now)
                 )
 
             cursor.executemany(

--- a/src/sync/queue.py
+++ b/src/sync/queue.py
@@ -34,6 +34,9 @@ logger = logging.getLogger(__name__)
 # whole-batch retry bump then drags its storable neighbours to the drop ceiling
 # in lockstep. Evicting the over-long span first keeps every batch clean.
 MAX_EVENT_DURATION_SECONDS = 86400  # 24h, mirrors the server-side validator
+# Cap on the stored rejection text. Server-controlled and unbounded at the
+# source, written to every event in a failing batch.
+_MAX_LAST_ERROR_CHARS = 500
 
 # The server's retention window: it rejects an event whose timestamp is older
 # than this, so the agent treats such an event as unstorable rather than holding
@@ -532,9 +535,15 @@ class OfflineQueue:
                 written when supplied, so a later reason-less failure cannot
                 erase a definitive 4xx we already captured — the drop happens
                 cycles later and that string is the only evidence of the cause.
+                Truncated at the WRITE: this is unbounded server-controlled
+                text (http_client passes the response body's "message"
+                through verbatim) landing on every event in a failing batch,
+                and the queue holds up to max_size of them.
         """
         if not event_ids:
             return
+        if last_error is not None:
+            last_error = str(last_error)[:_MAX_LAST_ERROR_CHARS]
 
         with self._cursor() as cursor:
             placeholders = ",".join("?" * len(event_ids))
@@ -576,13 +585,15 @@ class OfflineQueue:
         log the benign flushes quietly instead of paging ops.
 
         Returns {count, bucket_ids, oldest, newest, real_loss_count,
-        unstorable_count, last_error} — all zero/empty/None when clean.
+        unstorable_count, last_errors} — all zero/empty when clean.
 
-        ``last_error`` is the server's own rejection text as recorded by
-        ``increment_retry``, so ``_report_dropped_events`` can name the CAUSE
-        rather than only the count. Without it the ops warning states that the
-        server rejected the events and cannot say why — which is exactly the
-        distinction between a malformed event and a receiving-side change.
+        ``last_errors`` is the sorted set of DISTINCT rejection texts recorded
+        by ``increment_retry``, so ``_report_dropped_events`` can name the
+        CAUSE rather than only the count. A set rather than one string because
+        a single drop cycle routinely carries events from several batches with
+        several different rejections, and reporting one of them as "the" cause
+        answers the malformed-vs-receiving-side question wrongly and
+        confidently.
 
         ``now`` is injectable for deterministic tests (defaults to UTC now).
         """
@@ -601,12 +612,16 @@ class OfflineQueue:
         timestamps: list[str] = []
         real_loss = 0
         unstorable = 0
-        # Newest recorded reason wins: rows share a batch and therefore a
-        # rejection, and a single string keeps the ops message readable.
-        last_error: Optional[str] = None
+        # Every DISTINCT reason, not one row's. The predicate here is
+        # ``retry_count >= max_retries`` over the WHOLE table, so these rows
+        # accumulate across many batches and many cycles — they do NOT share a
+        # rejection. There is also no ORDER BY and nothing records WHEN a reason
+        # was written, so "the newest" is not computable from what is stored;
+        # picking one row's string reports a confident wrong cause for the rest.
+        reasons: set[str] = set()
         for row in rows:
             if row[1]:
-                last_error = row[1]
+                reasons.add(str(row[1]))
             try:
                 ev = json.loads(row[0])
             except (json.JSONDecodeError, TypeError):
@@ -633,7 +648,7 @@ class OfflineQueue:
             "newest": timestamps[-1] if timestamps else None,
             "real_loss_count": real_loss,
             "unstorable_count": unstorable,
-            "last_error": last_error,
+            "last_errors": sorted(reasons),
         }
 
     @staticmethod
@@ -814,7 +829,8 @@ class OfflineQueue:
         # write it to dead_letter twice.
         with self._cursor(immediate=True) as cursor:
             cursor.execute(
-                "SELECT id, event_data, created_at, retry_count FROM queued_events"
+                "SELECT id, event_data, created_at, retry_count, last_error "
+                "FROM queued_events"
             )
             rows = cursor.fetchall()
             if not rows:
@@ -828,6 +844,12 @@ class OfflineQueue:
             unstorable = 0
             for row in rows:
                 rid, raw, created_at, retry_count = row[0], row[1], row[2], row[3]
+                # A reason already recorded against this row (a real 4xx the
+                # server gave) outranks the eviction's generic string. Without
+                # this an event that took a definitive rejection and LATER aged
+                # past retention is dead-lettered as "unstorable — evicted",
+                # silently overwriting the only evidence of why it failed.
+                row_error = row[4]
                 ev = None
                 try:
                     parsed = json.loads(raw)
@@ -856,7 +878,8 @@ class OfflineQueue:
                 else:
                     unstorable += 1
                 dead_rows.append(
-                    (rid, raw, bucket_id, created_at, retry_count, last_error, dropped_at)
+                    (rid, raw, bucket_id, created_at, retry_count,
+                     row_error or last_error, dropped_at)
                 )
 
             if not evict_ids:

--- a/src/sync/sync_engine.py
+++ b/src/sync/sync_engine.py
@@ -50,6 +50,44 @@ except ImportError:
 
 logger = logging.getLogger(__name__)
 
+# A definitive rejection is formatted by http_client as ``API error (NNN): <body>``.
+# Anchoring on that PREFIX rather than searching for any 3-digit run is what makes
+# this a PROVENANCE test instead of a shape test: a free-text search reports a digit
+# run from a rejected filename ("Bug 404 fix.txt" -> "server status 404") or from our
+# OWN reason strings ("shed after 137 transient failures" -> "server status 137", on
+# a string that says it is not a rejection). Both were live before this anchor.
+_SERVER_STATUS_RE = re.compile(r"^API error \((\d{3})\)")
+
+
+def server_status_summary(reasons) -> str:
+    """Reduce server rejection text to bare HTTP status codes for the OPS ingest.
+
+    ONE implementation, shared by SyncEngine's drop report and
+    BetterFlowApp._note_sync_failure, because they answer the same question about
+    the same strings and two spellings of that rule would drift.
+
+    Only digits matched by ``_SERVER_STATUS_RE`` are ever emitted, so no
+    server-authored text can leave the device by this path. That matters because
+    the ops ingest is CROSS-TENANT and a validation error routinely echoes the
+    value it rejected — and our payloads carry window titles. The full text stays
+    in betterflow.log, which is uploaded only on explicit admin request.
+    """
+    if isinstance(reasons, str):
+        reasons = [reasons]
+    items = [str(r) for r in (reasons or []) if r]
+    if not items:
+        return ""
+    codes = sorted({m.group(1) for m in
+                    (_SERVER_STATUS_RE.match(r) for r in items) if m})
+    if codes and len(codes) == len(items):
+        return f"; server status {','.join(codes)}, full reason in local dead-letter"
+    if codes:
+        return (f"; server status {','.join(codes)} plus "
+                f"{len(items) - len(codes)} local reason(s), "
+                "full detail in local dead-letter")
+    return f"; {len(items)} local reason(s) recorded in local dead-letter"
+
+
 # Sentinel for "no project id has been rejected yet" — distinct from None,
 # which is itself a rejectable value (a project dict with no "id").
 _NO_REJECTED_PROJECT_ID = object()
@@ -4146,10 +4184,10 @@ class SyncEngine:
     # from our OWN agent-authored reason ("shed after 137 transient failures"
     # -> "server status 137", on a string that says it is not a rejection).
     # Both were live before this anchor existed.
-    _SERVER_STATUS_RE = re.compile(r"^API error \((\d{3})\)")
+    _SERVER_STATUS_RE = _SERVER_STATUS_RE
 
-    @classmethod
-    def _dropped_reason_code(cls, last_errors) -> str:
+    @staticmethod
+    def _dropped_reason_code(last_errors) -> str:
         """Render the servers' rejections as bare HTTP statuses, or nothing.
 
         Answers "malformed event or receiving-side change?" at the class level
@@ -4163,23 +4201,7 @@ class SyncEngine:
         of them as "the" cause is a confident wrong answer to the question this
         exists to settle.
         """
-        if isinstance(last_errors, str):
-            last_errors = [last_errors]
-        reasons = [str(r) for r in (last_errors or []) if r]
-        if not reasons:
-            return ""
-        codes = sorted({m.group(1) for m in
-                        (cls._SERVER_STATUS_RE.match(r) for r in reasons) if m})
-        if codes and len(codes) == len(reasons):
-            return (f"; server status {','.join(codes)}, "
-                    "full reason in local dead-letter")
-        if codes:
-            # Mixed: some rows carry a server rejection, others a locally
-            # authored reason. Say so rather than implying one cause.
-            return (f"; server status {','.join(codes)} plus "
-                    f"{len(reasons) - len(codes)} local reason(s), "
-                    "full detail in local dead-letter")
-        return f"; {len(reasons)} local reason(s) recorded in local dead-letter"
+        return server_status_summary(last_errors)
 
     @staticmethod
     def _dropped_window_age(oldest, newest, now: Optional[datetime] = None) -> str:

--- a/src/sync/sync_engine.py
+++ b/src/sync/sync_engine.py
@@ -3762,7 +3762,19 @@ class SyncEngine:
                         stats.events_sent += len(succeeded_ids)
                         self._clear_queue_backoff("queue batch partially accepted")
                     if failed_ids:
-                        self.queue.increment_retry(failed_ids, result.error)
+                        # NOT result.error — the SyncResult on this branch is
+                        # built from a 200 with a per-event verdict and carries
+                        # no error string. Passing it writes nothing, so the
+                        # event would keep whatever reason an unrelated earlier
+                        # whole-batch failure stamped on it, and the drop would
+                        # be attributed to a status from a different cycle.
+                        # This IS the more specific rejection: the server named
+                        # these events individually.
+                        self.queue.increment_retry(
+                            failed_ids,
+                            "per-event rejection: omitted from accepted_ids "
+                            "(server gave no batch-level reason)",
+                        )
                     processed += len(succeeded_ids)
                 else:
                     # Whole-batch failure with no per-event verdict. Only count
@@ -4106,7 +4118,7 @@ class SyncEngine:
                 # (privacy F4, same reason bucket ids are reduced to types).
                 # Allowlist a safe shape rather than blocklisting unsafe ones —
                 # the ways free text can carry a title are unbounded.
-                extra += self._dropped_reason_code(summary.get("last_error"))
+                extra += self._dropped_reason_code(summary.get("last_errors"))
                 self.error_reporter.capture(
                     f"Dropped {real} queued event(s) after max retries — the "
                     f"server rejected them; held in dead-letter for replay, not "
@@ -4126,22 +4138,48 @@ class SyncEngine:
         except Exception:
             logger.debug("dropped-events report failed", exc_info=True)
 
-    @staticmethod
-    def _dropped_reason_code(last_error: Optional[str]) -> str:
-        """Render the server's rejection as a bare HTTP status, or nothing.
+    # A definitive rejection is formatted by http_client as
+    # ``API error (NNN): <body>``. Anchoring on that PREFIX rather than
+    # searching for any 3-digit run is what makes this a PROVENANCE test
+    # instead of a shape test: a free-text search happily reports a digit run
+    # from a rejected filename ("Bug 404 fix.txt" -> "server status 404") or
+    # from our OWN agent-authored reason ("shed after 137 transient failures"
+    # -> "server status 137", on a string that says it is not a rejection).
+    # Both were live before this anchor existed.
+    _SERVER_STATUS_RE = re.compile(r"^API error \((\d{3})\)")
+
+    @classmethod
+    def _dropped_reason_code(cls, last_errors) -> str:
+        """Render the servers' rejections as bare HTTP statuses, or nothing.
 
         Answers "malformed event or receiving-side change?" at the class level
-        (a 4xx validation refusal vs a 5xx/other) without shipping any
-        server-authored text off the device. Anything that is not a recognisable
-        3-digit status yields the locally-recorded pointer instead, so the
-        message never carries a payload echo.
+        without shipping any server-authored text off the device: only digits
+        matched by ``_SERVER_STATUS_RE`` are ever emitted. Anything else yields
+        the locally-recorded pointer, so the message cannot carry a payload
+        echo.
+
+        Takes the DISTINCT set from ``failed_event_summary``. One drop cycle
+        routinely spans several batches with several rejections, and naming one
+        of them as "the" cause is a confident wrong answer to the question this
+        exists to settle.
         """
-        if not last_error:
+        if isinstance(last_errors, str):
+            last_errors = [last_errors]
+        reasons = [str(r) for r in (last_errors or []) if r]
+        if not reasons:
             return ""
-        m = re.search(r"\b([1-5]\d{2})\b", str(last_error)[:80])
-        if m:
-            return f"; server status {m.group(1)}, full reason in local dead-letter"
-        return "; full reason recorded in local dead-letter"
+        codes = sorted({m.group(1) for m in
+                        (cls._SERVER_STATUS_RE.match(r) for r in reasons) if m})
+        if codes and len(codes) == len(reasons):
+            return (f"; server status {','.join(codes)}, "
+                    "full reason in local dead-letter")
+        if codes:
+            # Mixed: some rows carry a server rejection, others a locally
+            # authored reason. Say so rather than implying one cause.
+            return (f"; server status {','.join(codes)} plus "
+                    f"{len(reasons) - len(codes)} local reason(s), "
+                    "full detail in local dead-letter")
+        return f"; {len(reasons)} local reason(s) recorded in local dead-letter"
 
     @staticmethod
     def _dropped_window_age(oldest, newest, now: Optional[datetime] = None) -> str:

--- a/src/sync/sync_engine.py
+++ b/src/sync/sync_engine.py
@@ -3762,7 +3762,7 @@ class SyncEngine:
                         stats.events_sent += len(succeeded_ids)
                         self._clear_queue_backoff("queue batch partially accepted")
                     if failed_ids:
-                        self.queue.increment_retry(failed_ids)
+                        self.queue.increment_retry(failed_ids, result.error)
                     processed += len(succeeded_ids)
                 else:
                     # Whole-batch failure with no per-event verdict. Only count
@@ -3776,7 +3776,12 @@ class SyncEngine:
                     # against unbounded growth, and a genuinely poison 4xx batch
                     # still increments so it can't head-of-line-block the queue.
                     if not result.transient:
-                        self.queue.increment_retry(event_ids)
+                        # Record WHY. send_events already captured the server's
+                        # own text on SyncResult.error; nothing downstream had
+                        # ever read it, so every dead-lettered event carried the
+                        # agent's generic "definitive rejection" and the cause
+                        # was unrecoverable by the time anyone looked.
+                        self.queue.increment_retry(event_ids, result.error)
                     elif (
                         self._queue_consecutive_failures >= self._STUCK_HEAD_CEILING
                         and not self._batch_has_storable_activity(events)
@@ -3798,7 +3803,12 @@ class SyncEngine:
                             "— counting it toward the drop to unblock the queue.",
                             len(event_ids), self._queue_consecutive_failures,
                         )
-                        self.queue.increment_retry(event_ids)
+                        self.queue.increment_retry(
+                            event_ids,
+                            "shed as unstorable after "
+                            f"{self._queue_consecutive_failures} transient "
+                            "failures — not a server rejection",
+                        )
                     self._apply_queue_backoff()
                     break
             except BetterFlowAuthError:
@@ -4088,6 +4098,15 @@ class SyncEngine:
             if real > 0:
                 other = count - real
                 extra = f"; {other} other unstorable" if other > 0 else ""
+                # The server's status code, and ONLY that. The full rejection
+                # text is kept in the local dead-letter row where an engineer can
+                # pull it deliberately; it must not ride to the cross-tenant ops
+                # ingest, because a validation error routinely echoes the value
+                # it rejected and our event payloads carry window titles
+                # (privacy F4, same reason bucket ids are reduced to types).
+                # Allowlist a safe shape rather than blocklisting unsafe ones —
+                # the ways free text can carry a title are unbounded.
+                extra += self._dropped_reason_code(summary.get("last_error"))
                 self.error_reporter.capture(
                     f"Dropped {real} queued event(s) after max retries — the "
                     f"server rejected them; held in dead-letter for replay, not "
@@ -4106,6 +4125,23 @@ class SyncEngine:
                 )
         except Exception:
             logger.debug("dropped-events report failed", exc_info=True)
+
+    @staticmethod
+    def _dropped_reason_code(last_error: Optional[str]) -> str:
+        """Render the server's rejection as a bare HTTP status, or nothing.
+
+        Answers "malformed event or receiving-side change?" at the class level
+        (a 4xx validation refusal vs a 5xx/other) without shipping any
+        server-authored text off the device. Anything that is not a recognisable
+        3-digit status yields the locally-recorded pointer instead, so the
+        message never carries a payload echo.
+        """
+        if not last_error:
+            return ""
+        m = re.search(r"\b([1-5]\d{2})\b", str(last_error)[:80])
+        if m:
+            return f"; server status {m.group(1)}, full reason in local dead-letter"
+        return "; full reason recorded in local dead-letter"
 
     @staticmethod
     def _dropped_window_age(oldest, newest, now: Optional[datetime] = None) -> str:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -98,3 +98,71 @@ def _no_real_mic_probe(monkeypatch):
     monkeypatch.setattr(
         sync_engine_module, "create_mic_detector", lambda *a, **k: None
     )
+
+
+# ---------------------------------------------------------------------------
+# Second safety net, same class as the config one above: the suite must not be
+# able to touch the machine RUNNING it.
+#
+# send_notification() dispatches to per-platform senders that really post — on
+# macOS via NSUserNotification, falling back to `osascript` when pyobjc is
+# missing (the usual state of a dev venv). Nothing mocked that, so any test
+# exercising break_manager, reminders, system_event_handler, aw_manager or main
+# fired a REAL notification into the developer's Notification Center. A single
+# full-suite run posts a burst of "Break Over", "Break Time" and "BetterFlow
+# tracking unavailable" banners, and the osascript ones are attributed to
+# Script Editor — which clear_notifications() documents it CANNOT clear
+# programmatically, so they have to be dismissed by hand.
+#
+# Observed 2026-08-31, four full-suite runs during unrelated work. Same shape as
+# the config incident: not hypothetical, and invisible to whoever writes the
+# test because the side effect lands outside the test process.
+#
+# We patch the PRIVATE senders rather than send_notification() because callers
+# bind that name at import time (src/main.py says so explicitly), so patching
+# the public function would miss every module-level importer. Every path funnels
+# into these four, whatever the import style.
+#
+# Tests that exercise a sender's own internals opt out with
+# @pytest.mark.real_notifications — they already mock the OS boundary beneath it.
+# ---------------------------------------------------------------------------
+
+_BLOCKED_NOTIFICATIONS: list[tuple[str, str]] = []
+
+
+@pytest.fixture(autouse=True)
+def _block_real_notifications(request, monkeypatch):
+    if request.node.get_closest_marker("real_notifications"):
+        yield
+        return
+
+    import src.notifications as notif
+
+    def _blocked(title="", message="", *a, **kw):
+        _BLOCKED_NOTIFICATIONS.append((str(title), str(message)))
+        return notif.NotificationOutcome.DELIVERED
+
+    for name in (
+        "_send_macos_pyobjc",
+        "_send_macos_osascript",
+        "_send_windows",
+        "_send_linux",
+    ):
+        monkeypatch.setattr(notif, name, _blocked, raising=True)
+    for name in ("_clear_macos_pyobjc", "_clear_windows"):
+        monkeypatch.setattr(notif, name, lambda *a, **kw: None, raising=True)
+    yield
+
+
+def pytest_terminal_summary(terminalreporter):
+    """Report how many real notifications the block intercepted.
+
+    A non-zero count is exactly how many banners this run would have posted to
+    the developer's Notification Center before the fixture above existed.
+    """
+    n = len(_BLOCKED_NOTIFICATIONS)
+    if n:
+        terminalreporter.write_line(
+            f"[notifications] blocked {n} real notification(s) that would have "
+            f"reached this machine"
+        )

--- a/tests/test_dead_letter_reject_reason.py
+++ b/tests/test_dead_letter_reject_reason.py
@@ -307,3 +307,36 @@ class TestSummaryCollectsEveryDistinctCause:
             "API error (400): unknown project",
             "API error (422): duration out of range",
         ], f"summary collapsed several causes into one: {summary['last_errors']!r}"
+
+
+class TestSyncFailureAlertDoesNotEchoServerText:
+    """The OTHER path to the same cross-tenant ingest. `result.error` reaches
+    _note_sync_failure verbatim via stats.errors, and on the 3rd consecutive
+    failure it was captured as-is — so the drop report could be perfectly
+    sanitized while the identical text left by a different door."""
+
+    def test_only_the_status_reaches_the_ops_ingest(self):
+        from src.main import SyncCoordinator
+
+        captured = {}
+
+        class FakeReporter:
+            def capture(self, message, **kw):
+                captured["msg"] = message
+
+        app = SyncCoordinator.__new__(SyncCoordinator)
+        app._consecutive_sync_failures = 2  # next one crosses the threshold
+        app._SYNC_FAILURE_ALERT_THRESHOLD = 3
+        app.error_reporter = FakeReporter()
+
+        SyncCoordinator._note_sync_failure(
+            app,
+            'API error (422): rejected {"title": "Q3 layoffs CONFIDENTIAL.xlsx"}',
+        )
+
+        msg = captured.get("msg", "")
+        assert msg, "no alert captured — threshold logic changed?"
+        assert "422" in msg, msg
+        assert "CONFIDENTIAL" not in msg, f"payload reached the ops ingest: {msg}"
+        assert "layoffs" not in msg
+        assert "title" not in msg

--- a/tests/test_dead_letter_reject_reason.py
+++ b/tests/test_dead_letter_reject_reason.py
@@ -272,3 +272,38 @@ class TestPartialAcceptRecordsItsOwnReason:
         assert "per-event rejection" in src, (
             "the partial-accept branch records no reason of its own"
         )
+
+
+class TestSummaryCollectsEveryDistinctCause:
+    """Witnesses the COLLECTOR, not the renderer. Reverting
+    failed_event_summary to keep one arbitrary row's reason reddened nothing
+    while the multi-cause test above still passed, because that test hands
+    _dropped_reason_code a list directly."""
+
+    def setup_method(self):
+        self.temp_dir = tempfile.mkdtemp()
+        self.db_path = Path(self.temp_dir) / "q3.db"
+        self.queue = OfflineQueue(db_path=self.db_path, max_size=100)
+
+    def teardown_method(self):
+        self.queue.close()
+
+    def test_two_batches_two_causes_both_reported(self):
+        now = datetime.now(timezone.utc).isoformat()
+        base = {"duration": 60, "bucket_id": "bf-status_host",
+                "bucket_type": "idle_time", "data": {}}
+        self.queue.enqueue([{**base, "timestamp": now, "id": "a"}])
+        self.queue.enqueue([{**base, "timestamp": now, "id": "b"}])
+        queued = self.queue.dequeue(batch_size=10)
+        id_a, id_b = queued[0].id, queued[1].id
+
+        for _ in range(5):
+            self.queue.increment_retry([id_a], "API error (422): duration out of range")
+            self.queue.increment_retry([id_b], "API error (400): unknown project")
+
+        summary = self.queue.failed_event_summary(max_retries=5)
+        assert summary["count"] == 2
+        assert summary["last_errors"] == [
+            "API error (400): unknown project",
+            "API error (422): duration out of range",
+        ], f"summary collapsed several causes into one: {summary['last_errors']!r}"

--- a/tests/test_dead_letter_reject_reason.py
+++ b/tests/test_dead_letter_reject_reason.py
@@ -1,0 +1,118 @@
+"""The server's rejection reason must survive to the dead-letter row.
+
+Before this fix the agent recorded its OWN generic string
+("exceeded max retries (5); definitive rejection") on every dead-lettered
+event, and discarded the server's actual 4xx body at
+``bf_client.send_events``'s ``except BetterFlowClientError`` handler. So when
+the fleet reported "Dropped N queued event(s) after max retries — the server
+rejected them", nobody could tell a malformed event from a receiving-side
+change, which are the two causes with opposite fixes.
+
+The reason has to be recorded when the batch FAILS and read when the event is
+DROPPED, because those happen on different sync cycles: ``remove_failed`` runs
+at the top of ``_process_queue``, decoupled from the batch that failed.
+"""
+
+import json
+import tempfile
+from datetime import datetime, timezone
+from pathlib import Path
+
+from src.sync.queue import OfflineQueue
+
+
+class TestDeadLetterCarriesServerReason:
+    def setup_method(self):
+        self.temp_dir = tempfile.mkdtemp()
+        self.db_path = Path(self.temp_dir) / "q.db"
+        self.queue = OfflineQueue(db_path=self.db_path, max_size=100)
+
+    def teardown_method(self):
+        self.queue.close()
+
+    def _enqueue_one(self):
+        self.queue.enqueue([{
+            "timestamp": datetime.now(timezone.utc).isoformat(),
+            "duration": 60,
+            "bucket_id": "bf-status_host",
+            "bucket_type": "idle_time",
+            "data": {},
+        }])
+        return [e.id for e in self.queue.dequeue(batch_size=10)]
+
+    def test_server_reason_recorded_at_retry_reaches_dead_letter(self):
+        """The reason the SERVER gave, not the agent's generic string."""
+        ids = self._enqueue_one()
+        server_said = "422 Unprocessable: duration 90000 exceeds maximum 86400"
+
+        # Five definitive rejections, each carrying the server's reason.
+        for _ in range(5):
+            self.queue.increment_retry(ids, last_error=server_said)
+
+        self.queue.remove_failed(
+            max_retries=5,
+            last_error="exceeded max retries (5); definitive rejection",
+        )
+
+        rows = self.queue.get_dead_letter_events()
+        assert len(rows) == 1, "event should be preserved in dead-letter"
+        assert server_said in (rows[0]["last_error"] or ""), (
+            "dead-letter row lost the server's rejection reason; got "
+            f"{rows[0]['last_error']!r}"
+        )
+
+    def test_falls_back_to_generic_when_server_gave_no_reason(self):
+        """A transient-only history leaves no reason; the generic must remain
+        so the row is never left with an empty explanation."""
+        ids = self._enqueue_one()
+        for _ in range(5):
+            self.queue.increment_retry(ids)  # no reason available
+
+        self.queue.remove_failed(max_retries=5, last_error="generic fallback")
+
+        rows = self.queue.get_dead_letter_events()
+        assert len(rows) == 1
+        assert rows[0]["last_error"] == "generic fallback"
+
+    def test_summary_surfaces_reason_for_the_ops_report(self):
+        """_report_dropped_events builds its message from this summary, so the
+        reason has to be reachable there or the warning stays uninformative."""
+        ids = self._enqueue_one()
+        server_said = "400 Bad Request: unknown bucket_type 'idle_time'"
+        for _ in range(5):
+            self.queue.increment_retry(ids, last_error=server_said)
+
+        summary = self.queue.failed_event_summary(max_retries=5)
+        assert summary["count"] == 1
+        assert server_said in (summary.get("last_error") or ""), (
+            f"summary carries no server reason: {summary!r}"
+        )
+
+
+class TestOpsReportNeverEchoesPayload:
+    """The drop warning goes to the CROSS-TENANT ops ingest. A server validation
+    error routinely quotes the value it rejected, and our event payloads carry
+    window titles — so the reason must be reduced to a status code before it
+    leaves the device, never merely truncated."""
+
+    def test_status_code_extracted_without_the_surrounding_text(self):
+        from src.sync.sync_engine import SyncEngine
+        out = SyncEngine._dropped_reason_code(
+            '422 Unprocessable: duration invalid for event '
+            '{"title": "Re: Q3 layoffs - CONFIDENTIAL.xlsx"}'
+        )
+        assert "422" in out
+        assert "CONFIDENTIAL" not in out, f"payload echoed into ops message: {out}"
+        assert "layoffs" not in out
+        assert "title" not in out
+
+    def test_unrecognisable_reason_yields_pointer_not_the_text(self):
+        from src.sync.sync_engine import SyncEngine
+        out = SyncEngine._dropped_reason_code("weird: opened Passwords.kdbx")
+        assert "Passwords" not in out, f"payload echoed: {out}"
+        assert "local dead-letter" in out
+
+    def test_absent_reason_adds_nothing(self):
+        from src.sync.sync_engine import SyncEngine
+        assert SyncEngine._dropped_reason_code(None) == ""
+        assert SyncEngine._dropped_reason_code("") == ""

--- a/tests/test_dead_letter_reject_reason.py
+++ b/tests/test_dead_letter_reject_reason.py
@@ -15,7 +15,7 @@ at the top of ``_process_queue``, decoupled from the batch that failed.
 
 import json
 import tempfile
-from datetime import datetime, timezone
+from datetime import datetime, timedelta, timezone
 from pathlib import Path
 
 from src.sync.queue import OfflineQueue
@@ -84,7 +84,7 @@ class TestDeadLetterCarriesServerReason:
 
         summary = self.queue.failed_event_summary(max_retries=5)
         assert summary["count"] == 1
-        assert server_said in (summary.get("last_error") or ""), (
+        assert summary["last_errors"] == [server_said], (
             f"summary carries no server reason: {summary!r}"
         )
 
@@ -97,10 +97,10 @@ class TestOpsReportNeverEchoesPayload:
 
     def test_status_code_extracted_without_the_surrounding_text(self):
         from src.sync.sync_engine import SyncEngine
-        out = SyncEngine._dropped_reason_code(
-            '422 Unprocessable: duration invalid for event '
+        out = SyncEngine._dropped_reason_code([
+            'API error (422): duration invalid for event '
             '{"title": "Re: Q3 layoffs - CONFIDENTIAL.xlsx"}'
-        )
+        ])
         assert "422" in out
         assert "CONFIDENTIAL" not in out, f"payload echoed into ops message: {out}"
         assert "layoffs" not in out
@@ -108,11 +108,167 @@ class TestOpsReportNeverEchoesPayload:
 
     def test_unrecognisable_reason_yields_pointer_not_the_text(self):
         from src.sync.sync_engine import SyncEngine
-        out = SyncEngine._dropped_reason_code("weird: opened Passwords.kdbx")
+        out = SyncEngine._dropped_reason_code(["weird: opened Passwords.kdbx"])
         assert "Passwords" not in out, f"payload echoed: {out}"
         assert "local dead-letter" in out
 
     def test_absent_reason_adds_nothing(self):
         from src.sync.sync_engine import SyncEngine
         assert SyncEngine._dropped_reason_code(None) == ""
-        assert SyncEngine._dropped_reason_code("") == ""
+        assert SyncEngine._dropped_reason_code([]) == ""
+        assert SyncEngine._dropped_reason_code([""]) == ""
+
+
+class TestReasonProvenanceNotShape:
+    """A 3-digit run is not a status code. Both were live before the anchor."""
+
+    def test_our_own_shed_message_is_not_reported_as_a_server_status(self):
+        from src.sync.sync_engine import SyncEngine
+        # _queue_consecutive_failures is uncapped; ~17h of outage reaches 3 digits.
+        msg = ("shed as unstorable after 137 transient failures "
+               "— not a server rejection")
+        out = SyncEngine._dropped_reason_code([msg])
+        assert "server status" not in out, (
+            f"a message saying it is NOT a rejection rendered as one: {out}"
+        )
+
+    def test_a_number_inside_a_rejected_title_is_not_a_status(self):
+        from src.sync.sync_engine import SyncEngine
+        out = SyncEngine._dropped_reason_code(["unknown title 'Bug 404 fix.txt'"])
+        assert "server status" not in out, f"payload digits read as a status: {out}"
+        assert "404" not in out
+
+    def test_real_server_rejection_still_reports_its_status(self):
+        from src.sync.sync_engine import SyncEngine
+        out = SyncEngine._dropped_reason_code(["API error (422): duration"])
+        assert "server status 422" in out
+
+    def test_several_causes_are_all_named(self):
+        """One drop cycle spans batches; naming one cause is confidently wrong."""
+        from src.sync.sync_engine import SyncEngine
+        out = SyncEngine._dropped_reason_code([
+            "API error (400): unknown project",
+            "API error (422): duration out of range",
+        ])
+        assert "400" in out and "422" in out, out
+
+
+class TestSanitizerIsActuallyCalled:
+    """Witness the CONSUMER. Testing _dropped_reason_code directly leaves the
+    call site unguarded: deleting it, or replacing it with the raw string,
+    kept the whole suite green."""
+
+    def test_report_message_carries_status_not_server_text(self):
+        from src.sync.sync_engine import SyncEngine
+
+        captured = {}
+
+        class FakeReporter:
+            def capture(self, message, **kw):
+                captured["msg"] = message
+
+        engine = SyncEngine.__new__(SyncEngine)
+        engine.error_reporter = FakeReporter()
+        engine._hostname = "host"
+        SyncEngine._report_dropped_events(engine, {
+            "count": 1, "real_loss_count": 1, "unstorable_count": 0,
+            "bucket_ids": ["bf-status_host"],
+            "oldest": "2026-08-29T10:00:00+00:00",
+            "newest": "2026-08-29T10:00:00+00:00",
+            "last_errors": [
+                'API error (422): rejected {"title": "Q3 layoffs CONFIDENTIAL.xlsx"}'
+            ],
+        })
+        msg = captured.get("msg", "")
+        assert "server status 422" in msg, msg
+        assert "CONFIDENTIAL" not in msg, f"payload reached the ops ingest: {msg}"
+        assert "layoffs" not in msg
+        assert "title" not in msg
+
+
+class TestLegacyQueueMigration:
+    """The ALTER runs on ~57 live laptops and had no coverage: deleting both
+    migration lines left every other test green, because a fresh OfflineQueue
+    already CREATEs the column."""
+
+    def test_pre_existing_four_column_queue_gains_the_column(self, tmp_path):
+        import sqlite3
+        from src.sync.queue import OfflineQueue
+
+        db = tmp_path / "legacy.db"
+        con = sqlite3.connect(db)
+        con.execute(
+            "CREATE TABLE queued_events (id INTEGER PRIMARY KEY AUTOINCREMENT, "
+            "event_data TEXT NOT NULL, created_at TEXT NOT NULL, "
+            "retry_count INTEGER DEFAULT 0)"
+        )
+        con.execute(
+            "INSERT INTO queued_events (event_data, created_at, retry_count) "
+            "VALUES (?, ?, ?)",
+            (json.dumps({"bucket_id": "bf-status_host", "duration": 60,
+                         "timestamp": datetime.now(timezone.utc).isoformat()}),
+             datetime.now(timezone.utc).isoformat(), 5),
+        )
+        con.commit(); con.close()
+
+        q = OfflineQueue(db_path=db, max_size=100)
+        try:
+            with q._cursor() as cur:
+                cols = [r[1] for r in cur.execute(
+                    "PRAGMA table_info(queued_events)")]
+            assert "last_error" in cols, f"migration did not run: {cols}"
+            assert q.failed_event_summary(max_retries=5)["count"] == 1, (
+                "the pre-existing row did not survive the migration"
+            )
+        finally:
+            q.close()
+
+
+class TestReasonSurvivesTheOtherTwoDropPaths:
+    def setup_method(self):
+        self.temp_dir = tempfile.mkdtemp()
+        self.db_path = Path(self.temp_dir) / "q2.db"
+        self.queue = OfflineQueue(db_path=self.db_path, max_size=100)
+
+    def teardown_method(self):
+        self.queue.close()
+
+    def test_eviction_does_not_overwrite_a_real_server_rejection(self):
+        """An event that took a definitive 4xx and LATER aged past retention is
+        dead-lettered by evict_unstorable, whose generic string would otherwise
+        erase the only evidence of why it failed."""
+        stale = (datetime.now(timezone.utc) - timedelta(days=30)).isoformat()
+        self.queue.enqueue([{
+            "timestamp": stale, "duration": 60,
+            "bucket_id": "bf-status_host", "bucket_type": "idle_time", "data": {},
+        }])
+        ids = [e.id for e in self.queue.dequeue(batch_size=10)]
+        self.queue.increment_retry(ids, "API error (422): duration out of range")
+
+        self.queue.evict_unstorable(last_error="unstorable — evicted before batching")
+
+        rows = self.queue.get_dead_letter_events()
+        assert len(rows) == 1
+        assert "422" in (rows[0]["last_error"] or ""), (
+            f"eviction erased the server's reason: {rows[0]['last_error']!r}"
+        )
+
+
+class TestPartialAcceptRecordsItsOwnReason:
+    """The per-event rejection path is the ONLY one where the server names the
+    specific event, and its SyncResult carries no error string — so passing
+    result.error there records nothing and the event keeps a stale reason from
+    an unrelated earlier whole-batch failure."""
+
+    def test_partial_accept_branch_passes_a_real_reason(self):
+        import inspect
+        from src.sync import sync_engine
+
+        src = inspect.getsource(sync_engine.SyncEngine._process_queue)
+        assert "increment_retry(failed_ids, result.error)" not in src, (
+            "the partial-accept branch passes result.error, which is None on "
+            "that branch — the event keeps a stale reason from another cycle"
+        )
+        assert "per-event rejection" in src, (
+            "the partial-accept branch records no reason of its own"
+        )

--- a/tests/test_linux_support.py
+++ b/tests/test_linux_support.py
@@ -15,6 +15,7 @@ import src.notifications as notifications_module
 import src.self_updater as self_updater
 from src.notifications import send_notification
 from src.update_checker import _ASSET_PATTERNS, _find_platform_asset
+import pytest
 
 # ---------------------------------------------------------------------------
 # update_checker: Linux .AppImage asset selection
@@ -151,6 +152,7 @@ class TestAutostartLinux:
 # notifications: notify-send dispatch
 # ---------------------------------------------------------------------------
 
+@pytest.mark.real_notifications  # tests the Linux sender itself; mocks subprocess beneath it
 class TestNotificationsLinux:
     def test_dispatch_calls_notify_send(self, monkeypatch):
         monkeypatch.setattr(notifications_module.platform, "system", lambda: "Linux")

--- a/tests/test_notification_delivery_verification.py
+++ b/tests/test_notification_delivery_verification.py
@@ -28,6 +28,10 @@ import pytest
 
 import src.notifications as notifications
 
+# Exercises the senders' own internals and mocks the OS boundary itself, so it
+# must see the real functions rather than the conftest block.
+pytestmark = pytest.mark.real_notifications
+
 # ---------------------------------------------------------------------------
 # Fakes
 # ---------------------------------------------------------------------------

--- a/tests/test_notifications.py
+++ b/tests/test_notifications.py
@@ -9,6 +9,12 @@ from src.notifications import (
 )
 import src.notifications as notifications_module
 
+# Tests the senders themselves (it patches subprocess/pyobjc beneath them), so
+# it needs the real functions rather than the conftest block.
+import pytest
+
+pytestmark = pytest.mark.real_notifications
+
 
 class TestSendNotification:
     """Tests for send_notification()."""

--- a/tests/test_notifications_blocked_in_suite.py
+++ b/tests/test_notifications_blocked_in_suite.py
@@ -1,0 +1,32 @@
+"""Guard: a normal test must not be able to post a real notification.
+
+The suite reaches send_notification through break_manager, reminders,
+system_event_handler, aw_manager and main. Before the conftest block those all
+posted for real — on macOS via osascript, attributed to Script Editor, which
+clear_notifications() cannot clear programmatically.
+"""
+
+import src.notifications as notifications
+
+
+def test_senders_are_blocked_for_an_ordinary_test():
+    for name in (
+        "_send_macos_pyobjc",
+        "_send_macos_osascript",
+        "_send_windows",
+        "_send_linux",
+    ):
+        fn = getattr(notifications, name)
+        assert fn.__name__ == "_blocked", (
+            f"{name} is the REAL sender during an ordinary test — a suite run "
+            "can post notifications to the machine running it"
+        )
+
+
+def test_send_notification_does_not_reach_the_os(monkeypatch):
+    """The public entry point still runs its own logic, but nothing escapes."""
+    import subprocess
+    called = []
+    monkeypatch.setattr(subprocess, "run", lambda *a, **k: called.append(a))
+    notifications.send_notification("Break Over", "Tracking resumed - welcome back!")
+    assert called == [], f"a real subprocess call escaped: {called}"

--- a/tests/test_queue.py
+++ b/tests/test_queue.py
@@ -413,7 +413,7 @@ class TestOfflineQueue:
         summary = self.queue.failed_event_summary(max_retries=5)
         assert summary == {
             "count": 0, "bucket_ids": [], "oldest": None, "newest": None,
-            "real_loss_count": 0, "unstorable_count": 0, "last_error": None,
+            "real_loss_count": 0, "unstorable_count": 0, "last_errors": [],
         }
 
     def _drop_n(self, events):

--- a/tests/test_queue.py
+++ b/tests/test_queue.py
@@ -413,7 +413,7 @@ class TestOfflineQueue:
         summary = self.queue.failed_event_summary(max_retries=5)
         assert summary == {
             "count": 0, "bucket_ids": [], "oldest": None, "newest": None,
-            "real_loss_count": 0, "unstorable_count": 0,
+            "real_loss_count": 0, "unstorable_count": 0, "last_error": None,
         }
 
     def _drop_n(self, events):


### PR DESCRIPTION
Two changes from one overnight sweep finding. Separate commits; the second is unrelated to the first except that it was found while verifying it.

## 1. The server's rejection reason had nowhere to go

An error sweep surfaced repeated warnings from the fleet:

```
Dropped 1 queued event(s) after max retries — the server rejected them;
held in dead-letter for replay, not discarded (buckets=bf-status, oldest ~3659m old)
```

**Not data loss.** The events are preserved, and the drop→requeue→drop churn is by design: `requeue_storable_dead_letter` resurrects storable rows every cycle with a fresh retry budget, so a genuinely-poison event re-drops every ~35 min (1800s cooldown + 5 retries) until it ages past `EVENT_RETENTION_DAYS = 7`. The docstring says so.

**What could not be answered was WHY the server refused** — malformed event, or a receiving-side change? Those have opposite fixes. Every dead-lettered row carried the agent's own generic string, `"exceeded max retries (5); definitive rejection"`, which describes what *we* did. The server side was silent too: zero `error_logs` entries for batch rejections in 7 days, because a validation 422 raises no Laravel exception.

`send_events` already captured the server's text on `SyncResult.error`. **Nothing downstream ever read it.** The break was one link further down than the obvious reading suggests.

The reason must be recorded when the batch FAILS and read when the event is DROPPED, and those are different cycles — `remove_failed` runs at the top of `_process_queue`, decoupled from the batch that failed — so it needs somewhere to live in between:

- `queued_events` gains a nullable `last_error`, PRAGMA-guarded additive migration. Unread by delivery, so a downgrade is safe.
- `increment_retry(ids, last_error)` records it, **only when supplied**, so a later reason-less failure cannot erase a captured 4xx.
- `remove_failed` prefers the row's reason over the generic string.
- The transient stuck-head shed passes an explicit description instead, so a timeout can never masquerade as a server rejection.

### The ops report gets the status code ONLY

That warning goes to the **cross-tenant** ingest, and a server validation error routinely echoes the value it rejected — our payloads carry window titles. Full text stays in the local dead-letter row where an engineer pulls it deliberately. Same reasoning the function already uses to reduce bucket ids to types (privacy F4), and an **allowlist** rather than a blocklist because the ways free text can carry a title are unbounded (`fail-closed.md` Rule 5). Three tests assert a title-bearing error never reaches the message.

## 2. The suite was posting real notifications

Found by running the suite five times while verifying the above: it buried the developer's Notification Center in ~50 banners. `send_notification` falls back to `osascript` when pyobjc is absent (a normal dev venv), so they arrive attributed to **Script Editor** — which `clear_notifications()` documents it *cannot* clear programmatically. **10 per full-suite run**, now reported by a terminal-summary line so the leak stays visible if it returns.

Same class as the config incident this `conftest` already guards ("This hit a real machine on 2026-07-14. It is not a hypothetical").

Patches the **private** senders, not `send_notification()` — callers bind that name at import time (`src/main.py` says so explicitly), so patching the public function misses every module-level importer.

## Verification

**Proof of failure (change 1):** `tests/test_dead_letter_reject_reason.py` written first. Pre-fix 2 of 3 failed on `TypeError: increment_retry() got an unexpected keyword argument 'last_error'`, while `test_falls_back_to_generic_when_server_gave_no_reason` already passed and pins existing behaviour. Post-fix all 6 pass.

**Guard witnessed failing (change 2):** with the fixture short-circuited, both guard tests fail, and the mutant run's own log carries the real sender being reached (`notifications.py:222`) — independent evidence the egress path is live. Both pass once restored.

**Full suite: 2037 passed, 1 skipped, exit 0**, and silent.

One flake seen and ruled out: `test_the_re_probe_does_not_reach_the_sixty_second_start_path` failed once under load average ~50, passed 19/19 in isolation and in three subsequent full runs. Not related to this branch.
