### PR TITLE
Routine notices replace each other; instruction notices keep their verdict

### DIFF
--- a/src/main.py
+++ b/src/main.py
@@ -3584,7 +3584,16 @@ class BetterFlowApp:
         self.sync_engine.pause()
         self.tray.set_paused(True)
         self.reminder_manager.on_tracking_stopped()
-        send_notification("Tracking Paused", "Your activity is no longer being recorded.", sound=False)
+        # Paused/Resumed share ONE key (#221): they are two values of the same
+        # state, so the later must replace the earlier rather than sit under
+        # it. A user who pauses and resumes four times should see the current
+        # state once, not eight entries.
+        send_notification(
+            "Tracking Paused",
+            "Your activity is no longer being recorded.",
+            sound=False,
+            coalesce_key="tracking-state",
+        )
         logger.info("Tracking paused")
 
     def _on_resume(self) -> None:
@@ -3593,7 +3602,12 @@ class BetterFlowApp:
         self.sync_engine.resume()
         self.tray.set_paused(False)
         self.reminder_manager.on_tracking_started()
-        send_notification("Tracking Resumed", "Your activity is being recorded again.", sound=False)
+        send_notification(
+            "Tracking Resumed",
+            "Your activity is being recorded again.",
+            sound=False,
+            coalesce_key="tracking-state",
+        )
         logger.info("Tracking resumed")
 
     def _on_project_change(self, project: Optional[dict]) -> None:
@@ -3614,7 +3628,12 @@ class BetterFlowApp:
             self.tray.set_paused(True)
             self.reminder_manager.on_tracking_stopped()
             self.reminder_manager.on_private_started()
-            send_notification("Private Time", "Tracking is paused — your activity is private.", sound=False)
+            send_notification(
+                "Private Time",
+                "Tracking is paused — your activity is private.",
+                sound=False,
+                coalesce_key="private-time",
+            )
         else:
             logger.info("Private time ended — recording resumed")
             self._set_user_paused(False)
@@ -3623,7 +3642,12 @@ class BetterFlowApp:
             self.tray.set_paused(False)
             self.reminder_manager.on_private_ended()
             self.reminder_manager.on_tracking_started()
-            send_notification("Private Time Ended", "Tracking has resumed.", sound=False)
+            send_notification(
+                "Private Time Ended",
+                "Tracking has resumed.",
+                sound=False,
+                coalesce_key="private-time",
+            )
 
     def _auto_end_private(self, elapsed_seconds: float) -> None:
         """End Private Time the same way the user toggle does, with a message

--- a/src/notifications.py
+++ b/src/notifications.py
@@ -161,7 +161,7 @@ def _try_load_macos_pyobjc() -> bool:
 
 
 def send_notification(
-    title: str, message: str, sound: bool = True
+    title: str, message: str, sound: bool = True, coalesce_key: str | None = None
 ) -> NotificationOutcome:
     """Send a native OS notification and report what we know about it.
 
@@ -179,6 +179,14 @@ def send_notification(
         title: Notification title.
         message: Notification body text.
         sound: Whether to play a sound (macOS only).
+        coalesce_key: For ROUTINE, repeating notices. Posts under a stable
+            identifier so macOS REPLACES the previous notice of the same
+            kind instead of stacking another one (#221). Costs the delivery
+            verdict: with a stable id the read-back cannot tell this post's
+            record from the previous post's leftover, so the return is
+            ``UNKNOWN`` rather than ``DELIVERED``. Leave it None for any
+            notice carrying an instruction the agent cannot otherwise
+            deliver — those need the verdict more than they need tidiness.
 
     Returns:
         The strongest claim the platform actually supports. Only
@@ -190,7 +198,7 @@ def send_notification(
         if system == "Darwin":
             outcome = NotificationOutcome.UNKNOWN
             if _try_load_macos_pyobjc():
-                outcome = _send_macos_pyobjc(title, message, sound)
+                outcome = _send_macos_pyobjc(title, message, sound, coalesce_key)
                 if outcome is NotificationOutcome.DELIVERED:
                     return outcome
             # Reachable again. It never was while the pyobjc path returned a
@@ -249,7 +257,7 @@ def clear_notifications() -> None:
 
 
 def _send_macos_pyobjc(
-    title: str, message: str, sound: bool
+    title: str, message: str, sound: bool, coalesce_key: str | None = None
 ) -> NotificationOutcome:
     """Post a notification via NSUserNotification and verify it landed.
 
@@ -291,11 +299,27 @@ def _send_macos_pyobjc(
             except Exception as e:
                 logger.debug("Failed to attach notification icon: %s", e)
 
-        # Unique per send, so the read below is attributable to THIS post
-        # and macOS never coalesces two notices into one. Notifications
-        # posted before this change carry no identifier at all, which is
-        # why nothing could be attributed to a send.
-        marker = f"betterflow-{uuid.uuid4()}"
+        # THE IDENTIFIER DECIDES BOTH THINGS, AND THEY PULL OPPOSITE WAYS.
+        #
+        # Unique per send makes the read below attributable to THIS post,
+        # which is the whole basis of DELIVERED (#204). It is also exactly
+        # what tells macOS these are different notifications, so it never
+        # replaces an earlier one — 18 screen unlocks in one log produced 18
+        # separate "Welcome back!" entries (#221).
+        #
+        # That trains people to dismiss BetterFlow notifications without
+        # reading them, and this is the same channel that carries the Rosetta
+        # (#188) and Accessibility (#194, #205) notices — one-shot messages a
+        # user must read and act on, sitting in a stack of twenty routine
+        # ones. So the volume problem is a delivery problem for the notices
+        # that matter most.
+        #
+        # Split rather than pick one: routine repeating notices pass a
+        # coalesce_key and give up the verdict they never read; instruction
+        # notices keep the unique id and the verdict.
+        marker = (
+            f"betterflow-{coalesce_key}" if coalesce_key else f"betterflow-{uuid.uuid4()}"
+        )
         note.setIdentifier_(marker)
 
         center = NSUserNotificationCenter.defaultUserNotificationCenter()
@@ -308,6 +332,21 @@ def _send_macos_pyobjc(
     except Exception as e:
         logger.warning("pyobjc notification failed, will fall back: %s", e)
         return NotificationOutcome.FAILED
+
+    if coalesce_key:
+        # NOT VERIFIED, AND SAYING SO IS THE POINT (#221).
+        #
+        # A stable identifier is what makes macOS replace the previous notice,
+        # and it is also what makes the read-back unattributable: a hit could
+        # be this post's record or the leftover of the one it just replaced.
+        # Returning DELIVERED off that would be a guess wearing a verdict's
+        # clothes, which is the exact failure NotificationOutcome exists to
+        # close.
+        #
+        # UNKNOWN is honest and costs nothing real: the callers that pass a
+        # coalesce_key are routine notices whose return value nobody reads.
+        # Any caller that DOES need the verdict must not pass one.
+        return NotificationOutcome.UNKNOWN
 
     return _confirm_macos_delivery(marker)
 

--- a/src/system_event_handler.py
+++ b/src/system_event_handler.py
@@ -225,7 +225,17 @@ class SystemEventHandler:
         self.tray.set_state(TrayState.SYNCING)
         self.reminder_manager.on_tracking_started()
         self.coordinator.trigger_sync("unlock_sync")
-        send_notification("Welcome back!", _day_greeting(), sound=False)
+        # Coalesced (#221): this fires on EVERY unlock -- 18 times in one
+        # measured day -- and nothing reads its outcome. A stable key makes
+        # macOS replace the previous one instead of stacking another, which
+        # matters because the same channel carries the Rosetta and
+        # Accessibility notices a user must actually read.
+        #
+        # Distinct from the once-per-session greeting in main.py, which DOES
+        # read the delivery verdict and therefore keeps its unique identifier.
+        send_notification(
+            "Welcome back!", _day_greeting(), sound=False, coalesce_key="welcome-back"
+        )
 
     def on_network_change(self, is_online: bool) -> None:
         """Handle network connectivity change."""

--- a/tests/test_notification_coalescing.py
+++ b/tests/test_notification_coalescing.py
@@ -1,0 +1,123 @@
+"""#221 — routine notices must replace each other; instruction notices must not.
+
+#204 tags every notification with a one-shot identifier so the delivered-list
+read-back is attributable to THIS post, which is the whole basis of DELIVERED.
+A unique identifier is also exactly what tells macOS these are different
+notifications, so it never replaces an earlier one: 18 screen unlocks in one
+measured day produced 18 separate "Welcome back!" entries.
+
+The cost is not clutter. It trains people to dismiss BetterFlow notifications
+without reading them, and the same channel carries the Rosetta (#188) and
+Accessibility (#194, #205) notices — one-shot messages a user must read and act
+on, sitting in a stack of twenty routine ones.
+
+So the two properties are in direct tension and the split is per-caller:
+routine repeating notices pass a coalesce_key and give up a verdict nobody
+reads; instruction notices keep the unique id and the verdict.
+"""
+
+from unittest.mock import patch
+
+from src.notifications import NotificationOutcome, _send_macos_pyobjc
+
+
+class FakeNote:
+    def __init__(self):
+        self.identifier = None
+
+    def setTitle_(self, _):
+        pass
+
+    def setInformativeText_(self, _):
+        pass
+
+    def setSoundName_(self, _):
+        pass
+
+    def setContentImage_(self, _):
+        pass
+
+    def setIdentifier_(self, value):
+        self.identifier = value
+
+
+def _post(coalesce_key=None):
+    """Drive the real sender with the Foundation layer stubbed out.
+
+    Returns (outcome, identifier-actually-set).
+    """
+    note = FakeNote()
+
+    class FakeNSUserNotification:
+        @staticmethod
+        def alloc():
+            class _A:
+                @staticmethod
+                def init():
+                    return note
+            return _A()
+
+    class FakeCenter:
+        @staticmethod
+        def defaultUserNotificationCenter():
+            class _C:
+                @staticmethod
+                def deliverNotification_(_):
+                    pass
+            return _C()
+
+    fake_foundation = type("M", (), {
+        "NSUserNotification": FakeNSUserNotification,
+        "NSUserNotificationCenter": FakeCenter,
+    })
+
+    with patch.dict("sys.modules", {"Foundation": fake_foundation}):
+        with patch("src.notifications._resolve_icon_path", return_value=None):
+            with patch(
+                "src.notifications._confirm_macos_delivery",
+                return_value=NotificationOutcome.DELIVERED,
+            ):
+                outcome = _send_macos_pyobjc("t", "m", False, coalesce_key)
+    return outcome, note.identifier
+
+
+def test_a_coalesce_key_produces_a_stable_identifier():
+    """The regression. Two posts of the same kind must carry the SAME id, which
+    is what makes macOS replace rather than stack."""
+    _, first = _post(coalesce_key="welcome-back")
+    _, second = _post(coalesce_key="welcome-back")
+
+    assert first == second == "betterflow-welcome-back"
+
+
+def test_without_a_key_the_identifier_is_still_unique():
+    """The allowance witness for #204. Instruction notices must keep the
+    per-post id, or the delivered read-back stops being attributable and
+    DELIVERED becomes a guess."""
+    _, first = _post()
+    _, second = _post()
+
+    assert first != second
+    assert first.startswith("betterflow-")
+
+
+def test_a_coalesced_post_does_not_claim_DELIVERED():
+    """The honest half, and the reason this is not free.
+
+    With a stable id a read-back hit could be this post's record or the
+    leftover of the one it just replaced. The stub above returns DELIVERED
+    deliberately: if the sender consulted it, this test would fail.
+    """
+    outcome, _ = _post(coalesce_key="welcome-back")
+
+    assert outcome is NotificationOutcome.UNKNOWN
+    assert not outcome, "UNKNOWN must stay falsy — only a verified delivery is truthy"
+
+
+def test_an_uncoalesced_post_still_reports_the_verified_verdict():
+    """The other side of the same witness: the verdict path is untouched for
+    callers that did not opt in."""
+    outcome, _ = _post()
+
+    assert outcome is NotificationOutcome.DELIVERED
+    assert outcome


### PR DESCRIPTION
#204 tags every notification with a one-shot identifier so the delivered-list read-back is attributable to **this** post — the whole basis of `DELIVERED`. A unique identifier is also exactly what tells macOS these are *different* notifications, so it never replaces an earlier one. 18 screen unlocks in one measured day produced 18 separate "Welcome back!" entries.

The cost is not clutter. It trains people to dismiss BetterFlow notifications without reading them — and the same channel carries the Rosetta (#188) and Accessibility (#194, #205) notices, one-shot messages a user must read and act on, sitting in a stack of twenty routine ones. **The volume problem is a delivery problem for the notices that matter most.**

### The split is per caller, because the two properties cannot both be had per notification

```python
send_notification(..., coalesce_key="welcome-back")
```

A key means a stable identifier, so macOS replaces the previous notice of that kind — and the call returns `UNKNOWN` rather than `DELIVERED`, because with a stable id a read-back hit could be this post's record or the leftover of the one it just replaced. Claiming `DELIVERED` off that would be a guess wearing a verdict's clothes, which is the failure `NotificationOutcome` exists to close.

### Which callers — read, not pattern-matched

30 `send_notification` sites; **five** coalesced:

| caller | key |
|---|---|
| `system_event_handler` "Welcome back!" | `welcome-back` |
| `main` "Tracking Paused" / "Tracking Resumed" | `tracking-state` |
| `main` "Private Time" / "Private Time Ended" | `private-time` |

The paired states share **one** key each on purpose: they are two values of the same state, so the later must replace the earlier. Pause and resume four times and you should see the current state once, not eight entries.

**The one that looks routine and is not:** `main.py`'s session greeting also says "Welcome back" and is deliberately untouched. It *reads* its outcome and logs a warning when the user got no confirmation that tracking started. It fires once per session, not per unlock. The per-unlock notice ignores its return entirely. Matching on the title would have coalesced the wrong one.

### Witnessed by mutation, not by a pre-fix run

Restoring `notifications.py` to `origin/main` fails all four tests **at the signature** — `coalesce_key` does not exist there — which proves the parameter is new and says nothing about behaviour. I am not passing that off as a regression proof. The behavioural evidence is two mutants that keep the signature:

```
ignore the key, always uuid                  -> 1 failed, 3 passed
   test_a_coalesce_key_produces_a_stable_identifier

let a coalesced post consult the read-back   -> 1 failed, 3 passed
   test_a_coalesced_post_does_not_claim_DELIVERED
```

Each reddens exactly its own assertion, and **both #204 witnesses pass under both mutants** — which is what shows this does not regress delivery verification. The `DELIVERED` assertion is driven with the confirmation stub returning `DELIVERED`, so a coalesced post consulting it fails rather than passes.

| step | result |
|---|---|
| `pytest tests/` | **2091 passed**, 1 skipped (2087 before, plus these four) |
| `ruff` on `notifications.py` | clean — I introduced one `SIM108` and fixed it |
| `ruff` on the new test file | 9 findings, all `N802`/`SIM117` from Objective-C method names the fakes must mimic; `tests/` already carries 28 and 7 of those, and ruff is in no workflow here |
| gitleaks | clean |

### Scope

Desktop agent, so this reaches devices with the next agent release rather than on merge. And the reporter's specific stack was never reproduced — the issue says so, and some of that pile was likely accumulated across days rather than one alert repeating. This fixes the mechanism that makes such a pile possible.

Closes #221
