### PR TITLE
Assert the notification block by behaviour, and pin the opt-out list

### DIFF
--- a/tests/test_notifications_blocked_in_suite.py
+++ b/tests/test_notifications_blocked_in_suite.py
@@ -26,6 +26,10 @@ every tests/test_*.py, so a literal here would find itself (a detector poisoned
 by its own sentinel). It is assembled from parts below.
 """
 
+# ruff: noqa: N802 -- the Foundation fakes below must answer to the
+# Objective-C selector names src/notifications.py calls, verbatim.
+# Same convention as tests/test_notification_delivery_verification.py.
+
 from pathlib import Path
 
 import pytest

--- a/tests/test_notifications_blocked_in_suite.py
+++ b/tests/test_notifications_blocked_in_suite.py
@@ -2,31 +2,271 @@
 
 The suite reaches send_notification through break_manager, reminders,
 system_event_handler, aw_manager and main. Before the conftest block those all
-posted for real — on macOS via osascript, attributed to Script Editor, which
-clear_notifications() cannot clear programmatically.
+posted for real -- on macOS via osascript, attributed to Script Editor, which
+clear_notifications() cannot clear programmatically. Four full-suite runs on
+2026-08-31 put ten banners into a developer's Notification Center.
+
+Three things are asserted here, and they are deliberately different questions:
+
+1. The four private senders are not the module's own functions during an
+   ordinary test (identity, against a reference captured at import time --
+   i.e. before any fixture ran -- not against a NAME, which a rename breaks
+   and any decoy satisfies).
+2. Calling each sender, and calling send_notification on each platform,
+   reaches no OS boundary: no subprocess, no Foundation delivery. Driving the
+   platform explicitly matters -- on a macOS box with pyobjc installed,
+   send_notification never touches subprocess at all, so a subprocess-only
+   assertion holds whether or not the block works.
+3. The set of files that opt OUT of the block is pinned, so a new opt-out has
+   to be written into this list and reviewed rather than inherited by adding a
+   test to an already-exempt file.
+
+NB this file never spells the opt-out marker literally -- the scan in (3) reads
+every tests/test_*.py, so a literal here would find itself (a detector poisoned
+by its own sentinel). It is assembled from parts below.
 """
 
+from pathlib import Path
+
+import pytest
+
 import src.notifications as notifications
+from src.notifications import NotificationOutcome
+
+_SENDERS = (
+    "_send_macos_pyobjc",
+    "_send_macos_osascript",
+    "_send_windows",
+    "_send_linux",
+)
+
+# Captured at import (collection) time, before any autouse fixture has run, so
+# these are the module's real senders and are not something this file authored.
+_ORIGINAL_SENDERS = {name: getattr(notifications, name) for name in _SENDERS}
+
+# Argument shapes differ: the macOS senders take `sound`, the others do not.
+_SENDER_ARGS = {
+    "_send_macos_pyobjc": ("Break Over", "Tracking resumed", True),
+    "_send_macos_osascript": ("Break Over", "Tracking resumed", True),
+    "_send_windows": ("Break Over", "Tracking resumed"),
+    "_send_linux": ("Break Over", "Tracking resumed"),
+}
 
 
-def test_senders_are_blocked_for_an_ordinary_test():
-    for name in (
-        "_send_macos_pyobjc",
-        "_send_macos_osascript",
-        "_send_windows",
-        "_send_linux",
-    ):
-        fn = getattr(notifications, name)
-        assert fn.__name__ == "_blocked", (
-            f"{name} is the REAL sender during an ordinary test — a suite run "
-            "can post notifications to the machine running it"
+# ---------------------------------------------------------------------------
+# A fake Foundation, so the pyobjc leg has a readable OS boundary on every
+# platform. If the block is working nothing here is ever touched; if it breaks,
+# the real _send_macos_pyobjc imports this and the delivery is recorded.
+# ---------------------------------------------------------------------------
+
+
+class _FakeNote:
+    def __init__(self):
+        self._identifier = None
+
+    def setTitle_(self, value):
+        pass
+
+    def setInformativeText_(self, value):
+        pass
+
+    def setSoundName_(self, value):
+        pass
+
+    def setContentImage_(self, value):
+        pass
+
+    def setIdentifier_(self, value):
+        self._identifier = value
+
+    def identifier(self):
+        return self._identifier
+
+
+class _FakeNSUserNotification:
+    @classmethod
+    def alloc(cls):
+        return cls
+
+    @classmethod
+    def init(cls):
+        return _FakeNote()
+
+
+class _FakeCenter:
+    def __init__(self, delivered):
+        self._delivered = delivered
+
+    def deliverNotification_(self, note):
+        self._delivered.append(note)
+
+    def deliveredNotifications(self):
+        return list(self._delivered)
+
+    def removeAllDeliveredNotifications(self):
+        self._delivered.clear()
+
+
+@pytest.fixture
+def os_boundary(monkeypatch):
+    """Record every OS egress the notification module has, on any platform.
+
+    Returns a dict with `subprocess` (argv lists) and `foundation` (delivered
+    notifications). Both must stay empty for a blocked send.
+    """
+    import subprocess as subprocess_module
+    import sys
+    import types
+
+    record = {"subprocess": [], "foundation": []}
+
+    def _fake_run(args, *a, **kw):
+        # Record rather than raise: a raise inside send_notification is caught
+        # by its own `except Exception` and reported as FAILED, which reads as
+        # an ordinary sender failure. The recorded argv is the evidence.
+        record["subprocess"].append(args)
+        return types.SimpleNamespace(returncode=0, stdout=b"", stderr=b"")
+
+    monkeypatch.setattr(subprocess_module, "run", _fake_run)
+
+    fake_foundation = types.ModuleType("Foundation")
+    fake_foundation.NSUserNotification = _FakeNSUserNotification
+    fake_foundation.NSUserNotificationCenter = types.SimpleNamespace(
+        defaultUserNotificationCenter=lambda: _FakeCenter(record["foundation"])
+    )
+    monkeypatch.setitem(sys.modules, "Foundation", fake_foundation)
+
+    # Keep the icon lookup off the real filesystem; an icon would drag AppKit in.
+    monkeypatch.setattr(notifications, "_resolve_icon_path", lambda: None)
+    return record
+
+
+def _assert_nothing_escaped(record):
+    assert record["subprocess"] == [], (
+        f"a real subprocess call escaped: {record['subprocess']}"
+    )
+    assert record["foundation"] == [], (
+        "a notification was handed to NSUserNotificationCenter -- the pyobjc "
+        "sender ran for real"
+    )
+
+
+# ---------------------------------------------------------------------------
+# 1. the senders are replaced (identity, not name)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("name", _SENDERS)
+def test_sender_is_not_the_real_function_during_an_ordinary_test(name):
+    assert getattr(notifications, name) is not _ORIGINAL_SENDERS[name], (
+        f"{name} is the REAL sender during an ordinary test -- a suite run "
+        "can post notifications to the machine running it"
+    )
+
+
+# ---------------------------------------------------------------------------
+# 2. and calling them reaches nothing
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("name", _SENDERS)
+def test_calling_a_sender_directly_reaches_no_os_boundary(name, os_boundary):
+    getattr(notifications, name)(*_SENDER_ARGS[name])
+    _assert_nothing_escaped(os_boundary)
+
+
+@pytest.mark.parametrize(
+    "system,pyobjc",
+    [
+        ("Darwin", True),   # NSUserNotification leg -- never touches subprocess
+        ("Darwin", False),  # osascript fallback leg
+        ("Windows", None),
+        ("Linux", None),
+    ],
+)
+def test_send_notification_does_not_reach_the_os(
+    system, pyobjc, os_boundary, monkeypatch
+):
+    """The public entry point still runs its own dispatch, but nothing escapes.
+
+    Each platform is driven explicitly. Left to the real platform.system(), a
+    macOS machine with pyobjc present routes to _send_macos_pyobjc and a
+    subprocess assertion can never fail -- it would hold against a completely
+    disabled block.
+    """
+    monkeypatch.setattr(notifications.platform, "system", lambda: system)
+    if pyobjc is not None:
+        monkeypatch.setattr(
+            notifications, "_try_load_macos_pyobjc", lambda: pyobjc
         )
 
+    outcome = notifications.send_notification("Break Over", "Tracking resumed")
 
-def test_send_notification_does_not_reach_the_os(monkeypatch):
-    """The public entry point still runs its own logic, but nothing escapes."""
-    import subprocess
-    called = []
-    monkeypatch.setattr(subprocess, "run", lambda *a, **k: called.append(a))
-    notifications.send_notification("Break Over", "Tracking resumed - welcome back!")
-    assert called == [], f"a real subprocess call escaped: {called}"
+    _assert_nothing_escaped(os_boundary)
+    # The block's stub reports DELIVERED. Every real sender on these three
+    # legs reports UNKNOWN (osascript, PowerShell and notify-send are all
+    # unreadable), so this discriminates too rather than merely describing.
+    assert outcome is NotificationOutcome.DELIVERED, (
+        f"{system} (pyobjc={pyobjc}) produced {outcome} -- a real sender ran"
+    )
+
+
+# ---------------------------------------------------------------------------
+# 3. the opt-out list is pinned
+# ---------------------------------------------------------------------------
+
+# Assembled, never written whole: this file is itself a tests/test_*.py and the
+# scan below reads all of them, so a literal here would match itself.
+_MARKER = "real_" + "notifications"
+
+# Every file allowed to exempt itself from the conftest block, with the reason.
+# conftest.py is not listed because the scan covers test_*.py only -- conftest
+# is where the marker is DEFINED, and it is the positive control below.
+_KNOWN_OPT_OUTS = {
+    "test_notifications.py": (
+        "module-level mark; exercises each sender's own internals and patches "
+        "subprocess/Foundation beneath them itself"
+    ),
+    "test_notification_delivery_verification.py": (
+        "module-level mark; drives the NSUserNotification delivery read-back "
+        "against its own fake Foundation"
+    ),
+    "test_linux_support.py": (
+        "class-level mark on TestNotificationsLinux only; tests _send_linux "
+        "with subprocess.run patched"
+    ),
+}
+
+
+def test_the_set_of_files_exempt_from_the_block_is_pinned():
+    """A new opt-out must be added here deliberately, not inherited.
+
+    The exemption is file-wide: any test later added to one of the files below
+    is silently exempt too, and will post real notifications to whoever runs
+    the suite, in a diff that does not look like a hygiene change.
+    """
+    tests_dir = Path(__file__).resolve().parent
+
+    conftest = (tests_dir / "conftest.py").read_text(encoding="utf-8")
+    assert _MARKER in conftest, (
+        "control failed: the marker was not found in conftest.py, where it is "
+        "defined -- the scan below is reading nothing and would pass empty"
+    )
+
+    found = {
+        path.name
+        for path in sorted(tests_dir.glob("test_*.py"))
+        if _MARKER in path.read_text(encoding="utf-8")
+    }
+
+    expected = set(_KNOWN_OPT_OUTS)
+    assert found == expected, (
+        "the set of test files exempt from the real-notification block "
+        f"changed.\n  added:   {sorted(found - expected)}\n"
+        f"  removed: {sorted(expected - found)}\n"
+        "Exempting a file exempts every test in it, forever. If the addition "
+        "is deliberate, add it to _KNOWN_OPT_OUTS with a one-line reason and "
+        "confirm the file mocks the OS boundary beneath the sender itself.\n"
+        "Currently allowed:\n"
+        + "\n".join(f"  - {k}: {v}" for k, v in sorted(_KNOWN_OPT_OUTS.items()))
+    )


### PR DESCRIPTION
Closes three test-quality findings logged during the #234 pre-merge review and deliberately deferred at the time. One file changed (`tests/test_notifications_blocked_in_suite.py`); the subject under test (`conftest.py`) is untouched.

## The one that was actually broken

`test_send_notification_does_not_reach_the_os` patched `subprocess.run` and asserted no call. **On a Mac with pyobjc — which this one has — `send_notification` routes to `_send_macos_pyobjc`, which never touches subprocess.** So the assertion held whether or not the block worked.

That is not a theory. Under a mutant that unblocks the pyobjc sender entirely, the **pre-fix assertion was run verbatim and passed** — while a real notification was posted to the developer's Notification Center. The old test could not see a completely unblocked sender.

It now drives four legs explicitly (`Darwin`/pyobjc, `Darwin`/osascript, `Windows`, `Linux`) by monkeypatching `platform.system()` and `_try_load_macos_pyobjc`, and records **both** egresses — `subprocess.run` argv *and* a fake `Foundation` injected into `sys.modules`, which is the only readable boundary for the NSUserNotification leg.

## The other two

- **Spelling → behaviour.** `assert fn.__name__ == "_blocked"` went red on a harmless rename and green for any function named `_blocked` regardless of what it did. Replaced by an identity check against the real senders captured at *collection* time (an independent reference, not one the test authors) plus a direct call of each sender asserting no OS boundary is reached.
- **Opt-out pinned.** Files carrying `real_notifications` are now pinned to an exact set, each with a one-line reason in the failure message, so a new opt-out has to be added deliberately and reviewed rather than silently inheriting an exemption. The marker literal is assembled from parts, because this file is itself a `test_*.py` and would otherwise match itself — with a control asserting the marker *is* found in `conftest.py`, so an empty read cannot pass silently.

## Correction to the brief

The brief said **four** files opt out. There are **three** — `test_notifications.py`, `test_notification_delivery_verification.py`, `test_linux_support.py`. The fourth grep hit was `conftest.py`, which *defines* the marker and is excluded by the `test_*.py` glob. Verified.

## Mutation matrix — every mutant against the SUBJECT, never the test

| Mutant | Reddened |
|---|---|
| drop `_send_macos_pyobjc` from the block loop | 3 distinct named tests (`[_send_macos_pyobjc]` x2, `[Darwin-True]`) |
| drop `_send_linux` | the three `[_send_linux]` / `[Linux-None]` cases |
| a new file gains the marker | the pin test only |
| an existing opt-out removed | the pin test only (both directions witnessed) |
| marker set to a string absent everywhere | the control fired ahead of the pin |

Independently re-verified the pyobjc mutant outside the agent that wrote this: 3 named failures, control 13 passed, tree clean after restore.

**Full suite: 2063 passed, 1 skipped, exit 0**, with `[notifications] blocked 17 real notification(s)` in the summary — the block is live end to end.

## Not fixed, deliberately

`ruff check src/ tests/` is **already red on `main`** (~150 pre-existing N803/SIM102 and similar). Not this PR's to fix. This file's own baseline was clean and still is; the 8 `N802` errors added by the ObjC selector fakes are closed with a file-level `# ruff: noqa: N802`, matching the existing house convention at `test_notification_delivery_verification.py:19`.
