### PR TITLE
fix(errors): a dedup window longer than the default expired at the default

### DIFF
--- a/src/error_reporter.py
+++ b/src/error_reporter.py
@@ -78,7 +78,8 @@ class ErrorReporter:
         self._dedup_window = dedup_window
 
         # fingerprint -> monotonic timestamp of last send; guarded by _lock.
-        self._recent: dict[str, float] = {}
+        # fingerprint -> (monotonic timestamp, the window it was recorded under)
+        self._recent: dict[str, tuple[float, float]] = {}
         self._lock = threading.Lock()
 
     @property
@@ -144,21 +145,41 @@ class ErrorReporter:
         """True if this fingerprint hasn't been sent within the cooldown window.
 
         ``dedup_window`` overrides the instance default for this call only;
-        ``None`` means use the default. Pruning always uses the instance
-        default, since it only exists to bound the dict's growth.
+        ``None`` means use the default.
+
+        Each entry stores the window it was recorded under, and pruning keeps it
+        for the LONGER of that window and the instance default. Pruning on the
+        instance default alone deleted a longer-lived entry before the
+        suppression check below could read it, so a caller asking for 3600s got
+        300s of suppression and then started sending again -- on a ~5-minute
+        heartbeat that is one send per beat instead of one per hour.
+
+        The `max` is not belt-and-braces, it is the other half of the contract:
+        a `dedup_window=0` call still has to STAMP the fingerprint so the next
+        caller -- one that asked for nothing -- is suppressed by the instance
+        default. Pruning on the entry's own window alone would make a
+        zero-window entry instantly stale and let that next call through, which
+        is the override leaking into a caller that never used it.
+
+        Pruning exists only to bound the dict's growth, so it must never evict
+        something a later check could still need. Every entry does still expire.
         """
         window = self._dedup_window if dedup_window is None else dedup_window
         now = time.monotonic()
         with self._lock:
             # Prune stale entries so the dict can't grow without bound.
-            stale = [k for k, ts in self._recent.items() if now - ts > self._dedup_window]
+            stale = [
+                k
+                for k, (ts, w) in self._recent.items()
+                if now - ts > max(w, self._dedup_window)
+            ]
             for k in stale:
                 del self._recent[k]
 
             last = self._recent.get(key)
-            if last is not None and now - last < window:
+            if last is not None and now - last[0] < window:
                 return False
-            self._recent[key] = now
+            self._recent[key] = (now, window)
             return True
 
     def _build_payload(

--- a/tests/test_error_reporter.py
+++ b/tests/test_error_reporter.py
@@ -266,3 +266,82 @@ class TestNonBlocking:
                 if t.name == "error-report":
                     t.join(timeout=5)
             post.assert_called_once()
+
+
+class TestPerCallWindowSurvivesPruning:
+    """A per-call `dedup_window` LONGER than the instance default has to
+    actually hold for its full length.
+
+    Pruning ran on `self._dedup_window` and deleted the entry BEFORE the
+    suppression check read it, so a 3600s request expired after 300s and the
+    fingerprint went back to sending. Nothing caught it because every fixture in
+    `TestDedupWindowOverride` sets the instance default to 10_000 -- larger than
+    any override it passes -- and none of them advances the clock, so pruning
+    can never evict anything there. Correct and broken behave identically in
+    that region.
+
+    The live caller is sync_engine's `agent-below-minimum-version` alert
+    (dedup_window=3600 against the 300s default), which is the only override in
+    the tree larger than the default. main.py's `dedup_window=0` is smaller, so
+    it was never affected.
+    """
+
+    def test_a_window_longer_than_the_default_is_not_pruned_early(self) -> None:
+        r = _reporter(dedup_window=300.0)
+        with patch("src.error_reporter.requests.post") as post, patch(
+            "src.error_reporter.time.monotonic"
+        ) as clock:
+            post.return_value = MagicMock(status_code=200, text="ok")
+            clock.return_value = 1000.0
+            r.capture("stuck", fingerprint="fp", block=True, dedup_window=3600.0)
+            # Past the 300s instance default, well inside the 3600s asked for.
+            clock.return_value = 1000.0 + 305.0
+            r.capture("stuck", fingerprint="fp", block=True, dedup_window=3600.0)
+            assert post.call_count == 1
+
+    def test_a_realistic_heartbeat_cadence_sends_once_per_window_not_once_per_beat(
+        self,
+    ) -> None:
+        """The shape that made this operational: a ~5-minute heartbeat re-reports
+        the same fingerprint. Asking for 3600s must mean roughly one send an
+        hour, not one per beat."""
+        r = _reporter(dedup_window=300.0)
+        with patch("src.error_reporter.requests.post") as post, patch(
+            "src.error_reporter.time.monotonic"
+        ) as clock:
+            post.return_value = MagicMock(status_code=200, text="ok")
+            t = 1000.0
+            for _ in range(24):  # 24 beats x 310s = 2h04m
+                clock.return_value = t
+                r.capture("stuck", fingerprint="fp", block=True, dedup_window=3600.0)
+                t += 310.0
+            # Two hours, 3600s window: 2 sends. Pre-fix this was 24.
+            assert post.call_count == 2
+
+    def test_the_entry_still_expires_at_its_own_window(self) -> None:
+        """The dict must stay bounded. An entry carrying a long window is kept
+        for that window and no longer -- it does not become permanent."""
+        r = _reporter(dedup_window=300.0)
+        with patch("src.error_reporter.requests.post") as post, patch(
+            "src.error_reporter.time.monotonic"
+        ) as clock:
+            post.return_value = MagicMock(status_code=200, text="ok")
+            clock.return_value = 1000.0
+            r.capture("stuck", fingerprint="fp", block=True, dedup_window=3600.0)
+            clock.return_value = 1000.0 + 3601.0
+            r.capture("stuck", fingerprint="fp", block=True, dedup_window=3600.0)
+            assert post.call_count == 2
+
+    def test_a_default_window_entry_is_still_pruned_on_the_default(self) -> None:
+        """The allowance: an ordinary caller's entry must not be held for longer
+        than it asked for just because the storage now carries a window."""
+        r = _reporter(dedup_window=300.0)
+        with patch("src.error_reporter.requests.post") as post, patch(
+            "src.error_reporter.time.monotonic"
+        ) as clock:
+            post.return_value = MagicMock(status_code=200, text="ok")
+            clock.return_value = 1000.0
+            r.capture("ordinary", fingerprint="fp2", block=True)
+            clock.return_value = 1000.0 + 301.0
+            r.capture("ordinary", fingerprint="fp2", block=True)
+            assert post.call_count == 2


### PR DESCRIPTION
## What

#242 asks for `dedup_window=3600` on the `agent-below-minimum-version` alert so it reports hourly. It reported on **every heartbeat** instead — roughly 288 a day, the exact volume that commit message says it is avoiding.

`_should_send` pruned `_recent` using the **instance** default (300s), and did that *before* reading the entry for the suppression check. So a 3600s entry was deleted at 300s, the fingerprint looked new, and the next beat sent again.

Its docstring stated the reasoning out loud — *"pruning always uses the instance default, since it only exists to bound the dict's growth"* — which is true about the intent and wrong about the consequence.

## Evidence

Reproduced before fixing, at a realistic ~5-minute cadence:

```
assert 24 == 2      24 sends over two hours where 2 were asked for
```

## Why no test caught it

Every fixture in `TestDedupWindowOverride` sets the instance default to `10_000` — larger than any override it passes — and none of them advances the clock. Correct and broken return the same answer everywhere in that region.

`sync_engine.py:4228`'s `3600` is the only override in the tree larger than the default. `main.py:2019`'s `dedup_window=0` is smaller and was never affected.

## The fix

Each entry records the window it was stored under, and pruning keeps it for `max(that window, the instance default)`.

**The `max` is not defensive padding — it is the other half of the contract, and the existing suite is what said so.** Pruning on the entry's own window alone made a `dedup_window=0` entry instantly stale, which reddened `test_the_override_does_not_leak_to_later_default_calls`: a zero-window call still has to *stamp* the fingerprint so the next caller, who asked for nothing, is suppressed by the default.

Pruning exists only to bound growth, so it must never evict something a later check still needs.

## Mutation matrix

Each mechanism reddens a **distinct** named test; neither is covered by the other's witness.

| mutant | reddens |
|---|---|
| prune on `self._dedup_window` only (the original bug) | the two new cadence tests |
| prune on the entry window only (drops the `max`) | the pre-existing no-leak test |
| control, unmutated | 25 passed |

Full suite: **2100 passed, 1 skipped** — reconciles with the 2096 baseline plus the 4 tests added here.

## Scope

`_recent` is private to `_should_send`; no reader outside it, so changing the stored value shape is contained. No behaviour change for any caller that omits the parameter or passes one at or below the instance default.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013k5u8EchGFHGrK8voawqJd
