### PR TITLE
fix(aw): tell the fleet when the tracker port is held by something that is not capturing

### DIFF
--- a/src/aw_manager.py
+++ b/src/aw_manager.py
@@ -1252,11 +1252,14 @@ class AWManager:
             # It used to read "Here — and ONLY here", with a paragraph below
             # explaining why the other paths could get away with the TCP answer
             # because they only decide whether to START something. That was
-            # already half-false after #233. Today THIS branch and the two
-            # download-path attaches ask, through _external_server_capturing();
-            # the normal-path attach still does not, deliberately -- see the
-            # deferral note above it. So "only here" is wrong, and "every attach
-            # point asks" would be wrong too.
+            # already half-false after #233, and now every attach point asks:
+            # this branch and the two download-path attaches ask through
+            # _external_server_capturing(); the normal-path attach asks too, via
+            # _server_responding() directly (see the external-attach design note
+            # above it) -- it just does not ACT on a "no", only reports it
+            # through _external_server_not_responding. So "only here" is wrong,
+            # and so is "the normal-path attach doesn't ask" -- it asks, it just
+            # doesn't decide anything on the answer.
             #
             # What is still TRUE and specific to this branch: on a
             # Rosetta-missing Mac the listener is un-reapable by construction --
@@ -1462,7 +1465,7 @@ class AWManager:
         # this line on its own; two attempts produced two different regressions.
         if server_already_running:
             # ASK -- and deliberately do NOT act on the answer here. Read the
-            # deferral note above: a foreign holder is unreapable
+            # external-attach design note above: a foreign holder is unreapable
             # (_reap_orphan_processes is path-scoped to our own binaries), so
             # attaching is the behaviour that keeps the watchers alive and
             # self-heals when the holder dies. Two attempts to change that both
@@ -1482,9 +1485,6 @@ class AWManager:
                 )
             self._using_external = True
         else:
-            # We own the server here, so the external-server verdict is not ours
-            # to carry -- clear it or a stale True outlives its condition.
-            self._external_server_not_responding = False
             logger.info(f"Starting tracker components from {binaries_dir}")
 
             # Start server first
@@ -1503,7 +1503,7 @@ class AWManager:
                 # unreachable escalation fired force_restart (which IS a second
                 # route in; the first draft of this note wrongly called :752 the
                 # only one). Bounded, not permanent -- and still worse than
-                # keeping the watchers. See the deferral note above.
+                # keeping the watchers. See the external-attach design note above.
                 self.stop()
                 return False
 
@@ -1568,6 +1568,14 @@ class AWManager:
 
     def _stop_locked(self) -> None:
         """Terminate every tracked process. Caller must hold _lifecycle_lock."""
+        # Reset here too, before the early return below, mirroring the reset at
+        # the top of _start_locked: once we stop, we are not attached to
+        # anything, so "attached to a non-responding external server" cannot be
+        # true. set_capture_suppressed(True) calls ONLY this method, never
+        # _start_locked -- so without this reset a corpse-attach flag latched on
+        # a prior cycle survives suppression, and a device that is not
+        # capturing BY DESIGN reports itself as attached to a dead server.
+        self._external_server_not_responding = False
         if not self._processes:
             return
 
@@ -1889,6 +1897,17 @@ class AWManager:
             age = self._get_latest_window_event_age()
             running_for = self._component_running_seconds(watcher)
             reachable = self._window_tracker_reachable()
+            if reachable:
+                # The tick already asked /api/0/info to judge window-tracker staleness,
+                # and a server that ANSWERS is by definition not the non-responding
+                # holder this flag reports. Without this the flag is a latch on one 2s
+                # probe: an ActivityWatch that was merely still booting when the agent
+                # started sets it True and nothing re-derives it, because the routine
+                # tick never re-enters _start_locked while the port stays held. The
+                # asymmetry is what made it worth fixing -- on a real corpse the
+                # watchdog forces a restart and the flag refreshes, so it only latched
+                # in the case where it was WRONG.
+                self._external_server_not_responding = False
             if not self._is_window_tracker_stale(age, running_for, reachable):
                 # Emitting fresh window events again. (age None here is just
                 # launch lag or an AW outage, not recovery — don't count it.)

--- a/src/aw_manager.py
+++ b/src/aw_manager.py
@@ -1825,7 +1825,7 @@ class AWManager:
         ):
             age = self._get_latest_window_event_age()
             running_for = self._component_running_seconds(watcher)
-            reachable = self._port_in_use()
+            reachable = self._window_tracker_reachable()
             if not self._is_window_tracker_stale(age, running_for, reachable):
                 # Emitting fresh window events again. (age None here is just
                 # launch lag or an AW outage, not recovery — don't count it.)
@@ -2223,6 +2223,21 @@ class AWManager:
             return True
         except (urllib.error.URLError, OSError):
             return False
+
+    def _window_tracker_reachable(self) -> bool:
+        """Is AW reachable for the purpose of judging window-tracker staleness?
+
+        Named rather than inlined because the question is not "is the port
+        held". _is_window_tracker_stale reads this as "AW is reachable", and a
+        corpse holding the port answers True to a TCP connect -- so an AW
+        OUTAGE was being classified as a blind tracker, force-restarted, and
+        latched as _window_tracker_blind, which tells the user to check a
+        permission when the real fault is a dead server.
+
+        One HTTP ask, no port pre-check: a server that answers necessarily
+        holds the port, so the TCP connect would only add latency.
+        """
+        return self._server_responding()
 
     def _wait_for_server(self) -> bool:
         """Wait for tracker server to accept connections."""

--- a/src/aw_manager.py
+++ b/src/aw_manager.py
@@ -1419,12 +1419,14 @@ class AWManager:
                 self._dispatch_download_failure_report()
                 return False
 
-        # NOT _external_server_capturing(), and that is a DEFERRAL rather than
-        # an oversight. Every other attach point in this file asks /api/0/info;
-        # this one still trusts the bare TCP connect, so a port held by a
-        # process that answers nothing is still preferred over starting our own
-        # trackers. That is a real bug (a healthy machine runs its watchers into
-        # a server that answers nothing) and it is NOT fixed here.
+        # NOT _external_server_capturing(), deliberately, and this is no longer
+        # a deferred bug -- it is a decided design. A foreign holder is
+        # unreapable (_reap_orphan_processes is path-scoped to our binaries), so
+        # attaching is the behaviour that keeps the watchers alive and recovers
+        # when the holder dies; both attempts to change it regressed (table
+        # below). The device now REPORTS the condition instead, via
+        # _external_server_not_responding on the heartbeat. Change the reporting
+        # if it is wrong; do not change this line.
         #
         # Asking here was written, measured and reverted twice. The problem is
         # not the question, it is what you can do with a "no": the only answer
@@ -1823,16 +1825,24 @@ class AWManager:
         # special — otherwise fall through to watcher health/stale recovery,
         # which MUST run in external mode too. Returning early there was why a
         # blind/orphaned bf-idle-tracker never self-healed after an update.
-        # DELIBERATELY the bare port read, not _external_server_capturing().
-        # Asking /api/0/info here was tried and reverted: on a HEALTHY shared
-        # ActivityWatch that missed two answers (a load spike, a wake from
-        # sleep, a long AW query) it dropped external mode, spawned our own
-        # server against the port that healthy server still owns, failed to
-        # bind, and the teardown below cleared every watcher. `is_managing`
-        # then reads False, so main.py's 60s tick stops calling this method and
-        # nothing re-enters the branch -- permanent, on a healthy machine, with
-        # both capture-dead flags reading False. Measured against a control
-        # that reverted only this predicate:
+        # DELIBERATELY the bare port read, not _external_server_capturing() --
+        # and not _external_server_not_responding either. That field reports
+        # the ATTACH-side condition (does the server we are attached to answer
+        # /info); it is set True only in _start_locked's normal-path attach
+        # branch, and every other write resets it to False. This predicate
+        # asks something that field cannot answer: has the external server's
+        # socket disappeared. Tearing down external mode achieves nothing when
+        # the holder is unreapable (_reap_orphan_processes is path-scoped to
+        # our own binaries), so asking /info and acting on a "no" was tried
+        # and reverted instead: on a HEALTHY shared ActivityWatch that missed
+        # two answers (a load spike, a wake from sleep, a long AW query) it
+        # dropped external mode, spawned our own server against the port that
+        # healthy server still owns, failed to bind, and the teardown below
+        # cleared every watcher. `is_managing` then reads False, so main.py's
+        # 60s tick stops calling this method and nothing re-enters the branch
+        # -- permanent, on a healthy machine, with both capture-dead flags
+        # reading False. Measured against a control that reverted only this
+        # predicate:
         #
         #   asked /info   rc=False  _using_external=False  watchers=[]
         #   bare port     rc=True   _using_external=True   watchers=[2]

--- a/src/aw_manager.py
+++ b/src/aw_manager.py
@@ -540,6 +540,13 @@ class AWManager:
         # port we still capture, but restart_if_needed/force_restart manage
         # nothing, so the backend should know this device is un-self-healing.
         self._managed_components_unavailable: bool = False
+        # True only while we are attached to a process that holds the tracker
+        # port and does not answer /api/0/info. Deliberately NOT one of the two
+        # capture-dead flags: _start_component clears those on Popen success
+        # (:2110), and the watcher loop runs after the attach, so anything
+        # latched there is wiped inside the same _start_locked call (measured).
+        # Nothing else writes this one.
+        self._external_server_not_responding = False
         # Tri-state cache for the Apple-Silicon-without-Rosetta check. None =
         # not probed yet. Installing Rosetta needs no reboot, so force_restart()
         # clears this to let a device that was fixed recover on its own — but
@@ -1432,12 +1439,30 @@ class AWManager:
         # opinion rather than something the measurement establishes. Do not flip
         # this line on its own; two attempts produced two different regressions.
         if server_already_running:
-            logger.info(
-                f"Tracker server already running on port {self.aw_port}, "
-                "using external instance"
-            )
+            # ASK -- and deliberately do NOT act on the answer here. Read the
+            # deferral note above: a foreign holder is unreapable
+            # (_reap_orphan_processes is path-scoped to our own binaries), so
+            # attaching is the behaviour that keeps the watchers alive and
+            # self-heals when the holder dies. Two attempts to change that both
+            # regressed. What was missing was never the decision -- it was
+            # TELLING THE FLEET, which is all this does.
+            self._external_server_not_responding = not self._server_responding()
+            if self._external_server_not_responding:
+                logger.warning(
+                    "Attached to the process holding port %s, but it does not "
+                    "answer /api/0/info — this device is capturing NOTHING",
+                    self.aw_port,
+                )
+            else:
+                logger.info(
+                    f"Tracker server already running on port {self.aw_port}, "
+                    "using external instance"
+                )
             self._using_external = True
         else:
+            # We own the server here, so the external-server verdict is not ours
+            # to carry -- clear it or a stale True outlives its condition.
+            self._external_server_not_responding = False
             logger.info(f"Starting tracker components from {binaries_dir}")
 
             # Start server first

--- a/src/aw_manager.py
+++ b/src/aw_manager.py
@@ -540,12 +540,16 @@ class AWManager:
         # port we still capture, but restart_if_needed/force_restart manage
         # nothing, so the backend should know this device is un-self-healing.
         self._managed_components_unavailable: bool = False
-        # True only while we are attached to a process that holds the tracker
-        # port and does not answer /api/0/info. Deliberately NOT one of the two
-        # capture-dead flags: _start_component clears those on Popen success
+        # True when the most recent evaluation attached to a process that holds
+        # the tracker port and does not answer /api/0/info. Re-derived on every
+        # _start_locked call, so it cannot outlive its condition -- reset to
+        # False at the top of that method and set True only on the normal-path
+        # attach branch; the other three attach branches only fire when
+        # _external_server_capturing() is already true, so False is correct
+        # there without them touching this field. Deliberately NOT one of the
+        # two capture-dead flags: _start_component clears those on Popen success
         # (:2110), and the watcher loop runs after the attach, so anything
         # latched there is wiped inside the same _start_locked call (measured).
-        # Nothing else writes this one.
         self._external_server_not_responding = False
         # Tri-state cache for the Apple-Silicon-without-Rosetta check. None =
         # not probed yet. Installing Rosetta needs no reboot, so force_restart()
@@ -1194,6 +1198,15 @@ class AWManager:
         if self._capture_suppressed:
             logger.debug("Tracker start refused: capture is suppressed")
             return False
+
+        # Reset per evaluation, so this cannot outlive the condition that set it.
+        # There are four branches that attach to an external server (:1266 Rosetta,
+        # :1345 backoff, :1393 download-failure, :1461 normal path) and only the
+        # normal path can attach to a NON-responding one -- the other three attach
+        # only when _external_server_capturing() is already true. So resetting here
+        # and setting True in that one branch is the whole invariant: every other
+        # attach, and every early return below, correctly reads False.
+        self._external_server_not_responding = False
 
         # Probed BEFORE the Rosetta branch below, not after it. Our managed
         # binaries being unrunnable says nothing about whether SOMETHING is

--- a/src/aw_manager.py
+++ b/src/aw_manager.py
@@ -1897,17 +1897,23 @@ class AWManager:
             age = self._get_latest_window_event_age()
             running_for = self._component_running_seconds(watcher)
             reachable = self._window_tracker_reachable()
-            if reachable:
-                # The tick already asked /api/0/info to judge window-tracker staleness,
-                # and a server that ANSWERS is by definition not the non-responding
-                # holder this flag reports. Without this the flag is a latch on one 2s
-                # probe: an ActivityWatch that was merely still booting when the agent
-                # started sets it True and nothing re-derives it, because the routine
-                # tick never re-enters _start_locked while the port stays held. The
-                # asymmetry is what made it worth fixing -- on a real corpse the
-                # watchdog forces a restart and the flag refreshes, so it only latched
-                # in the case where it was WRONG.
-                self._external_server_not_responding = False
+            # A previous fix wave cleared _external_server_not_responding here
+            # when `reachable` is True, reasoning that a server which just
+            # answered /api/0/info cannot be the non-responding holder the
+            # flag reports. That clear is INERT on macOS: this whole block is
+            # gated on `watcher not in self._disabled_components`, and
+            # main.py unconditionally disables "bf-window-tracker" on darwin
+            # (the in-process window watcher covers it instead). So on the
+            # platform this file's Rosetta/Accessibility complexity exists
+            # for, the clear never ran, and the flag worked on Windows/Linux
+            # only -- a signal whose meaning silently depended on the OS.
+            # Reverted rather than repaired: a uniform latch, refreshed only
+            # by the next _start_locked evaluation (a restart, or
+            # set_capture_suppressed(False) on an empty process set), is
+            # honest everywhere. No consumer reads this key yet, so the
+            # latch costs nothing today. See disclosure_baseline.py and
+            # bf_client.py for what "refreshed only on evaluation" actually
+            # means for this field.
             if not self._is_window_tracker_stale(age, running_for, reachable):
                 # Emitting fresh window events again. (age None here is just
                 # launch lag or an AW outage, not recovery — don't count it.)

--- a/src/aw_manager.py
+++ b/src/aw_manager.py
@@ -541,15 +541,16 @@ class AWManager:
         # nothing, so the backend should know this device is un-self-healing.
         self._managed_components_unavailable: bool = False
         # True when the most recent evaluation attached to a process that holds
-        # the tracker port and does not answer /api/0/info. Re-derived on every
-        # _start_locked call, so it cannot outlive its condition -- reset to
-        # False at the top of that method and set True only on the normal-path
-        # attach branch; the other three attach branches only fire when
-        # _external_server_capturing() is already true, so False is correct
-        # there without them touching this field. Deliberately NOT one of the
-        # two capture-dead flags: _start_component clears those on Popen success
-        # (:2110), and the watcher loop runs after the attach, so anything
-        # latched there is wiped inside the same _start_locked call (measured).
+        # the tracker port and does not answer /api/0/info. Re-derived as the
+        # FIRST statement of _start_locked, before even the capture-suppressed
+        # guard, so it cannot outlive its condition -- reset to False there and
+        # set True only on the normal-path attach branch; the other three
+        # attach branches only fire when _external_server_capturing() is
+        # already true, so False is correct there without them touching this
+        # field. Deliberately NOT one of the two capture-dead flags:
+        # _start_component clears those on Popen success, and the watcher loop
+        # runs after the attach, so anything latched there is wiped inside the
+        # same _start_locked call (measured).
         self._external_server_not_responding = False
         # Tri-state cache for the Apple-Silicon-without-Rosetta check. None =
         # not probed yet. Installing Rosetta needs no reboot, so force_restart()
@@ -1192,21 +1193,27 @@ class AWManager:
                 )
 
     def _start_locked(self) -> bool:
+        # Reset per evaluation -- the FIRST statement in this method, before
+        # even the capture-suppressed guard, so "re-derived on every
+        # _start_locked call" is literally true with no exception to document.
+        # False is also the honest value while capture is suppressed: the
+        # device is not attached to a dead external server, it is not attached
+        # to anything. Of the four branches below that can attach to an
+        # external server -- the Rosetta attach, the backoff attach, the
+        # download-failure attach, and the normal-path attach -- only the
+        # normal-path attach can attach to a NON-responding one; the other
+        # three attach only when _external_server_capturing() is already true
+        # and each returns immediately after, so False is already correct
+        # there without them touching this field. Resetting here and setting
+        # True in the one normal-path branch is the whole invariant.
+        self._external_server_not_responding = False
+
         # Every route back to a running tracker funnels through here, so this one
         # guard is enough to keep start()/restart_if_needed()/force_restart() from
         # resurrecting capture while it is suppressed.
         if self._capture_suppressed:
             logger.debug("Tracker start refused: capture is suppressed")
             return False
-
-        # Reset per evaluation, so this cannot outlive the condition that set it.
-        # There are four branches that attach to an external server (:1266 Rosetta,
-        # :1345 backoff, :1393 download-failure, :1461 normal path) and only the
-        # normal path can attach to a NON-responding one -- the other three attach
-        # only when _external_server_capturing() is already true. So resetting here
-        # and setting True in that one branch is the whole invariant: every other
-        # attach, and every early return below, correctly reads False.
-        self._external_server_not_responding = False
 
         # Probed BEFORE the Rosetta branch below, not after it. Our managed
         # binaries being unrunnable says nothing about whether SOMETHING is

--- a/src/aw_manager.py
+++ b/src/aw_manager.py
@@ -1730,6 +1730,7 @@ class AWManager:
             # Written under this same lock in _start_locked, so read under it too
             # instead of racing a concurrent start/restart.
             download_failed = self.tracker_download_failed
+            external_dead = self._external_server_not_responding
 
         window_age = self._get_latest_window_event_age()
         # When the agent owns the AFK stream in-process, the external
@@ -1775,6 +1776,13 @@ class AWManager:
             # be flowing via an external server on the port, but nothing here can
             # restart or self-heal it, so an outage will not recover on its own.
             "managed_components_unavailable": managed_unavailable,
+            # We are attached to a process that holds the tracker port and does
+            # not answer /api/0/info, so nothing is being captured -- but this is
+            # NOT tracker_download_failed: our binaries are fine and there is
+            # nothing to reap (the holder is not ours). Distinct key so the alert
+            # can say "something else owns port 5600" instead of blaming the
+            # download.
+            "external_server_not_responding": external_dead,
         }
 
     def restart_if_needed(self) -> bool:

--- a/src/disclosure_baseline.py
+++ b/src/disclosure_baseline.py
@@ -623,6 +623,10 @@ HEARTBEAT_HEALTH_KEYS: tuple[str, ...] = (
     # field and update the notice text, not to drop it and go back to blind.
     "tracker_download_failed",
     "managed_components_unavailable",
+    # Whether some OTHER process owns the tracker port and is not serving.
+    # Reports a property of the MACHINE's port 5600, never anything about what
+    # the user did.
+    "external_server_not_responding",
     # The window watcher has stayed blind across repeated restarts. Exactly the
     # same category as idle_tracker_blind, which this list already carries: a
     # fact about whether a watcher on this machine is working, never about what

--- a/src/disclosure_baseline.py
+++ b/src/disclosure_baseline.py
@@ -623,9 +623,10 @@ HEARTBEAT_HEALTH_KEYS: tuple[str, ...] = (
     # field and update the notice text, not to drop it and go back to blind.
     "tracker_download_failed",
     "managed_components_unavailable",
-    # Whether some OTHER process owns the tracker port and is not serving.
-    # Reports a property of the MACHINE's port 5600, never anything about what
-    # the user did.
+    # Whether the most recent evaluation found some OTHER process owning the
+    # tracker port and not serving. Re-derived every evaluation, so it cannot
+    # outlive the condition that set it -- a property of the MACHINE's port
+    # 5600 at that moment, never anything about what the user did.
     "external_server_not_responding",
     # The window watcher has stayed blind across repeated restarts. Exactly the
     # same category as idle_tracker_blind, which this list already carries: a

--- a/src/disclosure_baseline.py
+++ b/src/disclosure_baseline.py
@@ -623,10 +623,12 @@ HEARTBEAT_HEALTH_KEYS: tuple[str, ...] = (
     # field and update the notice text, not to drop it and go back to blind.
     "tracker_download_failed",
     "managed_components_unavailable",
-    # Whether the most recent evaluation found some OTHER process owning the
-    # tracker port and not serving. Re-derived every evaluation, so it cannot
-    # outlive the condition that set it -- a property of the MACHINE's port
-    # 5600 at that moment, never anything about what the user did.
+    # Whether we are attached to some OTHER process owning the tracker port
+    # and not serving. A property of the MACHINE's port 5600, never anything
+    # about what the user did. Not refreshed every heartbeat -- it is set on
+    # attach and cleared by the next reachability check or by the trackers
+    # being stopped, so it can lag the condition by up to one restart cycle,
+    # never by more.
     "external_server_not_responding",
     # The window watcher has stayed blind across repeated restarts. Exactly the
     # same category as idle_tracker_blind, which this list already carries: a

--- a/src/disclosure_baseline.py
+++ b/src/disclosure_baseline.py
@@ -625,10 +625,17 @@ HEARTBEAT_HEALTH_KEYS: tuple[str, ...] = (
     "managed_components_unavailable",
     # Whether we are attached to some OTHER process owning the tracker port
     # and not serving. A property of the MACHINE's port 5600, never anything
-    # about what the user did. Not refreshed every heartbeat -- it is set on
-    # attach and cleared by the next reachability check or by the trackers
-    # being stopped, so it can lag the condition by up to one restart cycle,
-    # never by more.
+    # about what the user did. Not refreshed every heartbeat -- it is
+    # re-derived only when the tracker lifecycle is next EVALUATED (an
+    # attach, a restart, or capture resuming with no processes running), and
+    # the routine 60s health tick is not one of those moments while the port
+    # stays held. Stopping the trackers clears it immediately (attached to
+    # nothing cannot be attached to a dead server), so the CLEAR direction is
+    # bounded by that tick. The SET direction is not: a server that answers
+    # at attach and later goes unresponsive without releasing the port keeps
+    # this flag at its stale value until the next evaluation, which on a
+    # held port is the unreachable watchdog's force-restart (up to ~180s,
+    # not "one restart cycle"). Known and deliberate for now, not a bug.
     "external_server_not_responding",
     # The window watcher has stayed blind across repeated restarts. Exactly the
     # same category as idle_tracker_blind, which this list already carries: a

--- a/src/sync/bf_client.py
+++ b/src/sync/bf_client.py
@@ -522,9 +522,12 @@ class BetterFlowClient(BaseApiClient):
         # wire and can CLEAR a degraded episode rather than latching it.
         "tracker_download_failed",
         "managed_components_unavailable",
-        # Attached to a process holding the tracker port that does not answer
-        # /api/0/info: the device is capturing NOTHING, and no restart can fix
-        # it because a foreign holder is unreapable. Distinct from
+        # True when the most recent evaluation attached to a process that holds
+        # the tracker port and does not answer /api/0/info -- the device is
+        # capturing NOTHING that cycle. Re-derived on every AWManager start
+        # evaluation, so it cannot outlive its condition: a corpse that later
+        # gets replaced by a genuinely responding server clears this on the
+        # very next evaluation, no restart needed. Distinct from
         # tracker_download_failed (our binaries are fine) and from
         # managed_components_unavailable (we did start our watchers).
         "external_server_not_responding",

--- a/src/sync/bf_client.py
+++ b/src/sync/bf_client.py
@@ -522,14 +522,20 @@ class BetterFlowClient(BaseApiClient):
         # wire and can CLEAR a degraded episode rather than latching it.
         "tracker_download_failed",
         "managed_components_unavailable",
-        # True when the most recent evaluation attached to a process that holds
-        # the tracker port and does not answer /api/0/info -- the device is
-        # capturing NOTHING that cycle. Re-derived on every AWManager start
-        # evaluation, so it cannot outlive its condition: a corpse that later
-        # gets replaced by a genuinely responding server clears this on the
-        # very next evaluation, no restart needed. Distinct from
-        # tracker_download_failed (our binaries are fine) and from
-        # managed_components_unavailable (we did start our watchers).
+        # True when we are attached to a process that holds the tracker port
+        # and does not answer /api/0/info -- the device is capturing NOTHING.
+        # Not a per-cycle verdict: it is set once, in AWManager's normal-path
+        # attach, and stays latched until something actually re-derives it --
+        # the routine 60s tick does not re-enter that attach while the port
+        # stays held. What clears it: the SAME tick's window-tracker
+        # reachability check clears it the moment /api/0/info answers (a
+        # corpse that gets replaced by a genuinely responding server, or a
+        # server that was merely still booting when we first attached), and
+        # stopping the trackers (capture suppression, force-restart) clears it
+        # too, since a device attached to nothing cannot be attached to a dead
+        # server. Distinct from tracker_download_failed (our binaries are
+        # fine) and from managed_components_unavailable (we did start our
+        # watchers).
         "external_server_not_responding",
         # Third field of the same shape, found while fixing the two above: the
         # window watcher has stayed blind across repeated restarts (the macOS

--- a/src/sync/bf_client.py
+++ b/src/sync/bf_client.py
@@ -524,18 +524,20 @@ class BetterFlowClient(BaseApiClient):
         "managed_components_unavailable",
         # True when we are attached to a process that holds the tracker port
         # and does not answer /api/0/info -- the device is capturing NOTHING.
-        # Not a per-cycle verdict: it is set once, in AWManager's normal-path
-        # attach, and stays latched until something actually re-derives it --
-        # the routine 60s tick does not re-enter that attach while the port
-        # stays held. What clears it: the SAME tick's window-tracker
-        # reachability check clears it the moment /api/0/info answers (a
-        # corpse that gets replaced by a genuinely responding server, or a
-        # server that was merely still booting when we first attached), and
-        # stopping the trackers (capture suppression, force-restart) clears it
-        # too, since a device attached to nothing cannot be attached to a dead
-        # server. Distinct from tracker_download_failed (our binaries are
-        # fine) and from managed_components_unavailable (we did start our
-        # watchers).
+        # Not a per-cycle verdict: it is set only inside AWManager's
+        # _start_locked normal-path attach, and re-derived fresh only when
+        # that evaluation runs again. The routine 60s tick does NOT re-enter
+        # _start_locked while the port stays held, so a device attached to a
+        # corpse keeps reporting True until one of: the port is released (the
+        # external server dies and the routine tick starts our own), the
+        # 180s unreachable watchdog fires force_restart(), or capture is
+        # suppressed and later resumed with no processes running. A server
+        # that recovers WITHOUT any of those (still holds the port, starts
+        # answering again) is not re-evaluated by the routine tick and can
+        # leave this flag stuck True for up to that 180s watchdog window --
+        # a known, deliberate limitation, not a bug to chase. Distinct from
+        # tracker_download_failed (our binaries are fine) and from
+        # managed_components_unavailable (we did start our watchers).
         "external_server_not_responding",
         # Third field of the same shape, found while fixing the two above: the
         # window watcher has stayed blind across repeated restarts (the macOS

--- a/src/sync/bf_client.py
+++ b/src/sync/bf_client.py
@@ -522,6 +522,12 @@ class BetterFlowClient(BaseApiClient):
         # wire and can CLEAR a degraded episode rather than latching it.
         "tracker_download_failed",
         "managed_components_unavailable",
+        # Attached to a process holding the tracker port that does not answer
+        # /api/0/info: the device is capturing NOTHING, and no restart can fix
+        # it because a foreign holder is unreapable. Distinct from
+        # tracker_download_failed (our binaries are fine) and from
+        # managed_components_unavailable (we did start our watchers).
+        "external_server_not_responding",
         # Third field of the same shape, found while fixing the two above: the
         # window watcher has stayed blind across repeated restarts (the macOS
         # Accessibility counterpart of idle_tracker_blind, which IS forwarded).

--- a/tests/test_aw_manager_window_blind.py
+++ b/tests/test_aw_manager_window_blind.py
@@ -38,6 +38,11 @@ def _mgr(window_age, running_for, reachable=True):
     mgr._get_latest_window_event_age = MagicMock(return_value=window_age)
     mgr._get_latest_afk_event_age = MagicMock(return_value=5)  # afk fresh → idle block no-op
     mgr._port_in_use = MagicMock(return_value=reachable)
+    # `reachable` means "AW is reachable" (see the test names below), which is
+    # now asked via _server_responding() -- a corpse holding the port answers
+    # True to _port_in_use() alone, the same agreement region #246 documented.
+    # Stub both so the fixture answers the question the code actually asks.
+    mgr._server_responding = MagicMock(return_value=reachable)
     mgr._component_started_at = (
         {} if running_for is None
         else {"bf-window-tracker": time.monotonic() - running_for}

--- a/tests/test_external_server_capturing_class.py
+++ b/tests/test_external_server_capturing_class.py
@@ -120,12 +120,15 @@ class TestF2DownloadFailureAttachAsksTheServer:
 
 
 class TestF3NormalPathStillTrustsTheSocket_Deferred:
-    """F-3 is DEFERRED, and this pins the deferral so nobody flips the line.
+    """F-3 is a DECIDED DESIGN, and this pins it so nobody flips the line.
 
     The normal-path attach is the widest member of this class -- no download
     failure, no Rosetta, just a port held by something that answers nothing --
-    and it is genuinely still broken: a healthy machine attaches to the corpse
-    and runs its watchers into a server that answers nothing.
+    and attaching to it anyway is deliberate: a foreign holder is unreapable
+    (_reap_orphan_processes is path-scoped to our own binaries), so attaching
+    is what keeps the watchers alive and lets the device recover the moment
+    the holder dies. The device now REPORTS the condition instead of hiding
+    it, via _external_server_not_responding on the heartbeat.
 
     Making it ask was written, measured and reverted TWICE. The question is not
     the problem; what you can DO with a "no" is. The only answer available is to
@@ -147,9 +150,8 @@ class TestF3NormalPathStillTrustsTheSocket_Deferred:
     the watchers -- but the first draft of this docstring said "permanently"
     and that was not measured.
 
-    Both repairs were worse than the bug. The fix belongs at a different layer
-    (the rebuild route, or a spawn that reaps only its own server), so it is not
-    being bodged here.
+    Both repairs were worse than this design. Change the reporting if it is
+    wrong; do not change this line.
     """
 
     def test_a_dead_holder_is_still_attached_to_for_now(self):
@@ -182,7 +184,7 @@ class TestF3NormalPathStillTrustsTheSocket_Deferred:
 
 
 class TestF4RecoveryStillReadsTheBarePort_Deliberately:
-    """F-4 is DEFERRED, and this pins the deferral so nobody flips it back.
+    """F-4 is a DECIDED DESIGN, and this pins it so nobody flips it back.
 
     Making the external-vanished recovery ask /api/0/info is the obvious fourth
     member of this class, and it was written, measured and reverted. On a
@@ -196,11 +198,15 @@ class TestF4RecoveryStillReadsTheBarePort_Deliberately:
         asked /info   rc=False  _using_external=False  watchers=[]
         bare port     rc=True   _using_external=True   watchers=[2]
 
-    So it needs a debounce -- N consecutive non-answers, resetting on any
-    success -- which is its own change with its own evidence. Until then a
-    corpse holding the port keeps external mode, and the device recovers on the
-    next app start via the normal-path attach (F-3), which no longer defers to
-    a corpse in the first place.
+    So it still needs a debounce -- N consecutive non-answers, resetting on
+    any success -- which is its own change with its own evidence; that is
+    unchanged by the reporting fix in Tasks 1-2, because THIS predicate never
+    writes _external_server_not_responding. That field is F-3's: set only in
+    _start_locked's normal-path attach branch, and re-derived fresh on every
+    _start_locked call. Until a debounced ask lands, a corpse holding the port
+    keeps external mode here, and the device recovers on the next app start
+    via the normal-path attach (F-3), which no longer defers to a corpse in
+    the first place.
     """
 
     def test_a_corpse_holding_the_port_does_NOT_trigger_recovery_yet(self):

--- a/tests/test_external_server_not_responding.py
+++ b/tests/test_external_server_not_responding.py
@@ -83,25 +83,42 @@ class TestItReachesTheWire:
         )
 
 
-class TestTheFlagIsNotALatch:
-    def test_a_boot_blip_clears_on_the_next_reachable_tick(self):
-        """Finding 1 (fix round 3): health_snapshot() reads a value re-derived
-        ONLY inside _start_locked, and the routine 60s tick does not reach
-        _start_locked while the port stays held. So an ActivityWatch that was
-        merely still BOOTING when the agent started (port held, /info not yet
-        answering, 2s timeout) sets the flag True and it never clears on its
-        own -- UNTIL the routine tick's OWN reachability check (already
-        computed every tick to judge window-tracker staleness) notices AW now
-        answers and clears it. Drives restart_if_needed(), the real routine
-        tick, not _start_locked a second time.
+class TestTheFlagIsALatchUntilTheNextStartEvaluation:
+    def test_the_flag_is_a_latch_until_the_next_start_evaluation(self):
+        """Known, deliberate limitation -- not a regression to chase.
+
+        A prior fix wave (round 3) tried to clear this flag from the routine
+        60s tick's window-tracker reachability check, the moment /api/0/info
+        started answering again. That clear lived INSIDE the block gated on
+        `watcher not in self._disabled_components` (watcher =
+        "bf-window-tracker"), and main.py unconditionally disables
+        "bf-window-tracker" on darwin -- the in-process macOS window watcher
+        covers it instead. So the clear was inert on exactly the platform
+        this file's Rosetta/Accessibility complexity exists for, and worked
+        on Windows/Linux only: the same flag would mean a different thing
+        depending on the OS the device happened to run.
+
+        Reverted rather than repaired. The honest, platform-independent
+        behaviour pinned here: this flag is set or cleared ONLY inside a
+        `_start_locked` evaluation, and the routine 60s tick does not
+        re-enter `_start_locked` while the port stays held (see
+        _restart_if_needed_locked's bare-port check above). So a corpse that
+        starts answering again with no restart-ish event in between --
+        force_restart() via the 180s unreachable watchdog, or
+        set_capture_suppressed(False) on an empty process set -- keeps this
+        flag at its stale value. No consumer reads this key yet, so the cost
+        of the latch is zero today; fixing it for real needs a
+        platform-independent reachability point under the lock, which this
+        test deliberately does not attempt.
         """
         m = _mgr(port_held=True, answers=False)
         m._start_locked()
         assert m._external_server_not_responding is True
 
-        # AW finishes booting. Give the instance a live watcher process so the
-        # routine tick's window-tracker section -- not _start_locked -- is
-        # what runs and does the clearing.
+        # The corpse "recovers" -- starts answering -- with no restart-ish
+        # event in between. Give the instance a live watcher process so the
+        # routine tick's window-tracker section runs (it used to be where
+        # the now-reverted clear lived).
         window = MagicMock()
         window.poll.return_value = None
         m._processes = {"bf-window-tracker": window}
@@ -112,7 +129,10 @@ class TestTheFlagIsNotALatch:
         for _ in range(3):
             m.restart_if_needed()
 
-        assert m._external_server_not_responding is False
+        assert m._external_server_not_responding is True, (
+            "the routine tick must not clear this -- the clear was inert on "
+            "macOS and is gone on every platform now; see the class docstring"
+        )
 
 
 class TestTheFlagDoesNotOutliveTheCondition:

--- a/tests/test_external_server_not_responding.py
+++ b/tests/test_external_server_not_responding.py
@@ -83,6 +83,38 @@ class TestItReachesTheWire:
         )
 
 
+class TestTheFlagIsNotALatch:
+    def test_a_boot_blip_clears_on_the_next_reachable_tick(self):
+        """Finding 1 (fix round 3): health_snapshot() reads a value re-derived
+        ONLY inside _start_locked, and the routine 60s tick does not reach
+        _start_locked while the port stays held. So an ActivityWatch that was
+        merely still BOOTING when the agent started (port held, /info not yet
+        answering, 2s timeout) sets the flag True and it never clears on its
+        own -- UNTIL the routine tick's OWN reachability check (already
+        computed every tick to judge window-tracker staleness) notices AW now
+        answers and clears it. Drives restart_if_needed(), the real routine
+        tick, not _start_locked a second time.
+        """
+        m = _mgr(port_held=True, answers=False)
+        m._start_locked()
+        assert m._external_server_not_responding is True
+
+        # AW finishes booting. Give the instance a live watcher process so the
+        # routine tick's window-tracker section -- not _start_locked -- is
+        # what runs and does the clearing.
+        window = MagicMock()
+        window.poll.return_value = None
+        m._processes = {"bf-window-tracker": window}
+        m._get_latest_window_event_age = MagicMock(return_value=5)
+        m._get_latest_afk_event_age = MagicMock(return_value=5)
+        m._server_responding = MagicMock(return_value=True)
+
+        for _ in range(3):
+            m.restart_if_needed()
+
+        assert m._external_server_not_responding is False
+
+
 class TestTheFlagDoesNotOutliveTheCondition:
     def test_the_flag_does_not_outlive_the_condition_that_set_it(self):
         """The reviewer's exact two-cycle repro (Finding 1, fix round 1).
@@ -105,23 +137,26 @@ class TestTheFlagDoesNotOutliveTheCondition:
         assert m._external_server_not_responding is False
 
     def test_the_flag_does_not_outlive_suppressed_capture(self):
-        """Fix round 2, Finding 2. My own re-review reproduction:
+        """Fix round 2, Finding 2. My own re-review reproduction, THEN
+        corrected (fix round 3) to drive the real production entrypoint.
 
         cycle 1 (corpse):             flag=True
-        cycle 2 (capture suppressed): rc=False  flag=True   <- outlived its
-                                                                condition
+        cycle 2 (capture suppressed): flag=True   <- outlived its condition
 
-        The reset was sitting AFTER the _capture_suppressed early return, so a
-        suppressed evaluation never reached it. False is also the honest value
-        here: while capture is suppressed the device is not attached to a dead
-        external server, it is not attached to anything.
+        set_capture_suppressed(True) is the ONLY production caller that
+        suppresses capture, and it calls _stop_locked() -- never
+        _start_locked(). The public start() has zero callers in src/ or
+        tests/, so a test driving _start_locked() a second time to simulate
+        suppression witnesses a path production never takes; it was green
+        even while _stop_locked() left the flag latched. False is also the
+        honest value here: while capture is suppressed the device is not
+        attached to a dead external server, it is not attached to anything.
         """
         m = _mgr(port_held=True, answers=False)
         m._start_locked()
         assert m._external_server_not_responding is True
 
-        m._capture_suppressed = True
-        rc = m._start_locked()
+        m.set_capture_suppressed(True)
 
-        assert rc is False
+        assert m._capture_suppressed is True
         assert m._external_server_not_responding is False

--- a/tests/test_external_server_not_responding.py
+++ b/tests/test_external_server_not_responding.py
@@ -1,0 +1,62 @@
+"""A device attached to a corpse must SAY so (F-3, reporting half).
+
+The lifecycle is deliberately unchanged: a foreign process holding :5600 is
+unreapable (_reap_orphan_processes is path-scoped to our binaries), so
+attaching is the behaviour that keeps the watchers alive and self-heals when
+the holder dies. Two attempts to change that both regressed. What was missing
+was telling the fleet, which is what this flag does.
+"""
+
+from unittest.mock import MagicMock
+
+from src.aw_manager import AWManager
+
+
+def _mgr(*, port_held, answers):
+    m = AWManager()
+    m._capture_suppressed = False
+    m._get_binaries_dir = MagicMock(return_value="/tmp/bin")
+    m._rosetta_required = MagicMock(return_value=False)
+    m._port_in_use = MagicMock(return_value=port_held)
+    m._server_responding = MagicMock(return_value=answers)
+    m._start_component = MagicMock(return_value=True)
+    m._wait_for_server = MagicMock(return_value=True)
+    m._reap_orphan_processes = MagicMock()
+    return m
+
+
+class TestAttachedToACorpseIsReported:
+    def test_a_dead_holder_sets_the_flag(self):
+        m = _mgr(port_held=True, answers=False)
+        m._start_locked()
+        assert m._external_server_not_responding is True
+
+    def test_the_flag_survives_the_watcher_loop(self):
+        """_start_component clears the two capture-dead flags on success, which
+        is why this is a separate flag and not a reuse of those."""
+        m = _mgr(port_held=True, answers=False)
+        m._start_locked()
+        assert m._start_component.called, "fixture never reached the watcher loop"
+        assert m._external_server_not_responding is True
+
+    def test_the_lifecycle_is_UNCHANGED_by_this(self):
+        """The whole point: we still attach, and the watchers still start."""
+        m = _mgr(port_held=True, answers=False)
+        assert m._start_locked() is True
+        assert m._using_external is True
+        started = [c.args[0] for c in m._start_component.call_args_list]
+        assert "bf-window-tracker" in started and "bf-idle-tracker" in started
+
+
+class TestTheAllowanceDirection:
+    def test_a_live_external_server_does_not_set_it(self):
+        m = _mgr(port_held=True, answers=True)
+        m._start_locked()
+        assert m._external_server_not_responding is False
+
+    def test_starting_our_own_server_clears_it(self):
+        """A stale True must not outlive the condition."""
+        m = _mgr(port_held=False, answers=False)
+        m._external_server_not_responding = True
+        m._start_locked()
+        assert m._external_server_not_responding is False

--- a/tests/test_external_server_not_responding.py
+++ b/tests/test_external_server_not_responding.py
@@ -60,3 +60,24 @@ class TestTheAllowanceDirection:
         m._external_server_not_responding = True
         m._start_locked()
         assert m._external_server_not_responding is False
+
+
+class TestItReachesTheWire:
+    def test_health_snapshot_publishes_it(self):
+        m = _mgr(port_held=True, answers=False)
+        m._get_latest_window_event_age = MagicMock(return_value=5)
+        m._get_latest_afk_event_age = MagicMock(return_value=5)
+        m._window_titles_captured_recently = MagicMock(return_value=True)
+        m._start_locked()
+
+        assert m.health_snapshot()["external_server_not_responding"] is True
+
+    def test_the_key_is_on_the_heartbeat_allowlist(self):
+        """A field missing from HEARTBEAT_HEALTH_KEYS never leaves the machine,
+        silently -- health_snapshot publishing it is not enough."""
+        from src.sync.bf_client import BetterFlowClient
+
+        assert (
+            "external_server_not_responding"
+            in BetterFlowClient.HEARTBEAT_HEALTH_KEYS
+        )

--- a/tests/test_external_server_not_responding.py
+++ b/tests/test_external_server_not_responding.py
@@ -81,3 +81,25 @@ class TestItReachesTheWire:
             "external_server_not_responding"
             in BetterFlowClient.HEARTBEAT_HEALTH_KEYS
         )
+
+
+class TestTheFlagDoesNotOutliveTheCondition:
+    def test_the_flag_does_not_outlive_the_condition_that_set_it(self):
+        """The reviewer's exact two-cycle repro (Finding 1, fix round 1).
+
+        cycle 1: normal path, corpse holds the port -> flag correctly True.
+        cycle 2: Rosetta branch, external server now genuinely capturing
+                 (_port_in_use=True, _server_responding=True) -> attaches
+                 through a DIFFERENT branch than the normal path, and the
+                 stale True from cycle 1 must not survive.
+        """
+        m = _mgr(port_held=True, answers=False)
+        m._start_locked()
+        assert m._external_server_not_responding is True
+
+        m._rosetta_required = MagicMock(return_value=True)
+        m._port_in_use = MagicMock(return_value=True)
+        m._server_responding = MagicMock(return_value=True)
+        m._start_locked()
+
+        assert m._external_server_not_responding is False

--- a/tests/test_external_server_not_responding.py
+++ b/tests/test_external_server_not_responding.py
@@ -103,3 +103,25 @@ class TestTheFlagDoesNotOutliveTheCondition:
         m._start_locked()
 
         assert m._external_server_not_responding is False
+
+    def test_the_flag_does_not_outlive_suppressed_capture(self):
+        """Fix round 2, Finding 2. My own re-review reproduction:
+
+        cycle 1 (corpse):             flag=True
+        cycle 2 (capture suppressed): rc=False  flag=True   <- outlived its
+                                                                condition
+
+        The reset was sitting AFTER the _capture_suppressed early return, so a
+        suppressed evaluation never reached it. False is also the honest value
+        here: while capture is suppressed the device is not attached to a dead
+        external server, it is not attached to anything.
+        """
+        m = _mgr(port_held=True, answers=False)
+        m._start_locked()
+        assert m._external_server_not_responding is True
+
+        m._capture_suppressed = True
+        rc = m._start_locked()
+
+        assert rc is False
+        assert m._external_server_not_responding is False

--- a/tests/test_window_stale_needs_a_responding_server.py
+++ b/tests/test_window_stale_needs_a_responding_server.py
@@ -1,0 +1,36 @@
+"""A dead tracker server must not be reported as a blind window tracker.
+
+_is_window_tracker_stale reads `reachable` as "AW is reachable", per its own
+docstring -- otherwise a None event age is just an AW outage. It was fed
+_port_in_use(), and a corpse holding the port answers True, so an outage was
+classified as a blind tracker: a force-restart burst plus a latched
+_window_tracker_blind, which publishes a permissions story for a dead server.
+"""
+
+from unittest.mock import MagicMock
+
+from src.aw_manager import AWManager
+
+
+def _mgr(*, port_held, answers):
+    m = AWManager()
+    m._port_in_use = MagicMock(return_value=port_held)
+    m._server_responding = MagicMock(return_value=answers)
+    return m
+
+
+def test_a_corpse_holding_the_port_is_not_reachable():
+    m = _mgr(port_held=True, answers=False)
+    assert m._window_tracker_reachable() is False
+
+
+def test_a_responding_server_is_reachable():
+    """Allowance: the ordinary healthy case must still be reachable, or every
+    quiet window tracker stops being restarted."""
+    m = _mgr(port_held=True, answers=True)
+    assert m._window_tracker_reachable() is True
+
+
+def test_a_free_port_is_not_reachable():
+    m = _mgr(port_held=False, answers=False)
+    assert m._window_tracker_reachable() is False

--- a/tests/test_window_stale_needs_a_responding_server.py
+++ b/tests/test_window_stale_needs_a_responding_server.py
@@ -7,9 +7,10 @@ classified as a blind tracker: a force-restart burst plus a latched
 _window_tracker_blind, which publishes a permissions story for a dead server.
 """
 
+import time
 from unittest.mock import MagicMock
 
-from src.aw_manager import AWManager
+from src.aw_manager import WINDOW_BLIND_GRACE, AWManager
 
 
 def _mgr(*, port_held, answers):
@@ -34,3 +35,45 @@ def test_a_responding_server_is_reachable():
 def test_a_free_port_is_not_reachable():
     m = _mgr(port_held=False, answers=False)
     assert m._window_tracker_reachable() is False
+
+
+def test_a_held_but_dead_port_does_not_force_restart_the_watchers():
+    """The divergent case neither existing fixture can express.
+
+    tests/test_aw_manager_window_blind.py::_mgr feeds ONE value to both
+    _port_in_use and _server_responding, so no test drives the real
+    _restart_if_needed_locked with the shape this file exists for: the port
+    is HELD (a corpse), but the server does not ANSWER. That must read as an
+    AW outage, not a blind window tracker -- _is_window_tracker_stale's own
+    reachable=False branch exists precisely to avoid force-restarting a
+    watcher into a dead server. Reverting _window_tracker_reachable to ask
+    _port_in_use() instead of _server_responding() must redden this.
+    """
+    mgr = AWManager()
+    mgr._using_external = True
+    mgr._port_in_use = MagicMock(return_value=True)
+    mgr._server_responding = MagicMock(return_value=False)
+    mgr._get_binaries_dir = MagicMock(return_value="/tmp/bin")
+    mgr._start_component = MagicMock()
+    mgr._get_latest_window_event_age = MagicMock(return_value=None)
+    mgr._get_latest_afk_event_age = MagicMock(return_value=5)  # afk fresh -> idle block no-op
+
+    window = MagicMock()
+    window.poll.return_value = None
+    idle = MagicMock()
+    idle.poll.return_value = None
+    mgr._processes = {
+        "bf-window-tracker": window,
+        "bf-idle-tracker": idle,
+    }
+    mgr._component_started_at = {
+        "bf-window-tracker": time.monotonic() - (WINDOW_BLIND_GRACE + 120),
+    }
+
+    mgr.restart_if_needed()
+
+    assert not window.terminate.called, (
+        "a corpse holding the port must not be misread as a blind window "
+        "tracker and force-restarted"
+    )
+    assert not idle.terminate.called


### PR DESCRIPTION
## What

A device attached to a process that holds tracker port 5600 and does not answer `/api/0/info` is capturing **nothing** — and reported healthy. This adds `external_server_not_responding` to the heartbeat so the fleet can see it, and fixes a related misclassification where an ActivityWatch outage read as a *blind window tracker*.

**It changes no lifecycle behaviour.** That is the point. Two prior attempts fixed this by changing which processes run and both regressed — one destroyed every watcher on a healthy machine that missed two `/info` answers. A foreign process holding the port is unreapable by construction (`_reap_orphan_processes` is path-scoped to our own binaries), so no restart can fix it, and attaching is the behaviour that keeps the watchers alive and self-heals when the holder dies. The defect was never the decision; it was the silence.

Verified mechanically, not by reading — docstring-stripped executable-AST diff, statement level: the only changes in `_start_locked` are the new field's set/clear and a log-level `if/else`. `self._using_external = True` remains unconditional.

## The two fixes

**Reporting.** `_external_server_not_responding`, set at the normal-path attach, published via `health_snapshot()` and both allowlist copies (`bf_client.py` and `disclosure_baseline.py` — the parity test is the proof both were edited). Deliberately a **new** field rather than reusing `tracker_download_failed`: `_start_component` clears that on Popen success and the watcher loop runs after the attach, so a latch on it is wiped inside the same call. Measured.

**Misclassification.** `_is_window_tracker_stale` reads its `reachable` argument as "AW is reachable" — its own docstring says so — and was fed `_port_in_use()`. A corpse holding the port answers `True`, so an outage was classed as a blind tracker, force-restarted, and latched as `_window_tracker_blind`, telling the user to check a permission when the server was simply dead. Driven end to end against a real socket that accepts TCP and never speaks HTTP:

```
port_in_use: True   server_responding: False   window_reachable: False
external_server_not_responding   True     <- the new signal
window_tracker_blind             False    <- was the false permissions story
```

## Known limitation, deliberate and documented

The field is a **latch**: it is derived only during a `_start_locked` evaluation, and the routine 60s tick does not re-enter `_start_locked` while the port stays held. A device whose external server recovers is refreshed only by a restart-ish event — `force_restart` via the 180s unreachable watchdog, or suppress/resume with an empty `_processes`.

A clear keyed on the tick's existing reachability check was written, and reverted: it sits inside a `bf-window-tracker` block, and `main.py:2336` disables that component on darwin, so it worked on Windows/Linux and was **inert on macOS**. A signal whose meaning is platform-dependent is worse than a uniform documented latch, because the consumer gets written against whichever platform its author tested. The proper fix needs a platform-independent reachability point — on macOS that means a new HTTP call under the lock — and belongs with the alert that consumes it. `test_the_flag_is_a_latch_until_the_next_start_evaluation` pins the real behaviour rather than deleting the coverage.

## No consumer yet

Nothing stores or alerts on this key. `internal-tool2` treats the sibling keys as **request-only** — there is no `agent_devices` column and never was (`AgentDevice.php:474`), so no migration is needed, contrary to the plan's first draft. Both consumer repos were actively worked, so per `cross-repo-safety.md` Rule 1 that work is a written hand-off, not something this PR does. The latch above must be fixed **before** an alert reads this, or it will false-alarm on a machine whose ActivityWatch was merely slow to boot.

## Review

Five tasks, subagent-driven: per-task reviews, two fix rounds, a whole-branch review on the most capable model, one fix wave, one scoped re-review. Suite **2133 passed, 1 skipped** (baseline 2119 + 14).

Findings that shipped fixes rather than being argued away:
- a stale `True` that made a fully-capturing device report not-responding
- three comment claims falsified by running them, including one **this branch made false itself**
- a `disclosure_baseline.py` claim contradicting the repo's own 180s figure — that file is what legal/privacy review reads
- a Task 3 fix with no call-site witness (the fixture fed one value to both probes, so no test could express the divergence)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
