### PR TITLE
Wait on the condition, not the clock: four files of racy thread tests

### DIFF
--- a/tests/_watchdog_harness.py
+++ b/tests/_watchdog_harness.py
@@ -43,6 +43,55 @@ class _Recorder:
         return [c for c in self.captures if c.get("fingerprint") == fingerprint]
 
 
+# Generous by design. Every wait on a WatchdogSignal is a wait on a CONDITION,
+# so this bound is only reached when the Timer genuinely never ran — a real
+# failure. A slow machine waits longer; it does not go red.
+WATCHDOG_WAIT_SECONDS = 30.0
+
+# Both branches of _watchdog() (main.py): a cycle with transient API failures
+# reports "-offline", one without reports the bare fingerprint. Either means
+# the Timer ran and phase.at_deadline is stamped.
+_FIRE_TIME_FINGERPRINTS = frozenset(
+    {"sync-watchdog-timeout", "sync-watchdog-timeout-offline"}
+)
+
+
+class WatchdogSignal:
+    """Set the moment the watchdog Timer emits its fire-time report.
+
+    Lets a cycle wait for the Timer to have ACTUALLY fired instead of sleeping
+    a wall-clock margin and hoping. The margin was the last timing bet left in
+    these files: overshoot it and phase_at_deadline is 'unknown', which reads
+    as a product defect rather than as the scheduling artifact it is.
+
+    Waiting on the capture is sound because _watchdog() stamps
+    ``phase.at_deadline = phase.name`` BEFORE it captures (main.py) — so by the
+    time this Event is set, everything the assertions read is in place.
+
+    Installed as an instance-level wrapper around the reporter's own capture,
+    so the recorder underneath still records exactly what it recorded before.
+    """
+
+    def __init__(self, reporter):
+        self._event = threading.Event()
+        self._inner = reporter.capture
+        reporter.capture = self._capture
+
+    def _capture(self, message, **kwargs):
+        try:
+            return self._inner(message, **kwargs)
+        finally:
+            if kwargs.get("fingerprint") in _FIRE_TIME_FINGERPRINTS:
+                self._event.set()
+
+    def rearm(self):
+        """Forget a previous cycle's firing, for a test that runs two."""
+        self._event.clear()
+
+    def wait(self, timeout=WATCHDOG_WAIT_SECONDS):
+        return self._event.wait(timeout)
+
+
 class CoordinatorHarness:
     """Base class wiring a SyncCoordinator with mocked collaborators.
 
@@ -88,3 +137,14 @@ class CoordinatorHarness:
         self.coord.error_reporter = self.recorder
         self.coord._fetch_hours_today = Mock(return_value="1:00")
         self.coord._DO_SYNC_DEADLINE = self.TEST_DEADLINE
+        self._watchdog_signal = None
+
+    def watchdog_signal(self):
+        """A WatchdogSignal over whatever reporter is installed right now.
+
+        Created lazily, so a subclass that swaps in its own reporter after
+        setup_method (TestEveryOverrunIsCounted) still gets wrapped correctly.
+        """
+        if self._watchdog_signal is None:
+            self._watchdog_signal = WatchdogSignal(self.coord.error_reporter)
+        return self._watchdog_signal

--- a/tests/test_browser_auth.py
+++ b/tests/test_browser_auth.py
@@ -14,6 +14,29 @@ from src.auth.browser_auth import (
 )
 from src.auth.pkce import generate_pkce_pair
 
+# Generous by design: it is only ever reached when flow.start() genuinely never
+# opened the browser, which is a real failure. See _browser_opened.
+_OPEN_WAIT_SECONDS = 15.0
+
+
+def _browser_opened(mock_browser):
+    """An Event set when flow.start() actually calls webbrowser.open().
+
+    The callback simulators below used to time.sleep(0.1) and then read
+    mock_browser.call_args, betting that the main thread had reached
+    webbrowser.open() inside 100ms. Lose that bet and call_args is None, the
+    simulator dies on a TypeError in a daemon thread nobody joins, no callback
+    is ever made, and flow.start() returns error="timeout" — a red test that
+    names the SUT rather than the fixture.
+
+    start() binds and serves the callback server BEFORE opening the browser
+    (browser_auth.py: HTTPServer -> serve_forever thread -> webbrowser.open),
+    so this Event is also proof the port is listening.
+    """
+    opened = threading.Event()
+    mock_browser.side_effect = lambda *_a, **_k: opened.set()
+    return opened
+
 
 class TestPKCEGeneration:
     """Tests for PKCE code generation."""
@@ -242,14 +265,16 @@ class TestBrowserAuthFlow:
     def test_start_returns_code_and_verifier(self, mock_browser):
         """Test successful flow returns code and verifier."""
         flow = BrowserAuthFlow("https://betterflow.eu/sync/auth/authorize")
-        flow.TIMEOUT_SECONDS = 2
+        flow.TIMEOUT_SECONDS = 30
+
+        opened = _browser_opened(mock_browser)
 
         def simulate_callback():
-            """Simulate browser callback after short delay."""
-            import time
+            """Simulate the browser callback once the browser has been opened."""
             import requests
 
-            time.sleep(0.1)
+            if not opened.wait(_OPEN_WAIT_SECONDS):
+                return  # start() never opened the browser; it will report timeout
             # Extract port from browser URL
             url = mock_browser.call_args[0][0]
             port = url.split("callback_port=")[1].split("&")[0]
@@ -280,14 +305,16 @@ class TestBrowserAuthFlow:
     def test_start_state_mismatch_returns_failure(self, mock_browser):
         """Test state mismatch returns failure."""
         flow = BrowserAuthFlow("https://betterflow.eu/sync/auth/authorize")
-        flow.TIMEOUT_SECONDS = 2
+        flow.TIMEOUT_SECONDS = 30
+
+        opened = _browser_opened(mock_browser)
 
         def simulate_wrong_state_callback():
-            """Simulate callback with wrong state."""
-            import time
+            """Simulate callback with wrong state, once the browser is open."""
             import requests
 
-            time.sleep(0.1)
+            if not opened.wait(_OPEN_WAIT_SECONDS):
+                return
             url = mock_browser.call_args[0][0]
             port = url.split("callback_port=")[1].split("&")[0]
 
@@ -312,14 +339,16 @@ class TestBrowserAuthFlow:
     def test_start_error_callback_returns_failure(self, mock_browser):
         """Test error callback returns failure with error message."""
         flow = BrowserAuthFlow("https://betterflow.eu/sync/auth/authorize")
-        flow.TIMEOUT_SECONDS = 2
+        flow.TIMEOUT_SECONDS = 30
+
+        opened = _browser_opened(mock_browser)
 
         def simulate_error_callback():
-            """Simulate OAuth error callback."""
-            import time
+            """Simulate the OAuth error callback, once the browser is open."""
             import requests
 
-            time.sleep(0.1)
+            if not opened.wait(_OPEN_WAIT_SECONDS):
+                return
             url = mock_browser.call_args[0][0]
             port = url.split("callback_port=")[1].split("&")[0]
             state = url.split("state=")[1].split("&")[0]

--- a/tests/test_macos_window_watcher.py
+++ b/tests/test_macos_window_watcher.py
@@ -2,7 +2,6 @@
 
 import platform
 import threading
-import time
 from unittest.mock import MagicMock, patch
 
 import pytest
@@ -11,6 +10,45 @@ import pytest
 pytest.importorskip("AppKit", reason="PyObjC not installed - macOS-only")
 
 from src.sync.macos_window_watcher import MacOSWindowWatcher
+
+# Generous by design. Every wait below is on a CONDITION the watcher thread
+# signals, so this bound is only ever reached when the thread genuinely never
+# did the work — i.e. a real failure. A slow machine waits longer; it does not
+# go red. See _PollSignal.
+_WAIT_SECONDS = 10.0
+
+
+class _PollSignal:
+    """Wait for the watcher thread to have DONE the work, not for the clock.
+
+    These tests used to start the poll thread and ``time.sleep(0.2)`` with a
+    0.05s poll interval, betting that at least one iteration lands inside the
+    window. That bet loses on a loaded runner: ``test_browser_url_included``
+    failed the v1.5.129 release build on macos-latest/arm64 and passed on
+    re-run with byte-identical code, having passed on macos-14-large/x86_64 in
+    the same run. There is no sleep duration that fixes it — any wall-clock
+    margin is a bet on the slowest machine that will ever run the suite
+    (tests/test_watchdog_overrun_outcome.py makes the same argument).
+
+    So the thread signals each poll and the test blocks until the count it
+    needs has arrived. ``target=2`` is used by the negative tests, where
+    "nothing was posted" is only evidence if the loop demonstrably ran.
+    """
+
+    def __init__(self, target: int = 1):
+        self._target = target
+        self._reached = threading.Event()
+        self._lock = threading.Lock()
+        self.calls = 0
+
+    def note(self) -> None:
+        with self._lock:
+            self.calls += 1
+            if self.calls >= self._target:
+                self._reached.set()
+
+    def wait(self) -> bool:
+        return self._reached.wait(_WAIT_SECONDS)
 
 
 @pytest.mark.skipif(platform.system() != "Darwin", reason="macOS-only watcher")
@@ -48,10 +86,12 @@ class TestMacOSWindowWatcher:
 
         watcher, aw = self._make_watcher(poll_interval=0.05)
         watcher._stop_event = threading.Event()
+        posted = _PollSignal()
+        aw.post_heartbeat.side_effect = lambda *a, **k: posted.note()
 
         watcher._thread = threading.Thread(target=watcher._run, daemon=True)
         watcher._thread.start()
-        time.sleep(0.2)
+        assert posted.wait(), "the watcher thread never posted a heartbeat"
         watcher.stop()
 
         assert aw.post_heartbeat.called
@@ -74,10 +114,12 @@ class TestMacOSWindowWatcher:
 
         watcher, aw = self._make_watcher(poll_interval=0.05)
         watcher._stop_event = threading.Event()
+        posted = _PollSignal()
+        aw.post_heartbeat.side_effect = lambda *a, **k: posted.note()
 
         watcher._thread = threading.Thread(target=watcher._run, daemon=True)
         watcher._thread.start()
-        time.sleep(0.2)
+        assert posted.wait(), "the watcher thread never posted a heartbeat"
         watcher.stop()
 
         assert aw.post_heartbeat.called
@@ -88,14 +130,23 @@ class TestMacOSWindowWatcher:
     @patch("src.sync.macos_window_watcher.MacOSWindowWatcher._get_active_window")
     def test_none_result_skips_heartbeat(self, mock_get_window):
         """Test that None from _get_active_window doesn't post heartbeat."""
-        mock_get_window.return_value = None
+        # Two polls, so "nothing was posted" is evidence about the loop having
+        # RUN rather than about it never having started (the vacuous pass a
+        # too-short sleep produces here).
+        polled = _PollSignal(target=2)
+
+        def _none(*_a, **_k):
+            polled.note()
+            return None
+
+        mock_get_window.side_effect = _none
 
         watcher, aw = self._make_watcher(poll_interval=0.05)
         watcher._stop_event = threading.Event()
 
         watcher._thread = threading.Thread(target=watcher._run, daemon=True)
         watcher._thread.start()
-        time.sleep(0.2)
+        assert polled.wait(), "the watcher thread never polled twice"
         watcher.stop()
 
         aw.post_heartbeat.assert_not_called()
@@ -103,14 +154,23 @@ class TestMacOSWindowWatcher:
     @patch("src.sync.macos_window_watcher.MacOSWindowWatcher._get_active_window")
     def test_exception_handled_gracefully(self, mock_get_window):
         """Test that exceptions in polling don't crash the watcher thread."""
-        mock_get_window.side_effect = Exception("some error")
+        # Two raising polls: surviving ONE proves nothing about a loop that
+        # re-enters. Waiting on the count rather than on 0.2s of clock is what
+        # makes "repeated" true on a loaded machine as well as an idle one.
+        raised = _PollSignal(target=2)
+
+        def _boom(*_a, **_k):
+            raised.note()
+            raise Exception("some error")
+
+        mock_get_window.side_effect = _boom
 
         watcher, aw = self._make_watcher(poll_interval=0.05)
         watcher._stop_event = threading.Event()
 
         watcher._thread = threading.Thread(target=watcher._run, daemon=True)
         watcher._thread.start()
-        time.sleep(0.2)
+        assert raised.wait(), "the watcher thread never raised twice"
 
         # Thread should still be alive despite repeated exceptions
         assert watcher._thread.is_alive()

--- a/tests/test_sync_watchdog_outcome_classification.py
+++ b/tests/test_sync_watchdog_outcome_classification.py
@@ -23,7 +23,6 @@ reporter actually captured — never on arguments forwarded between functions
 """
 
 import threading
-import time
 from types import SimpleNamespace
 from unittest.mock import Mock
 
@@ -37,11 +36,11 @@ from src.sync.http_client import (
     transient_failure_count,
 )
 from src.sync.sync_engine import SyncEngine
+from tests._watchdog_harness import WatchdogSignal
 
 # Shrunk deadline so the watchdog fires inside a test, not in 150s. The
 # production value is pinned by tests/test_sync_watchdog_budget.py.
 _TEST_DEADLINE = 0.3
-_OVERRUN = 1.2  # comfortably past _TEST_DEADLINE, so the watchdog always fires
 
 
 def _ok_stats():
@@ -135,12 +134,20 @@ class _CoordinatorHarness:
         self.coord._DO_SYNC_DEADLINE = _TEST_DEADLINE
 
     def _run_overrunning_cycle(self, before_overrun=None):
-        """Drive one real _do_sync whose body outlives the watchdog deadline."""
+        """Drive one real _do_sync whose body outlives the watchdog deadline.
+
+        The body waits for the watchdog Timer to have FIRED rather than
+        sleeping a fixed 1.2s and assuming it did. A wall-clock margin is a bet
+        on the slowest machine that will ever run the suite; overshoot it here
+        and the cycle finishes before the Timer runs, so no report is captured
+        at all and every assertion below fails as if the classifier were broken.
+        """
+        fired = WatchdogSignal(self.coord.error_reporter)
 
         def _slow_sync(*_args, **_kwargs):
             if before_overrun is not None:
                 before_overrun()
-            time.sleep(_OVERRUN)
+            fired.wait()
             return _ok_stats()
 
         self.sync_engine.sync.side_effect = _slow_sync

--- a/tests/test_watchdog_cycle_phase.py
+++ b/tests/test_watchdog_cycle_phase.py
@@ -11,23 +11,32 @@ abandoned by _acquire_sync_slot's takeover keeps running, and an instance
 attribute would let that zombie overwrite its successor's phase.
 """
 
-import time
 from unittest.mock import Mock
 
 from src.main import _CyclePhase
 
 from ._watchdog_harness import CoordinatorHarness, _ok_stats
 
-_OVERRUN = 1.2
-
 
 class TestCyclePhase(CoordinatorHarness):
+    """Each overrunning stage below WAITS for the watchdog Timer instead of
+    sleeping 1.2s and hoping it fired inside that window.
+
+    A wall-clock margin is a bet on the slowest machine that will ever run the
+    suite — the bet that killed the v1.5.122 build in
+    tests/test_watchdog_overrun_outcome.py, and that is still what a
+    time.sleep(_OVERRUN) here is. Blocking on the Timer's own fire-time report
+    makes a loaded machine wait longer rather than report phase='unknown'.
+    """
+
     def test_a_fresh_box_starts_at_startup(self):
         assert _CyclePhase().name == "startup"
 
     def test_overrun_inside_sync_reports_phase_sync(self):
+        fired = self.watchdog_signal()
+
         def _slow_sync(*_a, **_k):
-            time.sleep(_OVERRUN)
+            fired.wait()
             return _ok_stats()
 
         self.sync_engine.sync.side_effect = _slow_sync
@@ -41,8 +50,10 @@ class TestCyclePhase(CoordinatorHarness):
         """The discriminating case: if the stamp were only ever set to 'sync',
         the test above would pass and this one would not."""
 
+        fired = self.watchdog_signal()
+
         def _slow_health():
-            time.sleep(_OVERRUN)
+            fired.wait()
             return True
 
         self.coord._monitor_capture_health = Mock(side_effect=_slow_health)
@@ -56,8 +67,10 @@ class TestCyclePhase(CoordinatorHarness):
         """Global constraint: adding context must not move the fingerprint,
         level or message of the group that already holds 34 occurrences."""
 
+        fired = self.watchdog_signal()
+
         def _slow_sync(*_a, **_k):
-            time.sleep(_OVERRUN)
+            fired.wait()
             return _ok_stats()
 
         self.sync_engine.sync.side_effect = _slow_sync

--- a/tests/test_watchdog_overrun_outcome.py
+++ b/tests/test_watchdog_overrun_outcome.py
@@ -8,8 +8,8 @@ The predicate is `elapsed >= deadline`, deliberately NOT "did the watchdog
 fire": deriving it from elapsed avoids racing the in-flight Timer thread, and
 means most of these tests never need the timer to fire at all.
 
-Duration is SCRIPTED, not slept
--------------------------------
+Duration is SCRIPTED, not slept; the Timer is WAITED FOR, not slept past
+-----------------------------------------------------------------------
 These tests used to choose a band by sleeping inside sync() and letting the
 real clock decide which band the cycle landed in. That cannot work at test
 scale: the bands are ratios of the deadline, so with TEST_DEADLINE = 0.3 the
@@ -23,16 +23,22 @@ validating on an idle laptop, which proved nothing about the runner. There is
 no sleep duration that fixes this, because any wall-clock margin is a bet on
 the slowest machine that will ever run the suite.
 
-So the duration _do_sync MEASURES now comes from a scripted clock
+So the duration _do_sync MEASURES comes from a scripted clock
 (`_ScriptedClock`, driving `SyncCoordinator._monotonic`) and is exact on any
 machine, while the duration the cycle really TAKES is a separate knob used
-only by the tests that need the watchdog Timer to have fired. Those get a
-generous multiple of the deadline (`_TIMER_SLEEP`, 3x) rather than a marginal
-one, because that margin is the only wall-clock dependency left in this file.
+only by the tests that need the watchdog Timer to have fired.
+
+That knob used to be a generous multiple of the deadline (`_TIMER_SLEEP`, 3x),
+described here as the only wall-clock dependency left in the file. It is now
+not a duration at all: those cycles BLOCK on the Timer's own fire-time report
+(`WatchdogSignal`). 3x was chosen as four times the worst overhead the runner
+had been SEEN to add, which is the same shape of bet as the 45ms margin the
+paragraph above rejects — just with better odds. Waiting on the condition
+removes the bet rather than improving it, and a loaded machine now waits
+longer instead of reporting phase_at_deadline='unknown'.
 """
 
 import threading
-import time
 
 import src.main as main_module
 from src.error_reporter import ErrorReporter
@@ -52,12 +58,6 @@ MODERATE_ELAPSED = 0.42  # 1.40x -> "0.4"
 SEVERE_ELAPSED = 0.81  # 2.70x -> "0.8"
 HEALTHY_ELAPSED = 0.02  # 0.07x -> no report at all
 
-# How long a cycle really runs when a test needs the Timer to have fired. 3x
-# the deadline, so there is 0.6s of slack on a deadline of 0.3 — four times the
-# worst overhead the CI runner has been seen to add. Deliberately generous: the
-# consequence of it being marginal is a phase_at_deadline of 'unknown', which
-# reads as a product defect rather than as the timing artifact it would be.
-_TIMER_SLEEP = 0.9
 
 
 def _outcome_captures(recorder):
@@ -112,18 +112,22 @@ class _Harness(CoordinatorHarness):
             "was added"
         )
 
-    def run_cycle(self, reports, real_sleep=0.0):
-        """Measured as `reports`; really takes `real_sleep`.
+    def run_cycle(self, reports, await_timer=False):
+        """Measured as `reports`; blocks in sync() until the Timer has fired if
+        `await_timer`.
 
-        Pass real_sleep=_TIMER_SLEEP only when the test needs the watchdog
-        Timer to have fired (i.e. it asserts on phase_at_deadline, or on the
-        fire-time report the Timer emits). Everything else leaves it at 0 and
-        runs in microseconds.
+        Pass await_timer=True only when the test needs the watchdog Timer to
+        have fired (i.e. it asserts on phase_at_deadline, or on the fire-time
+        report the Timer emits). Everything else leaves it False and runs in
+        microseconds.
         """
+        fired = self.watchdog_signal() if await_timer else None
+        if fired is not None:
+            fired.rearm()  # a second cycle must wait for ITS own firing
 
         def _sync(*_a, **_k):
-            if real_sleep:
-                time.sleep(real_sleep)
+            if fired is not None:
+                fired.wait()
             return _ok_stats()
 
         self.sync_engine.sync.side_effect = _sync
@@ -156,7 +160,7 @@ class TestOverrunIsMeasured(_Harness):
         assert self.recorder.by_fingerprint(MODERATE) == []
 
     def test_the_report_carries_the_elapsed_time_and_the_phase(self):
-        self.run_cycle(MODERATE_ELAPSED, real_sleep=_TIMER_SLEEP)
+        self.run_cycle(MODERATE_ELAPSED, await_timer=True)
 
         got = self.recorder.by_fingerprint(MODERATE)[0]
         assert got["context"]["phase_at_deadline"] == "sync"
@@ -208,7 +212,7 @@ class TestOverrunIsMeasured(_Harness):
         Needs the Timer, and asserts the deadline phase positively — a cycle
         where the Timer never fired would report 'unknown', which also differs
         from 'hours_fetch' and would pass this vacuously."""
-        self.run_cycle(MODERATE_ELAPSED, real_sleep=_TIMER_SLEEP)
+        self.run_cycle(MODERATE_ELAPSED, await_timer=True)
 
         got = self.recorder.by_fingerprint(MODERATE)[0]
         assert got["context"]["phase_at_deadline"] == "sync"
@@ -222,8 +226,10 @@ class TestOverrunIsMeasured(_Harness):
         agreement-region trap: test-fixture-discipline.md Phantom 12). This is
         the one fixture where the deadline is breached in a DIFFERENT phase,
         so only this test can tell a real snapshot from a constant."""
+        fired = self.watchdog_signal()
+
         def _slow_health():
-            time.sleep(_TIMER_SLEEP)
+            fired.wait()
             return True
 
         self.coord._monitor_capture_health = _slow_health
@@ -250,8 +256,10 @@ class TestOverrunIsMeasured(_Harness):
         (the same agreement-region shape as the capture_health test above,
         this time on the exit field). aw_bucket_fetch_failed returns _do_sync
         right after the post_sync stamp, before hours_fetch is ever reached."""
+        fired = self.watchdog_signal()
+
         def _slow_failed_sync(*_a, **_k):
-            time.sleep(_TIMER_SLEEP)
+            fired.wait()
             stats = _ok_stats()
             stats.aw_bucket_fetch_failed = True
             return stats
@@ -368,7 +376,7 @@ class TestExistingReportsAreUnchanged(_Harness):
         """The outcome report is additive. The group that already holds 34
         occurrences must keep firing exactly as before. Emitted by the Timer
         thread, so this one genuinely has to outlive the deadline."""
-        self.run_cycle(MODERATE_ELAPSED, real_sleep=_TIMER_SLEEP)
+        self.run_cycle(MODERATE_ELAPSED, await_timer=True)
 
         hung = self.recorder.by_fingerprint("sync-watchdog-timeout")
         assert len(hung) == 1, self.recorder.captures
@@ -453,8 +461,8 @@ class TestEveryOverrunIsCounted(_Harness):
 
         Both cycles must genuinely fire the Timer, or a single 'Sync hung'
         would mean 'suppressed once' and 'only fired once' indistinguishably."""
-        self.run_cycle(MODERATE_ELAPSED, real_sleep=_TIMER_SLEEP)
-        self.run_cycle(MODERATE_ELAPSED, real_sleep=_TIMER_SLEEP)
+        self.run_cycle(MODERATE_ELAPSED, await_timer=True)
+        self.run_cycle(MODERATE_ELAPSED, await_timer=True)
         self._drain()
 
         hung = [p for p in self.posted if p["message"].startswith("Sync hung")]


### PR DESCRIPTION
`test_browser_url_included` failed the **v1.5.129 release build** on macos-latest/arm64 and passed on re-run with byte-identical code. This makes that failure reproducible on demand, then removes it — and fixes three more files with the same shape.

## Reproducing the release failure deterministically

The watcher loop is `while not self._stop_event.wait(poll_interval)`, so the first poll lands at ~`poll_interval`. `sleep(0.2)` was a bet that thread start plus one poll fits inside 200ms. One knob — raise the poll interval above the sleep — and the **old** code fails every time, on the exact test that broke the release:

```
OLD form, poll 0.30 vs its own sleep(0.2):
  FAILED test_heartbeat_posted_with_correct_data
  FAILED test_browser_url_included          <- the release breaker
NEW form, same knob:                         passes
30 consecutive runs of the fixed file:       0 failures
```

Every fix below carries the same style of one-knob control: inject the delay the CI runner supplies for free, show the old form fails and the new passes.

## The four files

**`tests/test_macos_window_watcher.py`** — tests now block on a `threading.Event` the watcher thread sets, 10s bound. The two *negative* tests wait for **two** polls, so "nothing was posted" is evidence about a loop that ran rather than one that never started; the old sleep could pass vacuously. Old `PASS` at 0.05 / **`FAIL` at 0.30**; new passes at both. 50/50 green at load average 51.7.

**`tests/test_browser_auth.py`** — three OAuth callback simulators slept 0.1s then read `mock_browser.call_args`, betting the main thread had reached `webbrowser.open()`. Losing that bet gives `TypeError: 'NoneType' object is not subscriptable` in an unjoined thread and `error="timeout"` from `start()` — red, naming the SUT rather than the race. Now each waits on an Event set by the `webbrowser.open` mock, which also proves the callback port is listening. The two tests asserting the **timeout** path deliberately keep their short bound: a slow machine only makes a timeout more likely. With 300ms injected latency the old form fails with exactly that predicted error; new passes. 50/50 green at load 30.

**Three watchdog files** (+ new `tests/_watchdog_harness.py`) — cycles overran a 0.3s deadline by sleeping a fixed margin and assuming the Timer had fired. If the Timer thread is scheduled late the cycle finishes first, `phase_at_deadline` stays `'unknown'`, and every assertion fails as though the classifier were broken. `WatchdogSignal` now waits on the reporter's own fire-time capture — sound because `_watchdog()` stamps `phase.at_deadline` *before* it captures. With `threading.Timer` delayed 1.0s the old form captures **zero** fire-time reports; new passes. 50/50 green at load 72, and the trio got faster: 5.8s vs ~11s of sleeping.

Worth noting `test_watchdog_overrun_outcome`'s own header called its 3x margin "the only wall-clock dependency left in this file" — the same bet the header rejects elsewhere, at better odds. It is now gone.

## Deliberately left alone, with reasons

- **`test_dead_letter_replay_concurrency.py`** (`sleep(0.6)`) — not a wait-before-assert. The sleep *holds* a thread inside a critical window so a second can race in; synchronisation is already `Event.wait()` + `join()`. Its failure direction is a vacuous pass, never a spurious red. Converting it would make the correct-code path burn a full timeout. A coverage-strength question, not a flake.
- **`test_daily_time_tracker.py`** (`sleep(0.001)`) — pacing to encourage interleaving; assertions run after `t.join()`, which is the real synchronisation.
- **`test_sync_engine.py`** (`sleep(0.01)`) — simulating elapsed time for two distinct timestamps. No thread; a slower machine widens the gap.

## Verification

Full suite twice: **2052 passed, 1 skipped, exit 0** — once normally, and once under `PYTHONUTF8=0 LC_ALL=C` (the issue #231 lever), because this adds non-ASCII prose to docstrings and that class has broken a release here before.

`ruff check` clean on all changed files. `test_browser_auth.py` carries pre-existing lint debt, reduced 10 → 7 errors, not reformatted.
