### PR TITLE
fix(aw): both health flags can now take themselves back

### DIFF
--- a/src/aw_manager.py
+++ b/src/aw_manager.py
@@ -1893,7 +1893,19 @@ class AWManager:
         # nothing to retract -- virtually all of them, virtually always -- pays no
         # probe. Only a device currently REPORTING a non-responding holder spends
         # the /api/0/info ask, which is exactly when the answer is worth having.
-        if self._external_server_not_responding and self._window_tracker_reachable():
+        #
+        # `_server_responding()` directly, not the `_window_tracker_reachable()`
+        # alias: that name is about the WINDOW TRACKER's staleness judgement and
+        # this asks about the SERVER we attached to. Same one-line call today, but
+        # the alias would read as a dependency on the window tracker that is
+        # exactly what this placement exists to avoid.
+        #
+        # Position relative to the process-set guard below is NOT load-bearing --
+        # a mutant moving it below passes the whole suite. What matters is that it
+        # is outside the bf-window-tracker block, which macOS disables. Do not
+        # defend this line's position as covering the empty-_processes case: it
+        # does not, because main.py gates this whole method on is_managing.
+        if self._external_server_not_responding and self._server_responding():
             self._external_server_not_responding = False
 
         if not self._processes:

--- a/src/aw_manager.py
+++ b/src/aw_manager.py
@@ -649,6 +649,22 @@ class AWManager:
             # the saved write.
             if active:
                 self._idle_tracker_blind = False
+            else:
+                # RE-DERIVE on the way OUT -- the other half of the retraction
+                # above. `_idle_consecutive_stale` survives the whole round trip
+                # (nothing in this method touches it), so a tracker that was
+                # genuinely blind before in-process AFK took over is still blind
+                # when the external one becomes the source again. Clearing on the
+                # way in and never restoring left it reporting healthy, with
+                # main.py's Input Monitoring re-prompt -- gated on this flag --
+                # suppressed, while billing ran off a frozen AFK stream.
+                #
+                # Derived from the counter rather than remembered, so it cannot
+                # disagree with the latch in `_restart_if_needed_locked`, which
+                # applies the same threshold to the same counter.
+                self._idle_tracker_blind = (
+                    self._idle_consecutive_stale >= IDLE_BLIND_RESTART_THRESHOLD
+                )
 
             if not self._stop_external_when_inproc or active == was_active:
                 return
@@ -1864,6 +1880,22 @@ class AWManager:
             self._using_external = False
             return self._start_locked()
 
+        # Clear the attach-side flag as soon as the external server answers
+        # again. HERE, not inside the bf-window-tracker block below: main.py
+        # disables that component unconditionally on darwin, so the block never
+        # runs there. A first attempt at this clear lived inside it and was
+        # therefore inert on the one platform this file's Rosetta and
+        # Accessibility complexity exists for -- correct on Windows and Linux,
+        # silently absent on macOS, which is worse than a uniform latch because
+        # the signal's meaning becomes platform-dependent.
+        #
+        # Gated on the flag being SET, and `and` short-circuits, so a device with
+        # nothing to retract -- virtually all of them, virtually always -- pays no
+        # probe. Only a device currently REPORTING a non-responding holder spends
+        # the /api/0/info ask, which is exactly when the answer is worth having.
+        if self._external_server_not_responding and self._window_tracker_reachable():
+            self._external_server_not_responding = False
+
         if not self._processes:
             return False
 
@@ -1907,13 +1939,11 @@ class AWManager:
             # platform this file's Rosetta/Accessibility complexity exists
             # for, the clear never ran, and the flag worked on Windows/Linux
             # only -- a signal whose meaning silently depended on the OS.
-            # Reverted rather than repaired: a uniform latch, refreshed only
-            # by the next _start_locked evaluation (a restart, or
-            # set_capture_suppressed(False) on an empty process set), is
-            # honest everywhere. No consumer reads this key yet, so the
-            # latch costs nothing today. See disclosure_baseline.py and
-            # bf_client.py for what "refreshed only on evaluation" actually
-            # means for this field.
+            # Reverted, then repaired properly: the clear now lives ABOVE the
+            # process-set guard at the top of this method, where no component's
+            # enabled state can gate it, and is itself gated on the flag being
+            # SET so a device with nothing to retract pays no probe. This block
+            # keeps its own `reachable` for the staleness judgement below.
             if not self._is_window_tracker_stale(age, running_for, reachable):
                 # Emitting fresh window events again. (age None here is just
                 # launch lag or an AW outage, not recovery — don't count it.)

--- a/src/disclosure_baseline.py
+++ b/src/disclosure_baseline.py
@@ -629,13 +629,13 @@ HEARTBEAT_HEALTH_KEYS: tuple[str, ...] = (
     # re-derived only when the tracker lifecycle is next EVALUATED (an
     # attach, a restart, or capture resuming with no processes running), and
     # the routine 60s health tick is not one of those moments while the port
-    # stays held. Stopping the trackers clears it immediately (attached to
-    # nothing cannot be attached to a dead server), so the CLEAR direction is
-    # bounded by that tick. The SET direction is not: a server that answers
-    # at attach and later goes unresponsive without releasing the port keeps
-    # this flag at its stale value until the next evaluation, which on a
-    # held port is the unreachable watchdog's force-restart (up to ~180s,
-    # not "one restart cycle"). Known and deliberate for now, not a bug.
+    # stays held -- but the tick DOES clear it the moment the holder answers
+    # /api/0/info again, so the CLEAR direction is bounded by one cycle.
+    # The SET direction is not: a server that answers at attach and later goes
+    # unresponsive without releasing the port keeps this flag at its stale
+    # value until the next evaluation, which on a held port is the unreachable
+    # watchdog's force-restart (up to ~180s, not "one restart cycle"). That
+    # asymmetry is deliberate: the flag is slow to accuse and quick to retract.
     "external_server_not_responding",
     # The window watcher has stayed blind across repeated restarts. Exactly the
     # same category as idle_tracker_blind, which this list already carries: a

--- a/src/disclosure_baseline.py
+++ b/src/disclosure_baseline.py
@@ -630,7 +630,10 @@ HEARTBEAT_HEALTH_KEYS: tuple[str, ...] = (
     # attach, a restart, or capture resuming with no processes running), and
     # the routine 60s health tick is not one of those moments while the port
     # stays held -- but the tick DOES clear it the moment the holder answers
-    # /api/0/info again, so the CLEAR direction is bounded by one cycle.
+    # /api/0/info again, so the CLEAR direction is bounded by one cycle ON ANY
+    # DEVICE THE TICK RUNS FOR. main.py gates it on `is_managing` (a non-empty
+    # process set), so a device that attached externally and whose watchers never
+    # started has no tick, and there the ~180s force_restart bound still applies.
     # The SET direction is not: a server that answers at attach and later goes
     # unresponsive without releasing the port keeps this flag at its stale
     # value until the next evaluation, which on a held port is the unreachable

--- a/src/sync/bf_client.py
+++ b/src/sync/bf_client.py
@@ -524,18 +524,14 @@ class BetterFlowClient(BaseApiClient):
         "managed_components_unavailable",
         # True when we are attached to a process that holds the tracker port
         # and does not answer /api/0/info -- the device is capturing NOTHING.
-        # Not a per-cycle verdict: it is set only inside AWManager's
-        # _start_locked normal-path attach, and re-derived fresh only when
-        # that evaluation runs again. The routine 60s tick does NOT re-enter
-        # _start_locked while the port stays held, so a device attached to a
-        # corpse keeps reporting True until one of: the port is released (the
-        # external server dies and the routine tick starts our own), the
-        # 180s unreachable watchdog fires force_restart(), or capture is
-        # suppressed and later resumed with no processes running. A server
-        # that recovers WITHOUT any of those (still holds the port, starts
-        # answering again) is not re-evaluated by the routine tick and can
-        # leave this flag stuck True for up to that 180s watchdog window --
-        # a known, deliberate limitation, not a bug to chase. Distinct from
+        # SET only inside AWManager's _start_locked normal-path attach, and
+        # CLEARED by the routine 60s tick as soon as the holder answers
+        # /api/0/info again -- so a server that recovers while still holding the
+        # port is retracted within a cycle, without waiting for a restart or the
+        # 180s unreachable watchdog. The clear sits above the tick's process-set
+        # guard so no component's enabled state can gate it (an earlier one lived
+        # inside the bf-window-tracker block and was inert on macOS, where that
+        # component is disabled). Distinct from
         # tracker_download_failed (our binaries are fine) and from
         # managed_components_unavailable (we did start our watchers).
         "external_server_not_responding",

--- a/src/sync/bf_client.py
+++ b/src/sync/bf_client.py
@@ -526,9 +526,15 @@ class BetterFlowClient(BaseApiClient):
         # and does not answer /api/0/info -- the device is capturing NOTHING.
         # SET only inside AWManager's _start_locked normal-path attach, and
         # CLEARED by the routine 60s tick as soon as the holder answers
-        # /api/0/info again -- so a server that recovers while still holding the
-        # port is retracted within a cycle, without waiting for a restart or the
-        # 180s unreachable watchdog. The clear sits above the tick's process-set
+        # /api/0/info again -- so on any device the tick still runs for, a server
+        # that recovers while holding the port is retracted within a cycle rather
+        # than waiting for the 180s unreachable watchdog. NOT universal: main.py
+        # gates that tick on `is_managing`, i.e. a non-empty process set, so a
+        # device that attached externally and whose watchers never started (they
+        # cannot exec -- the EBADARCH / Apple-Silicon-without-Rosetta state) has
+        # no tick at all, and there the old ~180s force_restart bound still
+        # applies. Verified, not assumed: such a device reports flag True with
+        # is_managing False. The clear sits above the tick's process-set
         # guard so no component's enabled state can gate it (an earlier one lived
         # inside the bf-window-tracker block and was inert on macOS, where that
         # component is disabled). Distinct from

--- a/tests/test_external_server_not_responding.py
+++ b/tests/test_external_server_not_responding.py
@@ -83,42 +83,35 @@ class TestItReachesTheWire:
         )
 
 
-class TestTheFlagIsALatchUntilTheNextStartEvaluation:
-    def test_the_flag_is_a_latch_until_the_next_start_evaluation(self):
-        """Known, deliberate limitation -- not a regression to chase.
+class TestTheRoutineTickClearsItOnEveryPlatform:
+    """The latch this class used to DOCUMENT is now fixed.
 
-        A prior fix wave (round 3) tried to clear this flag from the routine
-        60s tick's window-tracker reachability check, the moment /api/0/info
-        started answering again. That clear lived INSIDE the block gated on
-        `watcher not in self._disabled_components` (watcher =
-        "bf-window-tracker"), and main.py unconditionally disables
-        "bf-window-tracker" on darwin -- the in-process macOS window watcher
-        covers it instead. So the clear was inert on exactly the platform
-        this file's Rosetta/Accessibility complexity exists for, and worked
-        on Windows/Linux only: the same flag would mean a different thing
-        depending on the OS the device happened to run.
+    It previously pinned a deliberate limitation: the flag was set or cleared
+    only inside a `_start_locked` evaluation, and the routine 60s tick does not
+    re-enter `_start_locked` while the port stays held -- so a corpse that
+    started answering again, with no restart-ish event in between, kept a stale
+    True. That was accepted because an earlier attempt to clear it from the tick
+    lived INSIDE the block gated on `watcher not in self._disabled_components`
+    (watcher = "bf-window-tracker"), and main.py disables that component
+    unconditionally on darwin. The clear worked on Windows/Linux and was inert on
+    macOS, making the flag mean different things per OS -- worse than a uniform
+    latch -- so it was reverted rather than repaired.
 
-        Reverted rather than repaired. The honest, platform-independent
-        behaviour pinned here: this flag is set or cleared ONLY inside a
-        `_start_locked` evaluation, and the routine 60s tick does not
-        re-enter `_start_locked` while the port stays held (see
-        _restart_if_needed_locked's bare-port check above). So a corpse that
-        starts answering again with no restart-ish event in between --
-        force_restart() via the 180s unreachable watchdog, or
-        set_capture_suppressed(False) on an empty process set -- keeps this
-        flag at its stale value. No consumer reads this key yet, so the cost
-        of the latch is zero today; fixing it for real needs a
-        platform-independent reachability point under the lock, which this
-        test deliberately does not attempt.
-        """
+    The repair is a platform-independent point: the tick now clears the flag
+    before the process-set guard, gated on the flag being SET so a device with
+    nothing to retract pays no probe. The per-platform assertions live in
+    tests/test_health_flag_rederivation.py; this class keeps the recovery
+    scenario that motivated the original limitation.
+    """
+
+    def test_a_corpse_that_starts_answering_clears_the_flag(self):
         m = _mgr(port_held=True, answers=False)
         m._start_locked()
         assert m._external_server_not_responding is True
 
-        # The corpse "recovers" -- starts answering -- with no restart-ish
-        # event in between. Give the instance a live watcher process so the
-        # routine tick's window-tracker section runs (it used to be where
-        # the now-reverted clear lived).
+        # The corpse "recovers" -- starts answering -- with NO restart-ish event
+        # in between (no force_restart, no suppress/resume). This is exactly the
+        # sequence the latch used to survive.
         window = MagicMock()
         window.poll.return_value = None
         m._processes = {"bf-window-tracker": window}
@@ -126,12 +119,12 @@ class TestTheFlagIsALatchUntilTheNextStartEvaluation:
         m._get_latest_afk_event_age = MagicMock(return_value=5)
         m._server_responding = MagicMock(return_value=True)
 
-        for _ in range(3):
-            m.restart_if_needed()
+        m.restart_if_needed()
 
-        assert m._external_server_not_responding is True, (
-            "the routine tick must not clear this -- the clear was inert on "
-            "macOS and is gone on every platform now; see the class docstring"
+        assert m._external_server_not_responding is False, (
+            "the routine tick did not retract the flag; a device whose "
+            "ActivityWatch was merely slow to boot reports capturing nothing "
+            "for the rest of the day"
         )
 
 

--- a/tests/test_health_flag_rederivation.py
+++ b/tests/test_health_flag_rederivation.py
@@ -1,0 +1,123 @@
+"""Two health flags that could not take themselves back.
+
+Both publish to the fleet every cycle via health_snapshot(), so a flag that
+cannot be retracted is an alert that outlives the thing it describes.
+
+#247  external_server_not_responding was a LATCH. It is derived only during a
+      _start_locked evaluation, and the routine 60s tick does not re-enter
+      _start_locked while the port stays held. A first attempt to clear it in
+      _restart_if_needed_locked was reverted because it sat INSIDE the
+      `bf-window-tracker` block -- and main.py disables that component
+      unconditionally on darwin, so it worked on Windows/Linux and was inert on
+      the platform this file's Rosetta/Accessibility complexity exists for.
+
+#240  _idle_tracker_blind is retracted when in-process AFK takes over, because
+      both of its writes live in a branch that source can no longer reach. But
+      it is not RE-DERIVED on the way out: _idle_consecutive_stale survives the
+      round trip, so a tracker that was genuinely blind before the switch comes
+      back reporting healthy, and the Input Monitoring re-prompt stays
+      suppressed while billing runs off a frozen AFK stream.
+"""
+
+from unittest.mock import MagicMock
+
+from src.aw_manager import IDLE_BLIND_RESTART_THRESHOLD, AWManager
+
+
+def _ticking(*, responding, disabled=()):
+    """A manager whose 60s tick will actually run (processes present)."""
+    m = AWManager()
+    m._capture_suppressed = False
+    m._get_binaries_dir = MagicMock(return_value="/tmp/bin")
+    m._port_in_use = MagicMock(return_value=True)
+    m._server_responding = MagicMock(return_value=responding)
+    m._start_component = MagicMock(return_value=True)
+    m.check_health = MagicMock(return_value=True)
+    m._get_latest_afk_event_age = MagicMock(return_value=5)
+    m._get_latest_window_event_age = MagicMock(return_value=5)
+    m._using_external = True
+    for c in disabled:
+        m._disabled_components.add(c)
+    m._processes = {
+        n: MagicMock(**{"poll.return_value": None})
+        for n in ("bf-window-tracker", "bf-idle-tracker")
+        if n not in disabled
+    }
+    return m
+
+
+class TestExternalServerFlagClearsOnEveryPlatform:
+    """macOS is the case the reverted attempt could not reach."""
+
+    def test_it_clears_on_the_macos_shape(self):
+        m = _ticking(responding=True, disabled=("bf-window-tracker",))
+        m._external_server_not_responding = True
+
+        m.restart_if_needed()
+
+        assert m._external_server_not_responding is False, (
+            "still latched with bf-window-tracker disabled -- the clear is "
+            "inside that component's block again, so it is inert on macOS"
+        )
+
+    def test_it_clears_on_the_windows_linux_shape(self):
+        m = _ticking(responding=True)
+        m._external_server_not_responding = True
+        m.restart_if_needed()
+        assert m._external_server_not_responding is False
+
+    def test_a_still_dead_server_keeps_the_flag(self):
+        """Control: the flag must not clear just because a tick ran."""
+        m = _ticking(responding=False, disabled=("bf-window-tracker",))
+        m._external_server_not_responding = True
+        m.restart_if_needed()
+        assert m._external_server_not_responding is True
+
+    def test_no_probe_is_paid_when_there_is_nothing_to_clear(self):
+        """Cost control: the flag is False on virtually every device, and this
+        runs every 60s under _lifecycle_lock. Asking /api/0/info when there is
+        nothing to retract would add a 2s-timeout call to every tick on macOS,
+        where the window-tracker block does not run at all."""
+        m = _ticking(responding=True, disabled=("bf-window-tracker",))
+        m._external_server_not_responding = False
+        before = m._server_responding.call_count
+
+        m.restart_if_needed()
+
+        assert m._server_responding.call_count == before, (
+            "paid for a reachability probe with no flag to clear"
+        )
+
+
+class TestIdleBlindIsReDerivedOnTheWayOut:
+    def test_a_still_earned_latch_comes_back(self):
+        m = _ticking(responding=True)
+        m._idle_consecutive_stale = IDLE_BLIND_RESTART_THRESHOLD
+        m._idle_tracker_blind = True
+
+        m.set_inproc_afk_active(True)
+        assert m._idle_tracker_blind is False, "precondition: #2413's retraction"
+
+        m.set_inproc_afk_active(False)
+
+        assert m._idle_tracker_blind is True, (
+            "the external tracker is live again and its stale counter never "
+            "moved, so it is still blind -- but the flag says healthy and the "
+            "Input Monitoring re-prompt stays suppressed"
+        )
+
+    def test_a_tracker_that_was_never_blind_stays_clear(self):
+        """Control: leaving in-process AFK must not INVENT a blind flag."""
+        m = _ticking(responding=True)
+        m._idle_consecutive_stale = 0
+        m.set_inproc_afk_active(True)
+        m.set_inproc_afk_active(False)
+        assert m._idle_tracker_blind is False
+
+    def test_entering_in_process_afk_still_retracts(self):
+        """Control: #2413's fix must survive."""
+        m = _ticking(responding=True)
+        m._idle_consecutive_stale = IDLE_BLIND_RESTART_THRESHOLD
+        m._idle_tracker_blind = True
+        m.set_inproc_afk_active(True)
+        assert m._idle_tracker_blind is False

--- a/tests/test_health_flag_rederivation.py
+++ b/tests/test_health_flag_rederivation.py
@@ -121,3 +121,68 @@ class TestIdleBlindIsReDerivedOnTheWayOut:
         m._idle_tracker_blind = True
         m.set_inproc_afk_active(True)
         assert m._idle_tracker_blind is False
+
+
+class TestTheOtherConfigAndTheDeviceWithNoTick:
+    """Two states the fixtures above cannot express.
+
+    Every fixture in this file leaves `stop_external_when_inproc` at its ctor
+    default of False, which is the config where the #240 re-derivation is least
+    interesting -- the external tracker keeps running throughout. With it True,
+    leaving in-process AFK STARTS A FRESH PROCESS, and the re-derivation declares
+    that new process blind from the old one's counter. That is intended (the
+    blind latch deliberately survives restarts, and the recovery path clears it
+    on the first fresh AFK event) but nothing pinned it, so the two configs
+    agreed on the value while differing in meaning.
+
+    And the clear added for #247 cannot help a device whose tick never runs:
+    main.py gates `restart_if_needed()` on `is_managing`, i.e. a non-empty
+    process set. A device that attached to a corpse and whose watchers could not
+    exec has none. Pinned so the comments claiming "bounded by one cycle" stay
+    honest about their scope.
+    """
+
+    def test_leaving_inproc_with_the_external_tracker_restarted_still_re_derives(self):
+        m = _ticking(responding=True)
+        m._stop_external_when_inproc = True
+        m._stop_idle_tracker_locked = MagicMock()
+        m._start_idle_tracker_locked = MagicMock()
+        m._idle_consecutive_stale = IDLE_BLIND_RESTART_THRESHOLD
+
+        m.set_inproc_afk_active(True)
+        assert m._idle_tracker_blind is False
+        m.set_inproc_afk_active(False)
+
+        assert m._start_idle_tracker_locked.called, (
+            "precondition: this config must actually restart the external tracker"
+        )
+        assert m._idle_tracker_blind is True, (
+            "the counter is what carries the blind verdict across the switch; a "
+            "fresh process does not clear it until it emits a real AFK event"
+        )
+
+    def test_a_device_with_no_tick_keeps_the_flag(self):
+        """The scope limit the heartbeat comments now state.
+
+        Attached to a corpse, watchers cannot exec, so `_processes` is empty and
+        main.py never calls restart_if_needed(). The flag stays True until the
+        180s force_restart -- documented, not fixed here, and asserted so the
+        claim in bf_client.py/disclosure_baseline.py cannot quietly become a
+        universal again.
+        """
+        m = AWManager()
+        m._capture_suppressed = False
+        m._get_binaries_dir = MagicMock(return_value="/tmp/bin")
+        m._rosetta_required = MagicMock(return_value=False)
+        m._port_in_use = MagicMock(return_value=True)
+        m._server_responding = MagicMock(return_value=False)
+        m._start_component = MagicMock(return_value=False)   # cannot exec
+        m._reap_orphan_processes = MagicMock()
+
+        assert m._start_locked() is True
+        assert m._external_server_not_responding is True
+        assert m._processes == {}
+        assert m.is_managing is False, (
+            "main.py gates restart_if_needed() on this, so the tick -- and the "
+            "clear -- never run for this device"
+        )


### PR DESCRIPTION
## What

Two flags that `health_snapshot()` publishes every cycle could not be retracted, so each was an alert outliving the thing it described.

**`#247` — `external_server_not_responding` was a latch.** Set inside `_start_locked`'s normal-path attach; the routine 60s tick does not re-enter `_start_locked` while the port stays held. So an ActivityWatch merely still **booting** at agent start (port held, `/info` not yet answering, 2s timeout) set it `True` and nothing re-derived it.

The asymmetry is what made it cost something: on a real corpse the server stays unreachable, so the 180s watchdog fires `force_restart` and the flag refreshes — it self-corrected when it was **right** and latched when it was **wrong**. A key that false-alarms on healthy machines is how an alert gets muted.

**`#240` — `_idle_tracker_blind` was retracted but never re-derived.** `_idle_consecutive_stale` survives the round trip, so a tracker genuinely blind before in-process AFK took over came back reporting healthy, with `main.py`'s Input Monitoring re-prompt — gated on that flag — suppressed while billing ran off a frozen AFK stream.

## Why the previous attempt was reverted, and what is different

The earlier clear lived inside the block gated on `watcher not in self._disabled_components` where watcher is `"bf-window-tracker"`, and `main.py:2336` disables that component unconditionally on darwin. It worked on Windows/Linux and was **inert on macOS** — a signal whose meaning depended on the OS, which is worse than a uniform latch.

It now sits at the top of `_restart_if_needed_locked`, outside any component's block, gated on the flag being **set** so a device with nothing to retract pays no probe. That cost control has its own test.

## Known scope limit, stated rather than implied

`main.py` gates the tick on `is_managing` (a non-empty process set), and an external attach never stores a server there. A device attached to a corpse whose watchers cannot exec — the EBADARCH / Apple-Silicon-without-Rosetta state — has no tick at all:

```
start rc=True   processes=[]   flag=True   is_managing=False
```

For that device the old ~180s `force_restart` bound still applies. The heartbeat comments name the gate, and a test pins the scope.

## Verification

Proof of failure: three defect tests fail pre-fix, four controls already pass — the macOS shape, a still-dead server that must **keep** the flag, and "leaving in-process AFK must not *invent* a blind flag".

Mutation matrix, control 17, every mutant collecting 17:

| mutant | witness |
|---|---|
| gate the clear on `bf-window-tracker` enabled (the reverted attempt) | `test_it_clears_on_the_macos_shape` |
| drop the flag short-circuit | `test_no_probe_is_paid_when_there_is_nothing_to_clear` |
| keep the `if`, delete the assignment | 3 tests |
| `>=` to `>` in the re-derivation | boundary pinned |
| else-branch to `False` (pre-fix) / to `True` | two distinct tests |

Suite **2152 passed, 1 skipped**.

## Audit gate

Reviewed on the correctness lens; both fixes found sound. Its one Important was that my rewritten comments claimed "bounded by one cycle" — a **fourth** false absolute on this branch, refuted with the reachable no-tick device above and now scoped. Also from the gate: call `_server_responding()` directly rather than the `_window_tracker_reachable()` alias (that name implies a dependency on the very component that broke the last attempt), note that the clear's position relative to the process-set guard is *not* load-bearing, and pin the `stop_external_when_inproc=True` config where the re-derivation means something different.

The test that previously **documented** the latch as a deliberate limitation now asserts the fixed behaviour; it failed on this branch, correctly, because the limitation it pinned is gone.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
