### PR TITLE
Report a device stuck below the server's minimum version (closes #211)

### DIFF
--- a/src/sync/sync_engine.py
+++ b/src/sync/sync_engine.py
@@ -4029,6 +4029,12 @@ class SyncEngine:
                 logger.warning(
                     f"Agent {AGENT_VERSION} is below minimum {min_version} — update required"
                 )
+                # Off-device too. Both actions below are LOCAL — a log nobody
+                # pulls and a staged update that may keep failing — so a device
+                # stuck under the floor was invisible to ops for days. #211
+                # caught one at 1.5.119 against a 1.5.124 floor, losing
+                # window-title categorisation the whole time.
+                self._report_below_minimum(min_version)
                 # Act on it, don't just log: stage the latest build now (applied
                 # on next idle) so a server-pushed urgent fix lands in minutes
                 # instead of waiting up to 6h for the periodic check. The handler
@@ -4185,6 +4191,44 @@ class SyncEngine:
     # -> "server status 137", on a string that says it is not a rejection).
     # Both were live before this anchor existed.
     _SERVER_STATUS_RE = _SERVER_STATUS_RE
+
+    def _report_below_minimum(self, min_version: str) -> None:
+        """Tell ops this device is running under the server's version floor.
+
+        The two existing responses are local: a warning in a log that is only
+        uploaded on request, and a staged update that a broken updater may never
+        apply. So "this machine has been stuck for days" was answerable only by
+        visiting it — the fail-closed test ("if this failed, would anything be
+        different?") answered no.
+
+        DURATION IS DELIBERATELY NOT TRACKED HERE. The ops ingest keys by
+        fingerprint and records first_seen/last_seen, so "below the floor for
+        more than a day" is a question the monitor answers from the report
+        stream. Persisting a first-seen timestamp on the device would need its
+        own table, would reset whenever the queue DB is rebuilt, and would
+        answer worse a question the ingest already answers for free.
+
+        Hourly dedup rather than the reporter's 300s default: this is a
+        slow-moving condition, and one report an hour is enough to establish a
+        span without burying the ingest.
+
+        Swallowed on failure — telemetry must never break the heartbeat it
+        rides on.
+        """
+        if self.error_reporter is None:
+            return
+        try:
+            self.error_reporter.capture(
+                f"Agent {AGENT_VERSION} is below the server minimum "
+                f"{min_version} and is still running — the update has not "
+                f"applied. Window-title categorisation degrades while stuck.",
+                level="warning",
+                tags={"component": "self-update"},
+                fingerprint="agent-below-minimum-version",
+                dedup_window=3600.0,
+            )
+        except Exception:  # noqa: BLE001
+            logger.debug("below-minimum report failed", exc_info=True)
 
     @staticmethod
     def _dropped_reason_code(last_errors) -> str:

--- a/tests/test_below_minimum_version_alert.py
+++ b/tests/test_below_minimum_version_alert.py
@@ -1,0 +1,91 @@
+"""A device stuck below the server's minimum version must be visible to ops.
+
+`_handle_heartbeat_payload` already detects below-minimum and does two things:
+logs a warning, and stages an update. Both are LOCAL. Nothing leaves the
+machine, so a device that keeps failing to update sits below the floor for days
+while the only evidence is a log nobody pulls — the exact "if this failed, would
+anything be different?" shape from fail-closed.md. Answer today: no.
+
+Issue #211 observed it on a real device: 1.5.119 against a 1.5.124 floor, the
+server logging `below minimum` on every sync, for days, with window-title
+categorisation lost the whole time.
+
+Deliberately NOT tracking duration on the device. The ops ingest already keys by
+fingerprint and records first_seen/last_seen, so "below the floor for more than a
+day" is a question the monitor can answer from the report stream. Persisting a
+first-seen timestamp on the agent would need a new table and would still reset
+if the DB were rebuilt, to answer a question the ingest answers for free.
+"""
+
+from unittest.mock import Mock
+
+from src.sync.sync_engine import SyncEngine
+
+
+class _Reporter:
+    def __init__(self):
+        self.captures = []
+
+    def capture(self, message, **kw):
+        self.captures.append((message, kw))
+
+
+def _engine(reporter):
+    engine = SyncEngine.__new__(SyncEngine)
+    engine.error_reporter = reporter
+    engine.on_update_required = None
+    return engine
+
+
+def test_below_minimum_is_reported_to_ops():
+    reporter = _Reporter()
+    engine = _engine(reporter)
+
+    SyncEngine._report_below_minimum(engine, "1.5.124")
+
+    assert reporter.captures, (
+        "a device below the minimum version reported nothing off-device; "
+        "the condition is invisible to ops until someone pulls the log"
+    )
+    message, kw = reporter.captures[0]
+    assert "1.5.124" in message, message
+    assert kw["level"] == "warning"
+    assert kw["fingerprint"] == "agent-below-minimum-version", (
+        "a stable fingerprint is what lets the ingest age this into "
+        "'stuck for more than a day' via first_seen"
+    )
+
+
+def test_the_report_carries_both_versions():
+    """Ops needs the gap, not just the fact. One version alone cannot tell a
+    device one release behind from one stuck twenty releases back."""
+    reporter = _Reporter()
+    SyncEngine._report_below_minimum(_engine(reporter), "1.5.124")
+
+    message = reporter.captures[0][0]
+    from src.sync.bf_client import AGENT_VERSION
+    assert AGENT_VERSION in message, f"running version missing: {message}"
+
+
+def test_no_reporter_is_survivable():
+    """Telemetry must never break the heartbeat it rides on."""
+    engine = SyncEngine.__new__(SyncEngine)
+    engine.error_reporter = None
+    SyncEngine._report_below_minimum(engine, "1.5.124")  # must not raise
+
+
+def test_a_reporter_that_raises_does_not_break_the_heartbeat():
+    engine = SyncEngine.__new__(SyncEngine)
+    engine.error_reporter = Mock()
+    engine.error_reporter.capture.side_effect = RuntimeError("ingest down")
+    SyncEngine._report_below_minimum(engine, "1.5.124")  # must not raise
+
+
+def test_the_detection_site_calls_it():
+    """Witness the CALL, not just the helper. A reporter nobody invokes is the
+    same silence this fixes (test-fixture-discipline Phantom 3)."""
+    import inspect
+    src = inspect.getsource(SyncEngine._send_heartbeat)
+    assert "_report_below_minimum" in src, (
+        "the below-minimum branch does not report; the helper is dead code"
+    )


### PR DESCRIPTION
Closes the last open mechanism of #211. The other three shipped in v1.5.127 (#219, #224): non-fatal `hdiutil detach`, the stale-copy sweep, and `open <path>` instead of `open -a`.

## The defect

The below-minimum branch already did two things, and **both are local**: it logged a warning to a file that is only uploaded on request, and it staged an update that a broken updater may never apply.

So a device under the floor was invisible to ops for as long as it stayed there. #211 caught one at **1.5.119 against a 1.5.124 floor**, losing window-title categorisation the whole time, while the server logged `below minimum` on every sync and nothing acted on it.

Apply `fail-closed.md`'s test — *"if this failed, would anything be different?"* — and the answer was **no**. That is the defect, not the failing update.

## Duration is deliberately NOT tracked on the device

The issue asks for an alert *"when it has been below the floor for more than a day"*, which reads as agent state. It should not be.

The ops ingest already keys by fingerprint and records `first_seen`/`last_seen`, so **the span is a question the monitor answers from the report stream**. Persisting a first-seen timestamp on the agent would:

- need its own table — there is no key-value store in the queue DB, only `queued_events`, `dead_letter_events`, `sync_checkpoints`, `app_categories` and `counted_time`;
- reset whenever that DB is rebuilt (it is rebuilt on integrity-check failure);
- and answer *worse* a question the ingest answers for free.

Hourly dedup rather than the reporter's 300s default: a slow-moving condition needs enough reports to establish a span, not 288 a day.

## Verification

**Proof of failure:** all 5 tests written first and failing (no such method), 5 passing after.

The suite covers more than the happy path:

- a **call-site witness** asserting the helper is invoked from `_send_heartbeat` — a reporter nobody calls is the same silence this fixes (`test-fixture-discipline.md` Phantom 3);
- both failure paths — no reporter, and a reporter that raises — because telemetry must never break the heartbeat it rides on;
- the message carries **both** versions, since one alone cannot distinguish a device one release behind from one stuck twenty back.

**Mutation matrix — distinct named killer each, clean control:**

```
remove the call site      -> test_the_detection_site_calls_it
drop the fingerprint      -> test_below_minimum_is_reported_to_ops
```

The second matters more than it looks: without a stable fingerprint the ingest cannot group the reports, and `first_seen` — the thing this design leans on instead of device state — stops meaning anything.

**Full suite: 2096 passed, 1 skipped, exit 0.**

## One correction made during the work

The call-site test originally named `_handle_heartbeat_payload`, which does not exist — the branch lives in `_send_heartbeat`. Caught by the test failing rather than by reading it back.

## Not in scope

The server already holds `agent_devices.agent_version` and its own floor, so it could answer *"which devices are stuck"* for the whole fleet in one query without 57 independent reporters. That is arguably the better home for the fleet-wide question, but it is an internal-tool2 change and another session's repo — noting it rather than acting on it.
