### PR TITLE
ci: add concurrency groups and scope gitleaks push trigger

### DIFF
--- a/.github/workflows/verify-tracker-pins.yml
+++ b/.github/workflows/verify-tracker-pins.yml
@@ -33,6 +33,10 @@ on:
 permissions:
   contents: read
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   verify-pins:
     runs-on: ubuntu-latest

--- a/.github/workflows/verify-tracker-pins.yml
+++ b/.github/workflows/verify-tracker-pins.yml
@@ -35,7 +35,7 @@ permissions:
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: true
+  cancel-in-progress: false
 
 jobs:
   verify-pins:


### PR DESCRIPTION
Two mechanical CI-throughput fixes. The org's self-hosted Railway runner fleet had backed up to 88 queued jobs.

## 1. Concurrency groups

Workflows with no top-level `concurrency:` key never cancel a superseded run, so every push to a branch stacks another job behind the one it just obsoleted. Added to every workflow in this repo that lacked one:

```yaml
concurrency:
  group: ${{ github.workflow }}-${{ github.ref }}
  cancel-in-progress: true
```

**Deploy, publish and release workflows are deliberately excluded** — cancelling a package publish or a signed release build mid-flight can leave a half-published artifact. Workflows that already declared a concurrency key were left exactly as they were, including one that sets `cancel-in-progress: false` on purpose.

## 2. gitleaks double-trigger

The gitleaks workflow fired on both a bare `push:` and a bare `pull_request:`, so a push to a PR branch scanned the same SHA twice. That double-trigger accounted for 45 of the 88 queued runs across the org. Only the push trigger changed:

```yaml
on:
  push:
    branches: [main, master]   # was: bare `push:`
  pull_request:
  workflow_dispatch:
```

Coverage is unchanged. PR branches are still scanned through `pull_request`, the default branch is still scanned on merge, and the manual full-history audit through `workflow_dispatch` is untouched.

## Verification

Every touched file was parsed with `yaml.safe_load` and the resulting object inspected — `concurrency.group`, `concurrency.cancel-in-progress` and the `on.push` value were each read back from the parsed YAML rather than from the diff. All files parse and carry the intended values.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
---

**Correction (follow-up commit on this branch)** — on a `schedule:` trigger `github.ref` is always the default branch, so every scheduled run shares one concurrency group and a slow run is cancelled by its successor. The check then goes silent exactly when the system it monitors is slow, and a cancelled monitor is indistinguishable from "found nothing". The concurrency group is kept (it still prevents overlap by queueing) with `cancel-in-progress: false`.