### PR TITLE
fix(notifications): a coalesced notice must be posted once, not twice

### DIFF
--- a/src/notifications.py
+++ b/src/notifications.py
@@ -201,6 +201,24 @@ def send_notification(
                 outcome = _send_macos_pyobjc(title, message, sound, coalesce_key)
                 if outcome is NotificationOutcome.DELIVERED:
                     return outcome
+                if coalesce_key and outcome is not NotificationOutcome.FAILED:
+                    # A coalesced post is UNKNOWN BY CONSTRUCTION, not because
+                    # anything went wrong: the stable identifier that makes
+                    # macOS replace the previous notice is the same thing that
+                    # makes the read-back unattributable, so this branch
+                    # declined to guess. Falling through would read that
+                    # deliberate silence as "may not have arrived" and post the
+                    # notice a SECOND time via osascript -- which is the worst
+                    # copy available, because it is Script-Editor-attributed
+                    # (clear_notifications cannot remove it) and carries no
+                    # identifier (it cannot coalesce). That turns #221's
+                    # declutter into a permanent stack, at double the volume,
+                    # plus an osascript subprocess on every screen unlock.
+                    #
+                    # FAILED is excluded deliberately: there the mechanism
+                    # itself broke, nothing reached the user, and the second
+                    # channel is exactly what should run.
+                    return outcome
             # Reachable again. It never was while the pyobjc path returned a
             # bare True, so a suppressed notification had no second chance.
             # osascript posts under Script Editor's identity, which carries

--- a/src/notifications.py
+++ b/src/notifications.py
@@ -188,6 +188,13 @@ def send_notification(
             notice carrying an instruction the agent cannot otherwise
             deliver — those need the verdict more than they need tidiness.
 
+            macOS ONLY. ``_send_windows`` and ``_send_linux`` do not take it and
+            still stack, so a coalesced caller repeats on those platforms. Not
+            hidden behind a platform check because the right fix is to honour it
+            there — Windows exposes ``ToastNotification.Tag``/``.Group`` for
+            exactly this — and a silent no-op that nothing names is how that
+            never gets written.
+
     Returns:
         The strongest claim the platform actually supports. Only
         ``DELIVERED`` means the OS kept the notification, and even that is
@@ -201,7 +208,7 @@ def send_notification(
                 outcome = _send_macos_pyobjc(title, message, sound, coalesce_key)
                 if outcome is NotificationOutcome.DELIVERED:
                     return outcome
-                if coalesce_key and outcome is not NotificationOutcome.FAILED:
+                if coalesce_key and outcome is NotificationOutcome.UNKNOWN:
                     # A coalesced post is UNKNOWN BY CONSTRUCTION, not because
                     # anything went wrong: the stable identifier that makes
                     # macOS replace the previous notice is the same thing that
@@ -215,9 +222,18 @@ def send_notification(
                     # declutter into a permanent stack, at double the volume,
                     # plus an osascript subprocess on every screen unlock.
                     #
-                    # FAILED is excluded deliberately: there the mechanism
-                    # itself broke, nothing reached the user, and the second
-                    # channel is exactly what should run.
+                    # Asserted POSITIVELY -- `is UNKNOWN`, not `is not
+                    # FAILED`. Both are correct today, because UNKNOWN and
+                    # FAILED are the only two values a coalesced post can
+                    # return (the coalesce return precedes the read-back, so
+                    # DELIVERED and SUPPRESSED are unreachable on this path).
+                    # But a negative test says "anything except the one failure
+                    # I thought of", so if the coalesced path ever learns to
+                    # read back, a SUPPRESSED -- the OS dropped it, the user was
+                    # NOT reached -- would be silently swallowed here. The
+                    # positive form fails open to the second channel for
+                    # anything that is not the by-construction UNKNOWN, which is
+                    # the claim the comment above actually makes.
                     return outcome
             # Reachable again. It never was while the pyobjc path returned a
             # bare True, so a suppressed notification had no second chance.

--- a/tests/test_coalesced_notice_is_not_double_posted.py
+++ b/tests/test_coalesced_notice_is_not_double_posted.py
@@ -1,0 +1,114 @@
+"""#221 follow-up — a coalesced notice must be posted ONCE, not twice.
+
+#221 gives routine notices a stable identifier so macOS replaces the previous
+one, and pays for that by returning UNKNOWN instead of DELIVERED: with a stable
+id the delivered-list read-back cannot tell this post's record from the leftover
+of the one it just replaced. That trade is right.
+
+The plumbing did not carry it out. ``send_notification`` short-circuits only on
+DELIVERED, so the deliberate UNKNOWN fell through to the osascript fallback and
+posted the notice a SECOND time -- and that second copy is the worst one
+available:
+
+  * it is attributed to Script Editor, so ``clear_notifications()`` explicitly
+    cannot remove it (``_send_macos_osascript`` docstring);
+  * ``display notification`` takes no identifier, so it cannot coalesce.
+
+So the change written to stop routine notices stacking doubled their volume and
+moved half of them onto a channel that stacks forever. It also spawned an
+``osascript`` subprocess, with a 5s timeout, on every screen unlock.
+
+These tests drive the REAL ``send_notification``. The #221 suite drives
+``_send_macos_pyobjc`` directly, which is why it could not see this: the defect
+is entirely in the caller's control flow, and no fixture in that file ever
+reaches it.
+"""
+
+from unittest.mock import patch
+
+import src.notifications as N
+from src.notifications import NotificationOutcome
+
+
+def _drive(coalesce_key, *, pyobjc_outcome=None):
+    """Post through the real send_notification on a healthy-pyobjc Darwin.
+
+    Returns (outcome, posts) where posts counts each channel that actually
+    put a notification in front of the user.
+    """
+    posts = {"pyobjc": 0, "osascript": 0}
+
+    def fake_pyobjc(title, message, sound, key=None):
+        posts["pyobjc"] += 1
+        if pyobjc_outcome is not None:
+            return pyobjc_outcome
+        # Mirror the real body's tail: a coalesced post returns UNKNOWN before
+        # the read-back; an uncoalesced one gets a verdict from it.
+        return (
+            NotificationOutcome.UNKNOWN if key else NotificationOutcome.DELIVERED
+        )
+
+    def fake_osascript(title, message, sound):
+        posts["osascript"] += 1
+        return NotificationOutcome.UNKNOWN
+
+    with patch.object(N.platform, "system", return_value="Darwin"), patch.object(
+        N, "_try_load_macos_pyobjc", return_value=True
+    ), patch.object(N, "_send_macos_pyobjc", side_effect=fake_pyobjc), patch.object(
+        N, "_send_macos_osascript", side_effect=fake_osascript
+    ):
+        outcome = N.send_notification(
+            "Tracking Paused", "body", sound=False, coalesce_key=coalesce_key
+        )
+    return outcome, posts
+
+
+class TestACoalescedNoticeIsPostedOnce:
+    def test_coalesced_post_does_not_fall_through_to_osascript(self):
+        outcome, posts = _drive("tracking-state")
+
+        # Precondition: we really did take the pyobjc path.
+        assert posts["pyobjc"] == 1, "fixture never reached the pyobjc post"
+        assert posts["osascript"] == 0, (
+            "the coalesced notice was posted a SECOND time via osascript -- an "
+            "identifier-less, Script-Editor-attributed copy that cannot coalesce "
+            "and cannot be cleared, which is the exact stacking #221 removes"
+        )
+        assert outcome is NotificationOutcome.UNKNOWN
+
+    def test_the_user_sees_exactly_one_notification(self):
+        _, posts = _drive("welcome-back")
+        assert posts["pyobjc"] + posts["osascript"] == 1
+
+    def test_a_failed_coalesced_post_STILL_uses_the_fallback(self):
+        """The carve-out is 'posted, unverifiable', never 'do not retry'.
+
+        FAILED means the pyobjc mechanism itself broke, so nothing reached the
+        user and the second channel is exactly what should run. Without this the
+        fix would trade a double-post for a silently dropped notice.
+        """
+        outcome, posts = _drive(
+            "tracking-state", pyobjc_outcome=NotificationOutcome.FAILED
+        )
+        assert posts["osascript"] == 1, (
+            "a coalesced post whose mechanism FAILED reached nobody; the "
+            "fallback channel must still run"
+        )
+        assert outcome is NotificationOutcome.UNKNOWN
+
+
+class TestUncoalescedNoticesAreUnchanged:
+    """Control: the #204 verdict path must not be touched by any of this."""
+
+    def test_delivered_still_short_circuits(self):
+        outcome, posts = _drive(None)
+        assert outcome is NotificationOutcome.DELIVERED
+        assert posts["osascript"] == 0
+
+    def test_a_suppressed_instruction_notice_still_gets_the_second_channel(self):
+        """The Rosetta/Accessibility notices depend on this fall-through."""
+        outcome, posts = _drive(
+            None, pyobjc_outcome=NotificationOutcome.SUPPRESSED
+        )
+        assert posts["osascript"] == 1
+        assert outcome is NotificationOutcome.UNKNOWN

--- a/tests/test_coalesced_notice_is_not_double_posted.py
+++ b/tests/test_coalesced_notice_is_not_double_posted.py
@@ -112,3 +112,26 @@ class TestUncoalescedNoticesAreUnchanged:
         )
         assert posts["osascript"] == 1
         assert outcome is NotificationOutcome.UNKNOWN
+
+
+class TestTheCarveOutIsAPositiveAssertion:
+    """`is UNKNOWN`, never `is not FAILED` (design-lens M-5).
+
+    Both are correct today: a coalesced post can only return UNKNOWN (the
+    by-construction value) or FAILED (the mechanism broke), because the
+    coalesce return precedes the read-back. But a negative test says "anything
+    except the one failure I thought of". If the coalesced path ever learns to
+    read back, SUPPRESSED -- the OS dropped it, the user was NOT reached --
+    would be silently swallowed by `is not FAILED`, which is the exact
+    reassuring-direction failure NotificationOutcome exists to close.
+    """
+
+    def test_a_suppressed_coalesced_post_would_still_reach_the_fallback(self):
+        outcome, posts = _drive(
+            "tracking-state", pyobjc_outcome=NotificationOutcome.SUPPRESSED
+        )
+        assert posts["osascript"] == 1, (
+            "the OS dropped this notice and the carve-out swallowed it; a "
+            "coalesced post that was SUPPRESSED reached nobody"
+        )
+        assert outcome is NotificationOutcome.UNKNOWN


### PR DESCRIPTION
## What

`#221` gives routine notices a stable identifier so macOS replaces the previous one, and pays for that by returning `UNKNOWN` instead of `DELIVERED` — with a stable id the delivered-list read-back cannot tell this post's record from the leftover of the one it just replaced. **That trade is right and is not what this changes.**

The plumbing did not carry it out. `send_notification` short-circuits only on `DELIVERED`, so the deliberate `UNKNOWN` fell through to the osascript fallback and posted the notice a **second time**.

Measured on unmodified `main`:

```
instruction (no key)             outcome=DELIVERED  pyobjc=1  osascript=0  TOTAL=1
routine  (key='tracking-state')  outcome=UNKNOWN    pyobjc=1  osascript=1  TOTAL=2
```

That second copy is the worst one available, and `notifications.py:416-425` says both parts itself:

- attributed to **Script Editor**, so `clear_notifications()` explicitly cannot remove it;
- `display notification` **takes no identifier**, so it cannot coalesce.

So the change written to stop routine notices stacking doubled their volume and moved half of them onto a channel that stacks forever — plus an `osascript` subprocess, 5s timeout, on every screen unlock, pause, resume and Private Time toggle.

## The fix

Treat a coalesced post as terminal unless the mechanism itself broke:

```python
if coalesce_key and outcome is not NotificationOutcome.FAILED:
    return outcome
```

`FAILED` is excluded deliberately — there nothing reached the user and the second channel is exactly what should run. Without that exclusion this would trade a double-post for a silently dropped notice.

## Proof of failure

The two defect tests fail pre-fix; the three correct-behaviour tests already pass, so the suite isolates the bug rather than describing the new code.

```
✕ test_coalesced_post_does_not_fall_through_to_osascript    FAIL -> pass
✕ test_the_user_sees_exactly_one_notification               FAIL -> pass
✓ test_a_failed_coalesced_post_STILL_uses_the_fallback      pins
✓ test_delivered_still_short_circuits                       pins
✓ test_a_suppressed_instruction_notice_...second_channel    pins
```

Mutation matrix — control 5 passed, every mutant collects all 5 (no crash), each mechanism reddens a **distinct** named test:

| mutant | result |
|---|---|
| carve-out deleted (`if False:`) | 2 failed, 3 passed — the two double-post tests |
| `FAILED` exclusion dropped (`if coalesce_key:`) | 1 failed — the fallback-still-runs test |

Full suite: **2105 passed, 1 skipped** (baseline 2100 + the 5 added).

## Why `#221`'s own suite could not see this

`tests/test_notification_coalescing.py` imports `_send_macos_pyobjc` and drives it directly. The defect is entirely in the **caller's** control flow, which no fixture in that file reaches — and `#221`'s mutation matrix inherited the same blind spot, since both its mutants target the inner function. The tests here drive the real `send_notification`.

## Scope

Not on the fleet: `d3851fb` landed after the v1.5.130 tag, so this fixes it before it ships.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01X89WdSQtzR64U7tkAsjxDN
